### PR TITLE
fix: createwallet to require 'load_on_startup' for descriptor wallets

### DIFF
--- a/doc/release-notes-16528.md
+++ b/doc/release-notes-16528.md
@@ -35,6 +35,7 @@ Descriptor Wallet should be created.
 
 Without those options being set, a Legacy Wallet will be created instead.
 
+
 #### `IsMine` Semantics
 
 `IsMine` refers to the function used to determine whether a script belongs to the wallet.
@@ -117,3 +118,4 @@ descriptors with private keys for now as explained earlier.
 ## RPC changes
  - `createwallet` has changed list of arguments: `createwallet "wallet_name" ( disable_private_keys blank "passphrase" avoid_reuse descriptors load_on_startup )`
 `load_on_startup` used to be an argument 5 but now has a number 6.
+ - `createwallet` requires specifying the `load_on_startup` flag when creating descriptor wallets due to breaking changes in v21.

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3032,6 +3032,9 @@ static RPCHelpMan createwallet()
 #ifndef USE_SQLITE
         throw JSONRPCError(RPC_WALLET_ERROR, "Compiled without sqlite support (required for descriptor wallets)");
 #endif
+        if (request.params[6].isNull()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "The createwallet RPC requires specifying the 'load_on_startup' flag when creating descriptor wallets. Dash Core v21 introduced this requirement due to breaking changes in the createwallet RPC.");
+        }
         flags |= WALLET_FLAG_DESCRIPTORS;
         warnings.emplace_back(Untranslated("Wallet is an experimental descriptor wallet"));
     }

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -704,6 +704,8 @@ class RPCOverloadWrapper():
     def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None, load_on_startup=None):
         if descriptors is None:
             descriptors = self.descriptors
+        if descriptors is not None and load_on_startup is None:
+            load_on_startup = False
         return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup)
 
     def importprivkey(self, privkey, label=None, rescan=None):


### PR DESCRIPTION
## Issue being fixed or feature implemented

RPC `createwallet` has changed list of arguments: `createwallet "wallet_name" ( disable_private_keys blank "passphrase" avoid_reuse descriptors load_on_startup )` since https://github.com/dashpay/dash/pull/5965
`load_on_startup` used to be an argument 5 but now it has a number 6. Both arguments 5 and 6 are boolean and it can confuse an user: they may even not notice that something wrong when it meant to be "load on startup" but got "descriptor wallet" which is not expected.

See also previous attempt to resolve issue: https://github.com/dashpay/dash/pull/6029


## What was done?
To prevent confusion if user is not aware about this breaking changes, the RPC createwallet throws an exception if user trying to create descriptor wallet but has not mentioned load_on_startup. This requirement can be removed when major amount of users updated to v21.



## How Has This Been Tested?
Run unit/functional tests

Tested with CLI:
```
$ createwallet "tmp-create" true true "" false true
RPC createwallet would not accept creating descriptor wallets without specifying 'load_on_startup' flag. It is required explicitly in v21 due to breaking changes in createwallet RPC (code -8)
$ createwallet "tmp-create" true true "" false true true
{
  "name": "tmp-create",
  "warning": "Empty string given as passphrase, wallet will not be encrypted.\nWallet is an experimental descriptor wallet"
}
```

## Breaking Changes
You can't more pass 'descriptor=NN' without  https://github.com/dashpay/dash/pull/5965 which has not been released yet.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone