### PR TITLE
fix: mixing for partially unlocked descriptor wallets

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -331,7 +331,7 @@ void LegacyScriptPubKeyMan::MarkUnusedAddresses(WalletBatch &batch, const CScrip
 void LegacyScriptPubKeyMan::UpgradeKeyMetadata()
 {
     LOCK(cs_KeyStore); // mapKeyMetadata
-    if (m_storage.IsLocked() || m_storage.IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA) || !IsHDEnabled()) {
+    if (m_storage.IsLocked(false) || m_storage.IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA) || !IsHDEnabled()) {
         return;
     }
 
@@ -1901,7 +1901,7 @@ void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, 
 std::map<CKeyID, CKey> DescriptorScriptPubKeyMan::GetKeys() const
 {
     AssertLockHeld(cs_desc_man);
-    if (m_storage.HasEncryptionKeys() && !m_storage.IsLocked()) {
+    if (m_storage.HasEncryptionKeys() && !m_storage.IsLocked(true)) {
         KeyMap keys;
         for (auto key_pair : m_map_crypted_keys) {
             const CPubKey& pubkey = key_pair.second.first;
@@ -2014,7 +2014,7 @@ bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const
     }
 
     if (m_storage.HasEncryptionKeys()) {
-        if (m_storage.IsLocked()) {
+        if (m_storage.IsLocked(true)) {
             return false;
         }
 
@@ -2423,7 +2423,7 @@ bool DescriptorScriptPubKeyMan::GetDescriptorString(std::string& out) const
 void DescriptorScriptPubKeyMan::UpgradeDescriptorCache()
 {
     LOCK(cs_desc_man);
-    if (m_storage.IsLocked() || m_storage.IsWalletFlagSet(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED)) {
+    if (m_storage.IsLocked(false) || m_storage.IsWalletFlagSet(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED)) {
         return;
     }
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -40,7 +40,7 @@ public:
     virtual void SetMinVersion(enum WalletFeature, WalletBatch* = nullptr) = 0;
     virtual const CKeyingMaterial& GetEncryptionKey() const = 0;
     virtual bool HasEncryptionKeys() const = 0;
-    virtual bool IsLocked(bool fForMixing = false) const = 0;
+    virtual bool IsLocked(bool fForMixing) const = 0;
 
     // for LegacyScriptPubKeyMan::TopUpInner needs:
     virtual void UpdateProgress(const std::string&, int) = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5459,21 +5459,11 @@ bool CWallet::IsLocked(bool fForMixing) const
 {
     if (!IsCrypted())
         return false;
-    bool result;
-    {
-        LOCK(cs_wallet);
-        result = vMasterKey.empty();
-    }
-    // fForMixing   fOnlyMixingAllowed  return
-    // ---------------------------------------
-    // true         true                result
-    // true         false               result
-    // false        true                true
-    // false        false               result
 
     if(!fForMixing && fOnlyMixingAllowed) return true;
 
-    return result;
+    LOCK(cs_wallet);
+    return vMasterKey.empty();
 }
 
 bool CWallet::Lock(bool fAllowMixing)


### PR DESCRIPTION
## Issue being fixed or feature implemented
As [noticed by kwvg](https://github.com/dashpay/dash/pull/6090#pullrequestreview-2153639183), mixing doesn't work with descriptor wallets if do "unlock only for mixing". This PR is aiming to fix this issue.
https://github.com/dashpay/dash-issues/issues/59

## What was done?
Removed default argument "bool mixing = false" from WalletStorage interface,
Refactored a logic of CWallet::IsLocked to make it shorter, clearer and unified with bitcoin.

## How Has This Been Tested?
A. Run Dash-Qt with descriptor wallet, run mixing, enter passphrase.
The wallet is partially unlocked (for mixing only) - possible to see yellow lock in status. Mixing happens.
B. Open "send transaction dialog", try to send a transaction: the app asks password to unlock wallet as expected.

Though, I am not sure how exactly to test that **all** rpc are indeed locked when descriptor wallet is unlocked for mixing only.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone