### PR TITLE
docs: fix missing 'apt get install', make build steps more prominent, format consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://www.dash.org
 For an immediately usable, binary version of the Dash Core software, see
 https://www.dash.org/downloads/.
 
-Further information about Dash Core is available in the [doc folder](/doc).
+Further information about Dash Core is available in [./doc/](/doc).
 
 What is Dash?
 -------------
@@ -42,6 +42,19 @@ completely stable.
 
 The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md)
 and useful hints for developers can be found in [doc/developer-notes.md](doc/developer-notes.md).
+
+Build / Compile from Source
+---------------------------
+
+The `./configure`, `make`, and `cmake` steps, as well as build dependencies, are in [./doc/](/doc) as well:
+
+- **Linux**: [./doc/build-unix.md](/doc/build-unix.md) \
+  Ubuntu, Debian, Fedora, Arch, and others
+- **macOS**: [./doc/build-osx.md](/doc/build-osx.md)
+- **Windows**: [./doc/build-windows.md](/doc/build-windows.md)
+- **OpenBSD**: [./doc/build-openbsd.md](/doc/build-openbsd.md)
+- **FreeBSD**: [./doc/build-freebsd.md](/doc/build-freebsd.md)
+- **NetBSD**: [./doc/build-netbsd.md](/doc/build-netbsd.md)
 
 Testing
 -------

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -74,7 +74,7 @@ Build requirements:
 
 Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
 
-    sudo apt-get libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev
+    sudo apt-get install libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev
 
 Berkeley DB is required for the wallet.
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -87,13 +87,13 @@ Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
 
 SQLite is required for the wallet:
 
-    sudo apt install libsqlite3-dev
+    sudo apt-get install libsqlite3-dev
 
 To build Dash Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
 Optional port mapping libraries (see: `--with-miniupnpc` and `--with-natpmp`):
 
-    sudo apt install libminiupnpc-dev libnatpmp-dev
+    sudo apt-get install libminiupnpc-dev libnatpmp-dev
 
 ZMQ dependencies (provides ZMQ API):
 
@@ -115,7 +115,7 @@ To build with Qt 5 you need the following:
 
 Additionally, to support Wayland protocol for modern desktop environments:
 
-    sudo apt install qtwayland5
+    sudo apt-get install qtwayland5
 
 libqrencode (optional) can be installed with:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -9,15 +9,17 @@ Note
 Always use absolute paths to configure and compile Dash Core and the dependencies.
 For example, when specifying the path of the dependency:
 
-    ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+```sh
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+```
 
-Here BDB_PREFIX must be an absolute path - it is defined using $(pwd) which ensures
+Here `BDB_PREFIX` must be an absolute path - it is defined using $(pwd) which ensures
 the usage of the absolute path.
 
 To Build
 ---------------------
 
-```bash
+```sh
 ./autogen.sh
 ./configure
 make
@@ -59,7 +61,9 @@ memory available when compiling Dash Core. On systems with less, gcc can be
 tuned to conserve memory with additional CXXFLAGS:
 
 
-    ./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
+```sh
+./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
+```
 
 
 ## Linux Distribution Specific Instructions
@@ -70,11 +74,15 @@ tuned to conserve memory with additional CXXFLAGS:
 
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils bison python3
+```sh
+sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils bison python3
+```
 
 Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
 
-    sudo apt-get install libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev
+```sh
+sudo apt-get install libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev
+```
 
 Berkeley DB is required for the wallet.
 
@@ -87,21 +95,29 @@ Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
 
 SQLite is required for the wallet:
 
-    sudo apt-get install libsqlite3-dev
+```sh
+sudo apt-get install libsqlite3-dev
+```
 
 To build Dash Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
 Optional port mapping libraries (see: `--with-miniupnpc` and `--with-natpmp`):
 
-    sudo apt-get install libminiupnpc-dev libnatpmp-dev
+```sh
+sudo apt-get install libminiupnpc-dev libnatpmp-dev
+```
 
 ZMQ dependencies (provides ZMQ API):
 
-    sudo apt-get install libzmq3-dev
+```sh
+sudo apt-get install libzmq3-dev
+```
 
 GMP dependencies (provides platform-optimized routines):
 
-   sudo apt-get install libgmp-dev
+```sh
+sudo apt-get install libgmp-dev
+```
 
 GUI dependencies:
 
@@ -111,15 +127,21 @@ To build without GUI pass `--without-gui`.
 
 To build with Qt 5 you need the following:
 
-    sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools
+```sh
+sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools
+```
 
 Additionally, to support Wayland protocol for modern desktop environments:
 
-    sudo apt-get install qtwayland5
+```sh
+sudo apt-get install qtwayland5
+```
 
 libqrencode (optional) can be installed with:
 
-    sudo apt-get install libqrencode-dev
+```sh
+sudo apt-get install libqrencode-dev
+```
 
 Once these are installed, they will be found by configure and a dash-qt executable will be
 built by default.
@@ -131,15 +153,21 @@ built by default.
 
 Build requirements:
 
-    sudo dnf install gcc-c++ libtool make autoconf automake python3
+```sh
+sudo dnf install gcc-c++ libtool make autoconf automake python3
+```
 
 Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
 
-    sudo dnf install libevent-devel boost-devel
+```sh
+sudo dnf install libevent-devel boost-devel
+```
 
 Berkeley DB is required for the wallet:
 
-    sudo dnf install libdb4-devel libdb4-cxx-devel
+```sh
+sudo dnf install libdb4-devel libdb4-cxx-devel
+```
 
 Newer Fedora releases, since Fedora 33, have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
 Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed executables, which
@@ -150,21 +178,29 @@ Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
 
 SQLite is required for the wallet:
 
-    sudo dnf install sqlite-devel
+```sh
+sudo dnf install sqlite-devel
+```
 
 To build Dash Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
 Optional port mapping libraries (see: `--with-miniupnpc` and `--with-natpmp`):
 
-    sudo dnf install miniupnpc-devel libnatpmp-devel
+```sh
+sudo dnf install miniupnpc-devel libnatpmp-devel
+```
 
 ZMQ dependencies (provides ZMQ API):
 
-    sudo dnf install zeromq-devel
+```sh
+sudo dnf install zeromq-devel
+```
 
 GMP dependencies (provides platform-optimized routines):
 
-    sudo dnf install gmp-devel
+```sh
+sudo dnf install gmp-devel
+```
 
 GUI dependencies:
 
@@ -174,15 +210,21 @@ To build without GUI pass `--without-gui`.
 
 To build with Qt 5 you need the following:
 
-    sudo dnf install qt5-qttools-devel qt5-qtbase-devel
+```sh
+sudo dnf install qt5-qttools-devel qt5-qtbase-devel
+```
 
 Additionally, to support Wayland protocol for modern desktop environments:
 
-    sudo dnf install qt5-qtwayland
+```sh
+sudo dnf install qt5-qtwayland
+```
 
 libqrencode (optional) can be installed with:
 
-    sudo dnf install qrencode-devel
+```sh
+sudo dnf install qrencode-devel
+```
 
 Once these are installed, they will be found by configure and a dash-qt executable will be
 built by default.
@@ -213,7 +255,7 @@ It is recommended to use Berkeley DB 4.8. If you have to build it yourself,
 you can use [the installation script included in contrib/](contrib/install_db4.sh)
 like so:
 
-```shell
+```sh
 ./contrib/install_db4.sh `pwd`
 ```
 
@@ -293,19 +335,23 @@ Additional Configure Flags
 --------------------------
 A list of additional configure flags can be displayed with:
 
-    ./configure --help
+```sh
+./configure --help
+```
 
 
 Setup and Build Example: Arch Linux
 -----------------------------------
 This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
 
-    pacman -S git base-devel boost libevent python
-    git clone https://github.com/dashpay/dash.git
-    cd dash/
-    ./autogen.sh
-    ./configure --disable-wallet --without-gui --without-miniupnpc
-    make check
+```sh
+pacman -S git base-devel boost libevent python
+git clone https://github.com/dashpay/dash.git
+cd dash/
+./autogen.sh
+./configure --disable-wallet --without-gui --without-miniupnpc
+make check
+```
 
 Note:
 Enabling wallet support requires either compiling against a Berkeley DB newer than 4.8 (package `db`) using `--with-incompatible-bdb`,


### PR DESCRIPTION
Developers come to Dash should have clear instruction for how to build / compile just by scanning the README.

Also, the instructions should be correct and consistent.

## What was done?

- `apt-get` => `apt-get install` (fix typo)
- `apt install` => `apt-get install` (due to subtle bugs with `apt` in non-interactive scripts)
- correct grammar `doc folder` => `./doc/`
- make build / compile documentation prominent in README.md \
  (easy to find via ctrl+f or scanning)
- use `` ```sh `` consistently for shell formatting (rather than mixing ``     ``, `` ```bash ``, `` ```shell ``, and `` ```sh ``

## How Has This Been Tested?

See <https://github.com/dashhive/dash/tree/doc-build-docs>.

Note that it's formatted well and consistently and the typos are fixed.

## Breaking Changes

N/A

Only fixes here.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have added or updated relevant unit/integration/functional/e2e tests~~
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

