### PR TITLE
backport: bitcoin-core/gui#154, #176, #221, #248, #251 - qt improvements and related fixes

### DIFF
--- a/doc/release-notes-154.md
+++ b/doc/release-notes-154.md
@@ -1,0 +1,4 @@
+Compatibility
+==============
+
+Dash Core change appearance when macOS "dark mode" is activated.

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -56,9 +56,6 @@
   <key>NSHighResolutionCapable</key>
     <string>True</string>
 
-  <key>NSRequiresAquaSystemAppearance</key>
-    <string>True</string>
-
   <key>NSHumanReadableCopyright</key>
   <string>Copyright © 2009-@COPYRIGHT_YEAR@ The Bitcoin Core developers, 2014-@COPYRIGHT_YEAR@ @COPYRIGHT_HOLDERS_FINAL@</string>
   <key>LSApplicationCategoryType</key>

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -87,6 +87,7 @@ QT_MOC_CPP = \
   qt/moc_transactiondesc.cpp \
   qt/moc_transactiondescdialog.cpp \
   qt/moc_transactionfilterproxy.cpp \
+  qt/moc_transactionoverviewwidget.cpp \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
   qt/moc_utilitydialog.cpp \
@@ -164,6 +165,7 @@ BITCOIN_QT_H = \
   qt/transactiondesc.h \
   qt/transactiondescdialog.h \
   qt/transactionfilterproxy.h \
+  qt/transactionoverviewwidget.h \
   qt/transactionrecord.h \
   qt/transactiontablemodel.h \
   qt/transactionview.h \

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -37,7 +37,23 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,1">
+     <item>
+      <spacer name="horizontalSpacerLeft">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
@@ -561,6 +577,19 @@
       </layout>
      </item>
      <item>
+      <spacer name="horizontalSpacerCenter">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <widget class="QFrame" name="frame_2">
@@ -628,6 +657,22 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item>
+      <spacer name="horizontalSpacerRight">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -638,7 +638,7 @@
            </layout>
           </item>
           <item>
-           <widget class="QListView" name="listTransactions">
+           <widget class="TransactionOverviewWidget" name="listTransactions">
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
@@ -648,8 +648,14 @@
             <property name="horizontalScrollBarPolicy">
              <enum>Qt::ScrollBarAlwaysOff</enum>
             </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QAbstractScrollArea::AdjustToContents</enum>
+            </property>
             <property name="selectionMode">
              <enum>QAbstractItemView::NoSelection</enum>
+            </property>
+            <property name="uniformItemSizes">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -678,6 +684,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TransactionOverviewWidget</class>
+   <extends>QListView</extends>
+   <header>qt/transactionoverviewwidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1785,14 +1785,14 @@ QString formatNiceTimeOffset(qint64 secs)
 
 QString formatBytes(uint64_t bytes)
 {
-    if(bytes < 1024)
+    if (bytes < 1'000)
         return QObject::tr("%1 B").arg(bytes);
-    if(bytes < 1024 * 1024)
-        return QObject::tr("%1 KB").arg(bytes / 1024);
-    if(bytes < 1024 * 1024 * 1024)
-        return QObject::tr("%1 MB").arg(bytes / 1024 / 1024);
+    if (bytes < 1'000'000)
+        return QObject::tr("%1 kB").arg(bytes / 1'000);
+    if (bytes < 1'000'000'000)
+        return QObject::tr("%1 MB").arg(bytes / 1'000'000);
 
-    return QObject::tr("%1 GB").arg(bytes / 1024 / 1024 / 1024);
+    return QObject::tr("%1 GB").arg(bytes / 1'000'000'000);
 }
 
 qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize, qreal font_size) {

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -11,6 +11,7 @@
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/transactionfilterproxy.h>
+#include <qt/transactionoverviewwidget.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/utilitydialog.h>
 #include <qt/walletmodel.h>
@@ -18,6 +19,8 @@
 #include <coinjoin/options.h>
 #include <interfaces/coinjoin.h>
 
+#include <algorithm>
+#include <map>
 #include <cmath>
 
 #include <QAbstractItemDelegate>
@@ -42,7 +45,7 @@ public:
     explicit TxViewDelegate(QObject* parent = nullptr) :
         QAbstractItemDelegate(), unit(BitcoinUnits::DASH)
     {
-
+        connect(this, &TxViewDelegate::width_changed, this, &TxViewDelegate::sizeHintChanged);
     }
 
     inline void paint(QPainter *painter, const QStyleOptionViewItem &option,
@@ -83,7 +86,8 @@ public:
         qint64 nAmount = index.data(TransactionTableModel::AmountRole).toLongLong();
         QString strAmount = BitcoinUnits::floorWithUnit(unit, nAmount, true, BitcoinUnits::SeparatorStyle::ALWAYS);
         painter->setPen(colorForeground);
-        painter->drawText(rectTopHalf, Qt::AlignRight | Qt::AlignVCenter, strAmount);
+        QRect amount_bounding_rect;
+        painter->drawText(rectTopHalf, Qt::AlignRight | Qt::AlignVCenter, strAmount, &amount_bounding_rect);
 
         // Draw second line (with the initial font)
         // Content: Address/label, Optional Watchonly indicator
@@ -93,6 +97,7 @@ public:
         QString address = indexAddress.data(Qt::DisplayRole).toString();
         painter->setPen(colorForeground);
         painter->drawText(rectBottomHalf, Qt::AlignLeft | Qt::AlignVCenter, address, &rectBounding);
+        int address_rect_min_width = rectBounding.width();
         // Optional Watchonly indicator
         if (index.data(TransactionTableModel::WatchonlyRole).toBool())
         {
@@ -101,17 +106,32 @@ public:
             iconWatchonly.paint(painter, rectWatchonly);
         }
 
+        const int minimum_width = std::max(address_rect_min_width, amount_bounding_rect.width() /*+ date_bounding_rect.width() */);
+        const auto search = m_minimum_width.find(index.row());
+        if (search == m_minimum_width.end() || search->second != minimum_width) {
+            m_minimum_width[index.row()] = minimum_width;
+            Q_EMIT width_changed(index);
+        }
         painter->restore();
     }
 
     inline QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override
     {
-        return QSize(ITEM_HEIGHT, ITEM_HEIGHT);
+        const auto search = m_minimum_width.find(index.row());
+        const int minimum_text_width = search == m_minimum_width.end() ? 0 : search->second;
+        return {ITEM_HEIGHT + 8 + minimum_text_width, ITEM_HEIGHT};
     }
 
     int unit;
 
+Q_SIGNALS:
+    //! An intermediate signal for emitting from the `paint() const` member function.
+    void width_changed(const QModelIndex& index) const;
+
+private:
+    mutable std::map<int, int> m_minimum_width;
 };
+
 #include <qt/overviewpage.moc>
 
 OverviewPage::OverviewPage(QWidget* parent) :
@@ -151,7 +171,7 @@ OverviewPage::OverviewPage(QWidget* parent) :
     // Note: minimum height of listTransactions will be set later in updateAdvancedCJUI() to reflect actual settings
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
 
-    connect(ui->listTransactions, &QListView::clicked, this, &OverviewPage::handleTransactionClicked);
+    connect(ui->listTransactions, &TransactionOverviewWidget::clicked, this, &OverviewPage::handleTransactionClicked);
 
     // init "out of sync" warning labels
     ui->labelWalletStatus->setText("(" + tr("out of sync") + ")");

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -239,8 +239,8 @@ void PaymentServer::handleURIOrFile(const QString& s)
                 if (!IsValidDestination(dest)) {
                     if (uri.hasQueryItem("r")) {  // payment request
                         Q_EMIT message(tr("URI handling"),
-                            tr("Cannot process payment request as BIP70 is no longer supported.")+
-                            tr("Due to discontinued support, you should request the merchant to provide you with a BIP21 compatible URI or use a wallet that does continue to support BIP70."),
+                            tr("Cannot process payment request as BIP70 is no longer supported.\n"
+                               "Due to discontinued support, you should request the merchant to provide you with a BIP21 compatible URI or use a wallet that does continue to support BIP70."),
                             CClientUIInterface::ICON_WARNING);
                     } else {
                         Q_EMIT message(tr("URI handling"), QString::fromStdString(error_msg),
@@ -262,8 +262,8 @@ void PaymentServer::handleURIOrFile(const QString& s)
     if (QFile::exists(s)) // payment request file
     {
         Q_EMIT message(tr("Payment request file handling"),
-            tr("Cannot process payment request as BIP70 is no longer supported.")+
-            tr("Due to discontinued support, you should request the merchant to provide you with a BIP21 compatible URI or use a wallet that does continue to support BIP70."),
+            tr("Cannot process payment request as BIP70 is no longer supported.\n"
+               "Due to discontinued support, you should request the merchant to provide you with a BIP21 compatible URI or use a wallet that does continue to support BIP70."),
             CClientUIInterface::ICON_WARNING);
     }
 }

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1544,7 +1544,6 @@ QWidget .QFrame#frame_2 .QLabel#labelTransactionsStatus { /* Recent Transactions
 
 QWidget .QFrame#frame_2 QListView { /* Transaction List */
     background: #00000000;
-    max-width: 430px;
     margin-right: 10px;
 }
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -154,6 +154,11 @@ Q_SIGNALS:
     void handleRestart(QStringList args);
 
 private:
+    struct TranslatedStrings {
+        const QString yes{tr("Yes")}, no{tr("No")}, to{tr("To")}, from{tr("From")},
+            ban_for{tr("Ban for")}, na{tr("N/A")}, unknown{tr("Unknown")};
+    } const ts;
+
     void startExecutor();
     void setTrafficGraphRange(TrafficGraphData::GraphRange range);
     /** Build parameter list for restart */

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -98,7 +98,7 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     float val = pow(10.0f, base);
     float val2 = val;
 
-    const QString units     = tr("KB/s");
+    const QString units = tr("kB/s");
     const float yMarginText = 2.0;
 
     // draw lines

--- a/src/qt/transactionoverviewwidget.h
+++ b/src/qt/transactionoverviewwidget.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TRANSACTIONOVERVIEWWIDGET_H
+#define BITCOIN_QT_TRANSACTIONOVERVIEWWIDGET_H
+
+#include <qt/transactiontablemodel.h>
+
+#include <QListView>
+#include <QSize>
+#include <QSizePolicy>
+
+QT_BEGIN_NAMESPACE
+class QShowEvent;
+class QWidget;
+QT_END_NAMESPACE
+
+class TransactionOverviewWidget : public QListView
+{
+    Q_OBJECT
+
+public:
+    explicit TransactionOverviewWidget(QWidget* parent = nullptr) : QListView(parent) {}
+
+    QSize sizeHint() const override
+    {
+        return {sizeHintForColumn(TransactionTableModel::ToAddress), QListView::sizeHint().height()};
+    }
+
+protected:
+    void showEvent(QShowEvent* event) override
+    {
+        Q_UNUSED(event);
+        QSizePolicy sp = sizePolicy();
+        sp.setHorizontalPolicy(QSizePolicy::Minimum);
+        setSizePolicy(sp);
+    }
+};
+
+#endif // BITCOIN_QT_TRANSACTIONOVERVIEWWIDGET_H

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -126,24 +126,23 @@ TransactionView::TransactionView(QWidget* parent) :
     vlayout->setContentsMargins(0,0,0,0);
     vlayout->setSpacing(0);
 
-    QTableView *view = new QTableView(this);
+    transactionView = new QTableView(this);
     vlayout->addLayout(hlayout);
     vlayout->addWidget(createDateRangeWidget());
-    vlayout->addWidget(view);
+    vlayout->addWidget(transactionView);
     vlayout->setSpacing(0);
 #ifndef Q_OS_MAC
-    int width = view->verticalScrollBar()->sizeHint().width();
+    int width = transactionView->verticalScrollBar()->sizeHint().width();
     // Cover scroll bar width with spacing
     hlayout->addSpacing(width);
     // Always show scroll bar
-    view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    transactionView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 #endif
-    view->setTabKeyNavigation(false);
-    view->setContextMenuPolicy(Qt::CustomContextMenu);
+    transactionView->setTabKeyNavigation(false);
+    transactionView->setContextMenuPolicy(Qt::CustomContextMenu);
 
-    view->installEventFilter(this);
+    transactionView->installEventFilter(this);
 
-    transactionView = view;
     transactionView->setObjectName("transactionView");
 
     // Actions
@@ -185,9 +184,9 @@ TransactionView::TransactionView(QWidget* parent) :
     connect(search_widget, &QLineEdit::textChanged, prefix_typing_delay, static_cast<void (QTimer::*)()>(&QTimer::start));
     connect(prefix_typing_delay, &QTimer::timeout, this, &TransactionView::changedSearch);
 
-    connect(view, &QTableView::doubleClicked, this, &TransactionView::doubleClicked);
-    connect(view, &QTableView::clicked, this, &TransactionView::computeSum);
-    connect(view, &QTableView::customContextMenuRequested, this, &TransactionView::contextualMenu);
+    connect(transactionView, &QTableView::doubleClicked, this, &TransactionView::doubleClicked);
+    connect(transactionView, &QTableView::clicked, this, &TransactionView::computeSum);
+    connect(transactionView, &QTableView::customContextMenuRequested, this, &TransactionView::contextualMenu);
 
     connect(abandonAction, &QAction::triggered, this, &TransactionView::abandonTx);
     connect(resendAction, &QAction::triggered, this, &TransactionView::resendTx);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -117,9 +117,24 @@ void WalletFrame::setCurrentWallet(WalletModel* wallet_model)
 {
     if (mapWalletViews.count(wallet_model) == 0) return;
 
+    // Stop the effect of hidden widgets on the size hint of the shown one in QStackedWidget.
+    WalletView* view_about_to_hide = currentWalletView();
+    if (view_about_to_hide) {
+        QSizePolicy sp = view_about_to_hide->sizePolicy();
+        sp.setHorizontalPolicy(QSizePolicy::Ignored);
+        view_about_to_hide->setSizePolicy(sp);
+    }
+
     WalletView *walletView = mapWalletViews.value(wallet_model);
-    walletStack->setCurrentWidget(walletView);
     assert(walletView);
+
+    // Set or restore the default QSizePolicy which could be set to QSizePolicy::Ignored previously.
+    QSizePolicy sp = walletView->sizePolicy();
+    sp.setHorizontalPolicy(QSizePolicy::Preferred);
+    walletView->setSizePolicy(sp);
+    walletView->updateGeometry();
+
+    walletStack->setCurrentWidget(walletView);
     walletView->updateEncryptionStatus();
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Backports of QT related improvements from bitcoin v22

## What was done?
See commits for list of backports.
Changes related to improved behavior of columns while resizing for Transactions List and Recent Requests is dropped due to low performance and buggy behaviour. bitcoin-core/gui#205 and bitcoin-core/gui#229 are DNM due to incompatibility with our table view.
It reverts also #5992 as better fix is found (see css changes).

## How Has This Been Tested?
Run qt app, try to resize main view with overview page.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone