### PR TITLE
fix: move cpp file of ehf_signals from headers to libbitcoin_server

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -233,7 +233,6 @@ BITCOIN_CORE_H = \
   llmq/dkgsession.h \
   llmq/dkgsessionhandler.h \
   llmq/dkgsessionmgr.h \
-  llmq/ehf_signals.cpp \
   llmq/ehf_signals.h \
   llmq/instantsend.h \
   llmq/options.h \
@@ -459,21 +458,22 @@ libbitcoin_server_a_SOURCES = \
   index/coinstatsindex.cpp \
   index/txindex.cpp \
   init.cpp \
-  llmq/quorums.cpp \
   llmq/blockprocessor.cpp \
-  llmq/commitment.cpp \
   llmq/chainlocks.cpp \
   llmq/clsig.cpp \
+  llmq/commitment.cpp \
+  llmq/context.cpp \
   llmq/debug.cpp \
+  llmq/dkgsession.cpp \
   llmq/dkgsessionhandler.cpp \
   llmq/dkgsessionmgr.cpp \
-  llmq/dkgsession.cpp \
-  llmq/context.cpp \
+  llmq/ehf_signals.cpp \
   llmq/instantsend.cpp \
   llmq/options.cpp \
-  llmq/snapshot.cpp \
+  llmq/quorums.cpp \
   llmq/signing.cpp \
   llmq/signing_shares.cpp \
+  llmq/snapshot.cpp \
   llmq/utils.cpp \
   mapport.cpp \
   masternode/node.cpp \


### PR DESCRIPTION
## What was done?
Moved cpp file from list of headers to list o libbitcoin_server where it is supposed to be.
Also recover alphabetical sort in file list for libbitcoin_server

## How Has This Been Tested?
Run CI

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone