### PR TITLE
test: disable mocktime in p2p_eviction.py

### DIFF
--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -48,6 +48,10 @@ class P2PEvict(BitcoinTestFramework):
         # 4 by netgroup, 4 that sent us blocks, 4 that sent us transactions and 8 via lowest ping time
         self.extra_args = [['-maxconnections=32']]
 
+    def setup_network(self):
+        self.disable_mocktime()
+        super().setup_network()
+
     def run_test(self):
         protected_peers = set()  # peers that we expect to be protected from eviction
         current_peer = -1


### PR DESCRIPTION
## Issue being fixed or feature implemented
No idea why CI has no issues but `p2p_eviction.py` fails locally after #6103 (my guess is that it's because P2PInterface can't work with mocktime properly).

## What was done?
Disable mocktime in `p2p_eviction.py`

## How Has This Been Tested?
Run tests locally

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

