### PR TITLE
fix: cppcheck warnings

### DIFF
--- a/src/masternode/utils.cpp
+++ b/src/masternode/utils.cpp
@@ -67,7 +67,7 @@ void CMasternodeUtils::DoMaintenance(CConnman& connman, CDeterministicMNManager&
                 if (pnode->IsInboundConn()) {
                     return;
                 }
-            } else if (GetTime<std::chrono::seconds>() - pnode->m_connected < 5s) {
+            } else if (GetTime<std::chrono::seconds>() - pnode->m_connected < PROBE_WAIT_INTERVAL) {
                 // non-verified, give it some time to verify itself
                 return;
             } else if (pnode->qwatch) {

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -70,7 +70,7 @@ static RPCHelpMan coinjoin()
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing has been started already.");
         }
 
-        ChainstateManager& chainman = EnsureChainman(node);
+        const ChainstateManager& chainman = EnsureChainman(node);
         CTxMemPool& mempool = EnsureMemPool(node);
         CConnman& connman = EnsureConnman(node);
         bool result = cj_clientman->DoAutomaticDenominating(chainman.ActiveChainstate(), connman, mempool);


### PR DESCRIPTION
## Issue being fixed or feature implemented

`cppcheck 2.11` on my localhost returns 2 failures, that are not caught by our CI, probably due to difference in version:

    ```
    src/rpc/coinjoin.cpp:73:28: warning: Variable 'chainman' can be declared as reference to const [constVariableReference]
     src/masternode/utils.cpp:0:0: warning: Internal Error. MathLib::toLongNumber: input was not completely consumed: 5s [cppcheckError]
    
    Advice not applicable in this specific case? Add an exception by updating
    IGNORED_WARNINGS in test/lint/lint-cppcheck-dash.sh
    ```
    

## What was done?
Adds missing const, workaround for probably a crash in cppcheck 2.11.

## How Has This Been Tested?
Run `test/lint/lint-cppcheck-dash.sh`

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone