### PR TITLE
fix: remove keypool replenishment stat and warning for descriptor wallet

### DIFF
--- a/doc/release-notes-6108.md
+++ b/doc/release-notes-6108.md
@@ -1,0 +1,4 @@
+RPC changes
+-----------
+
+- `getcoinjoininfo` will no longer report `keys_left` and will not incorrectly warn about keypool depletion with descriptor wallets

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -137,7 +137,7 @@ static RPCHelpMan getcoinjoininfo()
                                     {RPCResult::Type::NUM, "entries_count", "The number of entries in the mixing session"},
                                 }},
                             }},
-                            {RPCResult::Type::NUM, "keys_left", "How many new keys are left since last automatic backup"},
+                            {RPCResult::Type::NUM, "keys_left", /* optional */ true, "How many new keys are left since last automatic backup (if applicable)"},
                             {RPCResult::Type::STR, "warnings", "Warnings if any"},
                         }},
                     RPCResult{"for masternodes",
@@ -177,9 +177,14 @@ static RPCHelpMan getcoinjoininfo()
     CHECK_NONFATAL(manager != nullptr);
     manager->GetJsonInfo(obj);
 
-    obj.pushKV("keys_left",     wallet->nKeysLeftSinceAutoBackup);
-    obj.pushKV("warnings",      wallet->nKeysLeftSinceAutoBackup < COINJOIN_KEYS_THRESHOLD_WARNING
-                                        ? "WARNING: keypool is almost depleted!" : "");
+    std::string warning_msg{""};
+    if (wallet->IsLegacy()) {
+        obj.pushKV("keys_left", wallet->nKeysLeftSinceAutoBackup);
+        if (wallet->nKeysLeftSinceAutoBackup < COINJOIN_KEYS_THRESHOLD_WARNING) {
+            warning_msg = "WARNING: keypool is almost depleted!";
+        }
+    }
+    obj.pushKV("warnings", warning_msg);
 #endif // ENABLE_WALLET
 
     return obj;


### PR DESCRIPTION
## Breaking Changes

- `getcoinjoininfo` will no longer report `keys_left` and will not incorrectly warn about keypool depletion with descriptor wallets

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
