### PR TITLE
chore: translations 2024-07

### DIFF
--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -58,7 +58,7 @@ if not XGETTEXT:
     print('Cannot extract strings: xgettext utility is not installed or not configured.',file=sys.stderr)
     print('Please install package "gettext" and re-run \'./configure\'.',file=sys.stderr)
     sys.exit(1)
-child = Popen([XGETTEXT,'--output=-','-n','--keyword=_'] + files, stdout=PIPE)
+child = Popen([XGETTEXT,'--output=-','--from-code=utf-8','-n','--keyword=_'] + files, stdout=PIPE)
 (out, err) = child.communicate()
 
 messages = parse_po(out.decode('utf-8'))

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -321,7 +321,7 @@ bilingual_str CCoinJoinClientSession::GetStatus(bool fWaitForBlock) const
         return strAutoDenomResult;
     case POOL_STATE_SIGNING:
         if (nStatusMessageProgress % 70 <= 40)
-            return _("Found enough users, signing ...");
+            return _("Found enough users, signing…");
         else if (nStatusMessageProgress % 70 <= 50)
             strSuffix = ".";
         else if (nStatusMessageProgress % 70 <= 60)
@@ -330,7 +330,7 @@ bilingual_str CCoinJoinClientSession::GetStatus(bool fWaitForBlock) const
             strSuffix = "...";
         return strprintf(_("Found enough users, signing ( waiting %s )"), strSuffix);
     case POOL_STATE_ERROR:
-        return strprintf(_("%s request incomplete:"), gCoinJoinName) + strLastMessage + Untranslated(" ") + _("Will retry...");
+        return strprintf(_("%s request incomplete:"), gCoinJoinName) + strLastMessage + Untranslated(" ") + _("Will retry…");
     default:
         return strprintf(_("Unknown state: id = %u"), nState);
     }
@@ -807,7 +807,7 @@ bool CCoinJoinClientSession::DoAutomaticDenominating(CChainState& active_chainst
         }
 
         if (GetEntriesCount() > 0) {
-            strAutoDenomResult = _("Mixing in progress...");
+            strAutoDenomResult = _("Mixing in progress…");
             return false;
         }
 
@@ -912,7 +912,7 @@ bool CCoinJoinClientSession::DoAutomaticDenominating(CChainState& active_chainst
         }
 
         if (nSessionID) {
-            strAutoDenomResult = _("Mixing in progress...");
+            strAutoDenomResult = _("Mixing in progress…");
             return false;
         }
 
@@ -1115,7 +1115,7 @@ bool CCoinJoinClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, 
         nTimeLastSuccessfulStep = GetTime();
         WalletCJLogPrint(m_wallet, "CCoinJoinClientSession::JoinExistingQueue -- pending connection (from queue): nSessionDenom: %d (%s), addr=%s\n",
             nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), dmn->pdmnState->addr.ToString());
-        strAutoDenomResult = _("Trying to connect...");
+        strAutoDenomResult = _("Trying to connect…");
         return true;
     }
     strAutoDenomResult = _("Failed to find mixing queue to join");
@@ -1196,7 +1196,7 @@ bool CCoinJoinClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, CCon
         nTimeLastSuccessfulStep = GetTime();
         WalletCJLogPrint(m_wallet, "CCoinJoinClientSession::StartNewQueue -- pending connection, nSessionDenom: %d (%s), addr=%s\n",
             nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), dmn->pdmnState->addr.ToString());
-        strAutoDenomResult = _("Trying to connect...");
+        strAutoDenomResult = _("Trying to connect…");
         return true;
     }
     strAutoDenomResult = _("Failed to start a new mixing queue");
@@ -1231,7 +1231,7 @@ void CCoinJoinClientManager::ProcessPendingDsaRequest(CConnman& connman)
     LOCK(cs_deqsessions);
     for (auto& session : deqSessions) {
         if (session.ProcessPendingDsaRequest(connman)) {
-            strAutoDenomResult = _("Mixing in progress...");
+            strAutoDenomResult = _("Mixing in progress…");
         }
     }
 }

--- a/src/qt/dashstrings.cpp
+++ b/src/qt/dashstrings.cpp
@@ -23,10 +23,16 @@ QT_TRANSLATE_NOOP("dash-core", ""
 "-maxtxfee is set very high! Fees this large could be paid on a single "
 "transaction."),
 QT_TRANSLATE_NOOP("dash-core", ""
+"Cannot downgrade wallet from version %i to version %i. Wallet version "
+"unchanged."),
+QT_TRANSLATE_NOOP("dash-core", ""
 "Cannot obtain a lock on data directory %s. %s is probably already running."),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Cannot provide specific connections and have addrman find outgoing "
 "connections at the same."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"Cannot upgrade a non HD wallet from version %i to version %i which is non-HD "
+"wallet. Use upgradetohd RPC"),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Distributed under the MIT software license, see the accompanying file %s or "
 "%s"),
@@ -36,6 +42,13 @@ QT_TRANSLATE_NOOP("dash-core", ""
 "Error reading %s! All keys read correctly, but transaction data or address "
 "book entries might be missing or incorrect."),
 QT_TRANSLATE_NOOP("dash-core", ""
+"Error: Dumpfile format record is incorrect. Got \"%s\", expected \"format\"."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\"."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"Error: Dumpfile version is not supported. This version of bitcoin-wallet "
+"only supports version 1 dumpfiles. Got dumpfile with version %s"),
+QT_TRANSLATE_NOOP("dash-core", ""
 "Error: Listening for incoming connections failed (listen returned error %s)"),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Failed to create backup, file already exists! This could happen if you "
@@ -44,6 +57,9 @@ QT_TRANSLATE_NOOP("dash-core", ""
 QT_TRANSLATE_NOOP("dash-core", ""
 "Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -"
 "fallbackfee."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"File %s already exists. If you are sure this is what you want, move it out "
+"of the way first."),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Found unconfirmed denominated outputs, will wait till they confirm to "
 "continue."),
@@ -56,11 +72,30 @@ QT_TRANSLATE_NOOP("dash-core", ""
 "Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minrelay "
 "fee of %s to prevent stuck transactions)"),
 QT_TRANSLATE_NOOP("dash-core", ""
+"Invalid or corrupt peers.dat (%s). If you believe this is a bug, please "
+"report it to %s. As a workaround, you can move the file (%s) out of the way "
+"(rename, move, or delete) to have a new one created on the next start."),
+QT_TRANSLATE_NOOP("dash-core", ""
 "Make sure to encrypt your wallet and delete all non-encrypted backups after "
 "you have verified that the wallet works!"),
 QT_TRANSLATE_NOOP("dash-core", ""
 "More than one onion bind address is provided. Using %s for the automatically "
 "created Tor onion service."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"No dump file provided. To use createfromdump, -dumpfile=<filename> must be "
+"provided."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"No dump file provided. To use dump, -dumpfile=<filename> must be provided."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"No wallet file format provided. To use createfromdump, -format=<format> must "
+"be provided."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"Outbound connections restricted to Tor (-onlynet=onion) but the proxy for "
+"reaching the Tor network is explicitly forbidden: -onion=0"),
+QT_TRANSLATE_NOOP("dash-core", ""
+"Outbound connections restricted to Tor (-onlynet=onion) but the proxy for "
+"reaching the Tor network is not provided: none of -proxy, -onion or -"
+"listenonion is given"),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Please check that your computer's date and time are correct! If your clock "
 "is wrong, %s will not work properly."),
@@ -90,6 +125,9 @@ QT_TRANSLATE_NOOP("dash-core", ""
 "This is a pre-release test build - use at your own risk - do not use for "
 "mining or merchant applications"),
 QT_TRANSLATE_NOOP("dash-core", ""
+"This is the maximum transaction fee you pay (in addition to the normal fee) "
+"to prioritize partial spend avoidance over regular coin selection."),
+QT_TRANSLATE_NOOP("dash-core", ""
 "This is the transaction fee you may discard if change is smaller than dust "
 "at this level"),
 QT_TRANSLATE_NOOP("dash-core", ""
@@ -108,10 +146,16 @@ QT_TRANSLATE_NOOP("dash-core", ""
 "Unable to replay blocks. You will need to rebuild the database using -"
 "reindex-chainstate."),
 QT_TRANSLATE_NOOP("dash-core", ""
+"Unknown wallet file format \"%s\" provided. Please provide one of \"bdb\" or "
+"\"sqlite\"."),
+QT_TRANSLATE_NOOP("dash-core", ""
 "WARNING! Failed to replenish keypool, please unlock your wallet to do so."),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Wallet is locked, can't replenish keypool! Automatic backups and mixing are "
 "disabled, please unlock your wallet to replenish keypool."),
+QT_TRANSLATE_NOOP("dash-core", ""
+"Warning: Dumpfile wallet format \"%s\" does not match command line specified "
+"format \"%s\"."),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Warning: Private keys detected in wallet {%s} with disabled private keys"),
 QT_TRANSLATE_NOOP("dash-core", ""
@@ -122,6 +166,7 @@ QT_TRANSLATE_NOOP("dash-core", ""
 QT_TRANSLATE_NOOP("dash-core", ""
 "You need to rebuild the database using -reindex to go back to unpruned "
 "mode.  This will redownload the entire blockchain"),
+QT_TRANSLATE_NOOP("dash-core", "%s -- Incorrect seed, it should be a hex string"),
 QT_TRANSLATE_NOOP("dash-core", "%s can't be lower than %s"),
 QT_TRANSLATE_NOOP("dash-core", "%s failed"),
 QT_TRANSLATE_NOOP("dash-core", "%s is idle."),
@@ -151,9 +196,11 @@ QT_TRANSLATE_NOOP("dash-core", "Could not parse asmap file %s"),
 QT_TRANSLATE_NOOP("dash-core", "Disk space is too low!"),
 QT_TRANSLATE_NOOP("dash-core", "Do you want to rebuild the block database now?"),
 QT_TRANSLATE_NOOP("dash-core", "Done loading"),
+QT_TRANSLATE_NOOP("dash-core", "Dump file %s does not exist."),
 QT_TRANSLATE_NOOP("dash-core", "ERROR! Failed to create automatic backup"),
 QT_TRANSLATE_NOOP("dash-core", "Entries are full."),
 QT_TRANSLATE_NOOP("dash-core", "Entry exceeds maximum size."),
+QT_TRANSLATE_NOOP("dash-core", "Error creating %s"),
 QT_TRANSLATE_NOOP("dash-core", "Error initializing block database"),
 QT_TRANSLATE_NOOP("dash-core", "Error initializing wallet database environment %s!"),
 QT_TRANSLATE_NOOP("dash-core", "Error loading %s"),
@@ -164,12 +211,18 @@ QT_TRANSLATE_NOOP("dash-core", "Error loading %s: You can't disable HD on an alr
 QT_TRANSLATE_NOOP("dash-core", "Error loading block database"),
 QT_TRANSLATE_NOOP("dash-core", "Error opening block database"),
 QT_TRANSLATE_NOOP("dash-core", "Error reading from database, shutting down."),
+QT_TRANSLATE_NOOP("dash-core", "Error reading next record from wallet database"),
 QT_TRANSLATE_NOOP("dash-core", "Error upgrading chainstate database"),
 QT_TRANSLATE_NOOP("dash-core", "Error upgrading evo database"),
+QT_TRANSLATE_NOOP("dash-core", "Error: Couldn't create cursor into database"),
 QT_TRANSLATE_NOOP("dash-core", "Error: Disk space is low for %s"),
+QT_TRANSLATE_NOOP("dash-core", "Error: Dumpfile checksum does not match. Computed %s, expected %s"),
+QT_TRANSLATE_NOOP("dash-core", "Error: Got key that was not hex: %s"),
+QT_TRANSLATE_NOOP("dash-core", "Error: Got value that was not hex: %s"),
 QT_TRANSLATE_NOOP("dash-core", "Error: Keypool ran out, please call keypoolrefill first"),
-QT_TRANSLATE_NOOP("dash-core", "Error: failed to add socket to epollfd (epoll_ctl returned error %s)"),
-QT_TRANSLATE_NOOP("dash-core", "Error: failed to add socket to kqueuefd (kevent returned error %s)"),
+QT_TRANSLATE_NOOP("dash-core", "Error: Missing checksum"),
+QT_TRANSLATE_NOOP("dash-core", "Error: Unable to parse version %u as a uint32_t"),
+QT_TRANSLATE_NOOP("dash-core", "Error: Unable to write record to new wallet"),
 QT_TRANSLATE_NOOP("dash-core", "Exceeded max tries."),
 QT_TRANSLATE_NOOP("dash-core", "Failed to clear fulfilled requests cache at %s"),
 QT_TRANSLATE_NOOP("dash-core", "Failed to clear governance cache at %s"),
@@ -188,9 +241,9 @@ QT_TRANSLATE_NOOP("dash-core", "Failed to rescan the wallet during initializatio
 QT_TRANSLATE_NOOP("dash-core", "Failed to start a new mixing queue"),
 QT_TRANSLATE_NOOP("dash-core", "Failed to verify database"),
 QT_TRANSLATE_NOOP("dash-core", "Found enough users, signing ( waiting %s )"),
-QT_TRANSLATE_NOOP("dash-core", "Found enough users, signing ..."),
+QT_TRANSLATE_NOOP("dash-core", "Found enough users, signing…"),
 QT_TRANSLATE_NOOP("dash-core", "Ignoring duplicate -wallet %s."),
-QT_TRANSLATE_NOOP("dash-core", "Importing..."),
+QT_TRANSLATE_NOOP("dash-core", "Importing…"),
 QT_TRANSLATE_NOOP("dash-core", "Incompatible mode."),
 QT_TRANSLATE_NOOP("dash-core", "Incompatible version."),
 QT_TRANSLATE_NOOP("dash-core", "Incorrect -rescan mode, falling back to default value"),
@@ -215,15 +268,15 @@ QT_TRANSLATE_NOOP("dash-core", "Invalid script detected."),
 QT_TRANSLATE_NOOP("dash-core", "Invalid spork address specified with -sporkaddr"),
 QT_TRANSLATE_NOOP("dash-core", "Last queue was created too recently."),
 QT_TRANSLATE_NOOP("dash-core", "Last successful action was too recent."),
-QT_TRANSLATE_NOOP("dash-core", "Loading P2P addresses..."),
-QT_TRANSLATE_NOOP("dash-core", "Loading banlist..."),
-QT_TRANSLATE_NOOP("dash-core", "Loading block index..."),
-QT_TRANSLATE_NOOP("dash-core", "Loading wallet..."),
+QT_TRANSLATE_NOOP("dash-core", "Loading P2P addresses…"),
+QT_TRANSLATE_NOOP("dash-core", "Loading banlist…"),
+QT_TRANSLATE_NOOP("dash-core", "Loading block index…"),
+QT_TRANSLATE_NOOP("dash-core", "Loading wallet…"),
 QT_TRANSLATE_NOOP("dash-core", "Lock is already in place."),
 QT_TRANSLATE_NOOP("dash-core", "Masternode queue is full."),
 QT_TRANSLATE_NOOP("dash-core", "Masternode:"),
 QT_TRANSLATE_NOOP("dash-core", "Missing input transaction information."),
-QT_TRANSLATE_NOOP("dash-core", "Mixing in progress..."),
+QT_TRANSLATE_NOOP("dash-core", "Mixing in progress…"),
 QT_TRANSLATE_NOOP("dash-core", "Need to specify a port with -whitebind: '%s'"),
 QT_TRANSLATE_NOOP("dash-core", "No Masternodes detected."),
 QT_TRANSLATE_NOOP("dash-core", "No compatible Masternode found."),
@@ -238,10 +291,10 @@ QT_TRANSLATE_NOOP("dash-core", "Prune cannot be configured with a negative value
 QT_TRANSLATE_NOOP("dash-core", "Prune mode is incompatible with -coinstatsindex."),
 QT_TRANSLATE_NOOP("dash-core", "Prune mode is incompatible with -disablegovernance=false."),
 QT_TRANSLATE_NOOP("dash-core", "Prune mode is incompatible with -txindex."),
-QT_TRANSLATE_NOOP("dash-core", "Pruning blockstore..."),
+QT_TRANSLATE_NOOP("dash-core", "Pruning blockstore…"),
 QT_TRANSLATE_NOOP("dash-core", "Reducing -maxconnections from %d to %d, because of system limitations."),
-QT_TRANSLATE_NOOP("dash-core", "Replaying blocks..."),
-QT_TRANSLATE_NOOP("dash-core", "Rescanning..."),
+QT_TRANSLATE_NOOP("dash-core", "Replaying blocks…"),
+QT_TRANSLATE_NOOP("dash-core", "Rescanning…"),
 QT_TRANSLATE_NOOP("dash-core", "SQLiteDatabase: Failed to execute statement to verify database: %s"),
 QT_TRANSLATE_NOOP("dash-core", "SQLiteDatabase: Failed to prepare statement to verify database: %s"),
 QT_TRANSLATE_NOOP("dash-core", "SQLiteDatabase: Failed to read database verification error: %s"),
@@ -254,11 +307,11 @@ QT_TRANSLATE_NOOP("dash-core", "Specified -walletdir \"%s\" does not exist"),
 QT_TRANSLATE_NOOP("dash-core", "Specified -walletdir \"%s\" is a relative path"),
 QT_TRANSLATE_NOOP("dash-core", "Specified -walletdir \"%s\" is not a directory"),
 QT_TRANSLATE_NOOP("dash-core", "Specified blocks directory \"%s\" does not exist."),
-QT_TRANSLATE_NOOP("dash-core", "Starting network threads..."),
+QT_TRANSLATE_NOOP("dash-core", "Starting network threads…"),
 QT_TRANSLATE_NOOP("dash-core", "Submitted to masternode, waiting in queue %s"),
 QT_TRANSLATE_NOOP("dash-core", "Synchronization finished"),
-QT_TRANSLATE_NOOP("dash-core", "Synchronizing blockchain..."),
-QT_TRANSLATE_NOOP("dash-core", "Synchronizing governance objects..."),
+QT_TRANSLATE_NOOP("dash-core", "Synchronizing blockchain…"),
+QT_TRANSLATE_NOOP("dash-core", "Synchronizing governance objects…"),
 QT_TRANSLATE_NOOP("dash-core", "The source code is available from %s."),
 QT_TRANSLATE_NOOP("dash-core", "The specified config file %s does not exist"),
 QT_TRANSLATE_NOOP("dash-core", "The transaction amount is too small to pay the fee"),
@@ -267,7 +320,7 @@ QT_TRANSLATE_NOOP("dash-core", "This is expected because you are running a prune
 QT_TRANSLATE_NOOP("dash-core", "This is experimental software."),
 QT_TRANSLATE_NOOP("dash-core", "This is the minimum transaction fee you pay on every transaction."),
 QT_TRANSLATE_NOOP("dash-core", "This is the transaction fee you will pay if you send a transaction."),
-QT_TRANSLATE_NOOP("dash-core", "Topping up keypool..."),
+QT_TRANSLATE_NOOP("dash-core", "Topping up keypool…"),
 QT_TRANSLATE_NOOP("dash-core", "Transaction amount too small"),
 QT_TRANSLATE_NOOP("dash-core", "Transaction amounts must not be negative"),
 QT_TRANSLATE_NOOP("dash-core", "Transaction created successfully."),
@@ -276,13 +329,14 @@ QT_TRANSLATE_NOOP("dash-core", "Transaction has too long of a mempool chain"),
 QT_TRANSLATE_NOOP("dash-core", "Transaction must have at least one recipient"),
 QT_TRANSLATE_NOOP("dash-core", "Transaction not valid."),
 QT_TRANSLATE_NOOP("dash-core", "Transaction too large"),
-QT_TRANSLATE_NOOP("dash-core", "Trying to connect..."),
+QT_TRANSLATE_NOOP("dash-core", "Trying to connect…"),
 QT_TRANSLATE_NOOP("dash-core", "Unable to bind to %s on this computer (bind returned error %s)"),
 QT_TRANSLATE_NOOP("dash-core", "Unable to bind to %s on this computer. %s is probably already running."),
 QT_TRANSLATE_NOOP("dash-core", "Unable to create the PID file '%s': %s"),
 QT_TRANSLATE_NOOP("dash-core", "Unable to generate initial keys"),
 QT_TRANSLATE_NOOP("dash-core", "Unable to locate enough mixed funds for this transaction."),
 QT_TRANSLATE_NOOP("dash-core", "Unable to locate enough non-denominated funds for this transaction."),
+QT_TRANSLATE_NOOP("dash-core", "Unable to open %s for writing"),
 QT_TRANSLATE_NOOP("dash-core", "Unable to sign spork message, wrong key?"),
 QT_TRANSLATE_NOOP("dash-core", "Unable to start HTTP server. See debug log for details."),
 QT_TRANSLATE_NOOP("dash-core", "Unknown -blockfilterindex value %s."),
@@ -294,16 +348,16 @@ QT_TRANSLATE_NOOP("dash-core", "Unsupported logging category %s=%s."),
 QT_TRANSLATE_NOOP("dash-core", "Upgrading UTXO database"),
 QT_TRANSLATE_NOOP("dash-core", "Upgrading txindex database"),
 QT_TRANSLATE_NOOP("dash-core", "User Agent comment (%s) contains unsafe characters."),
-QT_TRANSLATE_NOOP("dash-core", "Verifying blocks..."),
-QT_TRANSLATE_NOOP("dash-core", "Verifying wallet(s)..."),
+QT_TRANSLATE_NOOP("dash-core", "Verifying blocks…"),
+QT_TRANSLATE_NOOP("dash-core", "Verifying wallet(s)…"),
 QT_TRANSLATE_NOOP("dash-core", "Very low number of keys left: %d"),
 QT_TRANSLATE_NOOP("dash-core", "Wallet is locked."),
 QT_TRANSLATE_NOOP("dash-core", "Wallet needed to be rewritten: restart %s to complete"),
 QT_TRANSLATE_NOOP("dash-core", "Warning: can't use %s and %s together, will prefer %s"),
 QT_TRANSLATE_NOOP("dash-core", "Warning: incorrect parameter %s, path must exist! Using default path."),
 QT_TRANSLATE_NOOP("dash-core", "Wasn't able to create wallet backup folder %s!"),
-QT_TRANSLATE_NOOP("dash-core", "Will retry..."),
-QT_TRANSLATE_NOOP("dash-core", "Wiping wallet transactions..."),
+QT_TRANSLATE_NOOP("dash-core", "Will retry…"),
+QT_TRANSLATE_NOOP("dash-core", "Wiping wallet transactions…"),
 QT_TRANSLATE_NOOP("dash-core", "You are starting with governance validation disabled."),
 QT_TRANSLATE_NOOP("dash-core", "You can not disable governance validation on a masternode."),
 QT_TRANSLATE_NOOP("dash-core", "You can not start a masternode with wallet enabled."),

--- a/src/qt/locale/dash_ar.ts
+++ b/src/qt/locale/dash_ar.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>أطلب دفعات (يولد كودات الرمز المربع وبيت كوين: العناوين المعطاة)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>خيارات</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>تشفير المحفظة</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>احتياط للمحفظة</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>تغيير كلمة المرور</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>إفتح المحفظة</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>توقيع الرسالة</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>التحقق من الرسالة</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;عناوين الإرسال</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;عناوين الاستقبال </translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>فتح URI</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>افتح المحفظة</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>افتح المحفظة</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>إغلاق المحفظة ...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>اظهر المعلومات حول Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>خيارات</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>حوالي %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>عرض او اخفاء النافذة الرئيسية</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>تشفير المحفظة</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>تشفير المفتاح الخاص بمحفظتك</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>احتياط للمحفظة</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>احفظ نسخة احتياطية للمحفظة في مكان آخر</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>تغيير كلمة المرور</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>تغيير كلمة المرور المستخدمة لتشفير المحفظة</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>إفتح المحفظة</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>غلق المحفظة</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>توقيع الرسالة</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>وقَع الرسائل بواسطة اداش الخاص بك لإثبات امتلاكك لهم</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>التحقق من الرسالة</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>عرض قائمة عناوين الإستقبال المستخدمة والملصقات</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>فتح URI</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>خيارات سطر الأوامر</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>إظهار معلومات حول%1</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>إنشاء المحفظة ...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>تم إلغاء تفعيل الشبكه</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>مزامنة الرؤوس (%1%) ...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>التزامن مع الشبكة...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>ترتيب الفهرسة الكتل على القرص...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>معالجة الكتل على القرص...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>إعادة الفهرسة الكتل على القرص ...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>اتصال إلي القرناء...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>تمت معالجة %n من كتل سجل المعاملات.</numerusform><numerusform>تمت معالجة %n من كتل سجل المعاملات.</numerusform><numerusform>تمت معالجة %n من كتل سجل المعاملات.</numerusform><numerusform>تمت معالجة %n من كتل سجل المعاملات.</numerusform><numerusform>تمت معالجة %n من كتل سجل المعاملات.</numerusform><numerusform>تمت معالجة %n من كتل سجل المعاملات.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 خلف</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>يمسك...</translation>
+        <source>Close Wallet…</source>
+        <translation>إغلاق المحفظة …</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>إنشاء المحفظة …</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>مزامنة الرؤوس (%1%) …</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>التزامن مع الشبكة…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>ترتيب الفهرسة الكتل على القرص…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>معالجة الكتل على القرص…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>إعادة الفهرسة الكتل على القرص …</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>اتصال إلي القرناء…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>يمسك…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>رسالة أصلية:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>جاري إنشاء المحفظة&lt;b&gt;%1&lt;/b&gt; ...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>جاري إنشاء المحفظة&lt;b&gt;%1&lt;/b&gt; …</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>انشاء</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>بما انه هذه اول مرة لانطلاق هذا البرنامج, فيمكنك ان تختار اين سيخزن %1 بياناته</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>عند النقر على "موافق" ، سيبدأ %1 في تنزيل ومعالجة سلسلة الكتل %4 الكاملة (%2 جيجابايت) بدءًا من المعاملات الأقدم في %3 عند تشغيل %4 في البداية.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>تُعد هذه المزامنة الأولية أمرًا شاقًا للغاية، وقد تعرض جهاز الكمبيوتر الخاص بك للمشاكل الذي لم يلاحظها أحد سابقًا. في كل مرة تقوم فيها بتشغيل %1، سيتابع التحميل من حيث تم التوقف.</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>نسخ نقطة خارجية</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>جارٍ التحديث ...</translation>
+        <source>Please wait…</source>
+        <translation>ارجوك انتظر…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>جارٍ التحديث …</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>تصفية حسب أي خاصية (مثل العنوان أو تجزئة البروتكس)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>ارجوك انتظر...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>معلومات إضافية عن DIP3 ماسترنود %1</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>عدد الكتل الفاضلة</translation>
     </message>
     <message>
-        <source>Unknown...</source>
+        <source>Unknown…</source>
         <translation>غير معرف</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>تحسب الان…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>تقدم يزيد بلساعة</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>تحسب الان...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>الوقت المتبقي للمزامنة</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>إخفاء</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>مجهول. مزامنة الرؤوس (%1،%2) ...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>مجهول. مزامنة الرؤوس (%1،%2) …</translation>
     </message>
 </context>
 <context>
@@ -1408,15 +1407,15 @@
         <translation>المحفظة الافتراضية</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>جاري فتح المحفظة&lt;b&gt;%1&lt;/b&gt; ...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>جاري فتح المحفظة&lt;b&gt;%1&lt;/b&gt; …</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
         <source>Options</source>
-        <translation>خيارات ...</translation>
+        <translation>خيارات …</translation>
     </message>
     <message>
         <source>&amp;Main</source>
@@ -1559,14 +1558,6 @@
         <translation>يتم تجاوز الخيارات المعينة في مربع الحوار هذا بواسطة سطر الأوامر أو في ملف التكوين:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>إخفاء الرمز من علبة النظام.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>رمز علبة اخفاء</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>التصغير بدلاً من الخروج من التطبيق عند إغلاق النافذة. عند تفعيل هذا الخيار، سيتم إغلاق التطبيق فقط بعد اختيار الخروج من القائمة.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>يمكن تعيين لغة واجهة للمستخدم هنا. سيتم تفعيل هذا الإعداد بعد إعادة تشغيل %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>لغة مفقودة أو ترجمة غير مكتملة؟ مساعدة في المساهمة بالترجمات هنا:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash: //' ليس URI صالحًا. استخدم "شرطة:" بدلاً من ذلك.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>عنوان الدفع غير صالح %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>لا يمكن تحليل العنوان! يمكن أن يكون ذلك بسبب عنوان داش غير صالح أو معلمات العنوان غير صحيحة.</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>وكيل المستخدم</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>رنين</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>أرسلت</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>وصلت</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>خطأ: يفتقد %1 ملف (ملفات) CSS في المسار -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 لم يخرج بعد بأمان...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 لم يخرج بعد بأمان…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,14 +2234,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>رمز كيو ار</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>&amp;حفظ الصورة</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>&amp;حفظ الصورة</translation>
     </message>
     <message>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>حدد نظير لعرض معلومات مفصلة.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>جهة</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>خدمات</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>نقاط الحظر</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>خلال %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>ابدا</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>داخل</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>خارجي</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>عادي</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>غير معروف</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>نسخ الكمية</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,7 +2722,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>نسخ &amp;العنوان</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>&amp;حفظ الصورة</translation>
     </message>
     <message>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ميزات التحكم بالعملة</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>مدخلات...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>اختيار تلقائيا</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>غبار:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>مدخلات…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>بعد الرسوم :</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>رسوم المعاملة:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>إختر …</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(الرسوم الذكية لم يتم تهيئتها بعد. عادة ما يستغرق ذلك بضع كتل …)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>قد يؤدي استخدام fallbackfee إلى إرسال معاملة تستغرق عدة ساعات أو أيام (أو أبداً) للتأكيد. فكر في اختيار الرسوم يدويًا أو انتظر حتى يتم التحقق من صحة السلسلة الكاملة.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>إختر …</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>تخصيص:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(الرسوم الذكية لم يتم تهيئتها بعد. عادة ما يستغرق ذلك بضع كتل ...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>اتمام إيقاف %1...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>اتمام إيقاف %1…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>هدا العام</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>المدى...</translation>
+        <source>Range…</source>
+        <translation>المدى…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>العثور على عدد كافٍ من المستخدمين ، والتوقيع (الانتظار %s)</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>العثور على عدد كافٍ من المستخدمين ، والتوقيع ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>استيراد...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>وضع غير متوافق.</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>الحد الأدنى لعدد مميّزي مواقع السبط المحدد </translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>جاري تحميل قائمة الحظر...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>قفل بالفعل في المكان.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>الدمج قيد التقدم ...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ليس في قائمة ماسترنود.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>تجريد مخزن الكتل…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>إعادة الكتل …</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>إعادة مسح</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>بدء مؤشرات شبكة الاتصال…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>تم إرساله إلى ماسترنود ، في الانتظار في قائمة الانتظار %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>انتهى التزامن</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>مزامنة بلوكشين…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>مزامنة كائنات الحوكمة …</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>يحتوي تعليق وكيل المستخدم (%s) على أحرف غير آمنة.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>التحقق من المحفظة (المحافظ) ...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>سيعيد المحاولة ...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>خطأ: مساحة القرص منخفضة لـ%s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>خطأ: فشل في إضافة مأخذ التوصيل إلى epollfd (أرجع epoll_ctl الخطأ %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>تم تجاوز الحد الأقصى من المحاولات.</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>فشل في إعادة فحص المحفظة أثناء التهيئة</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>العثور على عدد كافٍ من المستخدمين ، والتوقيع…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>إذن P2P غير صالح: '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>masternodeblsprivkey غير صالح. يرجى الاطلاع على الوثائق.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>تحميل مؤشر الكتلة</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>تحميل المحفظه</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>طابور ماسترنود ممتلئ.</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>معلومات حول معاملات الإدخال مفقودة.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>الدمج قيد التقدم …</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>وضع التجريد غير متوافق مع -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>تجريد مخزن الكتل...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>المقطع [%s] غير معروف.</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>-walletdir المحدد "%s" ليس دليلاً</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>مزامنة بلوكشين...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>الصفقة كبيرة جدا</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>تحاول الاتصال...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>يتعذر الربط مع %s على هذا الكمبيوتر. من المحتمل أن %s قيد التشغيل بالفعل.</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>ترقية قاعدة بيانات UTXO</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>التحقق من الكتل…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>التحقق من المحفظة (المحافظ) …</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>خطأ في ترقية قاعدة بيانات chainstate</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>خطأ: فشل إضافة مأخذ التوصيل إلى kqueuefd (أرجع kevent الخطأ%s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>تحميل عناوين P2P…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>جاري تحميل قائمة الحظر…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>تحميل مؤشر الكتلة</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>تحميل المحفظه</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>فشل في بدء صف مختلط جديد</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>استيراد…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>وضع المسح غير الصحيح ، والعودة إلى القيمة الافتراضية</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>عنوان spork غير صالح محدد بـ -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>تحميل عناوين P2P...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>تقليل -maxconnections من %d إلى %d ، بسبب قيود النظام.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>إعادة الكتل ...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>إعادة مسح</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>آخر إجراء ناجح كان حديثًا جدًا.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>بدء مؤشرات شبكة الاتصال...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>مزامنة كائنات الحوكمة ...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>شفرة المصدر متاح من %s.</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>المعاملة غير صالحة.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>تحاول الاتصال…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>تحديث قاعدة بيانات txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>التحقق من الكتل...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>عدد منخفض جدًا من المفاتيح المتبقية: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>تحذير: معلمة غير صحيحة%s ، يجب أن يكون المسار موجودًا! باستخدام المسار الافتراضي.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>سيعيد المحاولة …</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_bg.ts
+++ b/src/qt/locale/dash_bg.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Заявка за плащане (генерира QR кодове и Dash: URI)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Опции…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Шифриране на портфейла…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Запазване на портфейла…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Смяна на паролата…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Отключи Портфейл…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Подписване на &amp;съобщение…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Проверка на съобщение…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Адреси за изпращане</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Адреси за получаване</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Отвори &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Отвори портфейла</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Отворете портфейл </translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Затваряне на портфейла...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Покажи информация за Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Опции...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;Относно %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Показване и скриване на основния прозорец</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Шифриране на портфейла...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Криптирай частните ключове принадлежащи към твоя портфейл</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Запазване на портфейла...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Запазване на портфейла на друго място</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Смяна на паролата...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Променя паролата за криптиране на портфейла</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Отключи Портфейл...</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>&amp;Заключи Портфейл</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Подписване на &amp;съобщение...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Подпиши съобщения с твоите Dash адреси за да докажеш че ги притежаваш</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Проверка на съобщение...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Покажи списъкът от използвани адреси за получаване и наименования</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Отвори &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Опции на командния ред</translation>
     </message>
@@ -590,10 +589,6 @@
         <translation>Отвори dash: URI</translation>
     </message>
     <message>
-        <source>Create Wallet...</source>
-        <translation>Създай портфейл...</translation>
-    </message>
-    <message>
         <source>Create a new wallet</source>
         <translation>Създай нов портфейл</translation>
     </message>
@@ -633,30 +628,6 @@
         <source>Network activity disabled</source>
         <translation>Мрежова активност изключена</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Синхронизиране на Headers (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Синхронизиране с мрежата...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Индексиране блоковете на диска ...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Обработване блоковете на диска...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Преиндексиране на блокове на диска...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Свързване към пиъри...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>Обработени %n блок(а) от историята на транзакциите.</numerusform><numerusform>Обработени %n блока от историята на транзакциите.</numerusform></translation>
@@ -666,8 +637,40 @@
         <translation>%1 назад</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Зарежда блокове...</translation>
+        <source>Close Wallet…</source>
+        <translation>Затваряне на портфейла…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Създай портфейл…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Синхронизиране на Headers (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Синхронизиране с мрежата…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Индексиране блоковете на диска …</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Обработване блоковете на диска…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Преиндексиране на блокове на диска…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Свързване към пиъри…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Зарежда блокове…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -790,10 +793,6 @@
     <message>
         <source>Original message:</source>
         <translation>Оригинално съобщение:</translation>
-    </message>
-    <message>
-        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation>Възникна фатална грешка. %1 не може да продължи безопасно и ще се изключи.</translation>
     </message>
 </context>
 <context>
@@ -990,8 +989,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Създаване на портфейл &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Създаване на портфейл &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1128,10 +1127,6 @@
         <translation>Тъй като това е първият път, когато програмата се стартира, можете да изберете къде %1 да съхранява данните си.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Когато изберете OK, %1 ще започне да изтегля и обработва %4 блок верига (%2GB) стартирайки с първите транзакции в %3 когато %4 е  пуснат първоначално.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Тази първоначална синхронизация изисква много ресурси и може да покаже хардуерните проблеми с компютъра, които преди това не сте забелязали. Всеки път, когато стартирате %1, той ще продължи да се изтегля там, където е спрял.</translation>
     </message>
@@ -1251,8 +1246,12 @@
         <translation>Копирай Collateral Outpoint</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Обновяване...</translation>
+        <source>Please wait…</source>
+        <translation>Моля изчакайте…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Обновяване…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1287,10 +1286,6 @@
         <translation>Филтрирайте по някакво свойство (напр. Адрес или хеш на protx)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Моля изчакайте...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Допълнителна информация за DIP3 Masternode %1</translation>
     </message>
@@ -1314,8 +1309,12 @@
         <translation>Оставащ брой блокове</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Неизвестни...</translation>
+        <source>Unknown…</source>
+        <translation>Неизвестни…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>изчисляване…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1328,10 +1327,6 @@
     <message>
         <source>Progress increase per hour</source>
         <translation>Увеличаване напредъка за час</translation>
-    </message>
-    <message>
-        <source>calculating...</source>
-        <translation>изчисляване...</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
@@ -1471,14 +1466,6 @@
         <translation>Показва ако зададеното по подразбиране SOCKS5 proxy се използва за намиране на пиъри чрез тази мрежа.</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Скрий иконата от системният трей.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>Скрий трей иконата</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>При затваряне на прозореца приложението остава минимизирано. Ако изберете тази опция, приложението може да се затвори само чрез Изход в менюто.</translation>
     </message>
@@ -1577,12 +1564,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>Тук можете да промените езика на потребителския изглед. Настройката ще влезе в сила след рестартиране %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Липсва език или превода е непълен? Можете да помогнете с превода тук:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1886,10 +1867,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' не е валиден URI. Използвайте 'dash:' вместо това.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Невалиден адрес за плащане %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>Грешка при анализ на URI! Това може да е следствие от неправилен Dash адрес или неправилно зададени URI параметри.</translation>
     </message>
@@ -1902,18 +1879,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Потребителски агент</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Пинг</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Изпратени</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Получени</translation>
     </message>
     </context>
@@ -1962,8 +1943,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Покажи начален екран при стартиране (по подразбиране: %u)</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 все още не е излязъл безопастно...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 все още не е излязъл безопастно…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2073,15 +2054,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QR Код</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Запиши изображение...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Запиши изображение…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Запиши изображението...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Запиши изображението…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2195,10 +2176,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Избери пиър за подробна информация.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Направление</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
@@ -2277,10 +2254,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Услуги</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Точки за бан</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2407,18 +2380,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>чрез %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>никога</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Входящи</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Изходящи</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Редовно</translation>
     </message>
@@ -2434,7 +2395,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>Неизвестни</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2521,7 +2482,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Копирай сума</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2533,8 +2494,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Копирай адрес</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Запиши изображението...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Запиши изображението…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2587,10 +2548,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Функции за контрол на монетата</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Входове...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>автоматично избрано</translation>
     </message>
@@ -2619,6 +2576,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Незначителен остатък:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Входове…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>След таксата:</translation>
     </message>
@@ -2639,8 +2600,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Такса транзакция:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Избери...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Смарт таксата не е разпозната все още.Това ще отнеме няколко блока… )</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2659,6 +2620,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Използването на резервната такса може да доведе до изпращане на транзакция, което ще отнеме няколко часа или дни (или никога), за потвърждение. Помислете дали да изберете вашата такса ръчно или да изчакате, докато валидирате пълната верига.</translation>
     </message>
     <message>
+        <source>Choose…</source>
+        <translation>Избери…</translation>
+    </message>
+    <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
         <translation>Бележка: Няма достатъчно данни за оценка на таксата, вместо това използвайте резервната такса.</translation>
     </message>
@@ -2673,10 +2638,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Персонализиран:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Смарт таксата не е разпозната все още.Това ще отнеме няколко блока... )</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -2929,8 +2890,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 се изключва...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 се изключва…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3451,8 +3412,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Тази година</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>От - до...</translation>
+        <source>Range…</source>
+        <translation>От - до…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -3761,14 +3722,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Открити са достатъчно потребители, подписване ( изчаква %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Открити са достатъчно потребители, подписва...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Внасяне...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Несъвместим режим.</translation>
     </message>
@@ -3801,16 +3754,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Невалиден минимален брой ауторизатори на spork определен с -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Зареждане на бан лист...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Заключването е вече налично.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>В процес на смесване...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -3833,12 +3778,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Не е в Мasternode списъка.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Изчистване на блоковото пространство…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Възпроизвеждането на блокове …</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Повторно сканиране…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Стартиране на мрежовите нишки…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Изпратено към Мастернода, чака в опашката %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Синхронизацията е завършена</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Синхронизиране на блок веригата…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Синхронизиране на governance обектите…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -3851,14 +3820,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>User Agent comment (%s) съдържа опасни символи.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Проверка на портфейла(ите)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Ще опита отново...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -3949,10 +3910,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Грешка при надстройката на базата данни evo</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Грешка: неуспешно добавяне на socket към epollfd (epoll_ctl дава грешка %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Надвишен брой опити.</translation>
     </message>
@@ -3977,20 +3934,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Неуспешно сканиране на портфейла по време на инициализация</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Открити са достатъчно потребители, подписва…</translation>
+    </message>
+    <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
         <translation>Невалидно количество за -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid masternodeblsprivkey. Please see documentation.</source>
         <translation>Невалиден masternodeblsprivkey. Моля вижте документацията.</translation>
-    </message>
-    <message>
-        <source>Loading block index...</source>
-        <translation>Зареждане на блок индекса...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Зареждане на портфейла...</translation>
     </message>
     <message>
         <source>Masternode queue is full.</source>
@@ -4003,6 +3956,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Липсва входяща информация за транзакцията.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>В процес на смесване…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4033,10 +3990,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Изчистен режим е несъвместим с  -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Изчистване на блоковото пространство...</translation>
-    </message>
-    <message>
         <source>Specified -walletdir "%s" does not exist</source>
         <translation>Посоченият -walletdir "%s" не съществува</translation>
     </message>
@@ -4047,10 +4000,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Посоченият -walletdir "%s" не е папка</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Синхронизиране на блок веригата...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4085,10 +4034,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Транзакцията е твърде голяма</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Опит за свързване...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Невъзможно да се свърже към %s на този компютър. %s вероятно  вече работи.</translation>
     </message>
@@ -4099,6 +4044,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Обновяване на UTXO база данни</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Проверка на блоковете…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Проверка на портфейла(ите)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4233,8 +4186,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Грешка при надграждане на верижната база данни </translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Грешка:неуспешно добавяне на socket към kqueuefd (kevent дава грешка %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Зареждане на P2P адреси…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Зареждане на бан лист…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Зареждане на блок индекса…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Зареждане на портфейла…</translation>
     </message>
     <message>
         <source>Failed to find mixing queue to join</source>
@@ -4243,6 +4208,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Failed to start a new mixing queue</source>
         <translation>Неуспешно стартиране на нова опашка за миксиране</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation>Внасяне…</translation>
     </message>
     <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
@@ -4273,20 +4242,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Невалиден спорк адрес посочен с -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Зареждане на P2P адреси...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Намаляване -maxconnections от %d до %d, поради ограниченията на системата.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Възпроизвеждането на блокове ...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Повторно сканиране...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4311,14 +4268,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Last successful action was too recent.</source>
         <translation>Последното успешно действие беше твърде скоро.</translation>
-    </message>
-    <message>
-        <source>Starting network threads...</source>
-        <translation>Стартиране на мрежовите нишки...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Синхронизиране на governance обектите...</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -4349,6 +4298,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Транзакцията е невалидна.</translation>
     </message>
     <message>
+        <source>Trying to connect…</source>
+        <translation>Опит за свързване…</translation>
+    </message>
+    <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
         <translation>Не може да се свърже с %s на този компютър (връща грешка %s)</translation>
     </message>
@@ -4377,10 +4330,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Неподдържана категория на журналиране %s=%s.</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Проверка на блоковете...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Много малък останали ключове: %d</translation>
     </message>
@@ -4395,6 +4344,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Внимание: некоректен параметър %s, пътят трябва да съществува! Използвайте път по подразбиране.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Ще опита отново…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_de.ts
+++ b/src/qt/locale/dash_de.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Zahlungen anfordern (erzeugt QR-Codes und "dash:"-URIs)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Konfiguration…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>Wallet &amp;verschlüsseln…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>Wallet &amp;sichern…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>Passphrase &amp;ändern…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>Wallet &amp;entsperren</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Nachricht s&amp;ignieren…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>Nachricht &amp;verifizieren…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Absendeadressen</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Empfangsadressen</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>&amp;URI öffnen…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Wallet öffnen</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Eine Wallet öffnen</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Wallet schließen...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Informationen über Qt anzeigen</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Konfiguration...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>Über %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Das Hauptfenster anzeigen oder verstecken</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>Wallet &amp;verschlüsseln...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Verschlüsselt die zu ihrer Wallet gehörenden privaten Schlüssel</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>Wallet &amp;sichern...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Eine Wallet-Sicherungskopie erstellen und abspeichern</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>Passphrase &amp;ändern...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Ändert die Passphrase, die für die Wallet-Verschlüsselung benutzt wird</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>Wallet &amp;entsperren</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>Wallet &amp;sperren</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Nachricht s&amp;ignieren...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Nachrichten signieren, um den Besitz ihrer Dash-Adressen zu beweisen</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>Nachricht &amp;verifizieren...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Liste verwendeter Empfangsadressen und Bezeichnungen anzeigen</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>&amp;URI öffnen...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Kommandozeilenoptionen</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>Zeige Informationen über %1</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>Wallet erstellen...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>Netzwerk-Aktivität deaktiviert</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Synchronisiere Header (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Synchronisiere mit Netzwerk...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indiziere Blöcke auf Datenträger...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Verarbeite Blöcke auf Datenträger...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Reindiziere Blöcke auf Datenträger...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Verbinde mit Peers...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>%n Block des Transaktionsverlaufs verarbeitet.</numerusform><numerusform>%n Blöcke des Transaktionsverlaufs verarbeitet.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 im Rückstand</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Hole auf...</translation>
+        <source>Close Wallet…</source>
+        <translation>Wallet schließen…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Wallet erstellen…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Synchronisiere Header (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Synchronisiere mit Netzwerk…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indiziere Blöcke auf Datenträger…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Verarbeite Blöcke auf Datenträger…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Reindiziere Blöcke auf Datenträger…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Verbinde mit Peers…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Hole auf…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>Originalnachricht:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Erstelle Wallet &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Erstelle Wallet &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>Erstellen</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>Da Sie das Programm gerade zum ersten Mal starten, können Sie nun auswählen wo %1 seine Daten ablegen wird.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Wenn Sie OK klicken, wird der Download %1 angestoßen und die volle %4 Blockchain (%2GB) verarbeitet. Die Verarbeitung beginnt mit den frühesten Transaktionen in %3 , wenn %4 gestartet sind.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Diese initiale Synchronisation führt zur hohen Last und kann Hardwareprobleme, die bisher nicht aufgetreten sind, mit ihrem Computer verursachen. Jedes Mal, wenn Sie %1 ausführen, wird der Download zum letzten Synchronisationspunkt fortgesetzt.</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>Collateral Outpoint kopieren</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Aktualisiere...</translation>
+        <source>Please wait…</source>
+        <translation>Bitte warten…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Aktualisiere…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>Nach Eigenschaft filtern (z.B. Adresse oder Protx-Hash)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Bitte warten...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Zusätzliche Informationen für DIP3 Masternode %1</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>Anzahl verbleibender Blöcke</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Unbekannt...</translation>
+        <source>Unknown…</source>
+        <translation>Unbekannt…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>berechne…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>Fortschritt pro Stunde</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>berechne...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Geschätzte Dauer bis zur Synchronisation</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>Verbergen</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Unbekannt. Synchronisiere Headers (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Unbekannt. Synchronisiere Headers (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>default wallet</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Öffne Wallet &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Öffne Wallet &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>In diesem Dialog eingestellte Optionen werden in der Kommandozeile oder in der Konfigurationsdatei überschrieben:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Verberge Symbol im Infobereich.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;Infosymbol verbergen</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Minimiert die Anwendung anstatt sie zu beenden wenn das Fenster geschlossen wird. Wenn dies aktiviert ist, müssen Sie das Programm über "Beenden" im Menü schließen.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>Die Benutzeroberflächensprache kann hier festgelegt werden. Diese Einstellung wird nach einem Neustart von %1 wirksam werden.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Fehlt eine Sprache oder ist unvollständig übersetzt? Hier können Sie helfen:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' ist keine gültige URI. Verwende 'dash:' stattdessen.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Ungültige Zahlungsadresse %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI konnte nicht erfolgreich verarbeitet werden. Höchstwahrscheinlich ist dies entweder keine gültige Dash-Adresse oder die URI-Parameter sind falsch gesetzt. </translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Benutzerprogramm</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Gesendet</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Empfangen</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Fehler: %1 CSS-Datei(en) fehlen im Pfad -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 wurde noch nicht sicher beendet...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 wurde noch nicht sicher beendet…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>Grafik &amp;speichern...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>Grafik &amp;speichern…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>Grafik &amp;speichern...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>Grafik &amp;speichern…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Gegenstelle auswählen, um Detailinformationen zu sehen.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Richtung</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Version</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Dienste</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Ausschluss-Punktzahl</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>über %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>niemals</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Eingehend</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Ausgehend</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Standard</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>Unbekannt</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Betrag kopieren</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,8 +2722,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Addresse kopieren</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>Grafik &amp;speichern...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>Grafik &amp;speichern…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>"Coin Control"-Funktionen</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Inputs...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>automatisch ausgewählt</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>"Dust"</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Inputs…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Abzüglich Gebühr:</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Transaktionsgebühr:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Auswählen...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>("Intelligente" Gebühren sind noch nicht initialisiert. Dies dauert normalerweise ein paar Blöcke…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Wenn die Fallbackfee verwendet wird kann dies bedeuten, dass es Stunden oder Tage dauern kann, bis die Transaktion bestätigt wird (oder sie kann auch niemals bestätigt werden). Du kannst die Gebühr manuell einstellen oder warten, bis die vollständige Blockchain heruntergeladen wurde.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Auswählen…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Benutzerdefiniert:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>("Intelligente" Gebühren sind noch nicht initialisiert. Dies dauert normalerweise ein paar Blöcke...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 wird beendet...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 wird beendet…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Dieses Jahr</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Zeitraum...</translation>
+        <source>Range…</source>
+        <translation>Zeitraum…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Genug Partner gefunden, signiere ( warte %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Genug Partner gefunden, signiere ... </translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Importiere...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Inkompatibler Modus.</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ungültige minimale Anzahl an Spork-Unterzeichnern durch -minsporkkeys spezifiziert</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Lade Bann-Liste...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Schon gesperrt.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Am Mixen...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nicht in der Masternode-Liste.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Alte Blocks werden abgeschnitten/pruned…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Blöcke wiederherstellen…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Durchsuche erneut…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Netzwerk-Threads werden gestartet…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>An Masternode übermittelt, wartet in Warteschlange %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Synchronisation beendet</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Synchronisiere Blockchain…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Synchronisiere Governance Objekte…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Der "User Agent"-Text (%s) enthält unsichere Zeichen.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Verifiziere Wallet(s)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Versuche erneut...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Fehler: Geringer Speicherplatz für %s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Fehler: Hinzufügung eines Sockets zu epollfd fehlgeschlagen (epoll_ctl meldet Fehler %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Maximale Zahl an Versuchen überschritten.</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Rescan der Wallet während der Initialisierung fehlgeschlagen</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Genug Partner gefunden, signiere…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>Ungültige P2P-Erlaubnis: '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ungültiger masternodeblsprivkey. Weitere Informationen befinden sich in der Dokumentation.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Lade Blockindex...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Lade Wallet...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Warteschlange der Masternode ist voll.</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Fehlende Informationen zur Eingangs-Transaktion.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Am Mixen…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Prune/Abschneiden ist zu -txindex nicht kompatibel.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Alte Blocks werden abgeschnitten/pruned...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>Abschnitt [%s] wird nicht erkannt.</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Spezifizierte -walletdir "%s" ist kein Verzeichnis</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Synchronisiere Blockchain...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Transaktion zu groß</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Verbindungsaufbau...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Kann auf diesem Computer nicht an %s binden. Evtl. wurde %s bereits gestartet.</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Aktualisierung der UTXO Datenbank</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Verifiziere Blöcke…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Verifiziere Wallet(s)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Fehler bei der Aktualisierung einer Kettenstatus-Datenbank</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Fehler: Hinzufügung eines Sockets zu kqueuefd fehlgeschlagen (kevent meldet Fehler %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Lade P2P-Adressen…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Lade Bann-Liste…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Lade Blockindex…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Lade Wallet…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Keine Warteschlange konnte zum mischen gestartet werden</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Importiere…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Falscher -Rescan-Modus, Zurückfallen auf Standardwert</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ungültige Spork-Adresse mit -sporkaddr angegeben</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Lade P2P-Adressen...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>-maxconnections wird wegen Systembeschränkungen von %d auf %d verringert.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Blöcke wiederherstellen...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Durchsuche erneut...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Letzte erfolgreiche Transaktion ist noch zu neu.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Netzwerk-Threads werden gestartet...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Synchronisiere Governance Objekte...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>Der Quellcode ist von %s verfügbar.</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>Transaktion ungültig.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Verbindungsaufbau…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Aktualisierung der txindex-Datenbank</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Verifiziere Blöcke...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Nur noch wenige Schlüssel verfügbar: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Warnung: Ungültiger Parameter %s. Pfad muss existieren! Nutze Standardpfad.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Versuche erneut…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_en.ts
+++ b/src/qt/locale/dash_en.ts
@@ -164,7 +164,7 @@
         <translation>Address</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <location line="+38"/>
         <source>(no label)</source>
         <translation>(no label)</translation>
     </message>
@@ -381,7 +381,7 @@
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+87"/>
+        <location filename="../bantablemodel.cpp" line="+85"/>
         <source>IP/Netmask</source>
         <translation>IP/Netmask</translation>
     </message>
@@ -400,9 +400,32 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <location filename="../bitcoin.cpp" line="+498"/>
+        <source>Runaway exception</source>
+        <translation>Runaway exception</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation>A fatal error occurred. %1 can no longer continue safely and will quit.</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Internal error</source>
+        <translation>Internal error</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</translation>
+    </message>
+</context>
+<context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+679"/>
+        <location filename="../bitcoingui.cpp" line="+681"/>
         <source>&amp;Overview</source>
         <translation>&amp;Overview</translation>
     </message>
@@ -412,7 +435,7 @@
         <translation>Show general overview of wallet</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-329"/>
         <source>&amp;Send</source>
         <translation>&amp;Send</translation>
     </message>
@@ -432,7 +455,57 @@
         <translation>Request payments (generates QR codes and dash: URIs)</translation>
     </message>
     <message>
-        <location line="+74"/>
+        <location line="+16"/>
+        <source>Ctrl+Q</source>
+        <translation>Ctrl+Q</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>&amp;Options…</source>
+        <translation>&amp;Options…</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Encrypt Wallet…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Backup Wallet…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Change Passphrase…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Unlock Wallet…</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Sign &amp;message…</source>
+        <translation>Sign &amp;message…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Verify message…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Load PSBT from file…</source>
+        <translation>&amp;Load PSBT from file…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Load PSBT from clipboard…</source>
+        <translation>Load PSBT from clipboard…</translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Sending addresses</translation>
     </message>
@@ -442,7 +515,12 @@
         <translation>&amp;Receiving addresses</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+3"/>
+        <source>Open &amp;URI…</source>
+        <translation>Open &amp;URI…</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Open Wallet</source>
         <translation>Open Wallet</translation>
     </message>
@@ -452,12 +530,7 @@
         <translation>Open a wallet</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Close Wallet...</source>
-        <translation>Close Wallet...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+4"/>
         <source>Close wallet</source>
         <translation>Close wallet</translation>
     </message>
@@ -487,7 +560,7 @@
         <translation>Main Window</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+57"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transactions</translation>
     </message>
@@ -507,7 +580,7 @@
         <translation>Browse masternodes</translation>
     </message>
     <message>
-        <location line="-333"/>
+        <location line="-332"/>
         <source>E&amp;xit</source>
         <translation>E&amp;xit</translation>
     </message>
@@ -527,12 +600,7 @@
         <translation>Show information about Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>&amp;Options...</source>
-        <translation>&amp;Options...</translation>
-    </message>
-    <message>
-        <location line="-7"/>
+        <location line="-5"/>
         <source>&amp;About %1</source>
         <translation>&amp;About %1</translation>
     </message>
@@ -557,42 +625,22 @@
         <translation>Show or hide the main Window</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Encrypt Wallet...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Encrypt the private keys that belong to your wallet</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Backup Wallet...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Backup wallet to another location</source>
         <translation>Backup wallet to another location</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Change Passphrase...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Change the passphrase used for wallet encryption</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Unlock Wallet...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Unlock wallet</source>
         <translation>Unlock wallet</translation>
     </message>
@@ -602,32 +650,17 @@
         <translation>&amp;Lock Wallet</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Sign &amp;message...</source>
-        <translation>Sign &amp;message...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Sign messages with your Dash addresses to prove you own them</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Verify message...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
         <translation>Verify messages to ensure they were signed with specified Dash addresses</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>&amp;Load PSBT from file...</source>
-        <translation>&amp;Load PSBT from file...</translation>
-    </message>
-    <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>&amp;Information</source>
         <translation>&amp;Information</translation>
     </message>
@@ -702,12 +735,7 @@
         <translation>Show the list of used receiving addresses and labels</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Open &amp;URI...</source>
-        <translation>Open &amp;URI...</translation>
-    </message>
-    <message>
-        <location line="+18"/>
+        <location line="+20"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Command-line options</translation>
     </message>
@@ -722,7 +750,7 @@
         <translation>default wallet</translation>
     </message>
     <message>
-        <location line="+493"/>
+        <location line="+492"/>
         <source>%1 client</source>
         <translation>%1 client</translation>
     </message>
@@ -739,7 +767,7 @@
         <translation>Wallet is &lt;b&gt;unencrypted&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="-1262"/>
+        <location line="-1261"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
@@ -754,12 +782,7 @@
         <translation>Load Partially Signed Dash Transaction</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Load PSBT from clipboard...</source>
-        <translation>Load PSBT from clipboard...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation>Load Partially Signed Bitcoin Transaction from clipboard</translation>
     </message>
@@ -774,22 +797,12 @@
         <translation>Open a dash: URI</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>Create Wallet...</source>
-        <translation>Create Wallet...</translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+12"/>
         <source>Create a new wallet</source>
         <translation>Create a new wallet</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Close All Wallets...</source>
-        <translation>Close All Wallets...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+3"/>
         <source>Close all wallets</source>
         <translation>Close all wallets</translation>
     </message>
@@ -829,7 +842,7 @@
         <translation>Tabs toolbar</translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+45"/>
         <source>&amp;Governance</source>
         <translation>&amp;Governance</translation>
     </message>
@@ -851,38 +864,8 @@
         <source>Network activity disabled</source>
         <translation>Network activity disabled</translation>
     </message>
-    <message>
-        <location line="+30"/>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Syncing Headers (%1%)...</translation>
-    </message>
-    <message>
-        <location line="+121"/>
-        <source>Synchronizing with network...</source>
-        <translation>Synchronizing with network...</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indexing blocks on disk...</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Processing blocks on disk...</source>
-        <translation>Processing blocks on disk...</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Reindexing blocks on disk...</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Connecting to peers...</source>
-        <translation>Connecting to peers...</translation>
-    </message>
     <message numerus="yes">
-        <location line="+9"/>
+        <location line="+177"/>
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
             <numerusform>Processed %n block of transaction history.</numerusform>
@@ -895,9 +878,64 @@
         <translation>%1 behind</translation>
     </message>
     <message>
+        <location line="-1020"/>
+        <source>Close Wallet…</source>
+        <translation>Close Wallet…</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Create Wallet…</source>
+        <translation>Create Wallet…</translation>
+    </message>
+    <message>
         <location line="+4"/>
-        <source>Catching up...</source>
-        <translation>Catching up...</translation>
+        <source>Close All Wallets…</source>
+        <translation>Close All Wallets…</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Ctrl+Shift+D</source>
+        <translation>Ctrl+Shift+D</translation>
+    </message>
+    <message>
+        <location line="+143"/>
+        <source>Ctrl+M</source>
+        <translation>Ctrl+M</translation>
+    </message>
+    <message>
+        <location line="+692"/>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Syncing Headers (%1%)…</translation>
+    </message>
+    <message>
+        <location line="+121"/>
+        <source>Synchronizing with network…</source>
+        <translation>Synchronizing with network…</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indexing blocks on disk…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Processing blocks on disk…</source>
+        <translation>Processing blocks on disk…</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Reindexing blocks on disk…</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Connecting to peers…</source>
+        <translation>Connecting to peers…</translation>
+    </message>
+    <message>
+        <location line="+32"/>
+        <source>Catching up…</source>
+        <translation>Catching up…</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -1044,14 +1082,9 @@
         <translation>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+92"/>
         <source>Original message:</source>
         <translation>Original message:</translation>
-    </message>
-    <message>
-        <location filename="../bitcoin.cpp" line="+494"/>
-        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation>A fatal error occurred. %1 can no longer continue safely and will quit.</translation>
     </message>
 </context>
 <context>
@@ -1298,11 +1331,11 @@
     <name>CreateWalletActivity</name>
     <message>
         <location filename="../walletcontroller.cpp" line="+254"/>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+28"/>
         <source>Create wallet failed</source>
         <translation>Create wallet failed</translation>
     </message>
@@ -1365,9 +1398,24 @@
         <translation>Make Blank Wallet</translation>
     </message>
     <message>
+        <location line="+7"/>
+        <source>Use descriptors for scriptPubKey management. This feature is well-tested but still considered experimental and not recommended for use yet.</source>
+        <translation>Use descriptors for scriptPubKey management. This feature is well-tested but still considered experimental and not recommended for use yet.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Descriptor Wallet (EXPERIMENTAL)</source>
+        <translation>Descriptor Wallet (EXPERIMENTAL)</translation>
+    </message>
+    <message>
         <location filename="../createwalletdialog.cpp" line="+21"/>
         <source>Create</source>
         <translation>Create</translation>
+    </message>
+    <message>
+        <location line="+41"/>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation>Compiled without sqlite support (required for descriptor wallets)</translation>
     </message>
 </context>
 <context>
@@ -1545,12 +1593,7 @@
         <translation>As this is the first time the program is launched, you can choose where %1 will store its data.</translation>
     </message>
     <message>
-        <location line="+157"/>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</translation>
-    </message>
-    <message>
-        <location line="+32"/>
+        <location line="+189"/>
         <source>Limit block chain storage to</source>
         <translation>Limit block chain storage to</translation>
     </message>
@@ -1570,7 +1613,12 @@
         <translation>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="-10"/>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</translation>
+    </message>
+    <message>
+        <location line="+20"/>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
         <translation>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</translation>
     </message>
@@ -1584,29 +1632,20 @@
         <source>Use a custom data directory:</source>
         <translation>Use a custom data directory:</translation>
     </message>
-    <message numerus="yes">
+    <message>
         <location filename="../intro.cpp" line="+199"/>
-        <source>%n GB of free space available</source>
-        <translation>
-            <numerusform>%n GB of free space available</numerusform>
-            <numerusform>%n GB of free space available</numerusform>
-        </translation>
+        <source>%1 GB of free space available</source>
+        <translation>%1 GB of free space available</translation>
     </message>
-    <message numerus="yes">
+    <message>
         <location line="+2"/>
-        <source>(of %n GB needed)</source>
-        <translation>
-            <numerusform>(of %n GB needed)</numerusform>
-            <numerusform>(of %n GB needed)</numerusform>
-        </translation>
+        <source>(of %1 GB needed)</source>
+        <translation>(of %1 GB needed)</translation>
     </message>
-    <message numerus="yes">
+    <message>
         <location line="+3"/>
-        <source>(%n GB needed for full chain)</source>
-        <translation>
-            <numerusform>(%n GB needed for full chain)</numerusform>
-            <numerusform>(%n GB needed for full chain)</numerusform>
-        </translation>
+        <source>(%1 GB needed for full chain)</source>
+        <translation>(%1 GB needed for full chain)</translation>
     </message>
     <message>
         <location line="+72"/>
@@ -1751,9 +1790,15 @@
         <translation>Copy Collateral Outpoint</translation>
     </message>
     <message>
-        <location line="+110"/>
-        <source>Updating...</source>
-        <translation>Updating...</translation>
+        <location line="+61"/>
+        <location line="+180"/>
+        <source>Please wait…</source>
+        <translation>Please wait…</translation>
+    </message>
+    <message>
+        <location line="-131"/>
+        <source>Updating…</source>
+        <translation>Updating…</translation>
     </message>
     <message>
         <location line="+37"/>
@@ -1797,13 +1842,7 @@
         <translation>Filter by any property (e.g. address or protx hash)</translation>
     </message>
     <message>
-        <location filename="../masternodelist.cpp" line="-106"/>
-        <location line="+180"/>
-        <source>Please wait...</source>
-        <translation>Please wait...</translation>
-    </message>
-    <message>
-        <location line="+46"/>
+        <location filename="../masternodelist.cpp" line="+120"/>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Additional information for DIP3 Masternode %1</translation>
     </message>
@@ -1834,11 +1873,17 @@
         <location line="+7"/>
         <location line="+20"/>
         <location filename="../modaloverlay.cpp" line="+166"/>
-        <source>Unknown...</source>
-        <translation>Unknown...</translation>
+        <source>Unknown…</source>
+        <translation>Unknown…</translation>
     </message>
     <message>
-        <location line="-13"/>
+        <location line="+32"/>
+        <location line="+14"/>
+        <source>calculating…</source>
+        <translation>calculating…</translation>
+    </message>
+    <message>
+        <location line="-59"/>
         <source>Last block time</source>
         <translation>Last block time</translation>
     </message>
@@ -1853,13 +1898,7 @@
         <translation>Progress increase per hour</translation>
     </message>
     <message>
-        <location line="+7"/>
         <location line="+14"/>
-        <source>calculating...</source>
-        <translation>calculating...</translation>
-    </message>
-    <message>
-        <location line="-7"/>
         <source>Estimated time left until synced</source>
         <translation>Estimated time left until synced</translation>
     </message>
@@ -1875,8 +1914,8 @@
     </message>
     <message>
         <location line="+124"/>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Unknown. Syncing Headers (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Unknown. Syncing Headers (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1911,8 +1950,8 @@
     </message>
     <message>
         <location line="+2"/>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1928,7 +1967,7 @@
         <translation>&amp;Main</translation>
     </message>
     <message>
-        <location line="+183"/>
+        <location line="+186"/>
         <source>Size of &amp;database cache</source>
         <translation>Size of &amp;database cache</translation>
     </message>
@@ -1943,7 +1982,7 @@
         <translation>(0 = auto, &lt;0 = leave that many cores free)</translation>
     </message>
     <message>
-        <location line="-232"/>
+        <location line="-235"/>
         <source>W&amp;allet</source>
         <translation>W&amp;allet</translation>
     </message>
@@ -1953,7 +1992,17 @@
         <translation>&amp;Appearance</translation>
     </message>
     <message>
-        <location line="+83"/>
+        <location line="+48"/>
+        <source>Show the icon in the system tray.</source>
+        <translation>Show the icon in the system tray.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Show tray icon</source>
+        <translation>&amp;Show tray icon</translation>
+    </message>
+    <message>
+        <location line="+35"/>
         <source>Prune &amp;block storage to</source>
         <translation>Prune &amp;block storage to</translation>
     </message>
@@ -2157,22 +2206,19 @@
         <translation>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+169"/>
+        <source>Language missing or translation incomplete? Help contributing translations here:
+https://explore.transifex.com/dash/dash/</source>
+        <translation>Language missing or translation incomplete? Help contributing translations here:
+https://explore.transifex.com/dash/dash/</translation>
+    </message>
+    <message>
+        <location line="+131"/>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
         <translation>Options set in this dialog are overridden by the command line or in the configuration file:</translation>
     </message>
     <message>
-        <location line="-945"/>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Hide the icon from the system tray.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;Hide tray icon</translation>
-    </message>
-    <message>
-        <location line="+17"/>
+        <location line="-925"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</translation>
     </message>
@@ -2193,7 +2239,7 @@
         <translation>Whether to show coin control features or not.</translation>
     </message>
     <message>
-        <location line="-208"/>
+        <location line="-211"/>
         <source>Automatically start %1 after logging in to the system.</source>
         <translation>Automatically start %1 after logging in to the system.</translation>
     </message>
@@ -2203,7 +2249,7 @@
         <translation>&amp;Start %1 on system login</translation>
     </message>
     <message>
-        <location line="+208"/>
+        <location line="+211"/>
         <source>Enable coin &amp;control features</source>
         <translation>Enable coin &amp;control features</translation>
     </message>
@@ -2218,12 +2264,12 @@
         <translation>This setting determines the amount of individual masternodes that an input will be mixed through.&lt;br/&gt;More rounds of mixing gives a higher degree of privacy, but also costs more in fees.</translation>
     </message>
     <message>
-        <location line="-397"/>
+        <location line="-400"/>
         <source>&amp;Network</source>
         <translation>&amp;Network</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+103"/>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
         <translation>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</translation>
     </message>
@@ -2297,12 +2343,12 @@
         <translation>M&amp;inimize on close</translation>
     </message>
     <message>
-        <location line="-81"/>
+        <location line="-84"/>
         <source>&amp;Display</source>
         <translation>&amp;Display</translation>
     </message>
     <message>
-        <location line="+728"/>
+        <location line="+731"/>
         <source>Connect to the Dash network through a separate SOCKS5 proxy for Tor onion services.</source>
         <translation>Connect to the Dash network through a separate SOCKS5 proxy for Tor onion services.</translation>
     </message>
@@ -2322,14 +2368,7 @@
         <translation>The user interface language can be set here. This setting will take effect after restarting %1.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</translation>
-    </message>
-    <message>
-        <location line="+26"/>
+        <location line="+47"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unit to show amounts in:</translation>
     </message>
@@ -2380,17 +2419,17 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+1"/>
-        <location line="+58"/>
+        <location line="+55"/>
         <source>Client restart required to activate changes.</source>
         <translation>Client restart required to activate changes.</translation>
     </message>
     <message>
-        <location line="-58"/>
+        <location line="-55"/>
         <source>Client will be shut down. Do you want to proceed?</source>
         <translation>Client will be shut down. Do you want to proceed?</translation>
     </message>
     <message>
-        <location line="+62"/>
+        <location line="+59"/>
         <source>This change would require a client restart.</source>
         <translation>This change would require a client restart.</translation>
     </message>
@@ -2408,14 +2447,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Form</translation>
     </message>
     <message>
-        <location line="+60"/>
+        <location line="+44"/>
         <location line="+298"/>
-        <location line="+237"/>
+        <location line="+224"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Dash network after a connection is established, but this process has not completed yet.</source>
         <translation>The displayed information may be out of date. Your wallet automatically synchronizes with the Dash network after a connection is established, but this process has not completed yet.</translation>
     </message>
     <message>
-        <location line="-325"/>
+        <location line="-312"/>
         <source>Available:</source>
         <translation>Available:</translation>
     </message>
@@ -2525,12 +2564,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>n/a</translation>
     </message>
     <message>
-        <location line="+119"/>
+        <location line="+106"/>
         <source>Recent transactions</source>
         <translation>Recent transactions</translation>
     </message>
     <message>
-        <location line="-81"/>
+        <location line="-68"/>
         <source>Start/Stop Mixing</source>
         <translation>Start/Stop Mixing</translation>
     </message>
@@ -2547,7 +2586,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>out of sync</translation>
     </message>
     <message>
-        <location line="+313"/>
+        <location line="+321"/>
         <source>Automatic backups are disabled, no mixing available!</source>
         <translation>Automatic backups are disabled, no mixing available!</translation>
     </message>
@@ -2558,7 +2597,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>No inputs detected</translation>
     </message>
     <message>
-        <location line="-201"/>
+        <location line="-209"/>
         <source>%1 Balance</source>
         <translation>%1 Balance</translation>
     </message>
@@ -2568,7 +2607,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Discreet mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Discreet mode.</translation>
     </message>
     <message numerus="yes">
-        <location line="+166"/>
+        <location line="+174"/>
         <location line="+20"/>
         <location line="+11"/>
         <source>%n Rounds</source>
@@ -2621,8 +2660,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>keys left: %1</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+133"/>
+        <location line="+18"/>
+        <location line="+135"/>
         <source>Start %1</source>
         <translation>Start %1</translation>
     </message>
@@ -2647,15 +2686,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Stop %1</translation>
     </message>
     <message>
-        <location line="-135"/>
+        <location line="-137"/>
         <location line="+54"/>
-        <location line="+117"/>
+        <location line="+119"/>
         <location line="+3"/>
         <source>Disabled</source>
         <translation>Disabled</translation>
     </message>
     <message>
-        <location line="-155"/>
+        <location line="-157"/>
         <source>Very low number of keys left since last automatic backup!</source>
         <translation>Very low number of keys left since last automatic backup!</translation>
     </message>
@@ -2676,23 +2715,23 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+8"/>
-        <location line="+16"/>
+        <location line="+17"/>
         <source>ERROR! Failed to create automatic backup</source>
         <translation>ERROR! Failed to create automatic backup</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
+        <location line="-16"/>
+        <location line="+18"/>
         <source>Mixing is disabled, please close your wallet and fix the issue!</source>
         <translation>Mixing is disabled, please close your wallet and fix the issue!</translation>
     </message>
     <message>
-        <location line="-11"/>
+        <location line="-12"/>
         <source>Enabled</source>
         <translation>Enabled</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+11"/>
         <source>see debug.log for details.</source>
         <translation>see debug.log for details.</translation>
     </message>
@@ -2726,8 +2765,8 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Save...</source>
-        <translation>Save...</translation>
+        <source>Save…</source>
+        <translation>Save…</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -2870,19 +2909,19 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+50"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <location line="+5"/>
         <location line="+8"/>
         <source>URI handling</source>
         <translation>URI handling</translation>
     </message>
     <message>
-        <location line="-26"/>
+        <location line="-29"/>
         <source>&apos;dash://&apos; is not a valid URI. Use &apos;dash:&apos; instead.</source>
         <translation>&apos;dash://&apos; is not a valid URI. Use &apos;dash:&apos; instead.</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+17"/>
         <location line="+23"/>
         <source>Cannot process payment request as BIP70 is no longer supported.</source>
         <translation>Cannot process payment request as BIP70 is no longer supported.</translation>
@@ -2894,12 +2933,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Due to discontinued support, you should request the merchant to provide you with a BIP21 compatible URI or use a wallet that does continue to support BIP70.</translation>
     </message>
     <message>
-        <location line="-20"/>
-        <source>Invalid payment address %1</source>
-        <translation>Invalid payment address %1</translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="-11"/>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</translation>
     </message>
@@ -2912,38 +2946,51 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.h" line="+86"/>
+        <location filename="../peertablemodel.h" line="+115"/>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer&apos;s User Agent string.</extracomment>
         <translation>User Agent</translation>
     </message>
     <message>
-        <location line="+0"/>
+        <location line="-9"/>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
-        <location line="+0"/>
+        <location line="-12"/>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation>Peer</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The &quot;type&quot; describes why the connection exists.</extracomment>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location line="+9"/>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Sent</translation>
     </message>
     <message>
-        <location line="+0"/>
+        <location line="+3"/>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Received</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <source>Peer Id</source>
-        <translation>Peer Id</translation>
-    </message>
-    <message>
-        <location line="+0"/>
+        <location line="-15"/>
         <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation>Address</translation>
     </message>
     <message>
-        <location line="+0"/>
+        <location line="+6"/>
         <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
         <translation>Network</translation>
     </message>
 </context>
@@ -3011,7 +3058,7 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="-327"/>
+        <location filename="../bitcoin.cpp" line="-339"/>
         <source>Do you want to reset settings to default values, or to abort without making changes?</source>
         <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
         <translation>Do you want to reset settings to default values, or to abort without making changes?</translation>
@@ -3023,7 +3070,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>A fatal error occured. Check that settings file is writable, or try running with -nosettings.</translation>
     </message>
     <message>
-        <location line="+328"/>
+        <location line="+341"/>
         <source>Choose data directory on startup (default: %u)</source>
         <translation>Choose data directory on startup (default: %u)</translation>
     </message>
@@ -3068,7 +3115,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Show splash screen on startup (default: %u)</translation>
     </message>
     <message>
-        <location line="+94"/>
+        <location line="+95"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Error: Specified data directory &quot;%1&quot; does not exist.</translation>
     </message>
@@ -3119,8 +3166,8 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+32"/>
-        <source>%1 didn&apos;t yet exit safely...</source>
-        <translation>%1 didn&apos;t yet exit safely...</translation>
+        <source>%1 didn&apos;t yet exit safely…</source>
+        <translation>%1 didn&apos;t yet exit safely…</translation>
     </message>
     <message>
         <location filename="../bitcoinunits.cpp" line="+256"/>
@@ -3128,7 +3175,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Amount</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+279"/>
+        <location filename="../guiutil.cpp" line="+295"/>
         <source>Enter a Dash address (e.g. %1)</source>
         <translation>Enter a Dash address (e.g. %1)</translation>
     </message>
@@ -3148,7 +3195,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>This can also be adjusted later in the &quot;Appearance&quot; tab of the preferences.</translation>
     </message>
     <message>
-        <location line="+1346"/>
+        <location line="+319"/>
+        <source>Ctrl+W</source>
+        <translation>Ctrl+W</translation>
+    </message>
+    <message>
+        <location line="+1034"/>
         <source>Unroutable</source>
         <translation>Unroutable</translation>
     </message>
@@ -3158,38 +3210,80 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Internal</translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+13"/>
+        <source>Inbound</source>
+        <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
+        <translation>Inbound</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Outbound</source>
+        <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
+        <translation>Outbound</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation>Full Relay</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation>Block Relay</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation>Manual</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation>Feeler</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation>Address Fetch</translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <source>%1 d</source>
         <translation>%1 d</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+26"/>
+        <location line="+27"/>
         <source>%1 s</source>
         <translation>%1 s</translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-12"/>
         <source>None</source>
         <translation>None</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="+0"/>
+        <location line="+1"/>
         <source>%1 ms</source>
         <translation>%1 ms</translation>
     </message>
@@ -3287,16 +3381,16 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+46"/>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Save Image...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Save Image…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
         <location filename="../qrimagewidget.cpp" line="+30"/>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Save Image...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Save Image…</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -3374,32 +3468,38 @@ https://www.transifex.com/projects/p/dash/</translation>
         <location line="+23"/>
         <location line="+26"/>
         <location line="+23"/>
+        <location line="+26"/>
+        <location line="+23"/>
+        <location line="+23"/>
+        <location line="+26"/>
+        <location line="+26"/>
+        <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
+        <location line="+23"/>
+        <location line="+26"/>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+26"/>
-        <location filename="../rpcconsole.cpp" line="+1265"/>
+        <location line="+26"/>
+        <location line="+26"/>
+        <location line="+26"/>
+        <location filename="../rpcconsole.cpp" line="+1324"/>
         <location line="+8"/>
         <location line="+4"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-1162"/>
+        <location line="-1324"/>
         <source>Number of connections</source>
         <translation>Number of connections</translation>
     </message>
@@ -3470,7 +3570,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Network Traffic</translation>
     </message>
     <message>
-        <location line="+1246"/>
+        <location line="+1330"/>
         <source>Received</source>
         <translation>Received</translation>
     </message>
@@ -3480,7 +3580,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Sent</translation>
     </message>
     <message>
-        <location line="-1213"/>
+        <location line="-1297"/>
         <source>&amp;Peers</source>
         <translation>&amp;Peers</translation>
     </message>
@@ -3496,23 +3596,37 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+63"/>
-        <location filename="../rpcconsole.cpp" line="-763"/>
-        <location line="+930"/>
+        <location filename="../rpcconsole.cpp" line="-44"/>
         <source>Select a peer to view detailed information.</source>
         <translation>Select a peer to view detailed information.</translation>
     </message>
     <message>
-        <location line="+126"/>
-        <source>Direction</source>
-        <translation>Direction</translation>
-    </message>
-    <message>
-        <location line="+23"/>
+        <location line="+152"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
         <location line="+72"/>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation>Whether the peer requested us to relay transactions.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Wants Tx Relay</source>
+        <translation>Wants Tx Relay</translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation>High bandwidth BIP152 compact block relay: %1</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>High Bandwidth</source>
+        <translation>High Bandwidth</translation>
+    </message>
+    <message>
+        <location line="+23"/>
         <source>Starting Block</source>
         <translation>Starting Block</translation>
     </message>
@@ -3527,7 +3641,28 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Synced Blocks</translation>
     </message>
     <message>
-        <location line="+256"/>
+        <location line="+46"/>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation>Elapsed time since a novel block passing initial validity checks was received from this peer.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Last Block</source>
+        <translation>Last Block</translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Last Transaction</source>
+        <translation>Last Transaction</translation>
+    </message>
+    <message>
+        <location line="+210"/>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation>The mapped Autonomous System used for diversifying peer selection.</translation>
     </message>
@@ -3535,6 +3670,39 @@ https://www.transifex.com/projects/p/dash/</translation>
         <location line="+3"/>
         <source>Mapped AS</source>
         <translation>Mapped AS</translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <translation>Whether we relay addresses to this peer.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Address Relay</source>
+        <translation>Address Relay</translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
+        <translation>Total number of addresses processed, excluding those dropped due to rate-limiting.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Addresses Processed</source>
+        <translation>Addresses Processed</translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Total number of addresses dropped due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
+        <translation>Total number of addresses dropped due to rate-limiting.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Addresses Rate-Limited</source>
+        <translation>Addresses Rate-Limited</translation>
     </message>
     <message>
         <location line="+81"/>
@@ -3562,13 +3730,13 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</translation>
     </message>
     <message>
-        <location line="-1400"/>
-        <location line="+935"/>
+        <location line="-1562"/>
+        <location line="+938"/>
         <source>User Agent</source>
         <translation>User Agent</translation>
     </message>
     <message>
-        <location line="-909"/>
+        <location line="-912"/>
         <source>Datadir</source>
         <translation>Datadir</translation>
     </message>
@@ -3668,22 +3836,27 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Permissions</translation>
     </message>
     <message>
-        <location line="+95"/>
+        <location line="+23"/>
+        <source>The direction and type of peer connection: %1</source>
+        <translation>The direction and type of peer connection: %1</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Direction/Type</source>
+        <translation>Direction/Type</translation>
+    </message>
+    <message>
+        <location line="+72"/>
         <source>Services</source>
         <translation>Services</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <source>Ban Score</source>
-        <translation>Ban Score</translation>
-    </message>
-    <message>
-        <location line="+23"/>
+        <location line="+144"/>
         <source>Connection Time</source>
         <translation>Connection Time</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+75"/>
         <source>Last Send</source>
         <translation>Last Send</translation>
     </message>
@@ -3718,12 +3891,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Time Offset</translation>
     </message>
     <message>
-        <location line="-1321"/>
+        <location line="-1405"/>
         <source>&amp;Wallet Repair</source>
         <translation>&amp;Wallet Repair</translation>
     </message>
     <message>
-        <location line="+1398"/>
+        <location line="+1560"/>
         <source>Wallet repair options.</source>
         <translation>Wallet repair options.</translation>
     </message>
@@ -3738,7 +3911,73 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-reindex: Rebuild block chain index from current blk000??.dat files.</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-805"/>
+        <location filename="../rpcconsole.cpp" line="-783"/>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation>Inbound: initiated by peer</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation>Outbound Full Relay: default</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation>Outbound Block Relay: does not relay transactions or addresses</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation>Outbound Manual: added using RPC %1 or %2/%3 configuration options</translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation>Outbound Feeler: short-lived, for testing addresses</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation>Outbound Address Fetch: short-lived, for soliciting addresses</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>To</source>
+        <translation>To</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation>we selected the peer for high bandwidth relay</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>From</source>
+        <translation>From</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation>the peer selected us for high bandwidth relay</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No</source>
+        <translation>No</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no high bandwidth relay selected</source>
+        <translation>no high bandwidth relay selected</translation>
+    </message>
+    <message>
+        <location line="+173"/>
         <source>&amp;Disconnect</source>
         <translation>&amp;Disconnect</translation>
     </message>
@@ -3776,7 +4015,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Unban</translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+222"/>
         <source>Welcome to the %1 RPC console.</source>
         <translation>Welcome to the %1 RPC console.</translation>
     </message>
@@ -3827,43 +4066,47 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Executing command without any wallet</translation>
     </message>
     <message>
-        <location line="+182"/>
-        <source>(peer id: %1)</source>
-        <translation>(peer id: %1)</translation>
+        <location line="+394"/>
+        <source>Ctrl+Shift+I</source>
+        <translation>Ctrl+Shift+I</translation>
     </message>
     <message>
-        <location line="-184"/>
+        <location line="+1"/>
+        <source>Ctrl+Shift+C</source>
+        <translation>Ctrl+Shift+C</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Ctrl+Shift+G</source>
+        <translation>Ctrl+Shift+G</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Ctrl+Shift+P</source>
+        <translation>Ctrl+Shift+P</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Ctrl+Shift+R</source>
+        <translation>Ctrl+Shift+R</translation>
+    </message>
+    <message>
+        <location line="-400"/>
         <source>Executing command using &quot;%1&quot; wallet</source>
         <translation>Executing command using &quot;%1&quot; wallet</translation>
     </message>
     <message>
-        <location line="+186"/>
+        <location line="+172"/>
+        <source>(peer: %1)</source>
+        <translation>(peer: %1)</translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>via %1</source>
         <translation>via %1</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+1"/>
-        <source>never</source>
-        <translation>never</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Inbound</source>
-        <translation>Inbound</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Outbound</source>
-        <translation>Outbound</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Outbound block-relay</source>
-        <translation>Outbound block-relay</translation>
-    </message>
-    <message>
-        <location line="+15"/>
+        <location line="+35"/>
         <source>Regular</source>
         <translation>Regular</translation>
     </message>
@@ -3878,10 +4121,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Verified Masternode</translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+12"/>
         <location line="+6"/>
         <source>Unknown</source>
         <translation>Unknown</translation>
+    </message>
+    <message>
+        <location filename="../rpcconsole.h" line="+198"/>
+        <source>Never</source>
+        <translation>Never</translation>
     </message>
 </context>
 <context>
@@ -4007,13 +4255,23 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Copy amount</translation>
     </message>
+    <message>
+        <location line="+120"/>
+        <source>Could not unlock wallet.</source>
+        <translation>Could not unlock wallet.</translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Could not generate new address</source>
+        <translation>Could not generate new address</translation>
+    </message>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
         <location filename="../forms/receiverequestdialog.ui" line="+14"/>
-        <source>Request payment to ...</source>
-        <translation>Request payment to ...</translation>
+        <source>Request payment to …</source>
+        <translation>Request payment to …</translation>
     </message>
     <message>
         <location line="+76"/>
@@ -4052,8 +4310,8 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Save Image...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Save Image…</translation>
     </message>
     <message>
         <location filename="../receiverequestdialog.cpp" line="+52"/>
@@ -4069,7 +4327,7 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+27"/>
+        <location filename="../recentrequeststablemodel.cpp" line="+29"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
@@ -4108,7 +4366,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+760"/>
+        <location filename="../sendcoinsdialog.cpp" line="+762"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
@@ -4118,12 +4376,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Coin Control Features</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <source>Inputs...</source>
-        <translation>Inputs...</translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+30"/>
         <source>automatically selected</source>
         <translation>automatically selected</translation>
     </message>
@@ -4158,7 +4411,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Dust:</translation>
     </message>
     <message>
-        <location line="+87"/>
+        <location line="-200"/>
+        <source>Inputs…</source>
+        <translation>Inputs…</translation>
+    </message>
+    <message>
+        <location line="+287"/>
         <source>After Fee:</source>
         <translation>After Fee:</translation>
     </message>
@@ -4183,12 +4441,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Transaction Fee:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <source>Choose...</source>
-        <translation>Choose...</translation>
-    </message>
-    <message>
-        <location line="+150"/>
+        <location line="+164"/>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
         <translation>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</translation>
     </message>
@@ -4198,7 +4451,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>A too low fee might result in a never confirming transaction (read the tooltip)</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+117"/>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Smart fee not initialized yet. This usually takes a few blocks…)</translation>
+    </message>
+    <message>
+        <location line="+26"/>
         <source>Confirmation time target:</source>
         <translation>Confirmation time target:</translation>
     </message>
@@ -4218,7 +4476,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="-22"/>
+        <source>Choose…</source>
+        <translation>Choose…</translation>
+    </message>
+    <message>
+        <location line="+25"/>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
         <translation>Note: Not enough data for fee estimation, using the fallback fee instead.</translation>
     </message>
@@ -4243,13 +4506,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Custom:</translation>
     </message>
     <message>
-        <location line="+52"/>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Smart fee not initialized yet. This usually takes a few blocks...)</translation>
-    </message>
-    <message>
-        <location line="+113"/>
-        <location filename="../sendcoinsdialog.cpp" line="-608"/>
+        <location line="+165"/>
+        <location filename="../sendcoinsdialog.cpp" line="-610"/>
         <source>Confirm the send action</source>
         <translation>Confirm the send action</translation>
     </message>
@@ -4320,7 +4578,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Copy change</translation>
     </message>
     <message>
-        <location line="+94"/>
+        <location line="+96"/>
         <source>%1 (%2 blocks)</source>
         <translation>%1 (%2 blocks)</translation>
     </message>
@@ -4351,7 +4609,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&lt;b&gt;(%1 of %2 entries displayed)&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="-244"/>
+        <location line="-246"/>
         <source>S&amp;end mixed funds</source>
         <translation>S&amp;end mixed funds</translation>
     </message>
@@ -4361,7 +4619,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Confirm the %1 send action</translation>
     </message>
     <message>
-        <location line="+80"/>
+        <location line="+82"/>
         <source>Cr&amp;eate Unsigned</source>
         <translation>Cr&amp;eate Unsigned</translation>
     </message>
@@ -4444,12 +4702,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>or</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>To review recipient list click &quot;Show Details...&quot;</source>
-        <translation>To review recipient list click &quot;Show Details...&quot;</translation>
-    </message>
-    <message>
-        <location line="+16"/>
+        <location line="+19"/>
         <source>Confirm send coins</source>
         <translation>Confirm send coins</translation>
     </message>
@@ -4484,7 +4737,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Send</translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="-17"/>
+        <source>To review recipient list click &quot;Show Details…&quot;</source>
+        <translation>To review recipient list click &quot;Show Details…&quot;</translation>
+    </message>
+    <message>
+        <location line="+63"/>
         <source>Partially Signed Transaction (Binary)</source>
         <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
         <translation>Partially Signed Transaction (Binary)</translation>
@@ -4672,8 +4930,8 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>ShutdownWindow</name>
     <message>
         <location filename="../utilitydialog.cpp" line="+74"/>
-        <source>%1 is shutting down...</source>
-        <translation>%1 is shutting down...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 is shutting down…</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -5298,7 +5556,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+231"/>
+        <location line="+233"/>
         <source>(no label)</source>
         <translation>(no label)</translation>
     </message>
@@ -5368,8 +5626,8 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Range...</source>
-        <translation>Range...</translation>
+        <source>Range…</source>
+        <translation>Range…</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -5558,7 +5816,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>The transaction history was successfully saved to %1.</translation>
     </message>
     <message>
-        <location line="+161"/>
+        <location line="+158"/>
         <source>QR code</source>
         <translation>QR code</translation>
     </message>
@@ -5584,7 +5842,7 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>WalletController</name>
     <message>
-        <location filename="../walletcontroller.cpp" line="-247"/>
+        <location filename="../walletcontroller.cpp" line="-250"/>
         <source>Close wallet</source>
         <translation>Close wallet</translation>
     </message>
@@ -5612,7 +5870,7 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+40"/>
+        <location filename="../walletframe.cpp" line="+41"/>
         <source>No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
@@ -5629,12 +5887,12 @@ Go to File &gt; Open Wallet to load a wallet.
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+261"/>
+        <location filename="../walletmodel.cpp" line="+265"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
     <message>
-        <location line="+341"/>
+        <location line="+322"/>
         <source>default wallet</source>
         <translation>default wallet</translation>
     </message>
@@ -5728,7 +5986,7 @@ Go to File &gt; Open Wallet to load a wallet.
 <context>
     <name>dash-core</name>
     <message>
-        <location filename="../dashstrings.cpp" line="+38"/>
+        <location filename="../dashstrings.cpp" line="+51"/>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation>Error: Listening for incoming connections failed (listen returned error %s)</translation>
     </message>
@@ -5738,7 +5996,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</translation>
     </message>
     <message>
-        <location line="+41"/>
+        <location line="+63"/>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
         <translation>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</translation>
     </message>
@@ -5748,12 +6006,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+37"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+20"/>
         <source>Already have that input.</source>
         <translation>Already have that input.</translation>
     </message>
@@ -5778,12 +6036,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Done loading</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Entries are full.</source>
         <translation>Entries are full.</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Error initializing block database</source>
         <translation>Error initializing block database</translation>
     </message>
@@ -5808,22 +6066,37 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Error reading from database, shutting down.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+10"/>
+        <source>Error: Missing checksum</source>
+        <translation>Error: Missing checksum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation>Error: Unable to parse version %u as a uint32_t</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation>Error: Unable to write record to new wallet</translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Failed to listen on any port. Use -listen=0 if you want this.</translation>
     </message>
     <message>
-        <location line="-160"/>
+        <location line="-213"/>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+8"/>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
         <translation>Cannot provide specific connections and have addrman find outgoing connections at the same.</translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+33"/>
         <source>Found unconfirmed denominated outputs, will wait till they confirm to continue.</source>
         <translation>Found unconfirmed denominated outputs, will wait till they confirm to continue.</translation>
     </message>
@@ -5838,42 +6111,32 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+39"/>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
         <translation>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+28"/>
         <source>Transaction index can&apos;t be disabled with governance validation enabled. Either start with -disablegovernance command line switch or enable transaction index.</source>
         <translation>Transaction index can&apos;t be disabled with governance validation enabled. Either start with -disablegovernance command line switch or enable transaction index.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <location line="+47"/>
         <source>Can&apos;t mix: no compatible inputs found!</source>
         <translation>Can&apos;t mix: no compatible inputs found!</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+17"/>
         <source>Entry exceeds maximum size.</source>
         <translation>Entry exceeds maximum size.</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+41"/>
         <source>Found enough users, signing ( waiting %s )</source>
         <translation>Found enough users, signing ( waiting %s )</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Found enough users, signing ...</source>
-        <translation>Found enough users, signing ...</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Importing...</source>
-        <translation>Importing...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+4"/>
         <source>Incompatible mode.</source>
         <translation>Incompatible mode.</translation>
     </message>
@@ -5913,22 +6176,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Invalid minimum number of spork signers specified with -minsporkkeys</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Loading banlist...</source>
-        <translation>Loading banlist...</translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Lock is already in place.</source>
         <translation>Lock is already in place.</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>Mixing in progress...</source>
-        <translation>Mixing in progress...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+5"/>
         <source>Need to specify a port with -whitebind: &apos;%s&apos;</source>
         <translation>Need to specify a port with -whitebind: &apos;%s&apos;</translation>
     </message>
@@ -5953,7 +6206,27 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Not in the Masternode list.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+5"/>
+        <source>Pruning blockstore…</source>
+        <translation>Pruning blockstore…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Replaying blocks…</source>
+        <translation>Replaying blocks…</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Rescanning…</source>
+        <translation>Rescanning…</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Starting network threads…</source>
+        <translation>Starting network threads…</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Submitted to masternode, waiting in queue %s</translation>
     </message>
@@ -5963,7 +6236,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Synchronization finished</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+1"/>
+        <source>Synchronizing blockchain…</source>
+        <translation>Synchronizing blockchain…</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronizing governance objects…</source>
+        <translation>Synchronizing governance objects…</translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation>Unable to start HTTP server. See debug log for details.</translation>
     </message>
@@ -5976,16 +6259,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <location line="+5"/>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>User Agent comment (%s) contains unsafe characters.</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Verifying wallet(s)...</source>
-        <translation>Verifying wallet(s)...</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Will retry...</source>
-        <translation>Will retry...</translation>
     </message>
     <message>
         <location line="-167"/>
@@ -6008,7 +6281,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Can&apos;t mix while sync in progress.</translation>
     </message>
     <message>
-        <location line="+74"/>
+        <location line="+82"/>
         <source>Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
         <translation>Invalid netmask specified in -whitelist: &apos;%s&apos;</translation>
     </message>
@@ -6018,17 +6291,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Invalid script detected.</translation>
     </message>
     <message>
-        <location line="-198"/>
+        <location line="-251"/>
         <source>%s file contains all private keys from this wallet. Do not share it with anyone!</source>
         <translation>%s file contains all private keys from this wallet. Do not share it with anyone!</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+37"/>
         <source>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
         <translation>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+25"/>
         <source>Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</source>
         <translation>Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</translation>
     </message>
@@ -6038,7 +6311,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+24"/>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <translation>Prune configured below the minimum of %d MiB.  Please use a higher number.</translation>
     </message>
@@ -6058,7 +6331,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>The transaction amount is too small to send after the fee has been deducted</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+17"/>
         <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
         <translation>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</translation>
     </message>
@@ -6068,7 +6341,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Transaction needs a change address, but we can&apos;t generate it. Please call keypoolrefill first.</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+9"/>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
         <translation>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</translation>
     </message>
@@ -6078,7 +6351,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Wallet is locked, can&apos;t replenish keypool! Automatic backups and mixing are disabled, please unlock your wallet to replenish keypool.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+11"/>
         <source>You need to rebuild the database using -reindex to change -timestampindex</source>
         <translation>You need to rebuild the database using -reindex to change -timestampindex</translation>
     </message>
@@ -6088,7 +6361,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>%s failed</source>
         <translation>%s failed</translation>
     </message>
@@ -6123,19 +6396,24 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Could not parse asmap file %s</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>ERROR! Failed to create automatic backup</source>
         <translation>ERROR! Failed to create automatic backup</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
         <translation>Error loading %s: Private keys can only be disabled during creation</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+9"/>
         <source>Error upgrading evo database</source>
         <translation>Error upgrading evo database</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Couldn&apos;t create cursor into database</source>
+        <translation>Error: Couldn&apos;t create cursor into database</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6144,16 +6422,26 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+1"/>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation>Error: Dumpfile checksum does not match. Computed %s, expected %s</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation>Error: Got key that was not hex: %s</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation>Error: Got value that was not hex: %s</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation>Error: Keypool ran out, please call keypoolrefill first</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+4"/>
         <source>Exceeded max tries.</source>
         <translation>Exceeded max tries.</translation>
     </message>
@@ -6188,7 +6476,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Failed to verify database</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
+        <source>Found enough users, signing…</source>
+        <translation>Found enough users, signing…</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation>Ignoring duplicate -wallet %s.</translation>
     </message>
@@ -6208,17 +6501,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Invalid masternodeblsprivkey. Please see documentation.</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <source>Loading block index...</source>
-        <translation>Loading block index...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Loading wallet...</source>
-        <translation>Loading wallet...</translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+12"/>
         <source>Masternode queue is full.</source>
         <translation>Masternode queue is full.</translation>
     </message>
@@ -6233,7 +6516,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Missing input transaction information.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+1"/>
+        <source>Mixing in progress…</source>
+        <translation>Mixing in progress…</translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>No errors detected.</source>
         <translation>No errors detected.</translation>
     </message>
@@ -6273,12 +6561,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Prune mode is incompatible with -txindex.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Pruning blockstore...</source>
-        <translation>Pruning blockstore...</translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
         <translation>SQLiteDatabase: Failed to execute statement to verify database: %s</translation>
     </message>
@@ -6318,12 +6601,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Specified -walletdir &quot;%s&quot; is not a directory</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Synchronizing blockchain...</source>
-        <translation>Synchronizing blockchain...</translation>
-    </message>
-    <message>
-        <location line="+5"/>
+        <location line="+10"/>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
         <translation>The wallet will avoid paying less than the minimum relay fee.</translation>
     </message>
@@ -6343,7 +6621,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>This is the transaction fee you will pay if you send a transaction.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
+        <source>Topping up keypool…</source>
+        <translation>Topping up keypool…</translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Transaction amounts must not be negative</source>
         <translation>Transaction amounts must not be negative</translation>
     </message>
@@ -6363,12 +6646,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Transaction too large</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Trying to connect...</source>
-        <translation>Trying to connect...</translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Unable to bind to %s on this computer. %s is probably already running.</translation>
     </message>
@@ -6383,7 +6661,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Unable to generate initial keys</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
+        <source>Unable to open %s for writing</source>
+        <translation>Unable to open %s for writing</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Unknown -blockfilterindex value %s.</source>
         <translation>Unknown -blockfilterindex value %s.</translation>
     </message>
@@ -6398,7 +6681,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Upgrading UTXO database</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+3"/>
+        <source>Verifying blocks…</source>
+        <translation>Verifying blocks…</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Verifying wallet(s)…</source>
+        <translation>Verifying wallet(s)…</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation>Wallet needed to be rewritten: restart %s to complete</translation>
     </message>
@@ -6408,7 +6701,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Wasn&apos;t able to create wallet backup folder %s!</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+2"/>
+        <source>Wiping wallet transactions…</source>
+        <translation>Wiping wallet transactions…</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>You can not start a masternode with wallet enabled.</source>
         <translation>You can not start a masternode with wallet enabled.</translation>
     </message>
@@ -6433,7 +6731,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>see debug.log for details.</translation>
     </message>
     <message>
-        <location line="-302"/>
+        <location line="-356"/>
         <source>The %s developers</source>
         <translation>The %s developers</translation>
     </message>
@@ -6444,11 +6742,21 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+6"/>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation>Cannot obtain a lock on data directory %s. %s is probably already running.</translation>
     </message>
     <message>
         <location line="+5"/>
+        <source>Cannot upgrade a non HD wallet from version %i to version %i which is non-HD wallet. Use upgradetohd RPC</source>
+        <translation>Cannot upgrade a non HD wallet from version %i to version %i which is non-HD wallet. Use upgradetohd RPC</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation>Distributed under the MIT software license, see the accompanying file %s or %s</translation>
     </message>
@@ -6463,12 +6771,62 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+3"/>
+        <source>Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
+        <translation>Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
+        <translation>Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation>File %s already exists. If you are sure this is what you want, move it out of the way first.</translation>
+    </message>
+    <message>
+        <location line="+6"/>
         <source>Incorrect or no devnet genesis block found. Wrong datadir for devnet specified?</source>
         <translation>Incorrect or no devnet genesis block found. Wrong datadir for devnet specified?</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+8"/>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
         <translation>Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</translation>
     </message>
@@ -6479,6 +6837,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+25"/>
+        <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <translation>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
         <translation>This is the transaction fee you may discard if change is smaller than dust at this level</translation>
     </message>
@@ -6493,12 +6856,27 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</translation>
     </message>
     <message>
+        <location line="+3"/>
+        <source>Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
+        <translation>Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</translation>
+    </message>
+    <message>
         <location line="+8"/>
+        <source>Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
+        <translation>Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation>Warning: Private keys detected in wallet {%s} with disabled private keys</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+10"/>
+        <source>%s -- Incorrect seed, it should be a hex string</source>
+        <translation>%s -- Incorrect seed, it should be a hex string</translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>%s is not a valid backup folder!</source>
         <translation>%s is not a valid backup folder!</translation>
     </message>
@@ -6558,7 +6936,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Disk space is too low!</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+3"/>
+        <source>Dump file %s does not exist.</source>
+        <translation>Dump file %s does not exist.</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Error creating %s</source>
+        <translation>Error creating %s</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Error loading %s</source>
         <translation>Error loading %s</translation>
     </message>
@@ -6579,16 +6967,36 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+4"/>
+        <source>Error reading next record from wallet database</source>
+        <translation>Error reading next record from wallet database</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Error upgrading chainstate database</source>
         <translation>Error upgrading chainstate database</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Error: failed to add socket to kqueuefd (kevent returned error %s)</translation>
+        <location line="+56"/>
+        <source>Loading P2P addresses…</source>
+        <translation>Loading P2P addresses…</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
+        <source>Loading banlist…</source>
+        <translation>Loading banlist…</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Loading block index…</source>
+        <translation>Loading block index…</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Loading wallet…</source>
+        <translation>Loading wallet…</translation>
+    </message>
+    <message>
+        <location line="-47"/>
         <source>Failed to clear fulfilled requests cache at %s</source>
         <translation>Failed to clear fulfilled requests cache at %s</translation>
     </message>
@@ -6633,7 +7041,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Failed to start a new mixing queue</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+5"/>
+        <source>Importing…</source>
+        <translation>Importing…</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Incorrect -rescan mode, falling back to default value</translation>
     </message>
@@ -6678,12 +7091,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Invalid spork address specified with -sporkaddr</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Loading P2P addresses...</source>
-        <translation>Loading P2P addresses...</translation>
-    </message>
-    <message>
-        <location line="+20"/>
+        <location line="+23"/>
         <source>Prune mode is incompatible with -coinstatsindex.</source>
         <translation>Prune mode is incompatible with -coinstatsindex.</translation>
     </message>
@@ -6693,17 +7101,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Reducing -maxconnections from %d to %d, because of system limitations.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Replaying blocks...</source>
-        <translation>Replaying blocks...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Rescanning...</source>
-        <translation>Rescanning...</translation>
-    </message>
-    <message>
-        <location line="+6"/>
+        <location line="+8"/>
         <source>Session not complete!</source>
         <translation>Session not complete!</translation>
     </message>
@@ -6728,27 +7126,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Last queue was created too recently.</translation>
     </message>
     <message>
-        <location line="-203"/>
+        <location line="-256"/>
         <source>%s corrupt. Try using the wallet tool dash-wallet to salvage or restoring a backup.</source>
         <translation>%s corrupt. Try using the wallet tool dash-wallet to salvage or restoring a backup.</translation>
     </message>
     <message>
-        <location line="+204"/>
+        <location line="+257"/>
         <source>Last successful action was too recent.</source>
         <translation>Last successful action was too recent.</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <source>Starting network threads...</source>
-        <translation>Starting network threads...</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Synchronizing governance objects...</source>
-        <translation>Synchronizing governance objects...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+45"/>
         <source>The source code is available from %s.</source>
         <translation>The source code is available from %s.</translation>
     </message>
@@ -6768,12 +7156,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>This is experimental software.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Topping up keypool...</source>
-        <translation>Topping up keypool...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+4"/>
         <source>Transaction amount too small</source>
         <translation>Transaction amount too small</translation>
     </message>
@@ -6793,7 +7176,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Transaction not valid.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
+        <source>Trying to connect…</source>
+        <translation>Trying to connect…</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
         <translation>Unable to bind to %s on this computer (bind returned error %s)</translation>
     </message>
@@ -6808,7 +7196,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Unable to locate enough non-denominated funds for this transaction.</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Unable to sign spork message, wrong key?</source>
         <translation>Unable to sign spork message, wrong key?</translation>
     </message>
@@ -6833,12 +7221,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Upgrading txindex database</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Verifying blocks...</source>
-        <translation>Verifying blocks...</translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+4"/>
         <source>Very low number of keys left: %d</source>
         <translation>Very low number of keys left: %d</translation>
     </message>
@@ -6858,12 +7241,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Warning: incorrect parameter %s, path must exist! Using default path.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Wiping wallet transactions...</source>
-        <translation>Wiping wallet transactions...</translation>
+        <location line="+2"/>
+        <source>Will retry…</source>
+        <translation>Will retry…</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>You are starting with governance validation disabled.</source>
         <translation>You are starting with governance validation disabled.</translation>
     </message>

--- a/src/qt/locale/dash_en.xlf
+++ b/src/qt/locale/dash_en.xlf
@@ -136,15 +136,15 @@
         <target xml:space="preserve">Export Address List</target>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg27">
+      <trans-unit id="_msg27" approved="yes">
         <source xml:space="preserve">Comma separated file</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Comma separated file</target>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</note>
       </trans-unit>
-      <trans-unit id="_msg28">
+      <trans-unit id="_msg28" approved="yes">
         <source xml:space="preserve">There was an error trying to save the address list to %1. Please try again.</source>
-        <target xml:space="preserve" state="needs-review-translation">There was an error trying to save the address list to %1. Please try again.</target>
+        <target xml:space="preserve">There was an error trying to save the address list to %1. Please try again.</target>
         <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
         <note annotates="source" from="developer">An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</note>
       </trans-unit>
@@ -170,7 +170,7 @@
       <trans-unit id="_msg32" approved="yes">
         <source xml:space="preserve">(no label)</source>
         <target xml:space="preserve">(no label)</target>
-        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -394,12 +394,12 @@
       <trans-unit id="_msg71" approved="yes">
         <source xml:space="preserve">IP/Netmask</source>
         <target xml:space="preserve">IP/Netmask</target>
-        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
       <trans-unit id="_msg72" approved="yes">
         <source xml:space="preserve">Banned Until</source>
         <target xml:space="preserve">Banned Until</target>
-        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -412,891 +412,921 @@
       </trans-unit>
     </group>
   </body></file>
-  <file original="../bitcoingui.cpp" datatype="cpp" source-language="en" target-language="en"><body>
-    <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
-      <trans-unit id="_msg74" approved="yes">
-        <source xml:space="preserve">&amp;Overview</source>
-        <target xml:space="preserve">&amp;Overview</target>
-        <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
+  <file original="../bitcoin.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BitcoinApplication">
+      <trans-unit id="_msg74">
+        <source xml:space="preserve">Runaway exception</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg75" approved="yes">
-        <source xml:space="preserve">Show general overview of wallet</source>
-        <target xml:space="preserve">Show general overview of wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">680</context></context-group>
+      <trans-unit id="_msg75">
+        <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <target xml:space="preserve" state="needs-review-translation">A fatal error occurred. %1 can no longer continue safely and will quit.</target>
+        <context-group purpose="location"><context context-type="linenumber">499</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg76" approved="yes">
-        <source xml:space="preserve">&amp;Send</source>
-        <target xml:space="preserve">&amp;Send</target>
-        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      <trans-unit id="_msg76">
+        <source xml:space="preserve">Internal error</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">508</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg77" approved="yes">
-        <source xml:space="preserve">Send coins to a Dash address</source>
-        <target xml:space="preserve">Send coins to a Dash address</target>
-        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      <trans-unit id="_msg77">
+        <source xml:space="preserve">An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">509</context></context-group>
       </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="QObject">
       <trans-unit id="_msg78" approved="yes">
-        <source xml:space="preserve">&amp;Receive</source>
-        <target xml:space="preserve">&amp;Receive</target>
-        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+        <source xml:space="preserve">Do you want to reset settings to default values, or to abort without making changes?</source>
+        <target xml:space="preserve">Do you want to reset settings to default values, or to abort without making changes?</target>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
+        <note annotates="source" from="developer">Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</note>
       </trans-unit>
       <trans-unit id="_msg79" approved="yes">
-        <source xml:space="preserve">Request payments (generates QR codes and dash: URIs)</source>
-        <target xml:space="preserve">Request payments (generates QR codes and dash: URIs)</target>
-        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+        <source xml:space="preserve">A fatal error occured. Check that settings file is writable, or try running with -nosettings.</source>
+        <target xml:space="preserve">A fatal error occured. Check that settings file is writable, or try running with -nosettings.</target>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
+        <note annotates="source" from="developer">Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</note>
       </trans-unit>
       <trans-unit id="_msg80" approved="yes">
-        <source xml:space="preserve">&amp;Sending addresses</source>
-        <target xml:space="preserve">&amp;Sending addresses</target>
-        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
+        <source xml:space="preserve">Choose data directory on startup (default: %u)</source>
+        <target xml:space="preserve">Choose data directory on startup (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">534</context></context-group>
       </trans-unit>
       <trans-unit id="_msg81" approved="yes">
-        <source xml:space="preserve">&amp;Receiving addresses</source>
-        <target xml:space="preserve">&amp;Receiving addresses</target>
-        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+        <source xml:space="preserve">Set the font family. Possible values: %1. (default: %2)</source>
+        <target xml:space="preserve">Set the font family. Possible values: %1. (default: %2)</target>
+        <context-group purpose="location"><context context-type="linenumber">536</context></context-group>
       </trans-unit>
       <trans-unit id="_msg82" approved="yes">
-        <source xml:space="preserve">Open Wallet</source>
-        <target xml:space="preserve">Open Wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg83" approved="yes">
-        <source xml:space="preserve">Open a wallet</source>
-        <target xml:space="preserve">Open a wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg84" approved="yes">
-        <source xml:space="preserve">Close Wallet...</source>
-        <target xml:space="preserve">Close Wallet...</target>
-        <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg85" approved="yes">
-        <source xml:space="preserve">Close wallet</source>
-        <target xml:space="preserve">Close wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">448</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg86" approved="yes">
-        <source xml:space="preserve">No wallets available</source>
-        <target xml:space="preserve">No wallets available</target>
+        <source xml:space="preserve">Set a scale factor which gets applied to the base font size. Possible range %1 (smallest fonts) to %2 (largest fonts). (default: %3)</source>
+        <target xml:space="preserve">Set a scale factor which gets applied to the base font size. Possible range %1 (smallest fonts) to %2 (largest fonts). (default: %3)</target>
         <context-group purpose="location"><context context-type="linenumber">537</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg83" approved="yes">
+        <source xml:space="preserve">Set the font weight for bold texts. Possible range %1 to %2 (default: %3)</source>
+        <target xml:space="preserve">Set the font weight for bold texts. Possible range %1 to %2 (default: %3)</target>
+        <context-group purpose="location"><context context-type="linenumber">538</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg84" approved="yes">
+        <source xml:space="preserve">Set the font weight for normal texts. Possible range %1 to %2 (default: %3)</source>
+        <target xml:space="preserve">Set the font weight for normal texts. Possible range %1 to %2 (default: %3)</target>
+        <context-group purpose="location"><context context-type="linenumber">539</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg85" approved="yes">
+        <source xml:space="preserve">Set language, for example &quot;de_DE&quot; (default: system locale)</source>
+        <target xml:space="preserve">Set language, for example &quot;de_DE&quot; (default: system locale)</target>
+        <context-group purpose="location"><context context-type="linenumber">540</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg86" approved="yes">
+        <source xml:space="preserve">Start minimized</source>
+        <target xml:space="preserve">Start minimized</target>
+        <context-group purpose="location"><context context-type="linenumber">541</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg87" approved="yes">
-        <source xml:space="preserve">&amp;Window</source>
-        <target xml:space="preserve">&amp;Window</target>
-        <context-group purpose="location"><context context-type="linenumber">606</context></context-group>
+        <source xml:space="preserve">Reset all settings changed in the GUI</source>
+        <target xml:space="preserve">Reset all settings changed in the GUI</target>
+        <context-group purpose="location"><context context-type="linenumber">542</context></context-group>
       </trans-unit>
       <trans-unit id="_msg88" approved="yes">
-        <source xml:space="preserve">Minimize</source>
-        <target xml:space="preserve">Minimize</target>
-        <context-group purpose="location"><context context-type="linenumber">608</context></context-group>
+        <source xml:space="preserve">Show splash screen on startup (default: %u)</source>
+        <target xml:space="preserve">Show splash screen on startup (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">543</context></context-group>
       </trans-unit>
       <trans-unit id="_msg89" approved="yes">
-        <source xml:space="preserve">Zoom</source>
-        <target xml:space="preserve">Zoom</target>
-        <context-group purpose="location"><context context-type="linenumber">618</context></context-group>
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; does not exist.</source>
+        <target xml:space="preserve">Error: Specified data directory &quot;%1&quot; does not exist.</target>
+        <context-group purpose="location"><context context-type="linenumber">638</context></context-group>
       </trans-unit>
       <trans-unit id="_msg90" approved="yes">
-        <source xml:space="preserve">Main Window</source>
-        <target xml:space="preserve">Main Window</target>
-        <context-group purpose="location"><context context-type="linenumber">636</context></context-group>
+        <source xml:space="preserve">Error: Cannot parse configuration file: %1.</source>
+        <target xml:space="preserve">Error: Cannot parse configuration file: %1.</target>
+        <context-group purpose="location"><context context-type="linenumber">644</context></context-group>
       </trans-unit>
       <trans-unit id="_msg91" approved="yes">
-        <source xml:space="preserve">&amp;Transactions</source>
-        <target xml:space="preserve">&amp;Transactions</target>
-        <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
+        <source xml:space="preserve">Error: %1</source>
+        <target xml:space="preserve">Error: %1</target>
+        <context-group purpose="location"><context context-type="linenumber">659</context></context-group>
       </trans-unit>
       <trans-unit id="_msg92" approved="yes">
-        <source xml:space="preserve">Browse transaction history</source>
-        <target xml:space="preserve">Browse transaction history</target>
-        <context-group purpose="location"><context context-type="linenumber">695</context></context-group>
+        <source xml:space="preserve">Error: Failed to load application fonts.</source>
+        <target xml:space="preserve">Error: Failed to load application fonts.</target>
+        <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
       </trans-unit>
       <trans-unit id="_msg93" approved="yes">
-        <source xml:space="preserve">&amp;Masternodes</source>
-        <target xml:space="preserve">&amp;Masternodes</target>
-        <context-group purpose="location"><context context-type="linenumber">706</context></context-group>
+        <source xml:space="preserve">Error: Specified font-family invalid. Valid values: %1.</source>
+        <target xml:space="preserve">Error: Specified font-family invalid. Valid values: %1.</target>
+        <context-group purpose="location"><context context-type="linenumber">723</context></context-group>
       </trans-unit>
       <trans-unit id="_msg94" approved="yes">
-        <source xml:space="preserve">Browse masternodes</source>
-        <target xml:space="preserve">Browse masternodes</target>
-        <context-group purpose="location"><context context-type="linenumber">707</context></context-group>
+        <source xml:space="preserve">Error: Specified font-weight-normal invalid. Valid range %1 to %2.</source>
+        <target xml:space="preserve">Error: Specified font-weight-normal invalid. Valid range %1 to %2.</target>
+        <context-group purpose="location"><context context-type="linenumber">733</context></context-group>
       </trans-unit>
       <trans-unit id="_msg95" approved="yes">
-        <source xml:space="preserve">E&amp;xit</source>
-        <target xml:space="preserve">E&amp;xit</target>
-        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
+        <source xml:space="preserve">Error: Specified font-weight-bold invalid. Valid range %1 to %2.</source>
+        <target xml:space="preserve">Error: Specified font-weight-bold invalid. Valid range %1 to %2.</target>
+        <context-group purpose="location"><context context-type="linenumber">743</context></context-group>
       </trans-unit>
       <trans-unit id="_msg96" approved="yes">
-        <source xml:space="preserve">Quit application</source>
-        <target xml:space="preserve">Quit application</target>
-        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+        <source xml:space="preserve">Error: Specified font-scale invalid. Valid range %1 to %2.</source>
+        <target xml:space="preserve">Error: Specified font-scale invalid. Valid range %1 to %2.</target>
+        <context-group purpose="location"><context context-type="linenumber">754</context></context-group>
       </trans-unit>
       <trans-unit id="_msg97" approved="yes">
-        <source xml:space="preserve">About &amp;Qt</source>
-        <target xml:space="preserve">About &amp;Qt</target>
-        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
+        <source xml:space="preserve">Error: Invalid -custom-css-dir path.</source>
+        <target xml:space="preserve">Error: Invalid -custom-css-dir path.</target>
+        <context-group purpose="location"><context context-type="linenumber">768</context></context-group>
       </trans-unit>
       <trans-unit id="_msg98" approved="yes">
-        <source xml:space="preserve">Show information about Qt</source>
-        <target xml:space="preserve">Show information about Qt</target>
-        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
+        <source xml:space="preserve">Error: %1 CSS file(s) missing in -custom-css-dir path.</source>
+        <target xml:space="preserve">Error: %1 CSS file(s) missing in -custom-css-dir path.</target>
+        <context-group purpose="location"><context context-type="linenumber">788</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg99" approved="yes">
-        <source xml:space="preserve">&amp;Options...</source>
-        <target xml:space="preserve">&amp;Options...</target>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+      <trans-unit id="_msg99">
+        <source xml:space="preserve">%1 didn&apos;t yet exit safely…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">820</context></context-group>
       </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bitcoingui.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
       <trans-unit id="_msg100" approved="yes">
-        <source xml:space="preserve">&amp;About %1</source>
-        <target xml:space="preserve">&amp;About %1</target>
-        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+        <source xml:space="preserve">&amp;Overview</source>
+        <target xml:space="preserve">&amp;Overview</target>
+        <context-group purpose="location"><context context-type="linenumber">681</context></context-group>
       </trans-unit>
       <trans-unit id="_msg101" approved="yes">
-        <source xml:space="preserve">Send %1 funds to a Dash address</source>
-        <target xml:space="preserve">Send %1 funds to a Dash address</target>
-        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+        <source xml:space="preserve">Show general overview of wallet</source>
+        <target xml:space="preserve">Show general overview of wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">682</context></context-group>
       </trans-unit>
       <trans-unit id="_msg102" approved="yes">
-        <source xml:space="preserve">Modify configuration options for %1</source>
-        <target xml:space="preserve">Modify configuration options for %1</target>
-        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
+        <source xml:space="preserve">&amp;Send</source>
+        <target xml:space="preserve">&amp;Send</target>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
       </trans-unit>
       <trans-unit id="_msg103" approved="yes">
-        <source xml:space="preserve">&amp;Show / Hide</source>
-        <target xml:space="preserve">&amp;Show / Hide</target>
-        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
+        <source xml:space="preserve">Send coins to a Dash address</source>
+        <target xml:space="preserve">Send coins to a Dash address</target>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
       <trans-unit id="_msg104" approved="yes">
-        <source xml:space="preserve">Show or hide the main Window</source>
-        <target xml:space="preserve">Show or hide the main Window</target>
-        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+        <source xml:space="preserve">&amp;Receive</source>
+        <target xml:space="preserve">&amp;Receive</target>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
       </trans-unit>
       <trans-unit id="_msg105" approved="yes">
-        <source xml:space="preserve">&amp;Encrypt Wallet...</source>
-        <target xml:space="preserve">&amp;Encrypt Wallet...</target>
-        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+        <source xml:space="preserve">Request payments (generates QR codes and dash: URIs)</source>
+        <target xml:space="preserve">Request payments (generates QR codes and dash: URIs)</target>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg106" approved="yes">
-        <source xml:space="preserve">Encrypt the private keys that belong to your wallet</source>
-        <target xml:space="preserve">Encrypt the private keys that belong to your wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
+      <trans-unit id="_msg106">
+        <source xml:space="preserve">Ctrl+Q</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg107" approved="yes">
-        <source xml:space="preserve">&amp;Backup Wallet...</source>
-        <target xml:space="preserve">&amp;Backup Wallet...</target>
-        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
+      <trans-unit id="_msg107">
+        <source xml:space="preserve">&amp;Options…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg108" approved="yes">
-        <source xml:space="preserve">Backup wallet to another location</source>
-        <target xml:space="preserve">Backup wallet to another location</target>
+      <trans-unit id="_msg108">
+        <source xml:space="preserve">&amp;Encrypt Wallet…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg109" approved="yes">
-        <source xml:space="preserve">&amp;Change Passphrase...</source>
-        <target xml:space="preserve">&amp;Change Passphrase...</target>
-        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg110" approved="yes">
-        <source xml:space="preserve">Change the passphrase used for wallet encryption</source>
-        <target xml:space="preserve">Change the passphrase used for wallet encryption</target>
+      <trans-unit id="_msg109">
+        <source xml:space="preserve">&amp;Backup Wallet…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg111" approved="yes">
-        <source xml:space="preserve">&amp;Unlock Wallet...</source>
-        <target xml:space="preserve">&amp;Unlock Wallet...</target>
-        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg112" approved="yes">
-        <source xml:space="preserve">Unlock wallet</source>
-        <target xml:space="preserve">Unlock wallet</target>
+      <trans-unit id="_msg110">
+        <source xml:space="preserve">&amp;Change Passphrase…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">399</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg113" approved="yes">
-        <source xml:space="preserve">&amp;Lock Wallet</source>
-        <target xml:space="preserve">&amp;Lock Wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg114" approved="yes">
-        <source xml:space="preserve">Sign &amp;message...</source>
-        <target xml:space="preserve">Sign &amp;message...</target>
+      <trans-unit id="_msg111">
+        <source xml:space="preserve">&amp;Unlock Wallet…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg115" approved="yes">
-        <source xml:space="preserve">Sign messages with your Dash addresses to prove you own them</source>
-        <target xml:space="preserve">Sign messages with your Dash addresses to prove you own them</target>
-        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg116" approved="yes">
-        <source xml:space="preserve">&amp;Verify message...</source>
-        <target xml:space="preserve">&amp;Verify message...</target>
-        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg117" approved="yes">
-        <source xml:space="preserve">Verify messages to ensure they were signed with specified Dash addresses</source>
-        <target xml:space="preserve">Verify messages to ensure they were signed with specified Dash addresses</target>
+      <trans-unit id="_msg112">
+        <source xml:space="preserve">Sign &amp;message…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg118">
-        <source xml:space="preserve">&amp;Load PSBT from file...</source>
+      <trans-unit id="_msg113">
+        <source xml:space="preserve">&amp;Verify message…</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg119" approved="yes">
-        <source xml:space="preserve">&amp;Information</source>
-        <target xml:space="preserve">&amp;Information</target>
+      <trans-unit id="_msg114">
+        <source xml:space="preserve">&amp;Load PSBT from file…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg115">
+        <source xml:space="preserve">Load PSBT from clipboard…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg120" approved="yes">
-        <source xml:space="preserve">Show diagnostic information</source>
-        <target xml:space="preserve">Show diagnostic information</target>
-        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg121" approved="yes">
-        <source xml:space="preserve">&amp;Debug console</source>
-        <target xml:space="preserve">&amp;Debug console</target>
-        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg122" approved="yes">
-        <source xml:space="preserve">&amp;Network Monitor</source>
-        <target xml:space="preserve">&amp;Network Monitor</target>
-        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg123" approved="yes">
-        <source xml:space="preserve">Show network monitor</source>
-        <target xml:space="preserve">Show network monitor</target>
-        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg124" approved="yes">
-        <source xml:space="preserve">&amp;Peers list</source>
-        <target xml:space="preserve">&amp;Peers list</target>
-        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg125" approved="yes">
-        <source xml:space="preserve">Show peers info</source>
-        <target xml:space="preserve">Show peers info</target>
-        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg126" approved="yes">
-        <source xml:space="preserve">Wallet &amp;Repair</source>
-        <target xml:space="preserve">Wallet &amp;Repair</target>
-        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg127" approved="yes">
-        <source xml:space="preserve">Show wallet repair options</source>
-        <target xml:space="preserve">Show wallet repair options</target>
-        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg128" approved="yes">
-        <source xml:space="preserve">Open Wallet &amp;Configuration File</source>
-        <target xml:space="preserve">Open Wallet &amp;Configuration File</target>
-        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg129" approved="yes">
-        <source xml:space="preserve">Open configuration file</source>
-        <target xml:space="preserve">Open configuration file</target>
-        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg130" approved="yes">
-        <source xml:space="preserve">Show Automatic &amp;Backups</source>
-        <target xml:space="preserve">Show Automatic &amp;Backups</target>
-        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg131" approved="yes">
-        <source xml:space="preserve">Show automatically created wallet backups</source>
-        <target xml:space="preserve">Show automatically created wallet backups</target>
-        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg132" approved="yes">
-        <source xml:space="preserve">Show the list of used sending addresses and labels</source>
-        <target xml:space="preserve">Show the list of used sending addresses and labels</target>
-        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg133" approved="yes">
-        <source xml:space="preserve">Show the list of used receiving addresses and labels</source>
-        <target xml:space="preserve">Show the list of used receiving addresses and labels</target>
+      <trans-unit id="_msg116" approved="yes">
+        <source xml:space="preserve">&amp;Sending addresses</source>
+        <target xml:space="preserve">&amp;Sending addresses</target>
         <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg134" approved="yes">
-        <source xml:space="preserve">Open &amp;URI...</source>
-        <target xml:space="preserve">Open &amp;URI...</target>
+      <trans-unit id="_msg117" approved="yes">
+        <source xml:space="preserve">&amp;Receiving addresses</source>
+        <target xml:space="preserve">&amp;Receiving addresses</target>
         <context-group purpose="location"><context context-type="linenumber">439</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg118">
+        <source xml:space="preserve">Open &amp;URI…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg119" approved="yes">
+        <source xml:space="preserve">Open Wallet</source>
+        <target xml:space="preserve">Open Wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">445</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg120" approved="yes">
+        <source xml:space="preserve">Open a wallet</source>
+        <target xml:space="preserve">Open a wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg121" approved="yes">
+        <source xml:space="preserve">Close wallet</source>
+        <target xml:space="preserve">Close wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg122" approved="yes">
+        <source xml:space="preserve">No wallets available</source>
+        <target xml:space="preserve">No wallets available</target>
+        <context-group purpose="location"><context context-type="linenumber">540</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg123" approved="yes">
+        <source xml:space="preserve">&amp;Window</source>
+        <target xml:space="preserve">&amp;Window</target>
+        <context-group purpose="location"><context context-type="linenumber">609</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg124" approved="yes">
+        <source xml:space="preserve">Minimize</source>
+        <target xml:space="preserve">Minimize</target>
+        <context-group purpose="location"><context context-type="linenumber">611</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg125" approved="yes">
+        <source xml:space="preserve">Zoom</source>
+        <target xml:space="preserve">Zoom</target>
+        <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg126" approved="yes">
+        <source xml:space="preserve">Main Window</source>
+        <target xml:space="preserve">Main Window</target>
+        <context-group purpose="location"><context context-type="linenumber">639</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg127" approved="yes">
+        <source xml:space="preserve">&amp;Transactions</source>
+        <target xml:space="preserve">&amp;Transactions</target>
+        <context-group purpose="location"><context context-type="linenumber">696</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg128" approved="yes">
+        <source xml:space="preserve">Browse transaction history</source>
+        <target xml:space="preserve">Browse transaction history</target>
+        <context-group purpose="location"><context context-type="linenumber">697</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg129" approved="yes">
+        <source xml:space="preserve">&amp;Masternodes</source>
+        <target xml:space="preserve">&amp;Masternodes</target>
+        <context-group purpose="location"><context context-type="linenumber">708</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg130" approved="yes">
+        <source xml:space="preserve">Browse masternodes</source>
+        <target xml:space="preserve">Browse masternodes</target>
+        <context-group purpose="location"><context context-type="linenumber">709</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg131" approved="yes">
+        <source xml:space="preserve">E&amp;xit</source>
+        <target xml:space="preserve">E&amp;xit</target>
+        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg132" approved="yes">
+        <source xml:space="preserve">Quit application</source>
+        <target xml:space="preserve">Quit application</target>
+        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg133" approved="yes">
+        <source xml:space="preserve">About &amp;Qt</source>
+        <target xml:space="preserve">About &amp;Qt</target>
+        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg134" approved="yes">
+        <source xml:space="preserve">Show information about Qt</source>
+        <target xml:space="preserve">Show information about Qt</target>
+        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg135" approved="yes">
-        <source xml:space="preserve">&amp;Command-line options</source>
-        <target xml:space="preserve">&amp;Command-line options</target>
-        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+        <source xml:space="preserve">&amp;About %1</source>
+        <target xml:space="preserve">&amp;About %1</target>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
       </trans-unit>
       <trans-unit id="_msg136" approved="yes">
-        <source xml:space="preserve">Show the %1 help message to get a list with possible Dash command-line options</source>
-        <target xml:space="preserve">Show the %1 help message to get a list with possible Dash command-line options</target>
-        <context-group purpose="location"><context context-type="linenumber">459</context></context-group>
+        <source xml:space="preserve">Send %1 funds to a Dash address</source>
+        <target xml:space="preserve">Send %1 funds to a Dash address</target>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
       </trans-unit>
       <trans-unit id="_msg137" approved="yes">
-        <source xml:space="preserve">default wallet</source>
-        <target xml:space="preserve">default wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">516</context></context-group>
+        <source xml:space="preserve">Modify configuration options for %1</source>
+        <target xml:space="preserve">Modify configuration options for %1</target>
+        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
       </trans-unit>
       <trans-unit id="_msg138" approved="yes">
-        <source xml:space="preserve">%1 client</source>
-        <target xml:space="preserve">%1 client</target>
-        <context-group purpose="location"><context context-type="linenumber">1009</context></context-group>
+        <source xml:space="preserve">&amp;Show / Hide</source>
+        <target xml:space="preserve">&amp;Show / Hide</target>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
       </trans-unit>
       <trans-unit id="_msg139" approved="yes">
+        <source xml:space="preserve">Show or hide the main Window</source>
+        <target xml:space="preserve">Show or hide the main Window</target>
+        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg140" approved="yes">
+        <source xml:space="preserve">Encrypt the private keys that belong to your wallet</source>
+        <target xml:space="preserve">Encrypt the private keys that belong to your wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg141" approved="yes">
+        <source xml:space="preserve">Backup wallet to another location</source>
+        <target xml:space="preserve">Backup wallet to another location</target>
+        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg142" approved="yes">
+        <source xml:space="preserve">Change the passphrase used for wallet encryption</source>
+        <target xml:space="preserve">Change the passphrase used for wallet encryption</target>
+        <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg143" approved="yes">
+        <source xml:space="preserve">Unlock wallet</source>
+        <target xml:space="preserve">Unlock wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg144" approved="yes">
+        <source xml:space="preserve">&amp;Lock Wallet</source>
+        <target xml:space="preserve">&amp;Lock Wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg145" approved="yes">
+        <source xml:space="preserve">Sign messages with your Dash addresses to prove you own them</source>
+        <target xml:space="preserve">Sign messages with your Dash addresses to prove you own them</target>
+        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg146" approved="yes">
+        <source xml:space="preserve">Verify messages to ensure they were signed with specified Dash addresses</source>
+        <target xml:space="preserve">Verify messages to ensure they were signed with specified Dash addresses</target>
+        <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg147" approved="yes">
+        <source xml:space="preserve">&amp;Information</source>
+        <target xml:space="preserve">&amp;Information</target>
+        <context-group purpose="location"><context context-type="linenumber">413</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg148" approved="yes">
+        <source xml:space="preserve">Show diagnostic information</source>
+        <target xml:space="preserve">Show diagnostic information</target>
+        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg149" approved="yes">
+        <source xml:space="preserve">&amp;Debug console</source>
+        <target xml:space="preserve">&amp;Debug console</target>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg150" approved="yes">
+        <source xml:space="preserve">&amp;Network Monitor</source>
+        <target xml:space="preserve">&amp;Network Monitor</target>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg151" approved="yes">
+        <source xml:space="preserve">Show network monitor</source>
+        <target xml:space="preserve">Show network monitor</target>
+        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg152" approved="yes">
+        <source xml:space="preserve">&amp;Peers list</source>
+        <target xml:space="preserve">&amp;Peers list</target>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg153" approved="yes">
+        <source xml:space="preserve">Show peers info</source>
+        <target xml:space="preserve">Show peers info</target>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg154" approved="yes">
+        <source xml:space="preserve">Wallet &amp;Repair</source>
+        <target xml:space="preserve">Wallet &amp;Repair</target>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg155" approved="yes">
+        <source xml:space="preserve">Show wallet repair options</source>
+        <target xml:space="preserve">Show wallet repair options</target>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg156" approved="yes">
+        <source xml:space="preserve">Open Wallet &amp;Configuration File</source>
+        <target xml:space="preserve">Open Wallet &amp;Configuration File</target>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg157" approved="yes">
+        <source xml:space="preserve">Open configuration file</source>
+        <target xml:space="preserve">Open configuration file</target>
+        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg158" approved="yes">
+        <source xml:space="preserve">Show Automatic &amp;Backups</source>
+        <target xml:space="preserve">Show Automatic &amp;Backups</target>
+        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg159" approved="yes">
+        <source xml:space="preserve">Show automatically created wallet backups</source>
+        <target xml:space="preserve">Show automatically created wallet backups</target>
+        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg160" approved="yes">
+        <source xml:space="preserve">Show the list of used sending addresses and labels</source>
+        <target xml:space="preserve">Show the list of used sending addresses and labels</target>
+        <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg161" approved="yes">
+        <source xml:space="preserve">Show the list of used receiving addresses and labels</source>
+        <target xml:space="preserve">Show the list of used receiving addresses and labels</target>
+        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg162" approved="yes">
+        <source xml:space="preserve">&amp;Command-line options</source>
+        <target xml:space="preserve">&amp;Command-line options</target>
+        <context-group purpose="location"><context context-type="linenumber">460</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg163" approved="yes">
+        <source xml:space="preserve">Show the %1 help message to get a list with possible Dash command-line options</source>
+        <target xml:space="preserve">Show the %1 help message to get a list with possible Dash command-line options</target>
+        <context-group purpose="location"><context context-type="linenumber">462</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg164" approved="yes">
+        <source xml:space="preserve">default wallet</source>
+        <target xml:space="preserve">default wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">519</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg165" approved="yes">
+        <source xml:space="preserve">%1 client</source>
+        <target xml:space="preserve">%1 client</target>
+        <context-group purpose="location"><context context-type="linenumber">1011</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg166" approved="yes">
         <source xml:space="preserve">Wallet: %1
 </source>
         <target xml:space="preserve">Wallet: %1
 </target>
-        <context-group purpose="location"><context context-type="linenumber">1757</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1759</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg140" approved="yes">
+      <trans-unit id="_msg167" approved="yes">
         <source xml:space="preserve">Wallet is &lt;b&gt;unencrypted&lt;/b&gt;</source>
         <target xml:space="preserve">Wallet is &lt;b&gt;unencrypted&lt;/b&gt;</target>
-        <context-group purpose="location"><context context-type="linenumber">1832</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1834</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg141" approved="yes">
+      <trans-unit id="_msg168" approved="yes">
         <source xml:space="preserve">&amp;File</source>
         <target xml:space="preserve">&amp;File</target>
-        <context-group purpose="location"><context context-type="linenumber">570</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">573</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg142" approved="yes">
+      <trans-unit id="_msg169" approved="yes">
         <source xml:space="preserve">Show information about %1</source>
         <target xml:space="preserve">Show information about %1</target>
-        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg143" approved="yes">
+      <trans-unit id="_msg170" approved="yes">
         <source xml:space="preserve">Load Partially Signed Dash Transaction</source>
         <target xml:space="preserve">Load Partially Signed Dash Transaction</target>
-        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg144">
-        <source xml:space="preserve">Load PSBT from clipboard...</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg145">
+      <trans-unit id="_msg171" approved="yes">
         <source xml:space="preserve">Load Partially Signed Bitcoin Transaction from clipboard</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+        <target xml:space="preserve">Load Partially Signed Bitcoin Transaction from clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg146" approved="yes">
+      <trans-unit id="_msg172" approved="yes">
         <source xml:space="preserve">Open debugging and diagnostic console</source>
         <target xml:space="preserve">Open debugging and diagnostic console</target>
-        <context-group purpose="location"><context context-type="linenumber">413</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg147" approved="yes">
+      <trans-unit id="_msg173" approved="yes">
         <source xml:space="preserve">Open a dash: URI</source>
         <target xml:space="preserve">Open a dash: URI</target>
-        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg148" approved="yes">
-        <source xml:space="preserve">Create Wallet...</source>
-        <target xml:space="preserve">Create Wallet...</target>
-        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg149" approved="yes">
+      <trans-unit id="_msg174" approved="yes">
         <source xml:space="preserve">Create a new wallet</source>
         <target xml:space="preserve">Create a new wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg150">
-        <source xml:space="preserve">Close All Wallets...</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg151">
-        <source xml:space="preserve">Close all wallets</source>
-        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg152" approved="yes">
+      <trans-unit id="_msg175" approved="yes">
+        <source xml:space="preserve">Close all wallets</source>
+        <target xml:space="preserve">Close all wallets</target>
+        <context-group purpose="location"><context context-type="linenumber">458</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg176" approved="yes">
         <source xml:space="preserve">%1 &amp;information</source>
         <target xml:space="preserve">%1 &amp;information</target>
-        <context-group purpose="location"><context context-type="linenumber">461</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">464</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg153" approved="yes">
+      <trans-unit id="_msg177" approved="yes">
         <source xml:space="preserve">Show the %1 basic information</source>
         <target xml:space="preserve">Show the %1 basic information</target>
-        <context-group purpose="location"><context context-type="linenumber">463</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">466</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg154">
+      <trans-unit id="_msg178" approved="yes">
         <source xml:space="preserve">&amp;Discreet mode</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
+        <target xml:space="preserve">&amp;Discreet mode</target>
+        <context-group purpose="location"><context context-type="linenumber">468</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg155">
+      <trans-unit id="_msg179" approved="yes">
         <source xml:space="preserve">Mask the values in the Overview tab</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg156" approved="yes">
+      <trans-unit id="_msg180" approved="yes">
         <source xml:space="preserve">&amp;Settings</source>
         <target xml:space="preserve">&amp;Settings</target>
-        <context-group purpose="location"><context context-type="linenumber">593</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">596</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg157" approved="yes">
+      <trans-unit id="_msg181" approved="yes">
         <source xml:space="preserve">&amp;Help</source>
         <target xml:space="preserve">&amp;Help</target>
-        <context-group purpose="location"><context context-type="linenumber">656</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">659</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg158" approved="yes">
+      <trans-unit id="_msg182" approved="yes">
         <source xml:space="preserve">Tabs toolbar</source>
         <target xml:space="preserve">Tabs toolbar</target>
-        <context-group purpose="location"><context context-type="linenumber">669</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg159" approved="yes">
+      <trans-unit id="_msg183" approved="yes">
         <source xml:space="preserve">&amp;Governance</source>
         <target xml:space="preserve">&amp;Governance</target>
-        <context-group purpose="location"><context context-type="linenumber">715</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg160" approved="yes">
+      <trans-unit id="_msg184" approved="yes">
         <source xml:space="preserve">View Governance Proposals</source>
         <target xml:space="preserve">View Governance Proposals</target>
-        <context-group purpose="location"><context context-type="linenumber">716</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1270</context></context-group>
-        <trans-unit id="_msg161[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">1272</context></context-group>
+        <trans-unit id="_msg185[0]" approved="yes">
           <source xml:space="preserve">%n active connection(s) to Dash network</source>
           <target xml:space="preserve">%n active connection to Dash network</target>
         </trans-unit>
-        <trans-unit id="_msg161[1]" approved="yes">
+        <trans-unit id="_msg185[1]" approved="yes">
           <source xml:space="preserve">%n active connection(s) to Dash network</source>
           <target xml:space="preserve">%n active connections to Dash network</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg162" approved="yes">
+      <trans-unit id="_msg186" approved="yes">
         <source xml:space="preserve">Network activity disabled</source>
         <target xml:space="preserve">Network activity disabled</target>
-        <context-group purpose="location"><context context-type="linenumber">1272</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg163" approved="yes">
-        <source xml:space="preserve">Syncing Headers (%1%)...</source>
-        <target xml:space="preserve">Syncing Headers (%1%)...</target>
-        <context-group purpose="location"><context context-type="linenumber">1302</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg164" approved="yes">
-        <source xml:space="preserve">Synchronizing with network...</source>
-        <target xml:space="preserve">Synchronizing with network...</target>
-        <context-group purpose="location"><context context-type="linenumber">1423</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg165" approved="yes">
-        <source xml:space="preserve">Indexing blocks on disk...</source>
-        <target xml:space="preserve">Indexing blocks on disk...</target>
-        <context-group purpose="location"><context context-type="linenumber">1428</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg166" approved="yes">
-        <source xml:space="preserve">Processing blocks on disk...</source>
-        <target xml:space="preserve">Processing blocks on disk...</target>
-        <context-group purpose="location"><context context-type="linenumber">1430</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg167" approved="yes">
-        <source xml:space="preserve">Reindexing blocks on disk...</source>
-        <target xml:space="preserve">Reindexing blocks on disk...</target>
-        <context-group purpose="location"><context context-type="linenumber">1434</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg168" approved="yes">
-        <source xml:space="preserve">Connecting to peers...</source>
-        <target xml:space="preserve">Connecting to peers...</target>
-        <context-group purpose="location"><context context-type="linenumber">1440</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1274</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1449</context></context-group>
-        <trans-unit id="_msg169[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">1451</context></context-group>
+        <trans-unit id="_msg187[0]" approved="yes">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
           <target xml:space="preserve">Processed %n block of transaction history.</target>
         </trans-unit>
-        <trans-unit id="_msg169[1]" approved="yes">
+        <trans-unit id="_msg187[1]" approved="yes">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
           <target xml:space="preserve">Processed %n blocks of transaction history.</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg170" approved="yes">
+      <trans-unit id="_msg188" approved="yes">
         <source xml:space="preserve">%1 behind</source>
         <target xml:space="preserve">%1 behind</target>
-        <context-group purpose="location"><context context-type="linenumber">1468</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1470</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg171" approved="yes">
-        <source xml:space="preserve">Catching up...</source>
-        <target xml:space="preserve">Catching up...</target>
-        <context-group purpose="location"><context context-type="linenumber">1472</context></context-group>
+      <trans-unit id="_msg189">
+        <source xml:space="preserve">Close Wallet…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg172" approved="yes">
+      <trans-unit id="_msg190">
+        <source xml:space="preserve">Create Wallet…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">453</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg191">
+        <source xml:space="preserve">Close All Wallets…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg192">
+        <source xml:space="preserve">Ctrl+Shift+D</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">469</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg193">
+        <source xml:space="preserve">Ctrl+M</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">612</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg194">
+        <source xml:space="preserve">Syncing Headers (%1%)…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg195">
+        <source xml:space="preserve">Synchronizing with network…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg196">
+        <source xml:space="preserve">Indexing blocks on disk…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1430</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg197">
+        <source xml:space="preserve">Processing blocks on disk…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1432</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg198">
+        <source xml:space="preserve">Reindexing blocks on disk…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1436</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg199">
+        <source xml:space="preserve">Connecting to peers…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1442</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg200">
+        <source xml:space="preserve">Catching up…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1474</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg201" approved="yes">
         <source xml:space="preserve">Last received block was generated %1 ago.</source>
         <target xml:space="preserve">Last received block was generated %1 ago.</target>
-        <context-group purpose="location"><context context-type="linenumber">1482</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg173" approved="yes">
-        <source xml:space="preserve">Transactions after this will not yet be visible.</source>
-        <target xml:space="preserve">Transactions after this will not yet be visible.</target>
         <context-group purpose="location"><context context-type="linenumber">1484</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg174" approved="yes">
+      <trans-unit id="_msg202" approved="yes">
+        <source xml:space="preserve">Transactions after this will not yet be visible.</source>
+        <target xml:space="preserve">Transactions after this will not yet be visible.</target>
+        <context-group purpose="location"><context context-type="linenumber">1486</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg203" approved="yes">
         <source xml:space="preserve">Up to date</source>
         <target xml:space="preserve">Up to date</target>
-        <context-group purpose="location"><context context-type="linenumber">1523</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1525</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg175" approved="yes">
+      <trans-unit id="_msg204" approved="yes">
         <source xml:space="preserve">Synchronizing additional data: %p%</source>
         <target xml:space="preserve">Synchronizing additional data: %p%</target>
-        <context-group purpose="location"><context context-type="linenumber">1536</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1538</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg176" approved="yes">
+      <trans-unit id="_msg205" approved="yes">
         <source xml:space="preserve">Error</source>
         <target xml:space="preserve">Error</target>
-        <context-group purpose="location"><context context-type="linenumber">1567</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1569</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg177" approved="yes">
+      <trans-unit id="_msg206" approved="yes">
         <source xml:space="preserve">Error: %1</source>
         <target xml:space="preserve">Error: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">1568</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1570</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg178" approved="yes">
+      <trans-unit id="_msg207" approved="yes">
         <source xml:space="preserve">Warning</source>
         <target xml:space="preserve">Warning</target>
-        <context-group purpose="location"><context context-type="linenumber">1571</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1573</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg179" approved="yes">
+      <trans-unit id="_msg208" approved="yes">
         <source xml:space="preserve">Warning: %1</source>
         <target xml:space="preserve">Warning: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">1572</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1574</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg180" approved="yes">
+      <trans-unit id="_msg209" approved="yes">
         <source xml:space="preserve">Information</source>
         <target xml:space="preserve">Information</target>
-        <context-group purpose="location"><context context-type="linenumber">1575</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1577</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg181" approved="yes">
+      <trans-unit id="_msg210" approved="yes">
         <source xml:space="preserve">Received and sent multiple transactions</source>
         <target xml:space="preserve">Received and sent multiple transactions</target>
-        <context-group purpose="location"><context context-type="linenumber">1730</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg182" approved="yes">
-        <source xml:space="preserve">Sent multiple transactions</source>
-        <target xml:space="preserve">Sent multiple transactions</target>
         <context-group purpose="location"><context context-type="linenumber">1732</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg183" approved="yes">
-        <source xml:space="preserve">Received multiple transactions</source>
-        <target xml:space="preserve">Received multiple transactions</target>
+      <trans-unit id="_msg211" approved="yes">
+        <source xml:space="preserve">Sent multiple transactions</source>
+        <target xml:space="preserve">Sent multiple transactions</target>
         <context-group purpose="location"><context context-type="linenumber">1734</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg184" approved="yes">
+      <trans-unit id="_msg212" approved="yes">
+        <source xml:space="preserve">Received multiple transactions</source>
+        <target xml:space="preserve">Received multiple transactions</target>
+        <context-group purpose="location"><context context-type="linenumber">1736</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg213" approved="yes">
         <source xml:space="preserve">Sent Amount: %1
 </source>
         <target xml:space="preserve">Sent Amount: %1
 </target>
-        <context-group purpose="location"><context context-type="linenumber">1744</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1746</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg185" approved="yes">
+      <trans-unit id="_msg214" approved="yes">
         <source xml:space="preserve">Received Amount: %1
 </source>
         <target xml:space="preserve">Received Amount: %1
 </target>
-        <context-group purpose="location"><context context-type="linenumber">1747</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1749</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg186" approved="yes">
+      <trans-unit id="_msg215" approved="yes">
         <source xml:space="preserve">Date: %1
 </source>
         <target xml:space="preserve">Date: %1
 </target>
-        <context-group purpose="location"><context context-type="linenumber">1754</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1756</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg187" approved="yes">
+      <trans-unit id="_msg216" approved="yes">
         <source xml:space="preserve">Amount: %1
 </source>
         <target xml:space="preserve">Amount: %1
 </target>
-        <context-group purpose="location"><context context-type="linenumber">1755</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1757</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg188" approved="yes">
+      <trans-unit id="_msg217" approved="yes">
         <source xml:space="preserve">Type: %1
 </source>
         <target xml:space="preserve">Type: %1
 </target>
-        <context-group purpose="location"><context context-type="linenumber">1759</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1761</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg189" approved="yes">
+      <trans-unit id="_msg218" approved="yes">
         <source xml:space="preserve">Label: %1
 </source>
         <target xml:space="preserve">Label: %1
 </target>
-        <context-group purpose="location"><context context-type="linenumber">1761</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1763</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg190" approved="yes">
+      <trans-unit id="_msg219" approved="yes">
         <source xml:space="preserve">Address: %1
 </source>
         <target xml:space="preserve">Address: %1
 </target>
-        <context-group purpose="location"><context context-type="linenumber">1763</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1765</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg191" approved="yes">
+      <trans-unit id="_msg220" approved="yes">
         <source xml:space="preserve">Sent transaction</source>
         <target xml:space="preserve">Sent transaction</target>
-        <context-group purpose="location"><context context-type="linenumber">1764</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1766</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg192" approved="yes">
+      <trans-unit id="_msg221" approved="yes">
         <source xml:space="preserve">Incoming transaction</source>
         <target xml:space="preserve">Incoming transaction</target>
-        <context-group purpose="location"><context context-type="linenumber">1764</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1766</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg193" approved="yes">
+      <trans-unit id="_msg222" approved="yes">
         <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
         <target xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</target>
-        <context-group purpose="location"><context context-type="linenumber">1819</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1821</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg194" approved="yes">
+      <trans-unit id="_msg223" approved="yes">
         <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <target xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</target>
-        <context-group purpose="location"><context context-type="linenumber">1841</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1843</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg195" approved="yes">
+      <trans-unit id="_msg224" approved="yes">
         <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt; for mixing only</source>
         <target xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt; for mixing only</target>
-        <context-group purpose="location"><context context-type="linenumber">1850</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1852</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg196" approved="yes">
+      <trans-unit id="_msg225" approved="yes">
         <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <target xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</target>
-        <context-group purpose="location"><context context-type="linenumber">1859</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1861</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg197" approved="yes">
+      <trans-unit id="_msg226" approved="yes">
         <source xml:space="preserve">Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
         <target xml:space="preserve">Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">1892</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1894</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg198" approved="yes">
+      <trans-unit id="_msg227" approved="yes">
         <source xml:space="preserve">Original message:</source>
         <target xml:space="preserve">Original message:</target>
-        <context-group purpose="location"><context context-type="linenumber">1992</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1986</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="UnitDisplayStatusBarControl">
-      <trans-unit id="_msg199" approved="yes">
+      <trans-unit id="_msg228" approved="yes">
         <source xml:space="preserve">Unit to show amounts in. Click to select another unit.</source>
         <target xml:space="preserve">Unit to show amounts in. Click to select another unit.</target>
-        <context-group purpose="location"><context context-type="linenumber">2039</context></context-group>
-      </trans-unit>
-    </group>
-  </body></file>
-  <file original="../bitcoin.cpp" datatype="cpp" source-language="en" target-language="en"><body>
-    <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
-      <trans-unit id="_msg200" approved="yes">
-        <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <target xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</target>
-        <context-group purpose="location"><context context-type="linenumber">494</context></context-group>
-      </trans-unit>
-    </group>
-    <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg201">
-        <source xml:space="preserve">Do you want to reset settings to default values, or to abort without making changes?</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
-        <note annotates="source" from="developer">Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</note>
-      </trans-unit>
-      <trans-unit id="_msg202">
-        <source xml:space="preserve">A fatal error occured. Check that settings file is writable, or try running with -nosettings.</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
-        <note annotates="source" from="developer">Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</note>
-      </trans-unit>
-      <trans-unit id="_msg203" approved="yes">
-        <source xml:space="preserve">Choose data directory on startup (default: %u)</source>
-        <target xml:space="preserve">Choose data directory on startup (default: %u)</target>
-        <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg204" approved="yes">
-        <source xml:space="preserve">Set the font family. Possible values: %1. (default: %2)</source>
-        <target xml:space="preserve">Set the font family. Possible values: %1. (default: %2)</target>
-        <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg205" approved="yes">
-        <source xml:space="preserve">Set a scale factor which gets applied to the base font size. Possible range %1 (smallest fonts) to %2 (largest fonts). (default: %3)</source>
-        <target xml:space="preserve">Set a scale factor which gets applied to the base font size. Possible range %1 (smallest fonts) to %2 (largest fonts). (default: %3)</target>
-        <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg206" approved="yes">
-        <source xml:space="preserve">Set the font weight for bold texts. Possible range %1 to %2 (default: %3)</source>
-        <target xml:space="preserve">Set the font weight for bold texts. Possible range %1 to %2 (default: %3)</target>
-        <context-group purpose="location"><context context-type="linenumber">522</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg207" approved="yes">
-        <source xml:space="preserve">Set the font weight for normal texts. Possible range %1 to %2 (default: %3)</source>
-        <target xml:space="preserve">Set the font weight for normal texts. Possible range %1 to %2 (default: %3)</target>
-        <context-group purpose="location"><context context-type="linenumber">523</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg208" approved="yes">
-        <source xml:space="preserve">Set language, for example &quot;de_DE&quot; (default: system locale)</source>
-        <target xml:space="preserve">Set language, for example &quot;de_DE&quot; (default: system locale)</target>
-        <context-group purpose="location"><context context-type="linenumber">524</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg209" approved="yes">
-        <source xml:space="preserve">Start minimized</source>
-        <target xml:space="preserve">Start minimized</target>
-        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg210" approved="yes">
-        <source xml:space="preserve">Reset all settings changed in the GUI</source>
-        <target xml:space="preserve">Reset all settings changed in the GUI</target>
-        <context-group purpose="location"><context context-type="linenumber">526</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg211" approved="yes">
-        <source xml:space="preserve">Show splash screen on startup (default: %u)</source>
-        <target xml:space="preserve">Show splash screen on startup (default: %u)</target>
-        <context-group purpose="location"><context context-type="linenumber">527</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg212" approved="yes">
-        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; does not exist.</source>
-        <target xml:space="preserve">Error: Specified data directory &quot;%1&quot; does not exist.</target>
-        <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg213" approved="yes">
-        <source xml:space="preserve">Error: Cannot parse configuration file: %1.</source>
-        <target xml:space="preserve">Error: Cannot parse configuration file: %1.</target>
-        <context-group purpose="location"><context context-type="linenumber">627</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg214" approved="yes">
-        <source xml:space="preserve">Error: %1</source>
-        <target xml:space="preserve">Error: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">642</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg215" approved="yes">
-        <source xml:space="preserve">Error: Failed to load application fonts.</source>
-        <target xml:space="preserve">Error: Failed to load application fonts.</target>
-        <context-group purpose="location"><context context-type="linenumber">693</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg216" approved="yes">
-        <source xml:space="preserve">Error: Specified font-family invalid. Valid values: %1.</source>
-        <target xml:space="preserve">Error: Specified font-family invalid. Valid values: %1.</target>
-        <context-group purpose="location"><context context-type="linenumber">706</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg217" approved="yes">
-        <source xml:space="preserve">Error: Specified font-weight-normal invalid. Valid range %1 to %2.</source>
-        <target xml:space="preserve">Error: Specified font-weight-normal invalid. Valid range %1 to %2.</target>
-        <context-group purpose="location"><context context-type="linenumber">716</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg218" approved="yes">
-        <source xml:space="preserve">Error: Specified font-weight-bold invalid. Valid range %1 to %2.</source>
-        <target xml:space="preserve">Error: Specified font-weight-bold invalid. Valid range %1 to %2.</target>
-        <context-group purpose="location"><context context-type="linenumber">726</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg219" approved="yes">
-        <source xml:space="preserve">Error: Specified font-scale invalid. Valid range %1 to %2.</source>
-        <target xml:space="preserve">Error: Specified font-scale invalid. Valid range %1 to %2.</target>
-        <context-group purpose="location"><context context-type="linenumber">737</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg220" approved="yes">
-        <source xml:space="preserve">Error: Invalid -custom-css-dir path.</source>
-        <target xml:space="preserve">Error: Invalid -custom-css-dir path.</target>
-        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg221" approved="yes">
-        <source xml:space="preserve">Error: %1 CSS file(s) missing in -custom-css-dir path.</source>
-        <target xml:space="preserve">Error: %1 CSS file(s) missing in -custom-css-dir path.</target>
-        <context-group purpose="location"><context context-type="linenumber">771</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg222" approved="yes">
-        <source xml:space="preserve">%1 didn&apos;t yet exit safely...</source>
-        <target xml:space="preserve">%1 didn&apos;t yet exit safely...</target>
-        <context-group purpose="location"><context context-type="linenumber">803</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">2033</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/coincontroldialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg223" approved="yes">
+      <trans-unit id="_msg229" approved="yes">
         <source xml:space="preserve">Quantity:</source>
         <target xml:space="preserve">Quantity:</target>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg224" approved="yes">
+      <trans-unit id="_msg230" approved="yes">
         <source xml:space="preserve">Bytes:</source>
         <target xml:space="preserve">Bytes:</target>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg225" approved="yes">
+      <trans-unit id="_msg231" approved="yes">
         <source xml:space="preserve">Amount:</source>
         <target xml:space="preserve">Amount:</target>
         <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg226" approved="yes">
+      <trans-unit id="_msg232" approved="yes">
         <source xml:space="preserve">Fee:</source>
         <target xml:space="preserve">Fee:</target>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg227" approved="yes">
+      <trans-unit id="_msg233" approved="yes">
         <source xml:space="preserve">Coin Selection</source>
         <target xml:space="preserve">Coin Selection</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg228" approved="yes">
+      <trans-unit id="_msg234" approved="yes">
         <source xml:space="preserve">Dust:</source>
         <target xml:space="preserve">Dust:</target>
         <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg229" approved="yes">
+      <trans-unit id="_msg235" approved="yes">
         <source xml:space="preserve">After Fee:</source>
         <target xml:space="preserve">After Fee:</target>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg230" approved="yes">
+      <trans-unit id="_msg236" approved="yes">
         <source xml:space="preserve">Change:</source>
         <target xml:space="preserve">Change:</target>
         <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg231" approved="yes">
+      <trans-unit id="_msg237" approved="yes">
         <source xml:space="preserve">(un)select all</source>
         <target xml:space="preserve">(un)select all</target>
         <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg232" approved="yes">
+      <trans-unit id="_msg238" approved="yes">
         <source xml:space="preserve">toggle lock state</source>
         <target xml:space="preserve">toggle lock state</target>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg233" approved="yes">
+      <trans-unit id="_msg239" approved="yes">
         <source xml:space="preserve">Tree mode</source>
         <target xml:space="preserve">Tree mode</target>
         <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg234" approved="yes">
+      <trans-unit id="_msg240" approved="yes">
         <source xml:space="preserve">List mode</source>
         <target xml:space="preserve">List mode</target>
         <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg235" approved="yes">
+      <trans-unit id="_msg241" approved="yes">
         <source xml:space="preserve">(1 locked)</source>
         <target xml:space="preserve">(1 locked)</target>
         <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg236" approved="yes">
+      <trans-unit id="_msg242" approved="yes">
         <source xml:space="preserve">Amount</source>
         <target xml:space="preserve">Amount</target>
         <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg237" approved="yes">
+      <trans-unit id="_msg243" approved="yes">
         <source xml:space="preserve">Received with label</source>
         <target xml:space="preserve">Received with label</target>
         <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg238" approved="yes">
+      <trans-unit id="_msg244" approved="yes">
         <source xml:space="preserve">Received with address</source>
         <target xml:space="preserve">Received with address</target>
         <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg239" approved="yes">
+      <trans-unit id="_msg245" approved="yes">
         <source xml:space="preserve">Mixing Rounds</source>
         <target xml:space="preserve">Mixing Rounds</target>
         <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg240" approved="yes">
+      <trans-unit id="_msg246" approved="yes">
         <source xml:space="preserve">Date</source>
         <target xml:space="preserve">Date</target>
         <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg241" approved="yes">
+      <trans-unit id="_msg247" approved="yes">
         <source xml:space="preserve">Confirmations</source>
         <target xml:space="preserve">Confirmations</target>
         <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg242" approved="yes">
+      <trans-unit id="_msg248" approved="yes">
         <source xml:space="preserve">Confirmed</source>
         <target xml:space="preserve">Confirmed</target>
         <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
@@ -1305,139 +1335,139 @@
   </body></file>
   <file original="../coincontroldialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg243" approved="yes">
+      <trans-unit id="_msg249" approved="yes">
         <source xml:space="preserve">Copy address</source>
         <target xml:space="preserve">Copy address</target>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg244" approved="yes">
+      <trans-unit id="_msg250" approved="yes">
         <source xml:space="preserve">Copy label</source>
         <target xml:space="preserve">Copy label</target>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg245" approved="yes">
+      <trans-unit id="_msg251" approved="yes">
         <source xml:space="preserve">Copy amount</source>
         <target xml:space="preserve">Copy amount</target>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg246" approved="yes">
+      <trans-unit id="_msg252" approved="yes">
         <source xml:space="preserve">Copy transaction ID</source>
         <target xml:space="preserve">Copy transaction ID</target>
         <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg247" approved="yes">
+      <trans-unit id="_msg253" approved="yes">
         <source xml:space="preserve">Lock unspent</source>
         <target xml:space="preserve">Lock unspent</target>
         <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg248" approved="yes">
+      <trans-unit id="_msg254" approved="yes">
         <source xml:space="preserve">Unlock unspent</source>
         <target xml:space="preserve">Unlock unspent</target>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg249" approved="yes">
+      <trans-unit id="_msg255" approved="yes">
         <source xml:space="preserve">Copy quantity</source>
         <target xml:space="preserve">Copy quantity</target>
         <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg250" approved="yes">
+      <trans-unit id="_msg256" approved="yes">
         <source xml:space="preserve">Copy fee</source>
         <target xml:space="preserve">Copy fee</target>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg251" approved="yes">
+      <trans-unit id="_msg257" approved="yes">
         <source xml:space="preserve">Copy after fee</source>
         <target xml:space="preserve">Copy after fee</target>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg252" approved="yes">
+      <trans-unit id="_msg258" approved="yes">
         <source xml:space="preserve">Copy bytes</source>
         <target xml:space="preserve">Copy bytes</target>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg253" approved="yes">
+      <trans-unit id="_msg259" approved="yes">
         <source xml:space="preserve">Copy dust</source>
         <target xml:space="preserve">Copy dust</target>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg254" approved="yes">
+      <trans-unit id="_msg260" approved="yes">
         <source xml:space="preserve">Copy change</source>
         <target xml:space="preserve">Copy change</target>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg255" approved="yes">
+      <trans-unit id="_msg261" approved="yes">
         <source xml:space="preserve">Please switch to &quot;List mode&quot; to use this function.</source>
         <target xml:space="preserve">Please switch to &quot;List mode&quot; to use this function.</target>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg256" approved="yes">
+      <trans-unit id="_msg262" approved="yes">
         <source xml:space="preserve">(%1 locked)</source>
         <target xml:space="preserve">(%1 locked)</target>
         <context-group purpose="location"><context context-type="linenumber">445</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg257" approved="yes">
+      <trans-unit id="_msg263" approved="yes">
         <source xml:space="preserve">yes</source>
         <target xml:space="preserve">yes</target>
         <context-group purpose="location"><context context-type="linenumber">602</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg258" approved="yes">
+      <trans-unit id="_msg264" approved="yes">
         <source xml:space="preserve">no</source>
         <target xml:space="preserve">no</target>
         <context-group purpose="location"><context context-type="linenumber">602</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg259" approved="yes">
+      <trans-unit id="_msg265" approved="yes">
         <source xml:space="preserve">This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
         <target xml:space="preserve">This label turns red if any recipient receives an amount smaller than the current dust threshold.</target>
         <context-group purpose="location"><context context-type="linenumber">616</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg260" approved="yes">
+      <trans-unit id="_msg266" approved="yes">
         <source xml:space="preserve">Can vary +/- %1 duff(s) per input.</source>
         <target xml:space="preserve">Can vary +/- %1 duff(s) per input.</target>
         <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg261" approved="yes">
+      <trans-unit id="_msg267" approved="yes">
         <source xml:space="preserve">Some coins were unselected because they were spent.</source>
         <target xml:space="preserve">Some coins were unselected because they were spent.</target>
         <context-group purpose="location"><context context-type="linenumber">641</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg262" approved="yes">
+      <trans-unit id="_msg268" approved="yes">
         <source xml:space="preserve">Show all coins</source>
         <target xml:space="preserve">Show all coins</target>
         <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg263" approved="yes">
+      <trans-unit id="_msg269" approved="yes">
         <source xml:space="preserve">Hide %1 coins</source>
         <target xml:space="preserve">Hide %1 coins</target>
         <context-group purpose="location"><context context-type="linenumber">667</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg264" approved="yes">
+      <trans-unit id="_msg270" approved="yes">
         <source xml:space="preserve">Show all %1 coins</source>
         <target xml:space="preserve">Show all %1 coins</target>
         <context-group purpose="location"><context context-type="linenumber">671</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg265" approved="yes">
+      <trans-unit id="_msg271" approved="yes">
         <source xml:space="preserve">Show spendable coins only</source>
         <target xml:space="preserve">Show spendable coins only</target>
         <context-group purpose="location"><context context-type="linenumber">673</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg266" approved="yes">
+      <trans-unit id="_msg272" approved="yes">
         <source xml:space="preserve">(no label)</source>
         <target xml:space="preserve">(no label)</target>
         <context-group purpose="location"><context context-type="linenumber">693</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">768</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg267" approved="yes">
+      <trans-unit id="_msg273" approved="yes">
         <source xml:space="preserve">change from %1 (%2)</source>
         <target xml:space="preserve">change from %1 (%2)</target>
         <context-group purpose="location"><context context-type="linenumber">763</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg268" approved="yes">
+      <trans-unit id="_msg274" approved="yes">
         <source xml:space="preserve">(change)</source>
         <target xml:space="preserve">(change)</target>
         <context-group purpose="location"><context context-type="linenumber">764</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg269" approved="yes">
+      <trans-unit id="_msg275" approved="yes">
         <source xml:space="preserve">n/a</source>
         <target xml:space="preserve">n/a</target>
         <context-group purpose="location"><context context-type="linenumber">788</context></context-group>
@@ -1446,158 +1476,173 @@
   </body></file>
   <file original="../walletcontroller.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletActivity">
-      <trans-unit id="_msg270" approved="yes">
-        <source xml:space="preserve">Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <target xml:space="preserve">Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</target>
+      <trans-unit id="_msg276">
+        <source xml:space="preserve">Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg271" approved="yes">
+      <trans-unit id="_msg277" approved="yes">
         <source xml:space="preserve">Create wallet failed</source>
         <target xml:space="preserve">Create wallet failed</target>
-        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg272" approved="yes">
+      <trans-unit id="_msg278" approved="yes">
         <source xml:space="preserve">Create wallet warning</source>
         <target xml:space="preserve">Create wallet warning</target>
-        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="OpenWalletActivity">
-      <trans-unit id="_msg273" approved="yes">
+      <trans-unit id="_msg279" approved="yes">
         <source xml:space="preserve">Open wallet failed</source>
         <target xml:space="preserve">Open wallet failed</target>
-        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg274" approved="yes">
+      <trans-unit id="_msg280" approved="yes">
         <source xml:space="preserve">Open wallet warning</source>
         <target xml:space="preserve">Open wallet warning</target>
-        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg275" approved="yes">
+      <trans-unit id="_msg281" approved="yes">
         <source xml:space="preserve">default wallet</source>
         <target xml:space="preserve">default wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg276" approved="yes">
-        <source xml:space="preserve">Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <target xml:space="preserve">Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</target>
-        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      <trans-unit id="_msg282">
+        <source xml:space="preserve">Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="WalletController">
-      <trans-unit id="_msg277" approved="yes">
+      <trans-unit id="_msg283" approved="yes">
         <source xml:space="preserve">Close wallet</source>
         <target xml:space="preserve">Close wallet</target>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg278" approved="yes">
+      <trans-unit id="_msg284" approved="yes">
         <source xml:space="preserve">Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <target xml:space="preserve">Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</target>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg279" approved="yes">
+      <trans-unit id="_msg285" approved="yes">
         <source xml:space="preserve">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
         <target xml:space="preserve">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</target>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg280">
+      <trans-unit id="_msg286" approved="yes">
         <source xml:space="preserve">Close all wallets</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Close all wallets</target>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg281">
+      <trans-unit id="_msg287" approved="yes">
         <source xml:space="preserve">Are you sure you wish to close all wallets?</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Are you sure you wish to close all wallets?</target>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/createwalletdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg282" approved="yes">
+      <trans-unit id="_msg288" approved="yes">
         <source xml:space="preserve">Create Wallet</source>
         <target xml:space="preserve">Create Wallet</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg283" approved="yes">
+      <trans-unit id="_msg289" approved="yes">
         <source xml:space="preserve">Wallet Name</source>
         <target xml:space="preserve">Wallet Name</target>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg284" approved="yes">
+      <trans-unit id="_msg290" approved="yes">
         <source xml:space="preserve">Wallet</source>
         <target xml:space="preserve">Wallet</target>
         <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg285" approved="yes">
+      <trans-unit id="_msg291" approved="yes">
         <source xml:space="preserve">Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
         <target xml:space="preserve">Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</target>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg286" approved="yes">
+      <trans-unit id="_msg292" approved="yes">
         <source xml:space="preserve">Encrypt Wallet</source>
         <target xml:space="preserve">Encrypt Wallet</target>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg287" approved="yes">
+      <trans-unit id="_msg293" approved="yes">
         <source xml:space="preserve">Advanced Options</source>
         <target xml:space="preserve">Advanced Options</target>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg288" approved="yes">
+      <trans-unit id="_msg294" approved="yes">
         <source xml:space="preserve">Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <target xml:space="preserve">Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</target>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg289" approved="yes">
+      <trans-unit id="_msg295" approved="yes">
         <source xml:space="preserve">Disable Private Keys</source>
         <target xml:space="preserve">Disable Private Keys</target>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg290" approved="yes">
+      <trans-unit id="_msg296" approved="yes">
         <source xml:space="preserve">Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
         <target xml:space="preserve">Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</target>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg291" approved="yes">
+      <trans-unit id="_msg297" approved="yes">
         <source xml:space="preserve">Make Blank Wallet</source>
         <target xml:space="preserve">Make Blank Wallet</target>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg298">
+        <source xml:space="preserve">Use descriptors for scriptPubKey management. This feature is well-tested but still considered experimental and not recommended for use yet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg299">
+        <source xml:space="preserve">Descriptor Wallet (EXPERIMENTAL)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../createwalletdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg292" approved="yes">
+      <trans-unit id="_msg300" approved="yes">
         <source xml:space="preserve">Create</source>
         <target xml:space="preserve">Create</target>
         <context-group purpose="location"><context context-type="linenumber">21</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg301">
+        <source xml:space="preserve">Compiled without sqlite support (required for descriptor wallets)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/editaddressdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg293" approved="yes">
+      <trans-unit id="_msg302" approved="yes">
         <source xml:space="preserve">Edit Address</source>
         <target xml:space="preserve">Edit Address</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg294" approved="yes">
+      <trans-unit id="_msg303" approved="yes">
         <source xml:space="preserve">&amp;Label</source>
         <target xml:space="preserve">&amp;Label</target>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg295" approved="yes">
+      <trans-unit id="_msg304" approved="yes">
         <source xml:space="preserve">The label associated with this address list entry</source>
         <target xml:space="preserve">The label associated with this address list entry</target>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg296" approved="yes">
+      <trans-unit id="_msg305" approved="yes">
         <source xml:space="preserve">&amp;Address</source>
         <target xml:space="preserve">&amp;Address</target>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg297" approved="yes">
+      <trans-unit id="_msg306" approved="yes">
         <source xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <target xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</target>
         <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
@@ -1606,42 +1651,42 @@
   </body></file>
   <file original="../editaddressdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg298" approved="yes">
+      <trans-unit id="_msg307" approved="yes">
         <source xml:space="preserve">New sending address</source>
         <target xml:space="preserve">New sending address</target>
         <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg299" approved="yes">
+      <trans-unit id="_msg308" approved="yes">
         <source xml:space="preserve">Edit receiving address</source>
         <target xml:space="preserve">Edit receiving address</target>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg300" approved="yes">
+      <trans-unit id="_msg309" approved="yes">
         <source xml:space="preserve">Edit sending address</source>
         <target xml:space="preserve">Edit sending address</target>
         <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg301" approved="yes">
+      <trans-unit id="_msg310" approved="yes">
         <source xml:space="preserve">The entered address &quot;%1&quot; is not a valid Dash address.</source>
         <target xml:space="preserve">The entered address &quot;%1&quot; is not a valid Dash address.</target>
         <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg302" approved="yes">
+      <trans-unit id="_msg311" approved="yes">
         <source xml:space="preserve">Address &quot;%1&quot; already exists as a receiving address with label &quot;%2&quot; and so cannot be added as a sending address.</source>
         <target xml:space="preserve">Address &quot;%1&quot; already exists as a receiving address with label &quot;%2&quot; and so cannot be added as a sending address.</target>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg303" approved="yes">
+      <trans-unit id="_msg312" approved="yes">
         <source xml:space="preserve">The entered address &quot;%1&quot; is already in the address book with label &quot;%2&quot;.</source>
         <target xml:space="preserve">The entered address &quot;%1&quot; is already in the address book with label &quot;%2&quot;.</target>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg304" approved="yes">
+      <trans-unit id="_msg313" approved="yes">
         <source xml:space="preserve">Could not unlock wallet.</source>
         <target xml:space="preserve">Could not unlock wallet.</target>
         <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg305" approved="yes">
+      <trans-unit id="_msg314" approved="yes">
         <source xml:space="preserve">New key generation failed.</source>
         <target xml:space="preserve">New key generation failed.</target>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
@@ -1650,72 +1695,54 @@
   </body></file>
   <file original="../intro.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="FreespaceChecker">
-      <trans-unit id="_msg306" approved="yes">
+      <trans-unit id="_msg315" approved="yes">
         <source xml:space="preserve">A new data directory will be created.</source>
         <target xml:space="preserve">A new data directory will be created.</target>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg307" approved="yes">
+      <trans-unit id="_msg316" approved="yes">
         <source xml:space="preserve">name</source>
         <target xml:space="preserve">name</target>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg308" approved="yes">
+      <trans-unit id="_msg317" approved="yes">
         <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <target xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</target>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg309" approved="yes">
+      <trans-unit id="_msg318" approved="yes">
         <source xml:space="preserve">Path already exists, and is not a directory.</source>
         <target xml:space="preserve">Path already exists, and is not a directory.</target>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg310" approved="yes">
+      <trans-unit id="_msg319" approved="yes">
         <source xml:space="preserve">Cannot create data directory here.</source>
         <target xml:space="preserve">Cannot create data directory here.</target>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <group restype="x-gettext-plurals">
+      <trans-unit id="_msg320">
+        <source xml:space="preserve">%1 GB of free space available</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
-        <trans-unit id="_msg311[0]" approved="yes">
-          <source xml:space="preserve">%n GB of free space available</source>
-          <target xml:space="preserve">%n GB of free space available</target>
-        </trans-unit>
-        <trans-unit id="_msg311[1]" approved="yes">
-          <source xml:space="preserve">%n GB of free space available</source>
-          <target xml:space="preserve">%n GB of free space available</target>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
+      </trans-unit>
+      <trans-unit id="_msg321">
+        <source xml:space="preserve">(of %1 GB needed)</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
-        <trans-unit id="_msg312[0]" approved="yes">
-          <source xml:space="preserve">(of %n GB needed)</source>
-          <target xml:space="preserve">(of %n GB needed)</target>
-        </trans-unit>
-        <trans-unit id="_msg312[1]" approved="yes">
-          <source xml:space="preserve">(of %n GB needed)</source>
-          <target xml:space="preserve">(of %n GB needed)</target>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
+      </trans-unit>
+      <trans-unit id="_msg322">
+        <source xml:space="preserve">(%1 GB needed for full chain)</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
-        <trans-unit id="_msg313[0]" approved="yes">
-          <source xml:space="preserve">(%n GB needed for full chain)</source>
-          <target xml:space="preserve">(%n GB needed for full chain)</target>
-        </trans-unit>
-        <trans-unit id="_msg313[1]" approved="yes">
-          <source xml:space="preserve">(%n GB needed for full chain)</source>
-          <target xml:space="preserve">(%n GB needed for full chain)</target>
-        </trans-unit>
-      </group>
-      <trans-unit id="_msg314" approved="yes">
+      </trans-unit>
+      <trans-unit id="_msg323" approved="yes">
         <source xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <target xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</target>
         <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg315" approved="yes">
+      <trans-unit id="_msg324" approved="yes">
         <source xml:space="preserve">Approximately %1 GB of data will be stored in this directory.</source>
         <target xml:space="preserve">Approximately %1 GB of data will be stored in this directory.</target>
         <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
@@ -1723,31 +1750,31 @@
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
         <note annotates="source" from="developer">Explanatory text on the capability of the current prune target.</note>
-        <trans-unit id="_msg316[0]">
+        <trans-unit id="_msg325[0]" approved="yes">
           <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
-          <target xml:space="preserve"></target>
+          <target xml:space="preserve">(sufficient to restore backups %n day old)</target>
         </trans-unit>
-        <trans-unit id="_msg316[1]">
+        <trans-unit id="_msg325[1]" approved="yes">
           <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
-          <target xml:space="preserve"></target>
+          <target xml:space="preserve">(sufficient to restore backups %n days old)</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg317" approved="yes">
+      <trans-unit id="_msg326" approved="yes">
         <source xml:space="preserve">%1 will download and store a copy of the Dash block chain.</source>
         <target xml:space="preserve">%1 will download and store a copy of the Dash block chain.</target>
         <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg318" approved="yes">
+      <trans-unit id="_msg327" approved="yes">
         <source xml:space="preserve">The wallet will also be stored in this directory.</source>
         <target xml:space="preserve">The wallet will also be stored in this directory.</target>
         <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg319" approved="yes">
+      <trans-unit id="_msg328" approved="yes">
         <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <target xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</target>
         <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg320" approved="yes">
+      <trans-unit id="_msg329" approved="yes">
         <source xml:space="preserve">Error</source>
         <target xml:space="preserve">Error</target>
         <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
@@ -1756,27 +1783,27 @@
   </body></file>
   <file original="../forms/governancelist.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="GovernanceList">
-      <trans-unit id="_msg321" approved="yes">
+      <trans-unit id="_msg330" approved="yes">
         <source xml:space="preserve">Form</source>
         <target xml:space="preserve">Form</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg322" approved="yes">
+      <trans-unit id="_msg331" approved="yes">
         <source xml:space="preserve">Filter List:</source>
         <target xml:space="preserve">Filter List:</target>
         <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg323" approved="yes">
+      <trans-unit id="_msg332" approved="yes">
         <source xml:space="preserve">Filter proposal list</source>
         <target xml:space="preserve">Filter proposal list</target>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg324" approved="yes">
+      <trans-unit id="_msg333" approved="yes">
         <source xml:space="preserve">Proposal Count:</source>
         <target xml:space="preserve">Proposal Count:</target>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg325" approved="yes">
+      <trans-unit id="_msg334" approved="yes">
         <source xml:space="preserve">Filter by Title</source>
         <target xml:space="preserve">Filter by Title</target>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
@@ -1785,66 +1812,66 @@
   </body></file>
   <file original="../governancelist.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="GovernanceList">
-      <trans-unit id="_msg326" approved="yes">
+      <trans-unit id="_msg335" approved="yes">
         <source xml:space="preserve">Proposal Info: %1</source>
         <target xml:space="preserve">Proposal Info: %1</target>
         <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="Proposal">
-      <trans-unit id="_msg327" approved="yes">
+      <trans-unit id="_msg336" approved="yes">
         <source xml:space="preserve">Passing +%1</source>
         <target xml:space="preserve">Passing +%1</target>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg328" approved="yes">
+      <trans-unit id="_msg337" approved="yes">
         <source xml:space="preserve">Needs additional %1 votes</source>
         <target xml:space="preserve">Needs additional %1 votes</target>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="ProposalModel">
-      <trans-unit id="_msg329" approved="yes">
+      <trans-unit id="_msg338" approved="yes">
         <source xml:space="preserve">Yes</source>
         <target xml:space="preserve">Yes</target>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg330" approved="yes">
+      <trans-unit id="_msg339" approved="yes">
         <source xml:space="preserve">No</source>
         <target xml:space="preserve">No</target>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg331" approved="yes">
+      <trans-unit id="_msg340" approved="yes">
         <source xml:space="preserve">Hash</source>
         <target xml:space="preserve">Hash</target>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg332" approved="yes">
+      <trans-unit id="_msg341" approved="yes">
         <source xml:space="preserve">Title</source>
         <target xml:space="preserve">Title</target>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg333" approved="yes">
+      <trans-unit id="_msg342" approved="yes">
         <source xml:space="preserve">Start</source>
         <target xml:space="preserve">Start</target>
         <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg334" approved="yes">
+      <trans-unit id="_msg343" approved="yes">
         <source xml:space="preserve">End</source>
         <target xml:space="preserve">End</target>
         <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg335" approved="yes">
+      <trans-unit id="_msg344" approved="yes">
         <source xml:space="preserve">Amount</source>
         <target xml:space="preserve">Amount</target>
         <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg336" approved="yes">
+      <trans-unit id="_msg345" approved="yes">
         <source xml:space="preserve">Active</source>
         <target xml:space="preserve">Active</target>
         <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg337" approved="yes">
+      <trans-unit id="_msg346" approved="yes">
         <source xml:space="preserve">Status</source>
         <target xml:space="preserve">Status</target>
         <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
@@ -1853,39 +1880,39 @@
   </body></file>
   <file original="../utilitydialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="HelpMessageDialog">
-      <trans-unit id="_msg338" approved="yes">
+      <trans-unit id="_msg347" approved="yes">
         <source xml:space="preserve">version</source>
         <target xml:space="preserve">version</target>
         <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg339" approved="yes">
+      <trans-unit id="_msg348" approved="yes">
         <source xml:space="preserve">About %1</source>
         <target xml:space="preserve">About %1</target>
         <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg340" approved="yes">
+      <trans-unit id="_msg349" approved="yes">
         <source xml:space="preserve">Command-line options</source>
         <target xml:space="preserve">Command-line options</target>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg341" approved="yes">
+      <trans-unit id="_msg350" approved="yes">
         <source xml:space="preserve">%1 information</source>
         <target xml:space="preserve">%1 information</target>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg342" approved="yes">
+      <trans-unit id="_msg351" approved="yes">
         <source xml:space="preserve">&lt;h3&gt;%1 Basics&lt;/h3&gt; %1 gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different &quot;inputs&quot; which you can think of as separate, discrete coins.&lt;br&gt; %1 uses an innovative process to mix your inputs with the inputs of two or more other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The %1 process works like this:&lt;/b&gt;&lt;ol type=&quot;1&quot;&gt; &lt;li&gt;%1 begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called &quot;masternodes.&quot; These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know &quot;who&quot; you are.&lt;/li&gt; &lt;li&gt;When two or more other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users&apos; wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it&apos;s called a &quot;round.&quot; Each round of %1 makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these &quot;change addresses.&quot; Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have %1 disabled. &lt;hr&gt;For more information, see the &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%1 documentation&lt;/a&gt;.</source>
         <target xml:space="preserve">&lt;h3&gt;%1 Basics&lt;/h3&gt; %1 gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different &quot;inputs&quot; which you can think of as separate, discrete coins.&lt;br&gt; %1 uses an innovative process to mix your inputs with the inputs of two or more other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The %1 process works like this:&lt;/b&gt;&lt;ol type=&quot;1&quot;&gt; &lt;li&gt;%1 begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called &quot;masternodes.&quot; These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know &quot;who&quot; you are.&lt;/li&gt; &lt;li&gt;When two or more other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users&apos; wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it&apos;s called a &quot;round.&quot; Each round of %1 makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these &quot;change addresses.&quot; Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have %1 disabled. &lt;hr&gt;For more information, see the &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%1 documentation&lt;/a&gt;.</target>
         <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="ShutdownWindow">
-      <trans-unit id="_msg343" approved="yes">
-        <source xml:space="preserve">%1 is shutting down...</source>
-        <target xml:space="preserve">%1 is shutting down...</target>
+      <trans-unit id="_msg352">
+        <source xml:space="preserve">%1 is shutting down…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg344" approved="yes">
+      <trans-unit id="_msg353" approved="yes">
         <source xml:space="preserve">Do not shut down the computer until this window disappears.</source>
         <target xml:space="preserve">Do not shut down the computer until this window disappears.</target>
         <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
@@ -1894,57 +1921,57 @@
   </body></file>
   <file original="../forms/intro.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg345" approved="yes">
+      <trans-unit id="_msg354" approved="yes">
         <source xml:space="preserve">Welcome</source>
         <target xml:space="preserve">Welcome</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg346" approved="yes">
+      <trans-unit id="_msg355" approved="yes">
         <source xml:space="preserve">Welcome to %1.</source>
         <target xml:space="preserve">Welcome to %1.</target>
         <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg347" approved="yes">
+      <trans-unit id="_msg356" approved="yes">
         <source xml:space="preserve">As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <target xml:space="preserve">As this is the first time the program is launched, you can choose where %1 will store its data.</target>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg348" approved="yes">
-        <source xml:space="preserve">When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <target xml:space="preserve">When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</target>
-        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg349">
+      <trans-unit id="_msg357" approved="yes">
         <source xml:space="preserve">Limit block chain storage to</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Limit block chain storage to</target>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg350" approved="yes">
+      <trans-unit id="_msg358" approved="yes">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <target xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</target>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg351">
+      <trans-unit id="_msg359" approved="yes">
         <source xml:space="preserve"> GB</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve"> GB</target>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg352" approved="yes">
+      <trans-unit id="_msg360" approved="yes">
         <source xml:space="preserve">This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <target xml:space="preserve">This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</target>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg353" approved="yes">
+      <trans-unit id="_msg361">
+        <source xml:space="preserve">When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg362" approved="yes">
         <source xml:space="preserve">If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
         <target xml:space="preserve">If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</target>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg354" approved="yes">
+      <trans-unit id="_msg363" approved="yes">
         <source xml:space="preserve">Use the default data directory</source>
         <target xml:space="preserve">Use the default data directory</target>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg355" approved="yes">
+      <trans-unit id="_msg364" approved="yes">
         <source xml:space="preserve">Use a custom data directory:</source>
         <target xml:space="preserve">Use a custom data directory:</target>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
@@ -1953,97 +1980,97 @@
   </body></file>
   <file original="../forms/masternodelist.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="MasternodeList">
-      <trans-unit id="_msg356" approved="yes">
+      <trans-unit id="_msg365" approved="yes">
         <source xml:space="preserve">Form</source>
         <target xml:space="preserve">Form</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg357" approved="yes">
+      <trans-unit id="_msg366" approved="yes">
         <source xml:space="preserve">Status</source>
         <target xml:space="preserve">Status</target>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg358" approved="yes">
+      <trans-unit id="_msg367" approved="yes">
         <source xml:space="preserve">Filter List:</source>
         <target xml:space="preserve">Filter List:</target>
         <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg359" approved="yes">
+      <trans-unit id="_msg368" approved="yes">
         <source xml:space="preserve">Filter masternode list</source>
         <target xml:space="preserve">Filter masternode list</target>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg360" approved="yes">
+      <trans-unit id="_msg369" approved="yes">
         <source xml:space="preserve">Node Count:</source>
         <target xml:space="preserve">Node Count:</target>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg361" approved="yes">
+      <trans-unit id="_msg370" approved="yes">
         <source xml:space="preserve">Show only masternodes this wallet has keys for.</source>
         <target xml:space="preserve">Show only masternodes this wallet has keys for.</target>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg362" approved="yes">
+      <trans-unit id="_msg371" approved="yes">
         <source xml:space="preserve">My masternodes only</source>
         <target xml:space="preserve">My masternodes only</target>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg363" approved="yes">
+      <trans-unit id="_msg372" approved="yes">
         <source xml:space="preserve">Service</source>
         <target xml:space="preserve">Service</target>
         <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg364" approved="yes">
+      <trans-unit id="_msg373" approved="yes">
         <source xml:space="preserve">Type</source>
         <target xml:space="preserve">Type</target>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg365" approved="yes">
+      <trans-unit id="_msg374" approved="yes">
         <source xml:space="preserve">PoSe Score</source>
         <target xml:space="preserve">PoSe Score</target>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg366" approved="yes">
+      <trans-unit id="_msg375" approved="yes">
         <source xml:space="preserve">Registered</source>
         <target xml:space="preserve">Registered</target>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg367" approved="yes">
+      <trans-unit id="_msg376" approved="yes">
         <source xml:space="preserve">Last Paid</source>
         <target xml:space="preserve">Last Paid</target>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg368" approved="yes">
+      <trans-unit id="_msg377" approved="yes">
         <source xml:space="preserve">Next Payment</source>
         <target xml:space="preserve">Next Payment</target>
         <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg369" approved="yes">
+      <trans-unit id="_msg378" approved="yes">
         <source xml:space="preserve">Payout Address</source>
         <target xml:space="preserve">Payout Address</target>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg370" approved="yes">
+      <trans-unit id="_msg379" approved="yes">
         <source xml:space="preserve">Operator Reward</source>
         <target xml:space="preserve">Operator Reward</target>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg371" approved="yes">
+      <trans-unit id="_msg380" approved="yes">
         <source xml:space="preserve">Collateral Address</source>
         <target xml:space="preserve">Collateral Address</target>
         <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg372" approved="yes">
+      <trans-unit id="_msg381" approved="yes">
         <source xml:space="preserve">Owner Address</source>
         <target xml:space="preserve">Owner Address</target>
         <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg373" approved="yes">
+      <trans-unit id="_msg382" approved="yes">
         <source xml:space="preserve">Voting Address</source>
         <target xml:space="preserve">Voting Address</target>
         <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg374" approved="yes">
+      <trans-unit id="_msg383" approved="yes">
         <source xml:space="preserve">Filter by any property (e.g. address or protx hash)</source>
         <target xml:space="preserve">Filter by any property (e.g. address or protx hash)</target>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
@@ -2052,64 +2079,64 @@
   </body></file>
   <file original="../masternodelist.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="MasternodeList">
-      <trans-unit id="_msg375" approved="yes">
+      <trans-unit id="_msg384" approved="yes">
         <source xml:space="preserve">Copy ProTx Hash</source>
         <target xml:space="preserve">Copy ProTx Hash</target>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg376" approved="yes">
+      <trans-unit id="_msg385" approved="yes">
         <source xml:space="preserve">Copy Collateral Outpoint</source>
         <target xml:space="preserve">Copy Collateral Outpoint</target>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg377" approved="yes">
-        <source xml:space="preserve">Updating...</source>
-        <target xml:space="preserve">Updating...</target>
+      <trans-unit id="_msg386">
+        <source xml:space="preserve">Please wait…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg387">
+        <source xml:space="preserve">Updating…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg378" approved="yes">
+      <trans-unit id="_msg388" approved="yes">
         <source xml:space="preserve">ENABLED</source>
         <target xml:space="preserve">ENABLED</target>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg379" approved="yes">
+      <trans-unit id="_msg389" approved="yes">
         <source xml:space="preserve">POSE_BANNED</source>
         <target xml:space="preserve">POSE_BANNED</target>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg380" approved="yes">
+      <trans-unit id="_msg390" approved="yes">
         <source xml:space="preserve">UNKNOWN</source>
         <target xml:space="preserve">UNKNOWN</target>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg381" approved="yes">
+      <trans-unit id="_msg391" approved="yes">
         <source xml:space="preserve">to %1</source>
         <target xml:space="preserve">to %1</target>
         <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg382" approved="yes">
+      <trans-unit id="_msg392" approved="yes">
         <source xml:space="preserve">to UNKNOWN</source>
         <target xml:space="preserve">to UNKNOWN</target>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg383" approved="yes">
+      <trans-unit id="_msg393" approved="yes">
         <source xml:space="preserve">but not claimed</source>
         <target xml:space="preserve">but not claimed</target>
         <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg384" approved="yes">
+      <trans-unit id="_msg394" approved="yes">
         <source xml:space="preserve">NONE</source>
         <target xml:space="preserve">NONE</target>
         <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg385" approved="yes">
-        <source xml:space="preserve">Please wait...</source>
-        <target xml:space="preserve">Please wait...</target>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg386" approved="yes">
+      <trans-unit id="_msg395" approved="yes">
         <source xml:space="preserve">Additional information for DIP3 Masternode %1</source>
         <target xml:space="preserve">Additional information for DIP3 Masternode %1</target>
         <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
@@ -2118,60 +2145,60 @@
   </body></file>
   <file original="../forms/modaloverlay.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg387" approved="yes">
+      <trans-unit id="_msg396" approved="yes">
         <source xml:space="preserve">Form</source>
         <target xml:space="preserve">Form</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg388" approved="yes">
+      <trans-unit id="_msg397" approved="yes">
         <source xml:space="preserve">Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the Dash network, as detailed below.</source>
         <target xml:space="preserve">Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the Dash network, as detailed below.</target>
         <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg389" approved="yes">
+      <trans-unit id="_msg398" approved="yes">
         <source xml:space="preserve">Attempting to spend Dash that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
         <target xml:space="preserve">Attempting to spend Dash that are affected by not-yet-displayed transactions will not be accepted by the network.</target>
         <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg390" approved="yes">
+      <trans-unit id="_msg399" approved="yes">
         <source xml:space="preserve">Number of blocks left</source>
         <target xml:space="preserve">Number of blocks left</target>
         <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg391" approved="yes">
-        <source xml:space="preserve">Unknown...</source>
-        <target xml:space="preserve">Unknown...</target>
+      <trans-unit id="_msg400">
+        <source xml:space="preserve">Unknown…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../modaloverlay.cpp</context><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg392" approved="yes">
+      <trans-unit id="_msg401">
+        <source xml:space="preserve">calculating…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg402" approved="yes">
         <source xml:space="preserve">Last block time</source>
         <target xml:space="preserve">Last block time</target>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg393" approved="yes">
+      <trans-unit id="_msg403" approved="yes">
         <source xml:space="preserve">Progress</source>
         <target xml:space="preserve">Progress</target>
         <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg394" approved="yes">
+      <trans-unit id="_msg404" approved="yes">
         <source xml:space="preserve">Progress increase per hour</source>
         <target xml:space="preserve">Progress increase per hour</target>
         <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg395" approved="yes">
-        <source xml:space="preserve">calculating...</source>
-        <target xml:space="preserve">calculating...</target>
-        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg396" approved="yes">
+      <trans-unit id="_msg405" approved="yes">
         <source xml:space="preserve">Estimated time left until synced</source>
         <target xml:space="preserve">Estimated time left until synced</target>
         <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg397" approved="yes">
+      <trans-unit id="_msg406" approved="yes">
         <source xml:space="preserve">Hide</source>
         <target xml:space="preserve">Hide</target>
         <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
@@ -2180,19 +2207,19 @@
   </body></file>
   <file original="../modaloverlay.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg398" approved="yes">
+      <trans-unit id="_msg407" approved="yes">
         <source xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <target xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</target>
         <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg399" approved="yes">
-        <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)...</source>
-        <target xml:space="preserve">Unknown. Syncing Headers (%1, %2%)...</target>
+      <trans-unit id="_msg408">
+        <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg400" approved="yes">
+      <trans-unit id="_msg409" approved="yes">
         <source xml:space="preserve">unknown</source>
         <target xml:space="preserve">unknown</target>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
@@ -2201,12 +2228,12 @@
   </body></file>
   <file original="../forms/openuridialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OpenURIDialog">
-      <trans-unit id="_msg401" approved="yes">
+      <trans-unit id="_msg410" approved="yes">
         <source xml:space="preserve">Open URI</source>
         <target xml:space="preserve">Open URI</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg402" approved="yes">
+      <trans-unit id="_msg411" approved="yes">
         <source xml:space="preserve">URI:</source>
         <target xml:space="preserve">URI:</target>
         <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
@@ -2215,1062 +2242,1069 @@
   </body></file>
   <file original="../forms/optionsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg403" approved="yes">
+      <trans-unit id="_msg412" approved="yes">
         <source xml:space="preserve">Options</source>
         <target xml:space="preserve">Options</target>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg404" approved="yes">
+      <trans-unit id="_msg413" approved="yes">
         <source xml:space="preserve">&amp;Main</source>
         <target xml:space="preserve">&amp;Main</target>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg405" approved="yes">
+      <trans-unit id="_msg414" approved="yes">
         <source xml:space="preserve">Size of &amp;database cache</source>
         <target xml:space="preserve">Size of &amp;database cache</target>
-        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg406" approved="yes">
+      <trans-unit id="_msg415" approved="yes">
         <source xml:space="preserve">Number of script &amp;verification threads</source>
         <target xml:space="preserve">Number of script &amp;verification threads</target>
-        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg407" approved="yes">
+      <trans-unit id="_msg416" approved="yes">
         <source xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</source>
         <target xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</target>
-        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg408" approved="yes">
+      <trans-unit id="_msg417" approved="yes">
         <source xml:space="preserve">W&amp;allet</source>
         <target xml:space="preserve">W&amp;allet</target>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg409" approved="yes">
+      <trans-unit id="_msg418" approved="yes">
         <source xml:space="preserve">&amp;Appearance</source>
         <target xml:space="preserve">&amp;Appearance</target>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg410" approved="yes">
-        <source xml:space="preserve">Prune &amp;block storage to</source>
-        <target xml:space="preserve">Prune &amp;block storage to</target>
-        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg411" approved="yes">
-        <source xml:space="preserve">GB</source>
-        <target xml:space="preserve">GB</target>
-        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg412" approved="yes">
-        <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</source>
-        <target xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</target>
-        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg413">
-        <source xml:space="preserve">Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+      <trans-unit id="_msg419">
+        <source xml:space="preserve">Show the icon in the system tray.</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
-        <note annotates="source" from="developer">Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</note>
-      </trans-unit>
-      <trans-unit id="_msg414" approved="yes">
-        <source xml:space="preserve">MiB</source>
-        <target xml:space="preserve">MiB</target>
-        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg415">
-        <source xml:space="preserve">Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
-        <note annotates="source" from="developer">Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</note>
-      </trans-unit>
-      <trans-unit id="_msg416" approved="yes">
-        <source xml:space="preserve">Whether to keep the specified custom change address or not.</source>
-        <target xml:space="preserve">Whether to keep the specified custom change address or not.</target>
-        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg417" approved="yes">
-        <source xml:space="preserve">Keep custom change &amp;address</source>
-        <target xml:space="preserve">Keep custom change &amp;address</target>
-        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg418" approved="yes">
-        <source xml:space="preserve">Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</source>
-        <target xml:space="preserve">Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</target>
-        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg419" approved="yes">
-        <source xml:space="preserve">Show Masternodes Tab</source>
-        <target xml:space="preserve">Show Masternodes Tab</target>
-        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg420" approved="yes">
-        <source xml:space="preserve">Show additional tab listing governance proposals.</source>
-        <target xml:space="preserve">Show additional tab listing governance proposals.</target>
-        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg421" approved="yes">
-        <source xml:space="preserve">Show Governance Tab</source>
-        <target xml:space="preserve">Show Governance Tab</target>
-        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg422" approved="yes">
-        <source xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</source>
-        <target xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</target>
-        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg423" approved="yes">
-        <source xml:space="preserve">Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</source>
-        <target xml:space="preserve">Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</target>
-        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg424" approved="yes">
-        <source xml:space="preserve">Show additional information and buttons on overview screen.</source>
-        <target xml:space="preserve">Show additional information and buttons on overview screen.</target>
-        <context-group purpose="location"><context context-type="linenumber">399</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg425" approved="yes">
-        <source xml:space="preserve">Enable advanced interface</source>
-        <target xml:space="preserve">Enable advanced interface</target>
-        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg426" approved="yes">
-        <source xml:space="preserve">Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
-        <target xml:space="preserve">Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</target>
-        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg427" approved="yes">
-        <source xml:space="preserve">Show popups for mixing transactions</source>
-        <target xml:space="preserve">Show popups for mixing transactions</target>
-        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg428" approved="yes">
-        <source xml:space="preserve">Show warning dialog when the wallet has very low number of keys left.</source>
-        <target xml:space="preserve">Show warning dialog when the wallet has very low number of keys left.</target>
-        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg429" approved="yes">
-        <source xml:space="preserve">Warn if the wallet is running out of keys</source>
-        <target xml:space="preserve">Warn if the wallet is running out of keys</target>
-        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg430" approved="yes">
-        <source xml:space="preserve">Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
-        <target xml:space="preserve">Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</target>
-        <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg431" approved="yes">
-        <source xml:space="preserve">Enable &amp;multi-session</source>
-        <target xml:space="preserve">Enable &amp;multi-session</target>
-        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg432" approved="yes">
-        <source xml:space="preserve">Use this many separate masternodes in parallel to mix funds.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
-        <target xml:space="preserve">Use this many separate masternodes in parallel to mix funds.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</target>
-        <context-group purpose="location"><context context-type="linenumber">441</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg433" approved="yes">
-        <source xml:space="preserve">Parallel sessions</source>
-        <target xml:space="preserve">Parallel sessions</target>
-        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg434" approved="yes">
-        <source xml:space="preserve">Mixing rounds</source>
-        <target xml:space="preserve">Mixing rounds</target>
-        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg435" approved="yes">
-        <source xml:space="preserve">This amount acts as a threshold to turn off mixing once it&apos;s reached.</source>
-        <target xml:space="preserve">This amount acts as a threshold to turn off mixing once it&apos;s reached.</target>
-        <context-group purpose="location"><context context-type="linenumber">487</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg436" approved="yes">
-        <source xml:space="preserve">Target balance</source>
-        <target xml:space="preserve">Target balance</target>
-        <context-group purpose="location"><context context-type="linenumber">502</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg437" approved="yes">
-        <source xml:space="preserve">How many inputs of each denominated amount are created.&lt;br/&gt;Lower these numbers if you want fewer smaller denominations.</source>
-        <target xml:space="preserve">How many inputs of each denominated amount are created.&lt;br/&gt;Lower these numbers if you want fewer smaller denominations.</target>
-        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg438" approved="yes">
-        <source xml:space="preserve">Inputs per denomination</source>
-        <target xml:space="preserve">Inputs per denomination</target>
-        <context-group purpose="location"><context context-type="linenumber">528</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg439" approved="yes">
-        <source xml:space="preserve">Try to create at least this many inputs for each denominated amount.&lt;br/&gt;Lower this number if you want fewer smaller denominations.</source>
-        <target xml:space="preserve">Try to create at least this many inputs for each denominated amount.&lt;br/&gt;Lower this number if you want fewer smaller denominations.</target>
-        <context-group purpose="location"><context context-type="linenumber">539</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg440" approved="yes">
-        <source xml:space="preserve">Target</source>
-        <target xml:space="preserve">Target</target>
-        <context-group purpose="location"><context context-type="linenumber">542</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg441" approved="yes">
-        <source xml:space="preserve">Create up to this many inputs for each denominated amount.&lt;br/&gt;Lower this number if you want fewer smaller denominations.</source>
-        <target xml:space="preserve">Create up to this many inputs for each denominated amount.&lt;br/&gt;Lower this number if you want fewer smaller denominations.</target>
-        <context-group purpose="location"><context context-type="linenumber">569</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg442" approved="yes">
-        <source xml:space="preserve">Maximum</source>
-        <target xml:space="preserve">Maximum</target>
-        <context-group purpose="location"><context context-type="linenumber">572</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg443" approved="yes">
-        <source xml:space="preserve">Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <target xml:space="preserve">Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</target>
-        <context-group purpose="location"><context context-type="linenumber">618</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg444" approved="yes">
-        <source xml:space="preserve">Map port using NA&amp;T-PMP</source>
-        <target xml:space="preserve">Map port using NA&amp;T-PMP</target>
-        <context-group purpose="location"><context context-type="linenumber">631</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg445" approved="yes">
-        <source xml:space="preserve">Accept connections from outside.</source>
-        <target xml:space="preserve">Accept connections from outside.</target>
-        <context-group purpose="location"><context context-type="linenumber">638</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg446" approved="yes">
-        <source xml:space="preserve">Allow incomin&amp;g connections</source>
-        <target xml:space="preserve">Allow incomin&amp;g connections</target>
-        <context-group purpose="location"><context context-type="linenumber">641</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg447" approved="yes">
-        <source xml:space="preserve">Connect to the Dash network through a SOCKS5 proxy.</source>
-        <target xml:space="preserve">Connect to the Dash network through a SOCKS5 proxy.</target>
-        <context-group purpose="location"><context context-type="linenumber">648</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg448" approved="yes">
-        <source xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <target xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</target>
-        <context-group purpose="location"><context context-type="linenumber">651</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg449" approved="yes">
-        <source xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <target xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</target>
-        <context-group purpose="location"><context context-type="linenumber">754</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">767</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg450" approved="yes">
-        <source xml:space="preserve">Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <target xml:space="preserve">Options set in this dialog are overridden by the command line or in the configuration file:</target>
-        <context-group purpose="location"><context context-type="linenumber">1080</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg451" approved="yes">
-        <source xml:space="preserve">Hide the icon from the system tray.</source>
-        <target xml:space="preserve">Hide the icon from the system tray.</target>
         <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg452" approved="yes">
-        <source xml:space="preserve">&amp;Hide tray icon</source>
-        <target xml:space="preserve">&amp;Hide tray icon</target>
+      <trans-unit id="_msg420">
+        <source xml:space="preserve">&amp;Show tray icon</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg421" approved="yes">
+        <source xml:space="preserve">Prune &amp;block storage to</source>
+        <target xml:space="preserve">Prune &amp;block storage to</target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg422" approved="yes">
+        <source xml:space="preserve">GB</source>
+        <target xml:space="preserve">GB</target>
+        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg423" approved="yes">
+        <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</source>
+        <target xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</target>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg424" approved="yes">
+        <source xml:space="preserve">Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <target xml:space="preserve">Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</target>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <note annotates="source" from="developer">Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</note>
+      </trans-unit>
+      <trans-unit id="_msg425" approved="yes">
+        <source xml:space="preserve">MiB</source>
+        <target xml:space="preserve">MiB</target>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg426" approved="yes">
+        <source xml:space="preserve">Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <target xml:space="preserve">Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</target>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+        <note annotates="source" from="developer">Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</note>
+      </trans-unit>
+      <trans-unit id="_msg427" approved="yes">
+        <source xml:space="preserve">Whether to keep the specified custom change address or not.</source>
+        <target xml:space="preserve">Whether to keep the specified custom change address or not.</target>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg428" approved="yes">
+        <source xml:space="preserve">Keep custom change &amp;address</source>
+        <target xml:space="preserve">Keep custom change &amp;address</target>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg429" approved="yes">
+        <source xml:space="preserve">Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</source>
+        <target xml:space="preserve">Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</target>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg430" approved="yes">
+        <source xml:space="preserve">Show Masternodes Tab</source>
+        <target xml:space="preserve">Show Masternodes Tab</target>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg431" approved="yes">
+        <source xml:space="preserve">Show additional tab listing governance proposals.</source>
+        <target xml:space="preserve">Show additional tab listing governance proposals.</target>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg432" approved="yes">
+        <source xml:space="preserve">Show Governance Tab</source>
+        <target xml:space="preserve">Show Governance Tab</target>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg433" approved="yes">
+        <source xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</source>
+        <target xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</target>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg434" approved="yes">
+        <source xml:space="preserve">Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</source>
+        <target xml:space="preserve">Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</target>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg435" approved="yes">
+        <source xml:space="preserve">Show additional information and buttons on overview screen.</source>
+        <target xml:space="preserve">Show additional information and buttons on overview screen.</target>
+        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg436" approved="yes">
+        <source xml:space="preserve">Enable advanced interface</source>
+        <target xml:space="preserve">Enable advanced interface</target>
+        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg437" approved="yes">
+        <source xml:space="preserve">Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
+        <target xml:space="preserve">Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</target>
+        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg438" approved="yes">
+        <source xml:space="preserve">Show popups for mixing transactions</source>
+        <target xml:space="preserve">Show popups for mixing transactions</target>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg439" approved="yes">
+        <source xml:space="preserve">Show warning dialog when the wallet has very low number of keys left.</source>
+        <target xml:space="preserve">Show warning dialog when the wallet has very low number of keys left.</target>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg440" approved="yes">
+        <source xml:space="preserve">Warn if the wallet is running out of keys</source>
+        <target xml:space="preserve">Warn if the wallet is running out of keys</target>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg441" approved="yes">
+        <source xml:space="preserve">Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
+        <target xml:space="preserve">Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</target>
+        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg442" approved="yes">
+        <source xml:space="preserve">Enable &amp;multi-session</source>
+        <target xml:space="preserve">Enable &amp;multi-session</target>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg443" approved="yes">
+        <source xml:space="preserve">Use this many separate masternodes in parallel to mix funds.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
+        <target xml:space="preserve">Use this many separate masternodes in parallel to mix funds.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</target>
+        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg444" approved="yes">
+        <source xml:space="preserve">Parallel sessions</source>
+        <target xml:space="preserve">Parallel sessions</target>
+        <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg445" approved="yes">
+        <source xml:space="preserve">Mixing rounds</source>
+        <target xml:space="preserve">Mixing rounds</target>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg446" approved="yes">
+        <source xml:space="preserve">This amount acts as a threshold to turn off mixing once it&apos;s reached.</source>
+        <target xml:space="preserve">This amount acts as a threshold to turn off mixing once it&apos;s reached.</target>
+        <context-group purpose="location"><context context-type="linenumber">490</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg447" approved="yes">
+        <source xml:space="preserve">Target balance</source>
+        <target xml:space="preserve">Target balance</target>
+        <context-group purpose="location"><context context-type="linenumber">505</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg448" approved="yes">
+        <source xml:space="preserve">How many inputs of each denominated amount are created.&lt;br/&gt;Lower these numbers if you want fewer smaller denominations.</source>
+        <target xml:space="preserve">How many inputs of each denominated amount are created.&lt;br/&gt;Lower these numbers if you want fewer smaller denominations.</target>
+        <context-group purpose="location"><context context-type="linenumber">528</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg449" approved="yes">
+        <source xml:space="preserve">Inputs per denomination</source>
+        <target xml:space="preserve">Inputs per denomination</target>
+        <context-group purpose="location"><context context-type="linenumber">531</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg450" approved="yes">
+        <source xml:space="preserve">Try to create at least this many inputs for each denominated amount.&lt;br/&gt;Lower this number if you want fewer smaller denominations.</source>
+        <target xml:space="preserve">Try to create at least this many inputs for each denominated amount.&lt;br/&gt;Lower this number if you want fewer smaller denominations.</target>
+        <context-group purpose="location"><context context-type="linenumber">542</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg451" approved="yes">
+        <source xml:space="preserve">Target</source>
+        <target xml:space="preserve">Target</target>
+        <context-group purpose="location"><context context-type="linenumber">545</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg452" approved="yes">
+        <source xml:space="preserve">Create up to this many inputs for each denominated amount.&lt;br/&gt;Lower this number if you want fewer smaller denominations.</source>
+        <target xml:space="preserve">Create up to this many inputs for each denominated amount.&lt;br/&gt;Lower this number if you want fewer smaller denominations.</target>
+        <context-group purpose="location"><context context-type="linenumber">572</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg453" approved="yes">
-        <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <target xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</target>
-        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+        <source xml:space="preserve">Maximum</source>
+        <target xml:space="preserve">Maximum</target>
+        <context-group purpose="location"><context context-type="linenumber">575</context></context-group>
       </trans-unit>
       <trans-unit id="_msg454" approved="yes">
-        <source xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items.&lt;br/&gt;%s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <target xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items.&lt;br/&gt;%s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</target>
-        <context-group purpose="location"><context context-type="linenumber">1013</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1026</context></context-group>
+        <source xml:space="preserve">Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <target xml:space="preserve">Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</target>
+        <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
       </trans-unit>
       <trans-unit id="_msg455" approved="yes">
-        <source xml:space="preserve">&amp;Third party transaction URLs</source>
-        <target xml:space="preserve">&amp;Third party transaction URLs</target>
-        <context-group purpose="location"><context context-type="linenumber">1016</context></context-group>
+        <source xml:space="preserve">Map port using NA&amp;T-PMP</source>
+        <target xml:space="preserve">Map port using NA&amp;T-PMP</target>
+        <context-group purpose="location"><context context-type="linenumber">634</context></context-group>
       </trans-unit>
       <trans-unit id="_msg456" approved="yes">
-        <source xml:space="preserve">Whether to show coin control features or not.</source>
-        <target xml:space="preserve">Whether to show coin control features or not.</target>
-        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+        <source xml:space="preserve">Accept connections from outside.</source>
+        <target xml:space="preserve">Accept connections from outside.</target>
+        <context-group purpose="location"><context context-type="linenumber">641</context></context-group>
       </trans-unit>
       <trans-unit id="_msg457" approved="yes">
+        <source xml:space="preserve">Allow incomin&amp;g connections</source>
+        <target xml:space="preserve">Allow incomin&amp;g connections</target>
+        <context-group purpose="location"><context context-type="linenumber">644</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg458" approved="yes">
+        <source xml:space="preserve">Connect to the Dash network through a SOCKS5 proxy.</source>
+        <target xml:space="preserve">Connect to the Dash network through a SOCKS5 proxy.</target>
+        <context-group purpose="location"><context context-type="linenumber">651</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg459" approved="yes">
+        <source xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <target xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</target>
+        <context-group purpose="location"><context context-type="linenumber">654</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg460" approved="yes">
+        <source xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <target xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</target>
+        <context-group purpose="location"><context context-type="linenumber">757</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">770</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">783</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg461">
+        <source xml:space="preserve">Language missing or translation incomplete? Help contributing translations here:
+https://explore.transifex.com/dash/dash/</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">952</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg462" approved="yes">
+        <source xml:space="preserve">Options set in this dialog are overridden by the command line or in the configuration file:</source>
+        <target xml:space="preserve">Options set in this dialog are overridden by the command line or in the configuration file:</target>
+        <context-group purpose="location"><context context-type="linenumber">1083</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg463" approved="yes">
+        <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <target xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</target>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg464" approved="yes">
+        <source xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items.&lt;br/&gt;%s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <target xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items.&lt;br/&gt;%s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</target>
+        <context-group purpose="location"><context context-type="linenumber">1016</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1029</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg465" approved="yes">
+        <source xml:space="preserve">&amp;Third party transaction URLs</source>
+        <target xml:space="preserve">&amp;Third party transaction URLs</target>
+        <context-group purpose="location"><context context-type="linenumber">1019</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg466" approved="yes">
+        <source xml:space="preserve">Whether to show coin control features or not.</source>
+        <target xml:space="preserve">Whether to show coin control features or not.</target>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg467" approved="yes">
         <source xml:space="preserve">Automatically start %1 after logging in to the system.</source>
         <target xml:space="preserve">Automatically start %1 after logging in to the system.</target>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg458" approved="yes">
+      <trans-unit id="_msg468" approved="yes">
         <source xml:space="preserve">&amp;Start %1 on system login</source>
         <target xml:space="preserve">&amp;Start %1 on system login</target>
         <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg459" approved="yes">
+      <trans-unit id="_msg469" approved="yes">
         <source xml:space="preserve">Enable coin &amp;control features</source>
         <target xml:space="preserve">Enable coin &amp;control features</target>
-        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg460" approved="yes">
+      <trans-unit id="_msg470" approved="yes">
         <source xml:space="preserve">&amp;Spend unconfirmed change</source>
         <target xml:space="preserve">&amp;Spend unconfirmed change</target>
-        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg461" approved="yes">
+      <trans-unit id="_msg471" approved="yes">
         <source xml:space="preserve">This setting determines the amount of individual masternodes that an input will be mixed through.&lt;br/&gt;More rounds of mixing gives a higher degree of privacy, but also costs more in fees.</source>
         <target xml:space="preserve">This setting determines the amount of individual masternodes that an input will be mixed through.&lt;br/&gt;More rounds of mixing gives a higher degree of privacy, but also costs more in fees.</target>
-        <context-group purpose="location"><context context-type="linenumber">464</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg462" approved="yes">
+      <trans-unit id="_msg472" approved="yes">
         <source xml:space="preserve">&amp;Network</source>
         <target xml:space="preserve">&amp;Network</target>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg463" approved="yes">
+      <trans-unit id="_msg473" approved="yes">
         <source xml:space="preserve">Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
         <target xml:space="preserve">Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</target>
-        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg464" approved="yes">
-        <source xml:space="preserve">Map port using &amp;UPnP</source>
-        <target xml:space="preserve">Map port using &amp;UPnP</target>
-        <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg465" approved="yes">
-        <source xml:space="preserve">Automatically open the Dash Core client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
-        <target xml:space="preserve">Automatically open the Dash Core client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</target>
-        <context-group purpose="location"><context context-type="linenumber">628</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg466" approved="yes">
-        <source xml:space="preserve">Proxy &amp;IP:</source>
-        <target xml:space="preserve">Proxy &amp;IP:</target>
-        <context-group purpose="location"><context context-type="linenumber">660</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">817</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg467" approved="yes">
-        <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <target xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</target>
-        <context-group purpose="location"><context context-type="linenumber">685</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">842</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg468" approved="yes">
-        <source xml:space="preserve">&amp;Port:</source>
-        <target xml:space="preserve">&amp;Port:</target>
-        <context-group purpose="location"><context context-type="linenumber">692</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">849</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg469" approved="yes">
-        <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
-        <target xml:space="preserve">Port of the proxy (e.g. 9050)</target>
-        <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">874</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg470" approved="yes">
-        <source xml:space="preserve">Used for reaching peers via:</source>
-        <target xml:space="preserve">Used for reaching peers via:</target>
-        <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg471" approved="yes">
-        <source xml:space="preserve">IPv4</source>
-        <target xml:space="preserve">IPv4</target>
-        <context-group purpose="location"><context context-type="linenumber">757</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg472" approved="yes">
-        <source xml:space="preserve">IPv6</source>
-        <target xml:space="preserve">IPv6</target>
-        <context-group purpose="location"><context context-type="linenumber">770</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg473" approved="yes">
-        <source xml:space="preserve">Tor</source>
-        <target xml:space="preserve">Tor</target>
-        <context-group purpose="location"><context context-type="linenumber">783</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
       <trans-unit id="_msg474" approved="yes">
-        <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
-        <target xml:space="preserve">Show only a tray icon after minimizing the window.</target>
-        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+        <source xml:space="preserve">Map port using &amp;UPnP</source>
+        <target xml:space="preserve">Map port using &amp;UPnP</target>
+        <context-group purpose="location"><context context-type="linenumber">624</context></context-group>
       </trans-unit>
       <trans-unit id="_msg475" approved="yes">
-        <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
-        <target xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</target>
-        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+        <source xml:space="preserve">Automatically open the Dash Core client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <target xml:space="preserve">Automatically open the Dash Core client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</target>
+        <context-group purpose="location"><context context-type="linenumber">631</context></context-group>
       </trans-unit>
       <trans-unit id="_msg476" approved="yes">
-        <source xml:space="preserve">M&amp;inimize on close</source>
-        <target xml:space="preserve">M&amp;inimize on close</target>
-        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+        <source xml:space="preserve">Proxy &amp;IP:</source>
+        <target xml:space="preserve">Proxy &amp;IP:</target>
+        <context-group purpose="location"><context context-type="linenumber">663</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">820</context></context-group>
       </trans-unit>
       <trans-unit id="_msg477" approved="yes">
+        <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <target xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</target>
+        <context-group purpose="location"><context context-type="linenumber">688</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">845</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg478" approved="yes">
+        <source xml:space="preserve">&amp;Port:</source>
+        <target xml:space="preserve">&amp;Port:</target>
+        <context-group purpose="location"><context context-type="linenumber">695</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">852</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg479" approved="yes">
+        <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
+        <target xml:space="preserve">Port of the proxy (e.g. 9050)</target>
+        <context-group purpose="location"><context context-type="linenumber">720</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">877</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg480" approved="yes">
+        <source xml:space="preserve">Used for reaching peers via:</source>
+        <target xml:space="preserve">Used for reaching peers via:</target>
+        <context-group purpose="location"><context context-type="linenumber">744</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg481" approved="yes">
+        <source xml:space="preserve">IPv4</source>
+        <target xml:space="preserve">IPv4</target>
+        <context-group purpose="location"><context context-type="linenumber">760</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg482" approved="yes">
+        <source xml:space="preserve">IPv6</source>
+        <target xml:space="preserve">IPv6</target>
+        <context-group purpose="location"><context context-type="linenumber">773</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg483" approved="yes">
+        <source xml:space="preserve">Tor</source>
+        <target xml:space="preserve">Tor</target>
+        <context-group purpose="location"><context context-type="linenumber">786</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg484" approved="yes">
+        <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
+        <target xml:space="preserve">Show only a tray icon after minimizing the window.</target>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg485" approved="yes">
+        <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
+        <target xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg486" approved="yes">
+        <source xml:space="preserve">M&amp;inimize on close</source>
+        <target xml:space="preserve">M&amp;inimize on close</target>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg487" approved="yes">
         <source xml:space="preserve">&amp;Display</source>
         <target xml:space="preserve">&amp;Display</target>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg478" approved="yes">
+      <trans-unit id="_msg488" approved="yes">
         <source xml:space="preserve">Connect to the Dash network through a separate SOCKS5 proxy for Tor onion services.</source>
         <target xml:space="preserve">Connect to the Dash network through a separate SOCKS5 proxy for Tor onion services.</target>
-        <context-group purpose="location"><context context-type="linenumber">805</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg479" approved="yes">
-        <source xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <target xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</target>
         <context-group purpose="location"><context context-type="linenumber">808</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg480" approved="yes">
+      <trans-unit id="_msg489" approved="yes">
+        <source xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <target xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</target>
+        <context-group purpose="location"><context context-type="linenumber">811</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg490" approved="yes">
         <source xml:space="preserve">User Interface &amp;language:</source>
         <target xml:space="preserve">User Interface &amp;language:</target>
-        <context-group purpose="location"><context context-type="linenumber">915</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">918</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg481" approved="yes">
+      <trans-unit id="_msg491" approved="yes">
         <source xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <target xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</target>
-        <context-group purpose="location"><context context-type="linenumber">928</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">931</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg482" approved="yes">
-        <source xml:space="preserve">Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <target xml:space="preserve">Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</target>
-        <context-group purpose="location"><context context-type="linenumber">949</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg483" approved="yes">
+      <trans-unit id="_msg492" approved="yes">
         <source xml:space="preserve">&amp;Unit to show amounts in:</source>
         <target xml:space="preserve">&amp;Unit to show amounts in:</target>
-        <context-group purpose="location"><context context-type="linenumber">975</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">978</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg484" approved="yes">
+      <trans-unit id="_msg493" approved="yes">
         <source xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <target xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</target>
-        <context-group purpose="location"><context context-type="linenumber">988</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">991</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg485" approved="yes">
+      <trans-unit id="_msg494" approved="yes">
         <source xml:space="preserve">Decimal digits</source>
         <target xml:space="preserve">Decimal digits</target>
-        <context-group purpose="location"><context context-type="linenumber">999</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1002</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg486" approved="yes">
+      <trans-unit id="_msg495" approved="yes">
         <source xml:space="preserve">Reset all client options to default.</source>
         <target xml:space="preserve">Reset all client options to default.</target>
-        <context-group purpose="location"><context context-type="linenumber">1126</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg487" approved="yes">
-        <source xml:space="preserve">&amp;Reset Options</source>
-        <target xml:space="preserve">&amp;Reset Options</target>
         <context-group purpose="location"><context context-type="linenumber">1129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg488" approved="yes">
+      <trans-unit id="_msg496" approved="yes">
+        <source xml:space="preserve">&amp;Reset Options</source>
+        <target xml:space="preserve">&amp;Reset Options</target>
+        <context-group purpose="location"><context context-type="linenumber">1132</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg497" approved="yes">
         <source xml:space="preserve">&amp;OK</source>
         <target xml:space="preserve">&amp;OK</target>
-        <context-group purpose="location"><context context-type="linenumber">1184</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1187</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg489" approved="yes">
+      <trans-unit id="_msg498" approved="yes">
         <source xml:space="preserve">&amp;Cancel</source>
         <target xml:space="preserve">&amp;Cancel</target>
-        <context-group purpose="location"><context context-type="linenumber">1197</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1200</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../optionsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg490" approved="yes">
+      <trans-unit id="_msg499" approved="yes">
         <source xml:space="preserve">Enable %1 features</source>
         <target xml:space="preserve">Enable %1 features</target>
         <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg491" approved="yes">
+      <trans-unit id="_msg500" approved="yes">
         <source xml:space="preserve">default</source>
         <target xml:space="preserve">default</target>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg492" approved="yes">
+      <trans-unit id="_msg501" approved="yes">
         <source xml:space="preserve">Confirm options reset</source>
         <target xml:space="preserve">Confirm options reset</target>
         <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg493" approved="yes">
+      <trans-unit id="_msg502" approved="yes">
         <source xml:space="preserve">Client restart required to activate changes.</source>
         <target xml:space="preserve">Client restart required to activate changes.</target>
         <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">453</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg494" approved="yes">
+      <trans-unit id="_msg503" approved="yes">
         <source xml:space="preserve">Client will be shut down. Do you want to proceed?</source>
         <target xml:space="preserve">Client will be shut down. Do you want to proceed?</target>
         <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg495" approved="yes">
+      <trans-unit id="_msg504" approved="yes">
         <source xml:space="preserve">This change would require a client restart.</source>
         <target xml:space="preserve">This change would require a client restart.</target>
-        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg496" approved="yes">
+      <trans-unit id="_msg505" approved="yes">
         <source xml:space="preserve">The supplied proxy address is invalid.</source>
         <target xml:space="preserve">The supplied proxy address is invalid.</target>
-        <context-group purpose="location"><context context-type="linenumber">485</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">482</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/overviewpage.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg497" approved="yes">
+      <trans-unit id="_msg506" approved="yes">
         <source xml:space="preserve">Form</source>
         <target xml:space="preserve">Form</target>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg498" approved="yes">
+      <trans-unit id="_msg507" approved="yes">
         <source xml:space="preserve">The displayed information may be out of date. Your wallet automatically synchronizes with the Dash network after a connection is established, but this process has not completed yet.</source>
         <target xml:space="preserve">The displayed information may be out of date. Your wallet automatically synchronizes with the Dash network after a connection is established, but this process has not completed yet.</target>
-        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">615</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg499" approved="yes">
-        <source xml:space="preserve">Available:</source>
-        <target xml:space="preserve">Available:</target>
-        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg500" approved="yes">
-        <source xml:space="preserve">Your current spendable balance</source>
-        <target xml:space="preserve">Your current spendable balance</target>
-        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg501" approved="yes">
-        <source xml:space="preserve">Pending:</source>
-        <target xml:space="preserve">Pending:</target>
-        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg502" approved="yes">
-        <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <target xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</target>
-        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg503" approved="yes">
-        <source xml:space="preserve">Immature:</source>
-        <target xml:space="preserve">Immature:</target>
-        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg504" approved="yes">
-        <source xml:space="preserve">Mined balance that has not yet matured</source>
-        <target xml:space="preserve">Mined balance that has not yet matured</target>
-        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg505" approved="yes">
-        <source xml:space="preserve">Balances</source>
-        <target xml:space="preserve">Balances</target>
-        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg506" approved="yes">
-        <source xml:space="preserve">Unconfirmed transactions to watch-only addresses</source>
-        <target xml:space="preserve">Unconfirmed transactions to watch-only addresses</target>
-        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg507" approved="yes">
-        <source xml:space="preserve">Mined balance in watch-only addresses that has not yet matured</source>
-        <target xml:space="preserve">Mined balance in watch-only addresses that has not yet matured</target>
-        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">586</context></context-group>
       </trans-unit>
       <trans-unit id="_msg508" approved="yes">
-        <source xml:space="preserve">Total:</source>
-        <target xml:space="preserve">Total:</target>
-        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+        <source xml:space="preserve">Available:</source>
+        <target xml:space="preserve">Available:</target>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
       <trans-unit id="_msg509" approved="yes">
-        <source xml:space="preserve">Your current total balance</source>
-        <target xml:space="preserve">Your current total balance</target>
-        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+        <source xml:space="preserve">Your current spendable balance</source>
+        <target xml:space="preserve">Your current spendable balance</target>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
       <trans-unit id="_msg510" approved="yes">
-        <source xml:space="preserve">Current total balance in watch-only addresses</source>
-        <target xml:space="preserve">Current total balance in watch-only addresses</target>
-        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg511" approved="yes">
-        <source xml:space="preserve">Watch-only:</source>
-        <target xml:space="preserve">Watch-only:</target>
-        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg512" approved="yes">
-        <source xml:space="preserve">Your current balance in watch-only addresses</source>
-        <target xml:space="preserve">Your current balance in watch-only addresses</target>
+        <source xml:space="preserve">Pending:</source>
+        <target xml:space="preserve">Pending:</target>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg511" approved="yes">
+        <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <target xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</target>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg512" approved="yes">
+        <source xml:space="preserve">Immature:</source>
+        <target xml:space="preserve">Immature:</target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg513" approved="yes">
-        <source xml:space="preserve">Spendable:</source>
-        <target xml:space="preserve">Spendable:</target>
-        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
+        <source xml:space="preserve">Mined balance that has not yet matured</source>
+        <target xml:space="preserve">Mined balance that has not yet matured</target>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
       </trans-unit>
       <trans-unit id="_msg514" approved="yes">
-        <source xml:space="preserve">Status:</source>
-        <target xml:space="preserve">Status:</target>
-        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+        <source xml:space="preserve">Balances</source>
+        <target xml:space="preserve">Balances</target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
       <trans-unit id="_msg515" approved="yes">
-        <source xml:space="preserve">Enabled/Disabled</source>
-        <target xml:space="preserve">Enabled/Disabled</target>
-        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+        <source xml:space="preserve">Unconfirmed transactions to watch-only addresses</source>
+        <target xml:space="preserve">Unconfirmed transactions to watch-only addresses</target>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
       <trans-unit id="_msg516" approved="yes">
-        <source xml:space="preserve">Completion:</source>
-        <target xml:space="preserve">Completion:</target>
-        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
+        <source xml:space="preserve">Mined balance in watch-only addresses that has not yet matured</source>
+        <target xml:space="preserve">Mined balance in watch-only addresses that has not yet matured</target>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
       <trans-unit id="_msg517" approved="yes">
-        <source xml:space="preserve">Amount and Rounds:</source>
-        <target xml:space="preserve">Amount and Rounds:</target>
-        <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
+        <source xml:space="preserve">Total:</source>
+        <target xml:space="preserve">Total:</target>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
       <trans-unit id="_msg518" approved="yes">
-        <source xml:space="preserve">0 DASH / 0 Rounds</source>
-        <target xml:space="preserve">0 DASH / 0 Rounds</target>
-        <context-group purpose="location"><context context-type="linenumber">472</context></context-group>
+        <source xml:space="preserve">Your current total balance</source>
+        <target xml:space="preserve">Your current total balance</target>
+        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
       <trans-unit id="_msg519" approved="yes">
-        <source xml:space="preserve">Submitted Denom:</source>
-        <target xml:space="preserve">Submitted Denom:</target>
-        <context-group purpose="location"><context context-type="linenumber">479</context></context-group>
+        <source xml:space="preserve">Current total balance in watch-only addresses</source>
+        <target xml:space="preserve">Current total balance in watch-only addresses</target>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
       <trans-unit id="_msg520" approved="yes">
-        <source xml:space="preserve">n/a</source>
-        <target xml:space="preserve">n/a</target>
-        <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
+        <source xml:space="preserve">Watch-only:</source>
+        <target xml:space="preserve">Watch-only:</target>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
       <trans-unit id="_msg521" approved="yes">
-        <source xml:space="preserve">Recent transactions</source>
-        <target xml:space="preserve">Recent transactions</target>
-        <context-group purpose="location"><context context-type="linenumber">608</context></context-group>
+        <source xml:space="preserve">Your current balance in watch-only addresses</source>
+        <target xml:space="preserve">Your current balance in watch-only addresses</target>
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
       <trans-unit id="_msg522" approved="yes">
-        <source xml:space="preserve">Start/Stop Mixing</source>
-        <target xml:space="preserve">Start/Stop Mixing</target>
-        <context-group purpose="location"><context context-type="linenumber">527</context></context-group>
+        <source xml:space="preserve">Spendable:</source>
+        <target xml:space="preserve">Spendable:</target>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
       <trans-unit id="_msg523" approved="yes">
+        <source xml:space="preserve">Status:</source>
+        <target xml:space="preserve">Status:</target>
+        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg524" approved="yes">
+        <source xml:space="preserve">Enabled/Disabled</source>
+        <target xml:space="preserve">Enabled/Disabled</target>
+        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg525" approved="yes">
+        <source xml:space="preserve">Completion:</source>
+        <target xml:space="preserve">Completion:</target>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg526" approved="yes">
+        <source xml:space="preserve">Amount and Rounds:</source>
+        <target xml:space="preserve">Amount and Rounds:</target>
+        <context-group purpose="location"><context context-type="linenumber">449</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg527" approved="yes">
+        <source xml:space="preserve">0 DASH / 0 Rounds</source>
+        <target xml:space="preserve">0 DASH / 0 Rounds</target>
+        <context-group purpose="location"><context context-type="linenumber">456</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg528" approved="yes">
+        <source xml:space="preserve">Submitted Denom:</source>
+        <target xml:space="preserve">Submitted Denom:</target>
+        <context-group purpose="location"><context context-type="linenumber">463</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg529" approved="yes">
+        <source xml:space="preserve">n/a</source>
+        <target xml:space="preserve">n/a</target>
+        <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg530" approved="yes">
+        <source xml:space="preserve">Recent transactions</source>
+        <target xml:space="preserve">Recent transactions</target>
+        <context-group purpose="location"><context context-type="linenumber">579</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg531" approved="yes">
+        <source xml:space="preserve">Start/Stop Mixing</source>
+        <target xml:space="preserve">Start/Stop Mixing</target>
+        <context-group purpose="location"><context context-type="linenumber">511</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg532" approved="yes">
         <source xml:space="preserve">The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</source>
         <target xml:space="preserve">The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</target>
-        <context-group purpose="location"><context context-type="linenumber">486</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../overviewpage.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg524" approved="yes">
+      <trans-unit id="_msg533" approved="yes">
         <source xml:space="preserve">out of sync</source>
         <target xml:space="preserve">out of sync</target>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg525" approved="yes">
+      <trans-unit id="_msg534" approved="yes">
         <source xml:space="preserve">Automatic backups are disabled, no mixing available!</source>
         <target xml:space="preserve">Automatic backups are disabled, no mixing available!</target>
-        <context-group purpose="location"><context context-type="linenumber">472</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">480</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg526" approved="yes">
+      <trans-unit id="_msg535" approved="yes">
         <source xml:space="preserve">No inputs detected</source>
         <target xml:space="preserve">No inputs detected</target>
-        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg527" approved="yes">
+      <trans-unit id="_msg536" approved="yes">
         <source xml:space="preserve">%1 Balance</source>
         <target xml:space="preserve">%1 Balance</target>
         <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg528">
+      <trans-unit id="_msg537" approved="yes">
         <source xml:space="preserve">Discreet mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Discreet mode.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Discreet mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Discreet mode.</target>
         <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
-        <trans-unit id="_msg529[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
+        <trans-unit id="_msg538[0]" approved="yes">
           <source xml:space="preserve">%n Rounds</source>
           <target xml:space="preserve">%n Round</target>
         </trans-unit>
-        <trans-unit id="_msg529[1]" approved="yes">
+        <trans-unit id="_msg538[1]" approved="yes">
           <source xml:space="preserve">%n Rounds</source>
           <target xml:space="preserve">%n Rounds</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg530" approved="yes">
+      <trans-unit id="_msg539" approved="yes">
         <source xml:space="preserve">Found enough compatible inputs to mix %1</source>
         <target xml:space="preserve">Found enough compatible inputs to mix %1</target>
-        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg531" approved="yes">
+      <trans-unit id="_msg540" approved="yes">
         <source xml:space="preserve">Not enough compatible inputs to mix &lt;span style=&apos;%1&apos;&gt;%2&lt;/span&gt;,&lt;br&gt;will mix &lt;span style=&apos;%1&apos;&gt;%3&lt;/span&gt; instead</source>
         <target xml:space="preserve">Not enough compatible inputs to mix &lt;span style=&apos;%1&apos;&gt;%2&lt;/span&gt;,&lt;br&gt;will mix &lt;span style=&apos;%1&apos;&gt;%3&lt;/span&gt; instead</target>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg532" approved="yes">
+      <trans-unit id="_msg541" approved="yes">
         <source xml:space="preserve">Overall progress</source>
         <target xml:space="preserve">Overall progress</target>
-        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg533" approved="yes">
+      <trans-unit id="_msg542" approved="yes">
         <source xml:space="preserve">Denominated</source>
         <target xml:space="preserve">Denominated</target>
-        <context-group purpose="location"><context context-type="linenumber">445</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">453</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg534" approved="yes">
+      <trans-unit id="_msg543" approved="yes">
         <source xml:space="preserve">Partially mixed</source>
         <target xml:space="preserve">Partially mixed</target>
-        <context-group purpose="location"><context context-type="linenumber">446</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg535" approved="yes">
+      <trans-unit id="_msg544" approved="yes">
         <source xml:space="preserve">Mixed</source>
         <target xml:space="preserve">Mixed</target>
-        <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">448</context></context-group>
-        <trans-unit id="_msg536[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">456</context></context-group>
+        <trans-unit id="_msg545[0]" approved="yes">
           <source xml:space="preserve">Denominated inputs have %5 of %n rounds on average</source>
           <target xml:space="preserve">Denominated inputs have %5 of %n round on average</target>
         </trans-unit>
-        <trans-unit id="_msg536[1]" approved="yes">
+        <trans-unit id="_msg545[1]" approved="yes">
           <source xml:space="preserve">Denominated inputs have %5 of %n rounds on average</source>
           <target xml:space="preserve">Denominated inputs have %5 of %n rounds on average</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg537" approved="yes">
+      <trans-unit id="_msg546" approved="yes">
         <source xml:space="preserve">keys left: %1</source>
         <target xml:space="preserve">keys left: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">530</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg538" approved="yes">
-        <source xml:space="preserve">Start %1</source>
-        <target xml:space="preserve">Start %1</target>
-        <context-group purpose="location"><context context-type="linenumber">544</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">677</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg539" approved="yes">
-        <source xml:space="preserve">If you don&apos;t want to see internal %1 fees/transactions select &quot;Most Common&quot; as Type on the &quot;Transactions&quot; tab.</source>
-        <target xml:space="preserve">If you don&apos;t want to see internal %1 fees/transactions select &quot;Most Common&quot; as Type on the &quot;Transactions&quot; tab.</target>
-        <context-group purpose="location"><context context-type="linenumber">640</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg540" approved="yes">
-        <source xml:space="preserve">%1 requires at least %2 to use.</source>
-        <target xml:space="preserve">%1 requires at least %2 to use.</target>
-        <context-group purpose="location"><context context-type="linenumber">651</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg541" approved="yes">
-        <source xml:space="preserve">Wallet is locked and user declined to unlock. Disabling %1.</source>
-        <target xml:space="preserve">Wallet is locked and user declined to unlock. Disabling %1.</target>
-        <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg542" approved="yes">
-        <source xml:space="preserve">Stop %1</source>
-        <target xml:space="preserve">Stop %1</target>
-        <context-group purpose="location"><context context-type="linenumber">681</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg543" approved="yes">
-        <source xml:space="preserve">Disabled</source>
-        <target xml:space="preserve">Disabled</target>
-        <context-group purpose="location"><context context-type="linenumber">546</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">600</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">720</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg544" approved="yes">
-        <source xml:space="preserve">Very low number of keys left since last automatic backup!</source>
-        <target xml:space="preserve">Very low number of keys left since last automatic backup!</target>
-        <context-group purpose="location"><context context-type="linenumber">565</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg545" approved="yes">
-        <source xml:space="preserve">We are about to create a new automatic backup for you, however &lt;span style=&apos;%1&apos;&gt; you should always make sure you have backups saved in some safe place&lt;/span&gt;!</source>
-        <target xml:space="preserve">We are about to create a new automatic backup for you, however &lt;span style=&apos;%1&apos;&gt; you should always make sure you have backups saved in some safe place&lt;/span&gt;!</target>
-        <context-group purpose="location"><context context-type="linenumber">566</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg546" approved="yes">
-        <source xml:space="preserve">Note: You can turn this message off in options.</source>
-        <target xml:space="preserve">Note: You can turn this message off in options.</target>
-        <context-group purpose="location"><context context-type="linenumber">569</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">538</context></context-group>
       </trans-unit>
       <trans-unit id="_msg547" approved="yes">
-        <source xml:space="preserve">WARNING! Something went wrong on automatic backup</source>
-        <target xml:space="preserve">WARNING! Something went wrong on automatic backup</target>
-        <context-group purpose="location"><context context-type="linenumber">585</context></context-group>
+        <source xml:space="preserve">Start %1</source>
+        <target xml:space="preserve">Start %1</target>
+        <context-group purpose="location"><context context-type="linenumber">556</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">691</context></context-group>
       </trans-unit>
       <trans-unit id="_msg548" approved="yes">
-        <source xml:space="preserve">ERROR! Failed to create automatic backup</source>
-        <target xml:space="preserve">ERROR! Failed to create automatic backup</target>
-        <context-group purpose="location"><context context-type="linenumber">593</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">609</context></context-group>
+        <source xml:space="preserve">If you don&apos;t want to see internal %1 fees/transactions select &quot;Most Common&quot; as Type on the &quot;Transactions&quot; tab.</source>
+        <target xml:space="preserve">If you don&apos;t want to see internal %1 fees/transactions select &quot;Most Common&quot; as Type on the &quot;Transactions&quot; tab.</target>
+        <context-group purpose="location"><context context-type="linenumber">654</context></context-group>
       </trans-unit>
       <trans-unit id="_msg549" approved="yes">
-        <source xml:space="preserve">Mixing is disabled, please close your wallet and fix the issue!</source>
-        <target xml:space="preserve">Mixing is disabled, please close your wallet and fix the issue!</target>
-        <context-group purpose="location"><context context-type="linenumber">594</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">611</context></context-group>
+        <source xml:space="preserve">%1 requires at least %2 to use.</source>
+        <target xml:space="preserve">%1 requires at least %2 to use.</target>
+        <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
       </trans-unit>
       <trans-unit id="_msg550" approved="yes">
-        <source xml:space="preserve">Enabled</source>
-        <target xml:space="preserve">Enabled</target>
-        <context-group purpose="location"><context context-type="linenumber">600</context></context-group>
+        <source xml:space="preserve">Wallet is locked and user declined to unlock. Disabling %1.</source>
+        <target xml:space="preserve">Wallet is locked and user declined to unlock. Disabling %1.</target>
+        <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
       </trans-unit>
       <trans-unit id="_msg551" approved="yes">
-        <source xml:space="preserve">see debug.log for details.</source>
-        <target xml:space="preserve">see debug.log for details.</target>
-        <context-group purpose="location"><context context-type="linenumber">610</context></context-group>
+        <source xml:space="preserve">Stop %1</source>
+        <target xml:space="preserve">Stop %1</target>
+        <context-group purpose="location"><context context-type="linenumber">695</context></context-group>
       </trans-unit>
       <trans-unit id="_msg552" approved="yes">
+        <source xml:space="preserve">Disabled</source>
+        <target xml:space="preserve">Disabled</target>
+        <context-group purpose="location"><context context-type="linenumber">558</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">612</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">731</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">734</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg553" approved="yes">
+        <source xml:space="preserve">Very low number of keys left since last automatic backup!</source>
+        <target xml:space="preserve">Very low number of keys left since last automatic backup!</target>
+        <context-group purpose="location"><context context-type="linenumber">577</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg554" approved="yes">
+        <source xml:space="preserve">We are about to create a new automatic backup for you, however &lt;span style=&apos;%1&apos;&gt; you should always make sure you have backups saved in some safe place&lt;/span&gt;!</source>
+        <target xml:space="preserve">We are about to create a new automatic backup for you, however &lt;span style=&apos;%1&apos;&gt; you should always make sure you have backups saved in some safe place&lt;/span&gt;!</target>
+        <context-group purpose="location"><context context-type="linenumber">578</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg555" approved="yes">
+        <source xml:space="preserve">Note: You can turn this message off in options.</source>
+        <target xml:space="preserve">Note: You can turn this message off in options.</target>
+        <context-group purpose="location"><context context-type="linenumber">581</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg556" approved="yes">
+        <source xml:space="preserve">WARNING! Something went wrong on automatic backup</source>
+        <target xml:space="preserve">WARNING! Something went wrong on automatic backup</target>
+        <context-group purpose="location"><context context-type="linenumber">597</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg557" approved="yes">
+        <source xml:space="preserve">ERROR! Failed to create automatic backup</source>
+        <target xml:space="preserve">ERROR! Failed to create automatic backup</target>
+        <context-group purpose="location"><context context-type="linenumber">605</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">622</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg558" approved="yes">
+        <source xml:space="preserve">Mixing is disabled, please close your wallet and fix the issue!</source>
+        <target xml:space="preserve">Mixing is disabled, please close your wallet and fix the issue!</target>
+        <context-group purpose="location"><context context-type="linenumber">606</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">624</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg559" approved="yes">
+        <source xml:space="preserve">Enabled</source>
+        <target xml:space="preserve">Enabled</target>
+        <context-group purpose="location"><context context-type="linenumber">612</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg560" approved="yes">
+        <source xml:space="preserve">see debug.log for details.</source>
+        <target xml:space="preserve">see debug.log for details.</target>
+        <context-group purpose="location"><context context-type="linenumber">623</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg561" approved="yes">
         <source xml:space="preserve">WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
         <target xml:space="preserve">WARNING! Failed to replenish keypool, please unlock your wallet to do so.</target>
-        <context-group purpose="location"><context context-type="linenumber">617</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">630</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/psbtoperationsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg553">
+      <trans-unit id="_msg562" approved="yes">
         <source xml:space="preserve">Dialog</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Dialog</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg554">
+      <trans-unit id="_msg563" approved="yes">
         <source xml:space="preserve">Sign Tx</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Sign Tx</target>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg555">
+      <trans-unit id="_msg564" approved="yes">
         <source xml:space="preserve">Broadcast Tx</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Broadcast Tx</target>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg556">
+      <trans-unit id="_msg565" approved="yes">
         <source xml:space="preserve">Copy to Clipboard</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Copy to Clipboard</target>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg557">
-        <source xml:space="preserve">Save...</source>
+      <trans-unit id="_msg566">
+        <source xml:space="preserve">Save…</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg558">
+      <trans-unit id="_msg567" approved="yes">
         <source xml:space="preserve">Close</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Close</target>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../psbtoperationsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg559">
+      <trans-unit id="_msg568" approved="yes">
         <source xml:space="preserve">Failed to load transaction: %1</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Failed to load transaction: %1</target>
         <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg560">
+      <trans-unit id="_msg569" approved="yes">
         <source xml:space="preserve">Failed to sign transaction: %1</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Failed to sign transaction: %1</target>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg561">
+      <trans-unit id="_msg570" approved="yes">
         <source xml:space="preserve">Could not sign any more inputs.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Could not sign any more inputs.</target>
         <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg562">
+      <trans-unit id="_msg571" approved="yes">
         <source xml:space="preserve">Signed %1 inputs, but more signatures are still required.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Signed %1 inputs, but more signatures are still required.</target>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg563">
+      <trans-unit id="_msg572" approved="yes">
         <source xml:space="preserve">Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Signed transaction successfully. Transaction is ready to broadcast.</target>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg564">
+      <trans-unit id="_msg573" approved="yes">
         <source xml:space="preserve">Unknown error processing transaction.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Unknown error processing transaction.</target>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg565">
+      <trans-unit id="_msg574" approved="yes">
         <source xml:space="preserve">Transaction broadcast successfully! Transaction ID: %1</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Transaction broadcast successfully! Transaction ID: %1</target>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg566">
+      <trans-unit id="_msg575" approved="yes">
         <source xml:space="preserve">Transaction broadcast failed: %1</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Transaction broadcast failed: %1</target>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg567">
+      <trans-unit id="_msg576" approved="yes">
         <source xml:space="preserve">PSBT copied to clipboard.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">PSBT copied to clipboard.</target>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg568">
+      <trans-unit id="_msg577" approved="yes">
         <source xml:space="preserve">Save Transaction Data</source>
-        <target xml:space="preserve" state="needs-review-translation">Save Transaction Data</target>
+        <target xml:space="preserve">Save Transaction Data</target>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg569">
+      <trans-unit id="_msg578" approved="yes">
         <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Partially Signed Transaction (Binary)</target>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
         <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
-      <trans-unit id="_msg570">
+      <trans-unit id="_msg579" approved="yes">
         <source xml:space="preserve">PSBT saved to disk.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">PSBT saved to disk.</target>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg571">
+      <trans-unit id="_msg580" approved="yes">
         <source xml:space="preserve"> * Sends %1 to %2</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve"> * Sends %1 to %2</target>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg572">
+      <trans-unit id="_msg581" approved="yes">
         <source xml:space="preserve">Unable to calculate transaction fee or total transaction amount.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Unable to calculate transaction fee or total transaction amount.</target>
         <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg573">
+      <trans-unit id="_msg582" approved="yes">
         <source xml:space="preserve">Pays transaction fee: </source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Pays transaction fee: </target>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg574">
+      <trans-unit id="_msg583" approved="yes">
         <source xml:space="preserve">Total Amount</source>
-        <target xml:space="preserve" state="needs-review-translation">Total Amount</target>
+        <target xml:space="preserve">Total Amount</target>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg575">
+      <trans-unit id="_msg584" approved="yes">
         <source xml:space="preserve">or</source>
-        <target xml:space="preserve" state="needs-review-translation">or</target>
+        <target xml:space="preserve">or</target>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg576">
+      <trans-unit id="_msg585" approved="yes">
         <source xml:space="preserve">Transaction has %1 unsigned inputs.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Transaction has %1 unsigned inputs.</target>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg577">
+      <trans-unit id="_msg586" approved="yes">
         <source xml:space="preserve">Transaction is missing some information about inputs.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Transaction is missing some information about inputs.</target>
         <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg578">
+      <trans-unit id="_msg587" approved="yes">
         <source xml:space="preserve">Transaction still needs signature(s).</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Transaction still needs signature(s).</target>
         <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg579">
+      <trans-unit id="_msg588" approved="yes">
         <source xml:space="preserve">(But this wallet cannot sign transactions.)</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">(But this wallet cannot sign transactions.)</target>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg580">
+      <trans-unit id="_msg589" approved="yes">
         <source xml:space="preserve">(But this wallet does not have the right keys.)</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">(But this wallet does not have the right keys.)</target>
         <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg581">
+      <trans-unit id="_msg590" approved="yes">
         <source xml:space="preserve">Transaction is fully signed and ready for broadcast.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Transaction is fully signed and ready for broadcast.</target>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg582">
+      <trans-unit id="_msg591" approved="yes">
         <source xml:space="preserve">Transaction status is unknown.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Transaction status is unknown.</target>
         <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../paymentserver.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PaymentServer">
-      <trans-unit id="_msg583" approved="yes">
+      <trans-unit id="_msg592" approved="yes">
         <source xml:space="preserve">Payment request error</source>
         <target xml:space="preserve">Payment request error</target>
         <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg584" approved="yes">
+      <trans-unit id="_msg593" approved="yes">
         <source xml:space="preserve">Cannot start dash: click-to-pay handler</source>
         <target xml:space="preserve">Cannot start dash: click-to-pay handler</target>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg585" approved="yes">
+      <trans-unit id="_msg594" approved="yes">
         <source xml:space="preserve">URI handling</source>
         <target xml:space="preserve">URI handling</target>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg586" approved="yes">
+      <trans-unit id="_msg595" approved="yes">
         <source xml:space="preserve">&apos;dash://&apos; is not a valid URI. Use &apos;dash:&apos; instead.</source>
         <target xml:space="preserve">&apos;dash://&apos; is not a valid URI. Use &apos;dash:&apos; instead.</target>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg587" approved="yes">
+      <trans-unit id="_msg596" approved="yes">
         <source xml:space="preserve">Cannot process payment request as BIP70 is no longer supported.</source>
         <target xml:space="preserve">Cannot process payment request as BIP70 is no longer supported.</target>
-        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg588" approved="yes">
+      <trans-unit id="_msg597" approved="yes">
         <source xml:space="preserve">Due to discontinued support, you should request the merchant to provide you with a BIP21 compatible URI or use a wallet that does continue to support BIP70.</source>
         <target xml:space="preserve">Due to discontinued support, you should request the merchant to provide you with a BIP21 compatible URI or use a wallet that does continue to support BIP70.</target>
-        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg589" approved="yes">
-        <source xml:space="preserve">Invalid payment address %1</source>
-        <target xml:space="preserve">Invalid payment address %1</target>
         <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg590" approved="yes">
+      <trans-unit id="_msg598" approved="yes">
         <source xml:space="preserve">URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <target xml:space="preserve">URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</target>
-        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg591" approved="yes">
+      <trans-unit id="_msg599" approved="yes">
         <source xml:space="preserve">Payment request file handling</source>
         <target xml:space="preserve">Payment request file handling</target>
-        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../peertablemodel.h" datatype="c" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg592" approved="yes">
+      <trans-unit id="_msg600" approved="yes">
         <source xml:space="preserve">User Agent</source>
         <target xml:space="preserve">User Agent</target>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
+        <note annotates="source" from="developer">Title of Peers Table column which contains the peer&apos;s User Agent string.</note>
       </trans-unit>
-      <trans-unit id="_msg593" approved="yes">
+      <trans-unit id="_msg601" approved="yes">
         <source xml:space="preserve">Ping</source>
         <target xml:space="preserve">Ping</target>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
+        <note annotates="source" from="developer">Title of Peers Table column which indicates the current latency of the connection with the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg594" approved="yes">
+      <trans-unit id="_msg602">
+        <source xml:space="preserve">Peer</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+        <note annotates="source" from="developer">Title of Peers Table column which contains a unique number used to identify a connection.</note>
+      </trans-unit>
+      <trans-unit id="_msg603">
+        <source xml:space="preserve">Type</source>
+        <target xml:space="preserve" state="needs-review-translation">Type</target>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+        <note annotates="source" from="developer">Title of Peers Table column which describes the type of peer connection. The &quot;type&quot; describes why the connection exists.</note>
+      </trans-unit>
+      <trans-unit id="_msg604" approved="yes">
         <source xml:space="preserve">Sent</source>
         <target xml:space="preserve">Sent</target>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
+        <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg595" approved="yes">
+      <trans-unit id="_msg605" approved="yes">
         <source xml:space="preserve">Received</source>
         <target xml:space="preserve">Received</target>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+        <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have received from the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg596">
-        <source xml:space="preserve">Peer Id</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg597">
+      <trans-unit id="_msg606" approved="yes">
         <source xml:space="preserve">Address</source>
-        <target xml:space="preserve" state="needs-review-translation">Address</target>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+        <target xml:space="preserve">Address</target>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+        <note annotates="source" from="developer">Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</note>
       </trans-unit>
-      <trans-unit id="_msg598">
+      <trans-unit id="_msg607" approved="yes">
         <source xml:space="preserve">Network</source>
-        <target xml:space="preserve" state="needs-review-translation">Network</target>
-        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+        <target xml:space="preserve">Network</target>
+        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+        <note annotates="source" from="developer">Title of Peers Table column which states the network the peer connected through.</note>
       </trans-unit>
     </group>
   </body></file>
   <file original="../bitcoinunits.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg599" approved="yes">
+      <trans-unit id="_msg608" approved="yes">
         <source xml:space="preserve">Amount</source>
         <target xml:space="preserve">Amount</target>
         <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
@@ -3279,220 +3313,267 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../guiutil.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg600" approved="yes">
+      <trans-unit id="_msg609" approved="yes">
         <source xml:space="preserve">Enter a Dash address (e.g. %1)</source>
         <target xml:space="preserve">Enter a Dash address (e.g. %1)</target>
-        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg601" approved="yes">
-        <source xml:space="preserve">Appearance Setup</source>
-        <target xml:space="preserve">Appearance Setup</target>
-        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg602" approved="yes">
-        <source xml:space="preserve">Please choose your preferred settings for the appearance of %1</source>
-        <target xml:space="preserve">Please choose your preferred settings for the appearance of %1</target>
-        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg603" approved="yes">
-        <source xml:space="preserve">This can also be adjusted later in the &quot;Appearance&quot; tab of the preferences.</source>
-        <target xml:space="preserve">This can also be adjusted later in the &quot;Appearance&quot; tab of the preferences.</target>
-        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg604">
-        <source xml:space="preserve">Unroutable</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">1643</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg605">
-        <source xml:space="preserve">Internal</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">1649</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg606" approved="yes">
-        <source xml:space="preserve">%1 d</source>
-        <target xml:space="preserve">%1 d</target>
-        <context-group purpose="location"><context context-type="linenumber">1664</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg607" approved="yes">
-        <source xml:space="preserve">%1 h</source>
-        <target xml:space="preserve">%1 h</target>
-        <context-group purpose="location"><context context-type="linenumber">1666</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg608" approved="yes">
-        <source xml:space="preserve">%1 m</source>
-        <target xml:space="preserve">%1 m</target>
-        <context-group purpose="location"><context context-type="linenumber">1668</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg609" approved="yes">
-        <source xml:space="preserve">%1 s</source>
-        <target xml:space="preserve">%1 s</target>
-        <context-group purpose="location"><context context-type="linenumber">1670</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1696</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
       <trans-unit id="_msg610" approved="yes">
-        <source xml:space="preserve">None</source>
-        <target xml:space="preserve">None</target>
-        <context-group purpose="location"><context context-type="linenumber">1686</context></context-group>
+        <source xml:space="preserve">Appearance Setup</source>
+        <target xml:space="preserve">Appearance Setup</target>
+        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
       </trans-unit>
       <trans-unit id="_msg611" approved="yes">
-        <source xml:space="preserve">N/A</source>
-        <target xml:space="preserve">N/A</target>
-        <context-group purpose="location"><context context-type="linenumber">1691</context></context-group>
+        <source xml:space="preserve">Please choose your preferred settings for the appearance of %1</source>
+        <target xml:space="preserve">Please choose your preferred settings for the appearance of %1</target>
+        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
       </trans-unit>
       <trans-unit id="_msg612" approved="yes">
+        <source xml:space="preserve">This can also be adjusted later in the &quot;Appearance&quot; tab of the preferences.</source>
+        <target xml:space="preserve">This can also be adjusted later in the &quot;Appearance&quot; tab of the preferences.</target>
+        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg613">
+        <source xml:space="preserve">Ctrl+W</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">632</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg614" approved="yes">
+        <source xml:space="preserve">Unroutable</source>
+        <target xml:space="preserve">Unroutable</target>
+        <context-group purpose="location"><context context-type="linenumber">1666</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg615" approved="yes">
+        <source xml:space="preserve">Internal</source>
+        <target xml:space="preserve">Internal</target>
+        <context-group purpose="location"><context context-type="linenumber">1672</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg616">
+        <source xml:space="preserve">Inbound</source>
+        <target xml:space="preserve" state="needs-review-translation">Inbound</target>
+        <context-group purpose="location"><context context-type="linenumber">1685</context></context-group>
+        <note annotates="source" from="developer">An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</note>
+      </trans-unit>
+      <trans-unit id="_msg617">
+        <source xml:space="preserve">Outbound</source>
+        <target xml:space="preserve" state="needs-review-translation">Outbound</target>
+        <context-group purpose="location"><context context-type="linenumber">1688</context></context-group>
+        <note annotates="source" from="developer">An outbound connection to a peer. An outbound connection is a connection initiated by us.</note>
+      </trans-unit>
+      <trans-unit id="_msg618">
+        <source xml:space="preserve">Full Relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1693</context></context-group>
+        <note annotates="source" from="developer">Peer connection type that relays all network information.</note>
+      </trans-unit>
+      <trans-unit id="_msg619">
+        <source xml:space="preserve">Block Relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1696</context></context-group>
+        <note annotates="source" from="developer">Peer connection type that relays network information about blocks and not transactions or addresses.</note>
+      </trans-unit>
+      <trans-unit id="_msg620">
+        <source xml:space="preserve">Manual</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1698</context></context-group>
+        <note annotates="source" from="developer">Peer connection type established manually through one of several methods.</note>
+      </trans-unit>
+      <trans-unit id="_msg621">
+        <source xml:space="preserve">Feeler</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1700</context></context-group>
+        <note annotates="source" from="developer">Short-lived peer connection type that tests the aliveness of known addresses.</note>
+      </trans-unit>
+      <trans-unit id="_msg622">
+        <source xml:space="preserve">Address Fetch</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1702</context></context-group>
+        <note annotates="source" from="developer">Short-lived peer connection type that solicits known addresses from a peer.</note>
+      </trans-unit>
+      <trans-unit id="_msg623" approved="yes">
+        <source xml:space="preserve">%1 d</source>
+        <target xml:space="preserve">%1 d</target>
+        <context-group purpose="location"><context context-type="linenumber">1715</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg624" approved="yes">
+        <source xml:space="preserve">%1 h</source>
+        <target xml:space="preserve">%1 h</target>
+        <context-group purpose="location"><context context-type="linenumber">1716</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg625" approved="yes">
+        <source xml:space="preserve">%1 m</source>
+        <target xml:space="preserve">%1 m</target>
+        <context-group purpose="location"><context context-type="linenumber">1717</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg626" approved="yes">
+        <source xml:space="preserve">%1 s</source>
+        <target xml:space="preserve">%1 s</target>
+        <context-group purpose="location"><context context-type="linenumber">1719</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1746</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg627" approved="yes">
+        <source xml:space="preserve">None</source>
+        <target xml:space="preserve">None</target>
+        <context-group purpose="location"><context context-type="linenumber">1734</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg628" approved="yes">
+        <source xml:space="preserve">N/A</source>
+        <target xml:space="preserve">N/A</target>
+        <context-group purpose="location"><context context-type="linenumber">1740</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg629" approved="yes">
         <source xml:space="preserve">%1 ms</source>
         <target xml:space="preserve">%1 ms</target>
-        <context-group purpose="location"><context context-type="linenumber">1691</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1741</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1709</context></context-group>
-        <trans-unit id="_msg613[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">1759</context></context-group>
+        <trans-unit id="_msg630[0]" approved="yes">
           <source xml:space="preserve">%n second(s)</source>
           <target xml:space="preserve">%n second</target>
         </trans-unit>
-        <trans-unit id="_msg613[1]" approved="yes">
+        <trans-unit id="_msg630[1]" approved="yes">
           <source xml:space="preserve">%n second(s)</source>
           <target xml:space="preserve">%n seconds</target>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1713</context></context-group>
-        <trans-unit id="_msg614[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">1763</context></context-group>
+        <trans-unit id="_msg631[0]" approved="yes">
           <source xml:space="preserve">%n minute(s)</source>
           <target xml:space="preserve">%n minute</target>
         </trans-unit>
-        <trans-unit id="_msg614[1]" approved="yes">
+        <trans-unit id="_msg631[1]" approved="yes">
           <source xml:space="preserve">%n minute(s)</source>
           <target xml:space="preserve">%n minutes</target>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1717</context></context-group>
-        <trans-unit id="_msg615[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">1767</context></context-group>
+        <trans-unit id="_msg632[0]" approved="yes">
           <source xml:space="preserve">%n hour(s)</source>
           <target xml:space="preserve">%n hour</target>
         </trans-unit>
-        <trans-unit id="_msg615[1]" approved="yes">
+        <trans-unit id="_msg632[1]" approved="yes">
           <source xml:space="preserve">%n hour(s)</source>
           <target xml:space="preserve">%n hours</target>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1721</context></context-group>
-        <trans-unit id="_msg616[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">1771</context></context-group>
+        <trans-unit id="_msg633[0]" approved="yes">
           <source xml:space="preserve">%n day(s)</source>
           <target xml:space="preserve">%n day</target>
         </trans-unit>
-        <trans-unit id="_msg616[1]" approved="yes">
+        <trans-unit id="_msg633[1]" approved="yes">
           <source xml:space="preserve">%n day(s)</source>
           <target xml:space="preserve">%n days</target>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1725</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1731</context></context-group>
-        <trans-unit id="_msg617[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">1775</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1781</context></context-group>
+        <trans-unit id="_msg634[0]" approved="yes">
           <source xml:space="preserve">%n week(s)</source>
           <target xml:space="preserve">%n week</target>
         </trans-unit>
-        <trans-unit id="_msg617[1]" approved="yes">
+        <trans-unit id="_msg634[1]" approved="yes">
           <source xml:space="preserve">%n week(s)</source>
           <target xml:space="preserve">%n weeks</target>
         </trans-unit>
       </group>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1731</context></context-group>
-        <trans-unit id="_msg618[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">1781</context></context-group>
+        <trans-unit id="_msg635[0]" approved="yes">
           <source xml:space="preserve">%n year(s)</source>
           <target xml:space="preserve">%n year</target>
         </trans-unit>
-        <trans-unit id="_msg618[1]" approved="yes">
+        <trans-unit id="_msg635[1]" approved="yes">
           <source xml:space="preserve">%n year(s)</source>
           <target xml:space="preserve">%n years</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg619" approved="yes">
+      <trans-unit id="_msg636" approved="yes">
         <source xml:space="preserve">%1 and %2</source>
         <target xml:space="preserve">%1 and %2</target>
-        <context-group purpose="location"><context context-type="linenumber">1731</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1781</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg620" approved="yes">
+      <trans-unit id="_msg637" approved="yes">
         <source xml:space="preserve">%1 B</source>
         <target xml:space="preserve">%1 B</target>
-        <context-group purpose="location"><context context-type="linenumber">1739</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1789</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg621" approved="yes">
+      <trans-unit id="_msg638" approved="yes">
         <source xml:space="preserve">%1 KB</source>
         <target xml:space="preserve">%1 KB</target>
-        <context-group purpose="location"><context context-type="linenumber">1741</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1791</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg622" approved="yes">
+      <trans-unit id="_msg639" approved="yes">
         <source xml:space="preserve">%1 MB</source>
         <target xml:space="preserve">%1 MB</target>
-        <context-group purpose="location"><context context-type="linenumber">1743</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1793</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg623" approved="yes">
+      <trans-unit id="_msg640" approved="yes">
         <source xml:space="preserve">%1 GB</source>
         <target xml:space="preserve">%1 GB</target>
-        <context-group purpose="location"><context context-type="linenumber">1745</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1795</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/qrdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QRDialog">
-      <trans-unit id="_msg624" approved="yes">
+      <trans-unit id="_msg641" approved="yes">
         <source xml:space="preserve">QR-Code Title</source>
         <target xml:space="preserve">QR-Code Title</target>
         <context-group purpose="location"><context context-type="linenumber">17</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg625" approved="yes">
+      <trans-unit id="_msg642" approved="yes">
         <source xml:space="preserve">QR Code</source>
         <target xml:space="preserve">QR Code</target>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg626" approved="yes">
-        <source xml:space="preserve">&amp;Save Image...</source>
-        <target xml:space="preserve">&amp;Save Image...</target>
+      <trans-unit id="_msg643">
+        <source xml:space="preserve">&amp;Save Image…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../qrimagewidget.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QRImageWidget">
-      <trans-unit id="_msg627" approved="yes">
-        <source xml:space="preserve">&amp;Save Image...</source>
-        <target xml:space="preserve">&amp;Save Image...</target>
+      <trans-unit id="_msg644">
+        <source xml:space="preserve">&amp;Save Image…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">30</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg628" approved="yes">
+      <trans-unit id="_msg645" approved="yes">
         <source xml:space="preserve">&amp;Copy Image</source>
         <target xml:space="preserve">&amp;Copy Image</target>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg629" approved="yes">
+      <trans-unit id="_msg646" approved="yes">
         <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
         <target xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</target>
         <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg630" approved="yes">
+      <trans-unit id="_msg647" approved="yes">
         <source xml:space="preserve">Error encoding URI into QR Code.</source>
         <target xml:space="preserve">Error encoding URI into QR Code.</target>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg631" approved="yes">
+      <trans-unit id="_msg648" approved="yes">
         <source xml:space="preserve">QR code support not available.</source>
         <target xml:space="preserve">QR code support not available.</target>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg632" approved="yes">
+      <trans-unit id="_msg649" approved="yes">
         <source xml:space="preserve">Save QR Code</source>
         <target xml:space="preserve">Save QR Code</target>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg633">
+      <trans-unit id="_msg650" approved="yes">
         <source xml:space="preserve">PNG Image</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">PNG Image</target>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
         <note annotates="source" from="developer">Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</note>
       </trans-unit>
@@ -3500,27 +3581,27 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../forms/debugwindow.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg634" approved="yes">
+      <trans-unit id="_msg651" approved="yes">
         <source xml:space="preserve">Tools window</source>
         <target xml:space="preserve">Tools window</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg635" approved="yes">
+      <trans-unit id="_msg652" approved="yes">
         <source xml:space="preserve">&amp;Information</source>
         <target xml:space="preserve">&amp;Information</target>
         <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg636" approved="yes">
+      <trans-unit id="_msg653" approved="yes">
         <source xml:space="preserve">General</source>
         <target xml:space="preserve">General</target>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg637" approved="yes">
+      <trans-unit id="_msg654" approved="yes">
         <source xml:space="preserve">Name</source>
         <target xml:space="preserve">Name</target>
         <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg638" approved="yes">
+      <trans-unit id="_msg655" approved="yes">
         <source xml:space="preserve">N/A</source>
         <target xml:space="preserve">N/A</target>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
@@ -3544,613 +3625,771 @@ https://www.transifex.com/projects/p/dash/</target>
         <context-group purpose="location"><context context-type="linenumber">969</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">995</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1018</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1041</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1064</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1087</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1113</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1136</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1159</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1182</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1205</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1228</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1251</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1274</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1297</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1320</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1343</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1369</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1392</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1415</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1441</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1265</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1273</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1277</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1044</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1067</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1090</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1116</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1142</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1168</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1191</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1214</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1237</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1260</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1286</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1312</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1335</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1358</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1381</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1404</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1427</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1453</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1476</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1499</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1525</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1551</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1577</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1603</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1324</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1332</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1336</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg639" approved="yes">
+      <trans-unit id="_msg656" approved="yes">
         <source xml:space="preserve">Number of connections</source>
         <target xml:space="preserve">Number of connections</target>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg640" approved="yes">
+      <trans-unit id="_msg657" approved="yes">
         <source xml:space="preserve">&amp;Open</source>
         <target xml:space="preserve">&amp;Open</target>
         <context-group purpose="location"><context context-type="linenumber">545</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg641" approved="yes">
+      <trans-unit id="_msg658" approved="yes">
         <source xml:space="preserve">Startup time</source>
         <target xml:space="preserve">Startup time</target>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg642" approved="yes">
+      <trans-unit id="_msg659" approved="yes">
         <source xml:space="preserve">Network</source>
         <target xml:space="preserve">Network</target>
         <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">985</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg643" approved="yes">
+      <trans-unit id="_msg660" approved="yes">
         <source xml:space="preserve">Last block time</source>
         <target xml:space="preserve">Last block time</target>
         <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg644" approved="yes">
+      <trans-unit id="_msg661" approved="yes">
         <source xml:space="preserve">Debug log file</source>
         <target xml:space="preserve">Debug log file</target>
         <context-group purpose="location"><context context-type="linenumber">535</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg645" approved="yes">
+      <trans-unit id="_msg662" approved="yes">
         <source xml:space="preserve">Client version</source>
         <target xml:space="preserve">Client version</target>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg646" approved="yes">
+      <trans-unit id="_msg663" approved="yes">
         <source xml:space="preserve">Block chain</source>
         <target xml:space="preserve">Block chain</target>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg647" approved="yes">
+      <trans-unit id="_msg664" approved="yes">
         <source xml:space="preserve">Memory Pool</source>
         <target xml:space="preserve">Memory Pool</target>
         <context-group purpose="location"><context context-type="linenumber">464</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg648" approved="yes">
+      <trans-unit id="_msg665" approved="yes">
         <source xml:space="preserve">Current number of transactions</source>
         <target xml:space="preserve">Current number of transactions</target>
         <context-group purpose="location"><context context-type="linenumber">471</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg649" approved="yes">
+      <trans-unit id="_msg666" approved="yes">
         <source xml:space="preserve">Memory usage</source>
         <target xml:space="preserve">Memory usage</target>
         <context-group purpose="location"><context context-type="linenumber">494</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg650" approved="yes">
+      <trans-unit id="_msg667" approved="yes">
         <source xml:space="preserve">&amp;Console</source>
         <target xml:space="preserve">&amp;Console</target>
         <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg651" approved="yes">
+      <trans-unit id="_msg668" approved="yes">
         <source xml:space="preserve">Clear console</source>
         <target xml:space="preserve">Clear console</target>
         <context-group purpose="location"><context context-type="linenumber">654</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg652" approved="yes">
+      <trans-unit id="_msg669" approved="yes">
         <source xml:space="preserve">&amp;Network Traffic</source>
         <target xml:space="preserve">&amp;Network Traffic</target>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg653" approved="yes">
+      <trans-unit id="_msg670" approved="yes">
         <source xml:space="preserve">Received</source>
         <target xml:space="preserve">Received</target>
-        <context-group purpose="location"><context context-type="linenumber">1310</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1394</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg654" approved="yes">
+      <trans-unit id="_msg671" approved="yes">
         <source xml:space="preserve">Sent</source>
         <target xml:space="preserve">Sent</target>
-        <context-group purpose="location"><context context-type="linenumber">1287</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1371</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg655" approved="yes">
+      <trans-unit id="_msg672" approved="yes">
         <source xml:space="preserve">&amp;Peers</source>
         <target xml:space="preserve">&amp;Peers</target>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg656" approved="yes">
+      <trans-unit id="_msg673" approved="yes">
         <source xml:space="preserve">Wallet:</source>
         <target xml:space="preserve">Wallet:</target>
         <context-group purpose="location"><context context-type="linenumber">608</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg657" approved="yes">
+      <trans-unit id="_msg674" approved="yes">
         <source xml:space="preserve">Banned peers</source>
         <target xml:space="preserve">Banned peers</target>
         <context-group purpose="location"><context context-type="linenumber">842</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg658" approved="yes">
+      <trans-unit id="_msg675" approved="yes">
         <source xml:space="preserve">Select a peer to view detailed information.</source>
         <target xml:space="preserve">Select a peer to view detailed information.</target>
         <context-group purpose="location"><context context-type="linenumber">905</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">514</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1444</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1292</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg659" approved="yes">
-        <source xml:space="preserve">Direction</source>
-        <target xml:space="preserve">Direction</target>
-        <context-group purpose="location"><context context-type="linenumber">1031</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg660" approved="yes">
+      <trans-unit id="_msg676" approved="yes">
         <source xml:space="preserve">Version</source>
         <target xml:space="preserve">Version</target>
-        <context-group purpose="location"><context context-type="linenumber">1054</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1057</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg661" approved="yes">
+      <trans-unit id="_msg677">
+        <source xml:space="preserve">Whether the peer requested us to relay transactions.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1129</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg678">
+        <source xml:space="preserve">Wants Tx Relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1132</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg679">
+        <source xml:space="preserve">High bandwidth BIP152 compact block relay: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1155</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg680">
+        <source xml:space="preserve">High Bandwidth</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1158</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg681" approved="yes">
         <source xml:space="preserve">Starting Block</source>
         <target xml:space="preserve">Starting Block</target>
-        <context-group purpose="location"><context context-type="linenumber">1126</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1181</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg662" approved="yes">
+      <trans-unit id="_msg682" approved="yes">
         <source xml:space="preserve">Synced Headers</source>
         <target xml:space="preserve">Synced Headers</target>
-        <context-group purpose="location"><context context-type="linenumber">1149</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1204</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg663" approved="yes">
+      <trans-unit id="_msg683" approved="yes">
         <source xml:space="preserve">Synced Blocks</source>
         <target xml:space="preserve">Synced Blocks</target>
-        <context-group purpose="location"><context context-type="linenumber">1172</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1227</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg664" approved="yes">
+      <trans-unit id="_msg684">
+        <source xml:space="preserve">Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1273</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg685">
+        <source xml:space="preserve">Last Block</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg686">
+        <source xml:space="preserve">Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1299</context></context-group>
+        <note annotates="source" from="developer">Tooltip text for the Last Transaction field in the peer details area.</note>
+      </trans-unit>
+      <trans-unit id="_msg687">
+        <source xml:space="preserve">Last Transaction</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1302</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg688" approved="yes">
         <source xml:space="preserve">The mapped Autonomous System used for diversifying peer selection.</source>
         <target xml:space="preserve">The mapped Autonomous System used for diversifying peer selection.</target>
-        <context-group purpose="location"><context context-type="linenumber">1428</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg665" approved="yes">
-        <source xml:space="preserve">Mapped AS</source>
-        <target xml:space="preserve">Mapped AS</target>
-        <context-group purpose="location"><context context-type="linenumber">1431</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg666" approved="yes">
-        <source xml:space="preserve">Rescan blockchain files 1</source>
-        <target xml:space="preserve">Rescan blockchain files 1</target>
         <context-group purpose="location"><context context-type="linenumber">1512</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg667" approved="yes">
+      <trans-unit id="_msg689" approved="yes">
+        <source xml:space="preserve">Mapped AS</source>
+        <target xml:space="preserve">Mapped AS</target>
+        <context-group purpose="location"><context context-type="linenumber">1515</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg690">
+        <source xml:space="preserve">Whether we relay addresses to this peer.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1538</context></context-group>
+        <note annotates="source" from="developer">Tooltip text for the Address Relay field in the peer details area.</note>
+      </trans-unit>
+      <trans-unit id="_msg691">
+        <source xml:space="preserve">Address Relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1541</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg692">
+        <source xml:space="preserve">Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1564</context></context-group>
+        <note annotates="source" from="developer">Tooltip text for the Addresses Processed field in the peer details area.</note>
+      </trans-unit>
+      <trans-unit id="_msg693">
+        <source xml:space="preserve">Addresses Processed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1567</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg694">
+        <source xml:space="preserve">Total number of addresses dropped due to rate-limiting.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1590</context></context-group>
+        <note annotates="source" from="developer">Tooltip text for the Addresses Rate-Limited field in the peer details area.</note>
+      </trans-unit>
+      <trans-unit id="_msg695">
+        <source xml:space="preserve">Addresses Rate-Limited</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1593</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg696" approved="yes">
+        <source xml:space="preserve">Rescan blockchain files 1</source>
+        <target xml:space="preserve">Rescan blockchain files 1</target>
+        <context-group purpose="location"><context context-type="linenumber">1674</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg697" approved="yes">
         <source xml:space="preserve">Rescan blockchain files 2</source>
         <target xml:space="preserve">Rescan blockchain files 2</target>
-        <context-group purpose="location"><context context-type="linenumber">1535</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1697</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg668" approved="yes">
+      <trans-unit id="_msg698" approved="yes">
         <source xml:space="preserve">The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockchain files or missing/obsolete transactions.</source>
         <target xml:space="preserve">The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockchain files or missing/obsolete transactions.</target>
-        <context-group purpose="location"><context context-type="linenumber">1492</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1654</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg669" approved="yes">
+      <trans-unit id="_msg699" approved="yes">
         <source xml:space="preserve">-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</source>
         <target xml:space="preserve">-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</target>
-        <context-group purpose="location"><context context-type="linenumber">1519</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1681</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg670" approved="yes">
+      <trans-unit id="_msg700" approved="yes">
         <source xml:space="preserve">-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</source>
         <target xml:space="preserve">-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</target>
-        <context-group purpose="location"><context context-type="linenumber">1542</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1704</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg671" approved="yes">
+      <trans-unit id="_msg701" approved="yes">
         <source xml:space="preserve">User Agent</source>
         <target xml:space="preserve">User Agent</target>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1077</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1080</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg672" approved="yes">
+      <trans-unit id="_msg702" approved="yes">
         <source xml:space="preserve">Datadir</source>
         <target xml:space="preserve">Datadir</target>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg673" approved="yes">
+      <trans-unit id="_msg703" approved="yes">
         <source xml:space="preserve">To specify a non-default location of the data directory use the &apos;%1&apos; option.</source>
         <target xml:space="preserve">To specify a non-default location of the data directory use the &apos;%1&apos; option.</target>
         <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg674" approved="yes">
+      <trans-unit id="_msg704" approved="yes">
         <source xml:space="preserve">Blocksdir</source>
         <target xml:space="preserve">Blocksdir</target>
         <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg675" approved="yes">
+      <trans-unit id="_msg705" approved="yes">
         <source xml:space="preserve">To specify a non-default location of the blocks directory use the &apos;%1&apos; option.</source>
         <target xml:space="preserve">To specify a non-default location of the blocks directory use the &apos;%1&apos; option.</target>
         <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg676" approved="yes">
+      <trans-unit id="_msg706" approved="yes">
         <source xml:space="preserve">Number of regular Masternodes</source>
         <target xml:space="preserve">Number of regular Masternodes</target>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg677" approved="yes">
+      <trans-unit id="_msg707" approved="yes">
         <source xml:space="preserve">Number of EvoNodes</source>
         <target xml:space="preserve">Number of EvoNodes</target>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg678" approved="yes">
+      <trans-unit id="_msg708" approved="yes">
         <source xml:space="preserve">Current block height</source>
         <target xml:space="preserve">Current block height</target>
         <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg679" approved="yes">
+      <trans-unit id="_msg709" approved="yes">
         <source xml:space="preserve">Last block hash</source>
         <target xml:space="preserve">Last block hash</target>
         <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg680" approved="yes">
+      <trans-unit id="_msg710" approved="yes">
         <source xml:space="preserve">Latest ChainLocked block hash</source>
         <target xml:space="preserve">Latest ChainLocked block hash</target>
         <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg681" approved="yes">
+      <trans-unit id="_msg711" approved="yes">
         <source xml:space="preserve">Latest ChainLocked block height</source>
         <target xml:space="preserve">Latest ChainLocked block height</target>
         <context-group purpose="location"><context context-type="linenumber">441</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg682" approved="yes">
+      <trans-unit id="_msg712" approved="yes">
         <source xml:space="preserve">Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <target xml:space="preserve">Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</target>
         <context-group purpose="location"><context context-type="linenumber">542</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg683" approved="yes">
+      <trans-unit id="_msg713" approved="yes">
         <source xml:space="preserve">InstantSend locks</source>
         <target xml:space="preserve">InstantSend locks</target>
         <context-group purpose="location"><context context-type="linenumber">557</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg684" approved="yes">
+      <trans-unit id="_msg714" approved="yes">
         <source xml:space="preserve">(none)</source>
         <target xml:space="preserve">(none)</target>
         <context-group purpose="location"><context context-type="linenumber">619</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg685" approved="yes">
+      <trans-unit id="_msg715" approved="yes">
         <source xml:space="preserve">Decrease font size</source>
         <target xml:space="preserve">Decrease font size</target>
         <context-group purpose="location"><context context-type="linenumber">640</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg686" approved="yes">
+      <trans-unit id="_msg716" approved="yes">
         <source xml:space="preserve">Increase font size</source>
         <target xml:space="preserve">Increase font size</target>
         <context-group purpose="location"><context context-type="linenumber">647</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg687" approved="yes">
+      <trans-unit id="_msg717" approved="yes">
         <source xml:space="preserve">&amp;Reset</source>
         <target xml:space="preserve">&amp;Reset</target>
         <context-group purpose="location"><context context-type="linenumber">759</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg688" approved="yes">
+      <trans-unit id="_msg718" approved="yes">
         <source xml:space="preserve">Node Type</source>
         <target xml:space="preserve">Node Type</target>
         <context-group purpose="location"><context context-type="linenumber">936</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg689" approved="yes">
+      <trans-unit id="_msg719" approved="yes">
         <source xml:space="preserve">PoSe Score</source>
         <target xml:space="preserve">PoSe Score</target>
         <context-group purpose="location"><context context-type="linenumber">959</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg690">
+      <trans-unit id="_msg720" approved="yes">
         <source xml:space="preserve">The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</target>
         <context-group purpose="location"><context context-type="linenumber">982</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg691">
+      <trans-unit id="_msg721" approved="yes">
         <source xml:space="preserve">Permissions</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Permissions</target>
         <context-group purpose="location"><context context-type="linenumber">1008</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg692" approved="yes">
+      <trans-unit id="_msg722">
+        <source xml:space="preserve">The direction and type of peer connection: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1031</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg723">
+        <source xml:space="preserve">Direction/Type</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1034</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg724" approved="yes">
         <source xml:space="preserve">Services</source>
         <target xml:space="preserve">Services</target>
-        <context-group purpose="location"><context context-type="linenumber">1103</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1106</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg693" approved="yes">
-        <source xml:space="preserve">Ban Score</source>
-        <target xml:space="preserve">Ban Score</target>
-        <context-group purpose="location"><context context-type="linenumber">1195</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg694" approved="yes">
+      <trans-unit id="_msg725" approved="yes">
         <source xml:space="preserve">Connection Time</source>
         <target xml:space="preserve">Connection Time</target>
-        <context-group purpose="location"><context context-type="linenumber">1218</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg695" approved="yes">
+      <trans-unit id="_msg726" approved="yes">
         <source xml:space="preserve">Last Send</source>
         <target xml:space="preserve">Last Send</target>
-        <context-group purpose="location"><context context-type="linenumber">1241</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg696" approved="yes">
+      <trans-unit id="_msg727" approved="yes">
         <source xml:space="preserve">Last Receive</source>
         <target xml:space="preserve">Last Receive</target>
-        <context-group purpose="location"><context context-type="linenumber">1264</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1348</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg697" approved="yes">
+      <trans-unit id="_msg728" approved="yes">
         <source xml:space="preserve">Ping Time</source>
         <target xml:space="preserve">Ping Time</target>
-        <context-group purpose="location"><context context-type="linenumber">1333</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1417</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg698" approved="yes">
+      <trans-unit id="_msg729" approved="yes">
         <source xml:space="preserve">The duration of a currently outstanding ping.</source>
         <target xml:space="preserve">The duration of a currently outstanding ping.</target>
-        <context-group purpose="location"><context context-type="linenumber">1356</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1440</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg699" approved="yes">
+      <trans-unit id="_msg730" approved="yes">
         <source xml:space="preserve">Ping Wait</source>
         <target xml:space="preserve">Ping Wait</target>
-        <context-group purpose="location"><context context-type="linenumber">1359</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1443</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg700" approved="yes">
+      <trans-unit id="_msg731" approved="yes">
         <source xml:space="preserve">Min Ping</source>
         <target xml:space="preserve">Min Ping</target>
-        <context-group purpose="location"><context context-type="linenumber">1382</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1466</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg701" approved="yes">
+      <trans-unit id="_msg732" approved="yes">
         <source xml:space="preserve">Time Offset</source>
         <target xml:space="preserve">Time Offset</target>
-        <context-group purpose="location"><context context-type="linenumber">1405</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1489</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg702" approved="yes">
+      <trans-unit id="_msg733" approved="yes">
         <source xml:space="preserve">&amp;Wallet Repair</source>
         <target xml:space="preserve">&amp;Wallet Repair</target>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg703" approved="yes">
+      <trans-unit id="_msg734" approved="yes">
         <source xml:space="preserve">Wallet repair options.</source>
         <target xml:space="preserve">Wallet repair options.</target>
-        <context-group purpose="location"><context context-type="linenumber">1482</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1644</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg704" approved="yes">
+      <trans-unit id="_msg735" approved="yes">
         <source xml:space="preserve">Rebuild index</source>
         <target xml:space="preserve">Rebuild index</target>
-        <context-group purpose="location"><context context-type="linenumber">1552</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1714</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg705" approved="yes">
+      <trans-unit id="_msg736" approved="yes">
         <source xml:space="preserve">-reindex: Rebuild block chain index from current blk000??.dat files.</source>
         <target xml:space="preserve">-reindex: Rebuild block chain index from current blk000??.dat files.</target>
-        <context-group purpose="location"><context context-type="linenumber">1559</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1721</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../rpcconsole.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg706" approved="yes">
+      <trans-unit id="_msg737">
+        <source xml:space="preserve">Inbound: initiated by peer</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">509</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for an inbound peer connection.</note>
+      </trans-unit>
+      <trans-unit id="_msg738">
+        <source xml:space="preserve">Outbound Full Relay: default</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">513</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</note>
+      </trans-unit>
+      <trans-unit id="_msg739">
+        <source xml:space="preserve">Outbound Block Relay: does not relay transactions or addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">516</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</note>
+      </trans-unit>
+      <trans-unit id="_msg740">
+        <source xml:space="preserve">Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</note>
+      </trans-unit>
+      <trans-unit id="_msg741">
+        <source xml:space="preserve">Outbound Feeler: short-lived, for testing addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">527</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</note>
+      </trans-unit>
+      <trans-unit id="_msg742">
+        <source xml:space="preserve">Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">530</context></context-group>
+        <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</note>
+      </trans-unit>
+      <trans-unit id="_msg743">
+        <source xml:space="preserve">To</source>
+        <target xml:space="preserve" state="needs-review-translation">To</target>
+        <context-group purpose="location"><context context-type="linenumber">534</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg744">
+        <source xml:space="preserve">we selected the peer for high bandwidth relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">534</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg745">
+        <source xml:space="preserve">From</source>
+        <target xml:space="preserve" state="needs-review-translation">From</target>
+        <context-group purpose="location"><context context-type="linenumber">535</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg746">
+        <source xml:space="preserve">the peer selected us for high bandwidth relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">535</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg747">
+        <source xml:space="preserve">No</source>
+        <target xml:space="preserve" state="needs-review-translation">No</target>
+        <context-group purpose="location"><context context-type="linenumber">536</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg748">
+        <source xml:space="preserve">no high bandwidth relay selected</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">536</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg749" approved="yes">
         <source xml:space="preserve">&amp;Disconnect</source>
         <target xml:space="preserve">&amp;Disconnect</target>
-        <context-group purpose="location"><context context-type="linenumber">639</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">709</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg707" approved="yes">
+      <trans-unit id="_msg750" approved="yes">
         <source xml:space="preserve">Ban for</source>
         <target xml:space="preserve">Ban for</target>
-        <context-group purpose="location"><context context-type="linenumber">640</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">641</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">642</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">711</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">712</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">713</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg708" approved="yes">
+      <trans-unit id="_msg751" approved="yes">
         <source xml:space="preserve">1 &amp;hour</source>
         <target xml:space="preserve">1 &amp;hour</target>
-        <context-group purpose="location"><context context-type="linenumber">640</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg709" approved="yes">
+      <trans-unit id="_msg752" approved="yes">
         <source xml:space="preserve">1 &amp;day</source>
         <target xml:space="preserve">1 &amp;day</target>
-        <context-group purpose="location"><context context-type="linenumber">641</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">711</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg710" approved="yes">
+      <trans-unit id="_msg753" approved="yes">
         <source xml:space="preserve">1 &amp;week</source>
         <target xml:space="preserve">1 &amp;week</target>
-        <context-group purpose="location"><context context-type="linenumber">642</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">712</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg711" approved="yes">
+      <trans-unit id="_msg754" approved="yes">
         <source xml:space="preserve">1 &amp;year</source>
         <target xml:space="preserve">1 &amp;year</target>
-        <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">713</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg712" approved="yes">
+      <trans-unit id="_msg755" approved="yes">
         <source xml:space="preserve">&amp;Unban</source>
         <target xml:space="preserve">&amp;Unban</target>
-        <context-group purpose="location"><context context-type="linenumber">680</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">750</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg713" approved="yes">
+      <trans-unit id="_msg756" approved="yes">
         <source xml:space="preserve">Welcome to the %1 RPC console.</source>
         <target xml:space="preserve">Welcome to the %1 RPC console.</target>
-        <context-group purpose="location"><context context-type="linenumber">903</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">972</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg714" approved="yes">
+      <trans-unit id="_msg757" approved="yes">
         <source xml:space="preserve">Use up and down arrows to navigate history, and %1 to clear screen.</source>
         <target xml:space="preserve">Use up and down arrows to navigate history, and %1 to clear screen.</target>
-        <context-group purpose="location"><context context-type="linenumber">904</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">973</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg715" approved="yes">
+      <trans-unit id="_msg758" approved="yes">
         <source xml:space="preserve">Type %1 for an overview of available commands.</source>
         <target xml:space="preserve">Type %1 for an overview of available commands.</target>
-        <context-group purpose="location"><context context-type="linenumber">905</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">974</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg716" approved="yes">
+      <trans-unit id="_msg759" approved="yes">
         <source xml:space="preserve">For more information on using this console type %1.</source>
         <target xml:space="preserve">For more information on using this console type %1.</target>
-        <context-group purpose="location"><context context-type="linenumber">906</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">975</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg717" approved="yes">
+      <trans-unit id="_msg760" approved="yes">
         <source xml:space="preserve">WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.</source>
         <target xml:space="preserve">WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.</target>
-        <context-group purpose="location"><context context-type="linenumber">908</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">977</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg718" approved="yes">
+      <trans-unit id="_msg761" approved="yes">
         <source xml:space="preserve">In:</source>
         <target xml:space="preserve">In:</target>
-        <context-group purpose="location"><context context-type="linenumber">939</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1008</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg719" approved="yes">
+      <trans-unit id="_msg762" approved="yes">
         <source xml:space="preserve">Out:</source>
         <target xml:space="preserve">Out:</target>
-        <context-group purpose="location"><context context-type="linenumber">940</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1009</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg720" approved="yes">
+      <trans-unit id="_msg763" approved="yes">
         <source xml:space="preserve">Network activity disabled</source>
         <target xml:space="preserve">Network activity disabled</target>
-        <context-group purpose="location"><context context-type="linenumber">943</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1012</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg721" approved="yes">
+      <trans-unit id="_msg764" approved="yes">
         <source xml:space="preserve">Total: %1 (Enabled: %2)</source>
         <target xml:space="preserve">Total: %1 (Enabled: %2)</target>
-        <context-group purpose="location"><context context-type="linenumber">987</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">991</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1056</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1060</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg722" approved="yes">
+      <trans-unit id="_msg765" approved="yes">
         <source xml:space="preserve">Executing command without any wallet</source>
         <target xml:space="preserve">Executing command without any wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">1059</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1128</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg723">
-        <source xml:space="preserve">(peer id: %1)</source>
+      <trans-unit id="_msg766">
+        <source xml:space="preserve">Ctrl+Shift+I</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">1241</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1522</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg724" approved="yes">
+      <trans-unit id="_msg767">
+        <source xml:space="preserve">Ctrl+Shift+C</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1523</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg768">
+        <source xml:space="preserve">Ctrl+Shift+G</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1524</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg769">
+        <source xml:space="preserve">Ctrl+Shift+P</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1525</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg770">
+        <source xml:space="preserve">Ctrl+Shift+R</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1526</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg771" approved="yes">
         <source xml:space="preserve">Executing command using &quot;%1&quot; wallet</source>
         <target xml:space="preserve">Executing command using &quot;%1&quot; wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">1057</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1126</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg725" approved="yes">
+      <trans-unit id="_msg772">
+        <source xml:space="preserve">(peer: %1)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1298</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg773" approved="yes">
         <source xml:space="preserve">via %1</source>
         <target xml:space="preserve">via %1</target>
-        <context-group purpose="location"><context context-type="linenumber">1243</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1300</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg726" approved="yes">
-        <source xml:space="preserve">never</source>
-        <target xml:space="preserve">never</target>
-        <context-group purpose="location"><context context-type="linenumber">1246</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1247</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg727" approved="yes">
-        <source xml:space="preserve">Inbound</source>
-        <target xml:space="preserve">Inbound</target>
-        <context-group purpose="location"><context context-type="linenumber">1258</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg728" approved="yes">
-        <source xml:space="preserve">Outbound</source>
-        <target xml:space="preserve">Outbound</target>
-        <context-group purpose="location"><context context-type="linenumber">1260</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg729" approved="yes">
-        <source xml:space="preserve">Outbound block-relay</source>
-        <target xml:space="preserve">Outbound block-relay</target>
-        <context-group purpose="location"><context context-type="linenumber">1261</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg730" approved="yes">
+      <trans-unit id="_msg774" approved="yes">
         <source xml:space="preserve">Regular</source>
         <target xml:space="preserve">Regular</target>
-        <context-group purpose="location"><context context-type="linenumber">1276</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg731" approved="yes">
+      <trans-unit id="_msg775" approved="yes">
         <source xml:space="preserve">Masternode</source>
         <target xml:space="preserve">Masternode</target>
-        <context-group purpose="location"><context context-type="linenumber">1280</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1339</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg732" approved="yes">
+      <trans-unit id="_msg776" approved="yes">
         <source xml:space="preserve">Verified Masternode</source>
         <target xml:space="preserve">Verified Masternode</target>
-        <context-group purpose="location"><context context-type="linenumber">1282</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1341</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg733" approved="yes">
+      <trans-unit id="_msg777" approved="yes">
         <source xml:space="preserve">Unknown</source>
         <target xml:space="preserve">Unknown</target>
-        <context-group purpose="location"><context context-type="linenumber">1297</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">1303</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1353</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1359</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../rpcconsole.h" datatype="c" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RPCConsole">
+      <trans-unit id="_msg778">
+        <source xml:space="preserve">Never</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/receivecoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg734" approved="yes">
+      <trans-unit id="_msg779" approved="yes">
         <source xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Dash network.</source>
         <target xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Dash network.</target>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg735" approved="yes">
+      <trans-unit id="_msg780" approved="yes">
         <source xml:space="preserve">&amp;Message:</source>
         <target xml:space="preserve">&amp;Message:</target>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg736" approved="yes">
+      <trans-unit id="_msg781" approved="yes">
         <source xml:space="preserve">An optional label to associate with the new receiving address.</source>
         <target xml:space="preserve">An optional label to associate with the new receiving address.</target>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg737" approved="yes">
+      <trans-unit id="_msg782" approved="yes">
         <source xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened.&lt;br&gt;Note: The message will not be sent with the payment over the Dash network.</source>
         <target xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened.&lt;br&gt;Note: The message will not be sent with the payment over the Dash network.</target>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg738" approved="yes">
+      <trans-unit id="_msg783" approved="yes">
         <source xml:space="preserve">An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
         <target xml:space="preserve">An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</target>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg739" approved="yes">
+      <trans-unit id="_msg784" approved="yes">
         <source xml:space="preserve">Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <target xml:space="preserve">Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</target>
         <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg740" approved="yes">
+      <trans-unit id="_msg785" approved="yes">
         <source xml:space="preserve">&amp;Label:</source>
         <target xml:space="preserve">&amp;Label:</target>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg741" approved="yes">
+      <trans-unit id="_msg786" approved="yes">
         <source xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <target xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</target>
         <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg742" approved="yes">
+      <trans-unit id="_msg787" approved="yes">
         <source xml:space="preserve">&amp;Amount:</source>
         <target xml:space="preserve">&amp;Amount:</target>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg743" approved="yes">
+      <trans-unit id="_msg788" approved="yes">
         <source xml:space="preserve">&amp;Create new receiving address</source>
         <target xml:space="preserve">&amp;Create new receiving address</target>
         <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg744" approved="yes">
+      <trans-unit id="_msg789" approved="yes">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <target xml:space="preserve">Clear all fields of the form.</target>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg745" approved="yes">
+      <trans-unit id="_msg790" approved="yes">
         <source xml:space="preserve">Clear</source>
         <target xml:space="preserve">Clear</target>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg746" approved="yes">
+      <trans-unit id="_msg791" approved="yes">
         <source xml:space="preserve">Requested payments history</source>
         <target xml:space="preserve">Requested payments history</target>
         <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg747" approved="yes">
+      <trans-unit id="_msg792" approved="yes">
         <source xml:space="preserve">Show the selected request (does the same as double clicking an entry)</source>
         <target xml:space="preserve">Show the selected request (does the same as double clicking an entry)</target>
         <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg748" approved="yes">
+      <trans-unit id="_msg793" approved="yes">
         <source xml:space="preserve">Show</source>
         <target xml:space="preserve">Show</target>
         <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg749" approved="yes">
+      <trans-unit id="_msg794" approved="yes">
         <source xml:space="preserve">Remove the selected entries from the list</source>
         <target xml:space="preserve">Remove the selected entries from the list</target>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg750" approved="yes">
+      <trans-unit id="_msg795" approved="yes">
         <source xml:space="preserve">Remove</source>
         <target xml:space="preserve">Remove</target>
         <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg751" approved="yes">
+      <trans-unit id="_msg796" approved="yes">
         <source xml:space="preserve">Enter a label to associate with the new receiving address</source>
         <target xml:space="preserve">Enter a label to associate with the new receiving address</target>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg752" approved="yes">
+      <trans-unit id="_msg797" approved="yes">
         <source xml:space="preserve">Enter a message to attach to the payment request</source>
         <target xml:space="preserve">Enter a message to attach to the payment request</target>
         <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
@@ -4159,81 +4398,91 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../receivecoinsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg753" approved="yes">
+      <trans-unit id="_msg798" approved="yes">
         <source xml:space="preserve">Copy URI</source>
         <target xml:space="preserve">Copy URI</target>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg754" approved="yes">
+      <trans-unit id="_msg799" approved="yes">
         <source xml:space="preserve">Copy address</source>
         <target xml:space="preserve">Copy address</target>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg755" approved="yes">
+      <trans-unit id="_msg800" approved="yes">
         <source xml:space="preserve">Copy label</source>
         <target xml:space="preserve">Copy label</target>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg756" approved="yes">
+      <trans-unit id="_msg801" approved="yes">
         <source xml:space="preserve">Copy message</source>
         <target xml:space="preserve">Copy message</target>
         <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg757" approved="yes">
+      <trans-unit id="_msg802" approved="yes">
         <source xml:space="preserve">Copy amount</source>
         <target xml:space="preserve">Copy amount</target>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg803">
+        <source xml:space="preserve">Could not unlock wallet.</source>
+        <target xml:space="preserve" state="needs-review-translation">Could not unlock wallet.</target>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg804">
+        <source xml:space="preserve">Could not generate new address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/receiverequestdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg758">
-        <source xml:space="preserve">Request payment to ...</source>
+      <trans-unit id="_msg805">
+        <source xml:space="preserve">Request payment to …</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg759">
+      <trans-unit id="_msg806" approved="yes">
         <source xml:space="preserve">Address:</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Address:</target>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg760">
+      <trans-unit id="_msg807" approved="yes">
         <source xml:space="preserve">Amount:</source>
-        <target xml:space="preserve" state="needs-review-translation">Amount:</target>
+        <target xml:space="preserve">Amount:</target>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg761">
+      <trans-unit id="_msg808" approved="yes">
         <source xml:space="preserve">Label:</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Label:</target>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg762">
+      <trans-unit id="_msg809" approved="yes">
         <source xml:space="preserve">Message:</source>
-        <target xml:space="preserve" state="needs-review-translation">Message:</target>
+        <target xml:space="preserve">Message:</target>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg763">
+      <trans-unit id="_msg810" approved="yes">
         <source xml:space="preserve">Wallet:</source>
-        <target xml:space="preserve" state="needs-review-translation">Wallet:</target>
+        <target xml:space="preserve">Wallet:</target>
         <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg764" approved="yes">
+      <trans-unit id="_msg811" approved="yes">
         <source xml:space="preserve">Copy &amp;URI</source>
         <target xml:space="preserve">Copy &amp;URI</target>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg765" approved="yes">
+      <trans-unit id="_msg812" approved="yes">
         <source xml:space="preserve">Copy &amp;Address</source>
         <target xml:space="preserve">Copy &amp;Address</target>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg766" approved="yes">
-        <source xml:space="preserve">&amp;Save Image...</source>
-        <target xml:space="preserve">&amp;Save Image...</target>
+      <trans-unit id="_msg813">
+        <source xml:space="preserve">&amp;Save Image…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg767" approved="yes">
+      <trans-unit id="_msg814" approved="yes">
         <source xml:space="preserve">Payment information</source>
         <target xml:space="preserve">Payment information</target>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
@@ -4242,7 +4491,7 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../receiverequestdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg768" approved="yes">
+      <trans-unit id="_msg815" approved="yes">
         <source xml:space="preserve">Request payment to %1</source>
         <target xml:space="preserve">Request payment to %1</target>
         <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
@@ -4251,219 +4500,219 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../recentrequeststablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RecentRequestsTableModel">
-      <trans-unit id="_msg769" approved="yes">
+      <trans-unit id="_msg816" approved="yes">
         <source xml:space="preserve">Date</source>
         <target xml:space="preserve">Date</target>
-        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg770" approved="yes">
+      <trans-unit id="_msg817" approved="yes">
         <source xml:space="preserve">Label</source>
         <target xml:space="preserve">Label</target>
-        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg771" approved="yes">
+      <trans-unit id="_msg818" approved="yes">
         <source xml:space="preserve">Message</source>
         <target xml:space="preserve">Message</target>
-        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg772" approved="yes">
+      <trans-unit id="_msg819" approved="yes">
         <source xml:space="preserve">(no label)</source>
         <target xml:space="preserve">(no label)</target>
-        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg773" approved="yes">
+      <trans-unit id="_msg820" approved="yes">
         <source xml:space="preserve">(no message)</source>
         <target xml:space="preserve">(no message)</target>
-        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg774" approved="yes">
+      <trans-unit id="_msg821" approved="yes">
         <source xml:space="preserve">(no amount requested)</source>
         <target xml:space="preserve">(no amount requested)</target>
-        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg775" approved="yes">
+      <trans-unit id="_msg822" approved="yes">
         <source xml:space="preserve">Requested</source>
         <target xml:space="preserve">Requested</target>
-        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/sendcoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg776" approved="yes">
+      <trans-unit id="_msg823" approved="yes">
         <source xml:space="preserve">Send Coins</source>
         <target xml:space="preserve">Send Coins</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">760</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">762</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg777" approved="yes">
+      <trans-unit id="_msg824" approved="yes">
         <source xml:space="preserve">Coin Control Features</source>
         <target xml:space="preserve">Coin Control Features</target>
         <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg778" approved="yes">
-        <source xml:space="preserve">Inputs...</source>
-        <target xml:space="preserve">Inputs...</target>
-        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg779" approved="yes">
+      <trans-unit id="_msg825" approved="yes">
         <source xml:space="preserve">automatically selected</source>
         <target xml:space="preserve">automatically selected</target>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg780" approved="yes">
+      <trans-unit id="_msg826" approved="yes">
         <source xml:space="preserve">Insufficient funds!</source>
         <target xml:space="preserve">Insufficient funds!</target>
         <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg781" approved="yes">
+      <trans-unit id="_msg827" approved="yes">
         <source xml:space="preserve">Quantity:</source>
         <target xml:space="preserve">Quantity:</target>
         <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg782" approved="yes">
+      <trans-unit id="_msg828" approved="yes">
         <source xml:space="preserve">Bytes:</source>
         <target xml:space="preserve">Bytes:</target>
         <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg783" approved="yes">
+      <trans-unit id="_msg829" approved="yes">
         <source xml:space="preserve">Amount:</source>
         <target xml:space="preserve">Amount:</target>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg784" approved="yes">
+      <trans-unit id="_msg830" approved="yes">
         <source xml:space="preserve">Fee:</source>
         <target xml:space="preserve">Fee:</target>
         <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg785" approved="yes">
+      <trans-unit id="_msg831" approved="yes">
         <source xml:space="preserve">Dust:</source>
         <target xml:space="preserve">Dust:</target>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg786" approved="yes">
+      <trans-unit id="_msg832">
+        <source xml:space="preserve">Inputs…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg833" approved="yes">
         <source xml:space="preserve">After Fee:</source>
         <target xml:space="preserve">After Fee:</target>
         <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg787" approved="yes">
+      <trans-unit id="_msg834" approved="yes">
         <source xml:space="preserve">Change:</source>
         <target xml:space="preserve">Change:</target>
         <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg788" approved="yes">
+      <trans-unit id="_msg835" approved="yes">
         <source xml:space="preserve">If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <target xml:space="preserve">If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</target>
         <context-group purpose="location"><context context-type="linenumber">458</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg789" approved="yes">
+      <trans-unit id="_msg836" approved="yes">
         <source xml:space="preserve">Custom change address</source>
         <target xml:space="preserve">Custom change address</target>
         <context-group purpose="location"><context context-type="linenumber">461</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg790" approved="yes">
+      <trans-unit id="_msg837" approved="yes">
         <source xml:space="preserve">Transaction Fee:</source>
         <target xml:space="preserve">Transaction Fee:</target>
         <context-group purpose="location"><context context-type="linenumber">658</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg791" approved="yes">
-        <source xml:space="preserve">Choose...</source>
-        <target xml:space="preserve">Choose...</target>
-        <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg792" approved="yes">
+      <trans-unit id="_msg838" approved="yes">
         <source xml:space="preserve">When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
         <target xml:space="preserve">When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</target>
         <context-group purpose="location"><context context-type="linenumber">822</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg793" approved="yes">
+      <trans-unit id="_msg839" approved="yes">
         <source xml:space="preserve">A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <target xml:space="preserve">A too low fee might result in a never confirming transaction (read the tooltip)</target>
         <context-group purpose="location"><context context-type="linenumber">825</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg794" approved="yes">
+      <trans-unit id="_msg840">
+        <source xml:space="preserve">(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">942</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg841" approved="yes">
         <source xml:space="preserve">Confirmation time target:</source>
         <target xml:space="preserve">Confirmation time target:</target>
         <context-group purpose="location"><context context-type="linenumber">968</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg795" approved="yes">
+      <trans-unit id="_msg842" approved="yes">
         <source xml:space="preserve">If the custom fee is set to 1000 duffs and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 duffs in fee,&lt;br /&gt;while &quot;at least&quot; pays 1000 duffs. For transactions bigger than a kilobyte both pay by kilobyte.</source>
         <target xml:space="preserve">If the custom fee is set to 1000 duffs and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 duffs in fee,&lt;br /&gt;while &quot;at least&quot; pays 1000 duffs. For transactions bigger than a kilobyte both pay by kilobyte.</target>
         <context-group purpose="location"><context context-type="linenumber">789</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg796" approved="yes">
+      <trans-unit id="_msg843" approved="yes">
         <source xml:space="preserve">per kilobyte</source>
         <target xml:space="preserve">per kilobyte</target>
         <context-group purpose="location"><context context-type="linenumber">792</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg797" approved="yes">
+      <trans-unit id="_msg844" approved="yes">
         <source xml:space="preserve">Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <target xml:space="preserve">Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</target>
         <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg798" approved="yes">
+      <trans-unit id="_msg845">
+        <source xml:space="preserve">Choose…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg846" approved="yes">
         <source xml:space="preserve">Note: Not enough data for fee estimation, using the fallback fee instead.</source>
         <target xml:space="preserve">Note: Not enough data for fee estimation, using the fallback fee instead.</target>
         <context-group purpose="location"><context context-type="linenumber">697</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg799" approved="yes">
+      <trans-unit id="_msg847" approved="yes">
         <source xml:space="preserve">Hide transaction fee settings</source>
         <target xml:space="preserve">Hide transaction fee settings</target>
         <context-group purpose="location"><context context-type="linenumber">735</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg800" approved="yes">
+      <trans-unit id="_msg848" approved="yes">
         <source xml:space="preserve">Hide</source>
         <target xml:space="preserve">Hide</target>
         <context-group purpose="location"><context context-type="linenumber">738</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg801" approved="yes">
+      <trans-unit id="_msg849" approved="yes">
         <source xml:space="preserve">Recommended:</source>
         <target xml:space="preserve">Recommended:</target>
         <context-group purpose="location"><context context-type="linenumber">857</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg802" approved="yes">
+      <trans-unit id="_msg850" approved="yes">
         <source xml:space="preserve">Custom:</source>
         <target xml:space="preserve">Custom:</target>
         <context-group purpose="location"><context context-type="linenumber">890</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg803" approved="yes">
-        <source xml:space="preserve">(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <target xml:space="preserve">(Smart fee not initialized yet. This usually takes a few blocks...)</target>
-        <context-group purpose="location"><context context-type="linenumber">942</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg804" approved="yes">
+      <trans-unit id="_msg851" approved="yes">
         <source xml:space="preserve">Confirm the send action</source>
         <target xml:space="preserve">Confirm the send action</target>
         <context-group purpose="location"><context context-type="linenumber">1055</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg805" approved="yes">
+      <trans-unit id="_msg852" approved="yes">
         <source xml:space="preserve">S&amp;end</source>
         <target xml:space="preserve">S&amp;end</target>
         <context-group purpose="location"><context context-type="linenumber">1058</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg806" approved="yes">
+      <trans-unit id="_msg853" approved="yes">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <target xml:space="preserve">Clear all fields of the form.</target>
         <context-group purpose="location"><context context-type="linenumber">1077</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg807" approved="yes">
+      <trans-unit id="_msg854" approved="yes">
         <source xml:space="preserve">Clear &amp;All</source>
         <target xml:space="preserve">Clear &amp;All</target>
         <context-group purpose="location"><context context-type="linenumber">1080</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg808" approved="yes">
+      <trans-unit id="_msg855" approved="yes">
         <source xml:space="preserve">Send to multiple recipients at once</source>
         <target xml:space="preserve">Send to multiple recipients at once</target>
         <context-group purpose="location"><context context-type="linenumber">1090</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg809" approved="yes">
+      <trans-unit id="_msg856" approved="yes">
         <source xml:space="preserve">Add &amp;Recipient</source>
         <target xml:space="preserve">Add &amp;Recipient</target>
         <context-group purpose="location"><context context-type="linenumber">1093</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg810" approved="yes">
+      <trans-unit id="_msg857" approved="yes">
         <source xml:space="preserve">Balance:</source>
         <target xml:space="preserve">Balance:</target>
         <context-group purpose="location"><context context-type="linenumber">1121</context></context-group>
@@ -4472,391 +4721,391 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../sendcoinsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg811" approved="yes">
+      <trans-unit id="_msg858" approved="yes">
         <source xml:space="preserve">Copy quantity</source>
         <target xml:space="preserve">Copy quantity</target>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg812" approved="yes">
+      <trans-unit id="_msg859" approved="yes">
         <source xml:space="preserve">Copy amount</source>
         <target xml:space="preserve">Copy amount</target>
         <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg813" approved="yes">
+      <trans-unit id="_msg860" approved="yes">
         <source xml:space="preserve">Copy fee</source>
         <target xml:space="preserve">Copy fee</target>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg814" approved="yes">
+      <trans-unit id="_msg861" approved="yes">
         <source xml:space="preserve">Copy after fee</source>
         <target xml:space="preserve">Copy after fee</target>
         <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg815" approved="yes">
+      <trans-unit id="_msg862" approved="yes">
         <source xml:space="preserve">Copy bytes</source>
         <target xml:space="preserve">Copy bytes</target>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg816" approved="yes">
+      <trans-unit id="_msg863" approved="yes">
         <source xml:space="preserve">Copy dust</source>
         <target xml:space="preserve">Copy dust</target>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg817" approved="yes">
+      <trans-unit id="_msg864" approved="yes">
         <source xml:space="preserve">Copy change</source>
         <target xml:space="preserve">Copy change</target>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg818" approved="yes">
+      <trans-unit id="_msg865" approved="yes">
         <source xml:space="preserve">%1 (%2 blocks)</source>
         <target xml:space="preserve">%1 (%2 blocks)</target>
-        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg819" approved="yes">
+      <trans-unit id="_msg866" approved="yes">
         <source xml:space="preserve">This will produce a Partially Signed Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <target xml:space="preserve">This will produce a Partially Signed Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</target>
-        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg820" approved="yes">
+      <trans-unit id="_msg867" approved="yes">
         <source xml:space="preserve">using</source>
         <target xml:space="preserve">using</target>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg821" approved="yes">
+      <trans-unit id="_msg868" approved="yes">
         <source xml:space="preserve">%1 to %2</source>
         <target xml:space="preserve">%1 to %2</target>
-        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg822" approved="yes">
+      <trans-unit id="_msg869" approved="yes">
         <source xml:space="preserve">Are you sure you want to send?</source>
         <target xml:space="preserve">Are you sure you want to send?</target>
-        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg823" approved="yes">
+      <trans-unit id="_msg870" approved="yes">
         <source xml:space="preserve">&lt;b&gt;(%1 of %2 entries displayed)&lt;/b&gt;</source>
         <target xml:space="preserve">&lt;b&gt;(%1 of %2 entries displayed)&lt;/b&gt;</target>
-        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg824" approved="yes">
+      <trans-unit id="_msg871" approved="yes">
         <source xml:space="preserve">S&amp;end mixed funds</source>
         <target xml:space="preserve">S&amp;end mixed funds</target>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg825" approved="yes">
+      <trans-unit id="_msg872" approved="yes">
         <source xml:space="preserve">Confirm the %1 send action</source>
         <target xml:space="preserve">Confirm the %1 send action</target>
         <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg826" approved="yes">
+      <trans-unit id="_msg873" approved="yes">
         <source xml:space="preserve">Cr&amp;eate Unsigned</source>
         <target xml:space="preserve">Cr&amp;eate Unsigned</target>
-        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg827" approved="yes">
+      <trans-unit id="_msg874" approved="yes">
         <source xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <target xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</target>
-        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg828" approved="yes">
+      <trans-unit id="_msg875" approved="yes">
         <source xml:space="preserve"> from wallet &apos;%1&apos;</source>
         <target xml:space="preserve"> from wallet &apos;%1&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg829" approved="yes">
+      <trans-unit id="_msg876" approved="yes">
         <source xml:space="preserve">%1 to &apos;%2&apos;</source>
         <target xml:space="preserve">%1 to &apos;%2&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg830" approved="yes">
+      <trans-unit id="_msg877" approved="yes">
         <source xml:space="preserve">Do you want to draft this transaction?</source>
         <target xml:space="preserve">Do you want to draft this transaction?</target>
-        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg831" approved="yes">
+      <trans-unit id="_msg878" approved="yes">
         <source xml:space="preserve">%1 funds only</source>
         <target xml:space="preserve">%1 funds only</target>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg832" approved="yes">
-        <source xml:space="preserve">any available funds</source>
-        <target xml:space="preserve">any available funds</target>
         <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg833" approved="yes">
+      <trans-unit id="_msg879" approved="yes">
+        <source xml:space="preserve">any available funds</source>
+        <target xml:space="preserve">any available funds</target>
+        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg880" approved="yes">
         <source xml:space="preserve">Transaction fee</source>
         <target xml:space="preserve">Transaction fee</target>
-        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg834" approved="yes">
+      <trans-unit id="_msg881" approved="yes">
         <source xml:space="preserve">(%1 transactions have higher fees usually due to no change output being allowed)</source>
         <target xml:space="preserve">(%1 transactions have higher fees usually due to no change output being allowed)</target>
-        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg835" approved="yes">
+      <trans-unit id="_msg882" approved="yes">
         <source xml:space="preserve">Transaction size: %1</source>
         <target xml:space="preserve">Transaction size: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg836" approved="yes">
+      <trans-unit id="_msg883" approved="yes">
         <source xml:space="preserve">Fee rate: %1</source>
         <target xml:space="preserve">Fee rate: %1</target>
-        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
-        <trans-unit id="_msg837[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
+        <trans-unit id="_msg884[0]" approved="yes">
           <source xml:space="preserve">This transaction will consume %n input(s)</source>
           <target xml:space="preserve">This transaction will consume %n input</target>
         </trans-unit>
-        <trans-unit id="_msg837[1]" approved="yes">
+        <trans-unit id="_msg884[1]" approved="yes">
           <source xml:space="preserve">This transaction will consume %n input(s)</source>
           <target xml:space="preserve">This transaction will consume %n inputs</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg838" approved="yes">
+      <trans-unit id="_msg885" approved="yes">
         <source xml:space="preserve">Warning: Using %1 with %2 or more inputs can harm your privacy and is not recommended</source>
         <target xml:space="preserve">Warning: Using %1 with %2 or more inputs can harm your privacy and is not recommended</target>
-        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg839" approved="yes">
-        <source xml:space="preserve">Click to learn more</source>
-        <target xml:space="preserve">Click to learn more</target>
         <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg840" approved="yes">
+      <trans-unit id="_msg886" approved="yes">
+        <source xml:space="preserve">Click to learn more</source>
+        <target xml:space="preserve">Click to learn more</target>
+        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg887" approved="yes">
         <source xml:space="preserve">Total Amount</source>
         <target xml:space="preserve">Total Amount</target>
-        <context-group purpose="location"><context context-type="linenumber">449</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg841" approved="yes">
+      <trans-unit id="_msg888" approved="yes">
         <source xml:space="preserve">or</source>
         <target xml:space="preserve">or</target>
-        <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg842" approved="yes">
-        <source xml:space="preserve">To review recipient list click &quot;Show Details...&quot;</source>
-        <target xml:space="preserve">To review recipient list click &quot;Show Details...&quot;</target>
-        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg843" approved="yes">
+      <trans-unit id="_msg889" approved="yes">
         <source xml:space="preserve">Confirm send coins</source>
         <target xml:space="preserve">Confirm send coins</target>
-        <context-group purpose="location"><context context-type="linenumber">471</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg844" approved="yes">
+      <trans-unit id="_msg890" approved="yes">
         <source xml:space="preserve">Confirm transaction proposal</source>
         <target xml:space="preserve">Confirm transaction proposal</target>
-        <context-group purpose="location"><context context-type="linenumber">471</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg845" approved="yes">
+      <trans-unit id="_msg891" approved="yes">
         <source xml:space="preserve">Create Unsigned</source>
         <target xml:space="preserve">Create Unsigned</target>
-        <context-group purpose="location"><context context-type="linenumber">472</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">474</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg846" approved="yes">
+      <trans-unit id="_msg892" approved="yes">
         <source xml:space="preserve">Save Transaction Data</source>
         <target xml:space="preserve">Save Transaction Data</target>
-        <context-group purpose="location"><context context-type="linenumber">516</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg847" approved="yes">
+      <trans-unit id="_msg893" approved="yes">
         <source xml:space="preserve">PSBT saved</source>
         <target xml:space="preserve">PSBT saved</target>
-        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">527</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg848" approved="yes">
+      <trans-unit id="_msg894" approved="yes">
         <source xml:space="preserve">Watch-only balance:</source>
         <target xml:space="preserve">Watch-only balance:</target>
-        <context-group purpose="location"><context context-type="linenumber">703</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">705</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg849" approved="yes">
+      <trans-unit id="_msg895" approved="yes">
         <source xml:space="preserve">Send</source>
         <target xml:space="preserve">Send</target>
-        <context-group purpose="location"><context context-type="linenumber">472</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">474</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg850">
-        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
+      <trans-unit id="_msg896">
+        <source xml:space="preserve">To review recipient list click &quot;Show Details…&quot;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg897" approved="yes">
+        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
+        <target xml:space="preserve">Partially Signed Transaction (Binary)</target>
+        <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
         <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
-      <trans-unit id="_msg851" approved="yes">
+      <trans-unit id="_msg898" approved="yes">
         <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
         <target xml:space="preserve">The recipient address is not valid. Please recheck.</target>
-        <context-group purpose="location"><context context-type="linenumber">733</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">735</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg852" approved="yes">
+      <trans-unit id="_msg899" approved="yes">
         <source xml:space="preserve">The amount to pay must be larger than 0.</source>
         <target xml:space="preserve">The amount to pay must be larger than 0.</target>
-        <context-group purpose="location"><context context-type="linenumber">736</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">738</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg853" approved="yes">
+      <trans-unit id="_msg900" approved="yes">
         <source xml:space="preserve">The amount exceeds your balance.</source>
         <target xml:space="preserve">The amount exceeds your balance.</target>
-        <context-group purpose="location"><context context-type="linenumber">739</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg854" approved="yes">
+      <trans-unit id="_msg901" approved="yes">
         <source xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</source>
         <target xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</target>
-        <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">744</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg855" approved="yes">
+      <trans-unit id="_msg902" approved="yes">
         <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
         <target xml:space="preserve">Duplicate address found: addresses should only be used once each.</target>
-        <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">747</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg856" approved="yes">
+      <trans-unit id="_msg903" approved="yes">
         <source xml:space="preserve">Transaction creation failed!</source>
         <target xml:space="preserve">Transaction creation failed!</target>
-        <context-group purpose="location"><context context-type="linenumber">748</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">750</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg857" approved="yes">
+      <trans-unit id="_msg904" approved="yes">
         <source xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</source>
         <target xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</target>
-        <context-group purpose="location"><context context-type="linenumber">752</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">754</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">870</context></context-group>
-        <trans-unit id="_msg858[0]" approved="yes">
+        <context-group purpose="location"><context context-type="linenumber">872</context></context-group>
+        <trans-unit id="_msg905[0]" approved="yes">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
           <target xml:space="preserve">Estimated to begin confirmation within %n block.</target>
         </trans-unit>
-        <trans-unit id="_msg858[1]" approved="yes">
+        <trans-unit id="_msg905[1]" approved="yes">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
           <target xml:space="preserve">Estimated to begin confirmation within %n blocks.</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg859" approved="yes">
+      <trans-unit id="_msg906" approved="yes">
         <source xml:space="preserve">Warning: Invalid Dash address</source>
         <target xml:space="preserve">Warning: Invalid Dash address</target>
-        <context-group purpose="location"><context context-type="linenumber">971</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">973</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg860" approved="yes">
+      <trans-unit id="_msg907" approved="yes">
         <source xml:space="preserve">Warning: Unknown change address</source>
         <target xml:space="preserve">Warning: Unknown change address</target>
-        <context-group purpose="location"><context context-type="linenumber">976</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">978</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg861" approved="yes">
+      <trans-unit id="_msg908" approved="yes">
         <source xml:space="preserve">Confirm custom change address</source>
         <target xml:space="preserve">Confirm custom change address</target>
-        <context-group purpose="location"><context context-type="linenumber">979</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">981</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg862" approved="yes">
+      <trans-unit id="_msg909" approved="yes">
         <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
         <target xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</target>
-        <context-group purpose="location"><context context-type="linenumber">979</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">981</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg863" approved="yes">
+      <trans-unit id="_msg910" approved="yes">
         <source xml:space="preserve">(no label)</source>
         <target xml:space="preserve">(no label)</target>
-        <context-group purpose="location"><context context-type="linenumber">1000</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1002</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/sendcoinsentry.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsEntry">
-      <trans-unit id="_msg864" approved="yes">
+      <trans-unit id="_msg911" approved="yes">
         <source xml:space="preserve">Pay &amp;To:</source>
         <target xml:space="preserve">Pay &amp;To:</target>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg865" approved="yes">
+      <trans-unit id="_msg912" approved="yes">
         <source xml:space="preserve">The Dash address to send the payment to</source>
         <target xml:space="preserve">The Dash address to send the payment to</target>
         <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg866" approved="yes">
+      <trans-unit id="_msg913" approved="yes">
         <source xml:space="preserve">Choose previously used address</source>
         <target xml:space="preserve">Choose previously used address</target>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg867" approved="yes">
+      <trans-unit id="_msg914" approved="yes">
         <source xml:space="preserve">Alt+A</source>
         <target xml:space="preserve">Alt+A</target>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg868" approved="yes">
+      <trans-unit id="_msg915" approved="yes">
         <source xml:space="preserve">Paste address from clipboard</source>
         <target xml:space="preserve">Paste address from clipboard</target>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg869" approved="yes">
+      <trans-unit id="_msg916" approved="yes">
         <source xml:space="preserve">Alt+P</source>
         <target xml:space="preserve">Alt+P</target>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg870" approved="yes">
+      <trans-unit id="_msg917" approved="yes">
         <source xml:space="preserve">Remove this entry</source>
         <target xml:space="preserve">Remove this entry</target>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">660</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1189</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg871" approved="yes">
+      <trans-unit id="_msg918" approved="yes">
         <source xml:space="preserve">&amp;Label:</source>
         <target xml:space="preserve">&amp;Label:</target>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg872" approved="yes">
+      <trans-unit id="_msg919" approved="yes">
         <source xml:space="preserve">Enter a label for this address to add it to the list of used addresses</source>
         <target xml:space="preserve">Enter a label for this address to add it to the list of used addresses</target>
         <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg873" approved="yes">
+      <trans-unit id="_msg920" approved="yes">
         <source xml:space="preserve">A&amp;mount:</source>
         <target xml:space="preserve">A&amp;mount:</target>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">689</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg874" approved="yes">
+      <trans-unit id="_msg921" approved="yes">
         <source xml:space="preserve">The amount to send in the selected unit</source>
         <target xml:space="preserve">The amount to send in the selected unit</target>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg875" approved="yes">
+      <trans-unit id="_msg922" approved="yes">
         <source xml:space="preserve">The fee will be deducted from the amount being sent. The recipient will receive a lower amount of Dash than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
         <target xml:space="preserve">The fee will be deducted from the amount being sent. The recipient will receive a lower amount of Dash than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</target>
         <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg876" approved="yes">
+      <trans-unit id="_msg923" approved="yes">
         <source xml:space="preserve">S&amp;ubtract fee from amount</source>
         <target xml:space="preserve">S&amp;ubtract fee from amount</target>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg877" approved="yes">
+      <trans-unit id="_msg924" approved="yes">
         <source xml:space="preserve">Use available balance</source>
         <target xml:space="preserve">Use available balance</target>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg878" approved="yes">
+      <trans-unit id="_msg925" approved="yes">
         <source xml:space="preserve">Message:</source>
         <target xml:space="preserve">Message:</target>
         <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg879" approved="yes">
+      <trans-unit id="_msg926" approved="yes">
         <source xml:space="preserve">A message that was attached to the dash: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Dash network.</source>
         <target xml:space="preserve">A message that was attached to the dash: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Dash network.</target>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg880" approved="yes">
+      <trans-unit id="_msg927" approved="yes">
         <source xml:space="preserve">This is an unauthenticated payment request.</source>
         <target xml:space="preserve">This is an unauthenticated payment request.</target>
         <context-group purpose="location"><context context-type="linenumber">627</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg881" approved="yes">
+      <trans-unit id="_msg928" approved="yes">
         <source xml:space="preserve">This is an authenticated payment request.</source>
         <target xml:space="preserve">This is an authenticated payment request.</target>
         <context-group purpose="location"><context context-type="linenumber">1152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg882" approved="yes">
+      <trans-unit id="_msg929" approved="yes">
         <source xml:space="preserve">Pay To:</source>
         <target xml:space="preserve">Pay To:</target>
         <context-group purpose="location"><context context-type="linenumber">642</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg883" approved="yes">
+      <trans-unit id="_msg930" approved="yes">
         <source xml:space="preserve">Memo:</source>
         <target xml:space="preserve">Memo:</target>
         <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
@@ -4866,140 +5115,140 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../forms/signverifymessagedialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg884" approved="yes">
+      <trans-unit id="_msg931" approved="yes">
         <source xml:space="preserve">Signatures - Sign / Verify a Message</source>
         <target xml:space="preserve">Signatures - Sign / Verify a Message</target>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg885" approved="yes">
+      <trans-unit id="_msg932" approved="yes">
         <source xml:space="preserve">&amp;Sign Message</source>
         <target xml:space="preserve">&amp;Sign Message</target>
         <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg886" approved="yes">
+      <trans-unit id="_msg933" approved="yes">
         <source xml:space="preserve">You can sign messages/agreements with your addresses to prove you can receive Dash sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <target xml:space="preserve">You can sign messages/agreements with your addresses to prove you can receive Dash sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</target>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg887" approved="yes">
+      <trans-unit id="_msg934" approved="yes">
         <source xml:space="preserve">The Dash address to sign the message with</source>
         <target xml:space="preserve">The Dash address to sign the message with</target>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg888" approved="yes">
+      <trans-unit id="_msg935" approved="yes">
         <source xml:space="preserve">Choose previously used address</source>
         <target xml:space="preserve">Choose previously used address</target>
         <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg889" approved="yes">
+      <trans-unit id="_msg936" approved="yes">
         <source xml:space="preserve">Alt+A</source>
         <target xml:space="preserve">Alt+A</target>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg890" approved="yes">
+      <trans-unit id="_msg937" approved="yes">
         <source xml:space="preserve">Paste address from clipboard</source>
         <target xml:space="preserve">Paste address from clipboard</target>
         <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg891" approved="yes">
+      <trans-unit id="_msg938" approved="yes">
         <source xml:space="preserve">Alt+P</source>
         <target xml:space="preserve">Alt+P</target>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg892" approved="yes">
+      <trans-unit id="_msg939" approved="yes">
         <source xml:space="preserve">Enter the message you want to sign here</source>
         <target xml:space="preserve">Enter the message you want to sign here</target>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg893" approved="yes">
+      <trans-unit id="_msg940" approved="yes">
         <source xml:space="preserve">Signature</source>
         <target xml:space="preserve">Signature</target>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg894" approved="yes">
+      <trans-unit id="_msg941" approved="yes">
         <source xml:space="preserve">Copy the current signature to the system clipboard</source>
         <target xml:space="preserve">Copy the current signature to the system clipboard</target>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg895" approved="yes">
+      <trans-unit id="_msg942" approved="yes">
         <source xml:space="preserve">Sign the message to prove you own this Dash address</source>
         <target xml:space="preserve">Sign the message to prove you own this Dash address</target>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg896" approved="yes">
+      <trans-unit id="_msg943" approved="yes">
         <source xml:space="preserve">Sign &amp;Message</source>
         <target xml:space="preserve">Sign &amp;Message</target>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg897" approved="yes">
+      <trans-unit id="_msg944" approved="yes">
         <source xml:space="preserve">Reset all sign message fields</source>
         <target xml:space="preserve">Reset all sign message fields</target>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg898" approved="yes">
+      <trans-unit id="_msg945" approved="yes">
         <source xml:space="preserve">Clear &amp;All</source>
         <target xml:space="preserve">Clear &amp;All</target>
         <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg899" approved="yes">
+      <trans-unit id="_msg946" approved="yes">
         <source xml:space="preserve">&amp;Verify Message</source>
         <target xml:space="preserve">&amp;Verify Message</target>
         <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg900" approved="yes">
+      <trans-unit id="_msg947" approved="yes">
         <source xml:space="preserve">Enter the receiver&apos;s address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
         <target xml:space="preserve">Enter the receiver&apos;s address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</target>
         <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg901" approved="yes">
+      <trans-unit id="_msg948" approved="yes">
         <source xml:space="preserve">The Dash address the message was signed with</source>
         <target xml:space="preserve">The Dash address the message was signed with</target>
         <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg902" approved="yes">
+      <trans-unit id="_msg949" approved="yes">
         <source xml:space="preserve">The signed message to verify</source>
         <target xml:space="preserve">The signed message to verify</target>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg903" approved="yes">
+      <trans-unit id="_msg950" approved="yes">
         <source xml:space="preserve">The signature given when the message was signed</source>
         <target xml:space="preserve">The signature given when the message was signed</target>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg904" approved="yes">
+      <trans-unit id="_msg951" approved="yes">
         <source xml:space="preserve">Verify the message to ensure it was signed with the specified Dash address</source>
         <target xml:space="preserve">Verify the message to ensure it was signed with the specified Dash address</target>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg905" approved="yes">
+      <trans-unit id="_msg952" approved="yes">
         <source xml:space="preserve">Verify &amp;Message</source>
         <target xml:space="preserve">Verify &amp;Message</target>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg906" approved="yes">
+      <trans-unit id="_msg953" approved="yes">
         <source xml:space="preserve">Reset all verify message fields</source>
         <target xml:space="preserve">Reset all verify message fields</target>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg907" approved="yes">
+      <trans-unit id="_msg954" approved="yes">
         <source xml:space="preserve">Enter a message to be signed</source>
         <target xml:space="preserve">Enter a message to be signed</target>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg908" approved="yes">
+      <trans-unit id="_msg955" approved="yes">
         <source xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</source>
         <target xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</target>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg909" approved="yes">
+      <trans-unit id="_msg956" approved="yes">
         <source xml:space="preserve">Enter a message to be verified</source>
         <target xml:space="preserve">Enter a message to be verified</target>
         <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg910" approved="yes">
+      <trans-unit id="_msg957" approved="yes">
         <source xml:space="preserve">Enter a signature for the message to be verified</source>
         <target xml:space="preserve">Enter a signature for the message to be verified</target>
         <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
@@ -5008,13 +5257,13 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../signverifymessagedialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg911" approved="yes">
+      <trans-unit id="_msg958" approved="yes">
         <source xml:space="preserve">The entered address is invalid.</source>
         <target xml:space="preserve">The entered address is invalid.</target>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg912" approved="yes">
+      <trans-unit id="_msg959" approved="yes">
         <source xml:space="preserve">Please check the address and try again.</source>
         <target xml:space="preserve">Please check the address and try again.</target>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
@@ -5022,59 +5271,59 @@ https://www.transifex.com/projects/p/dash/</target>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg913" approved="yes">
+      <trans-unit id="_msg960" approved="yes">
         <source xml:space="preserve">The entered address does not refer to a key.</source>
         <target xml:space="preserve">The entered address does not refer to a key.</target>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg914" approved="yes">
+      <trans-unit id="_msg961" approved="yes">
         <source xml:space="preserve">Wallet unlock was cancelled.</source>
         <target xml:space="preserve">Wallet unlock was cancelled.</target>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg915" approved="yes">
+      <trans-unit id="_msg962" approved="yes">
         <source xml:space="preserve">No error</source>
         <target xml:space="preserve">No error</target>
         <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg916" approved="yes">
+      <trans-unit id="_msg963" approved="yes">
         <source xml:space="preserve">Private key for the entered address is not available.</source>
         <target xml:space="preserve">Private key for the entered address is not available.</target>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg917" approved="yes">
+      <trans-unit id="_msg964" approved="yes">
         <source xml:space="preserve">Message signing failed.</source>
         <target xml:space="preserve">Message signing failed.</target>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg918" approved="yes">
+      <trans-unit id="_msg965" approved="yes">
         <source xml:space="preserve">Message signed.</source>
         <target xml:space="preserve">Message signed.</target>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg919" approved="yes">
+      <trans-unit id="_msg966" approved="yes">
         <source xml:space="preserve">The signature could not be decoded.</source>
         <target xml:space="preserve">The signature could not be decoded.</target>
         <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg920" approved="yes">
+      <trans-unit id="_msg967" approved="yes">
         <source xml:space="preserve">Please check the signature and try again.</source>
         <target xml:space="preserve">Please check the signature and try again.</target>
         <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg921" approved="yes">
+      <trans-unit id="_msg968" approved="yes">
         <source xml:space="preserve">The signature did not match the message digest.</source>
         <target xml:space="preserve">The signature did not match the message digest.</target>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg922" approved="yes">
+      <trans-unit id="_msg969" approved="yes">
         <source xml:space="preserve">Message verification failed.</source>
         <target xml:space="preserve">Message verification failed.</target>
         <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg923" approved="yes">
+      <trans-unit id="_msg970" approved="yes">
         <source xml:space="preserve">Message verified.</source>
         <target xml:space="preserve">Message verified.</target>
         <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
@@ -5083,22 +5332,22 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../trafficgraphwidget.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TrafficGraphWidget">
-      <trans-unit id="_msg924" approved="yes">
+      <trans-unit id="_msg971" approved="yes">
         <source xml:space="preserve">KB/s</source>
         <target xml:space="preserve">KB/s</target>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg925" approved="yes">
+      <trans-unit id="_msg972" approved="yes">
         <source xml:space="preserve">Total</source>
         <target xml:space="preserve">Total</target>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg926" approved="yes">
+      <trans-unit id="_msg973" approved="yes">
         <source xml:space="preserve">Received</source>
         <target xml:space="preserve">Received</target>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg927" approved="yes">
+      <trans-unit id="_msg974" approved="yes">
         <source xml:space="preserve">Sent</source>
         <target xml:space="preserve">Sent</target>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
@@ -5109,121 +5358,121 @@ https://www.transifex.com/projects/p/dash/</target>
     <group restype="x-trolltech-linguist-context" resname="TransactionDesc">
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
-        <trans-unit id="_msg928[0]" approved="yes">
+        <trans-unit id="_msg975[0]" approved="yes">
           <source xml:space="preserve">Open for %n more block(s)</source>
           <target xml:space="preserve">Open for %n more block</target>
         </trans-unit>
-        <trans-unit id="_msg928[1]" approved="yes">
+        <trans-unit id="_msg975[1]" approved="yes">
           <source xml:space="preserve">Open for %n more block(s)</source>
           <target xml:space="preserve">Open for %n more blocks</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg929" approved="yes">
+      <trans-unit id="_msg976" approved="yes">
         <source xml:space="preserve">Open until %1</source>
         <target xml:space="preserve">Open until %1</target>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg930" approved="yes">
+      <trans-unit id="_msg977" approved="yes">
         <source xml:space="preserve">conflicted</source>
         <target xml:space="preserve">conflicted</target>
         <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg931" approved="yes">
+      <trans-unit id="_msg978" approved="yes">
         <source xml:space="preserve">0/unconfirmed, %1</source>
         <target xml:space="preserve">0/unconfirmed, %1</target>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg932" approved="yes">
+      <trans-unit id="_msg979" approved="yes">
         <source xml:space="preserve">in memory pool</source>
         <target xml:space="preserve">in memory pool</target>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg933" approved="yes">
+      <trans-unit id="_msg980" approved="yes">
         <source xml:space="preserve">not in memory pool</source>
         <target xml:space="preserve">not in memory pool</target>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg934" approved="yes">
+      <trans-unit id="_msg981" approved="yes">
         <source xml:space="preserve">abandoned</source>
         <target xml:space="preserve">abandoned</target>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg935" approved="yes">
+      <trans-unit id="_msg982" approved="yes">
         <source xml:space="preserve">%1/unconfirmed</source>
         <target xml:space="preserve">%1/unconfirmed</target>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg936" approved="yes">
+      <trans-unit id="_msg983" approved="yes">
         <source xml:space="preserve">%1 confirmations</source>
         <target xml:space="preserve">%1 confirmations</target>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg937" approved="yes">
+      <trans-unit id="_msg984" approved="yes">
         <source xml:space="preserve">locked via ChainLocks</source>
         <target xml:space="preserve">locked via ChainLocks</target>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg938" approved="yes">
+      <trans-unit id="_msg985" approved="yes">
         <source xml:space="preserve">verified via InstantSend</source>
         <target xml:space="preserve">verified via InstantSend</target>
         <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg939" approved="yes">
+      <trans-unit id="_msg986" approved="yes">
         <source xml:space="preserve">Status</source>
         <target xml:space="preserve">Status</target>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg940" approved="yes">
+      <trans-unit id="_msg987" approved="yes">
         <source xml:space="preserve">Date</source>
         <target xml:space="preserve">Date</target>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg941" approved="yes">
+      <trans-unit id="_msg988" approved="yes">
         <source xml:space="preserve">Source</source>
         <target xml:space="preserve">Source</target>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg942" approved="yes">
+      <trans-unit id="_msg989" approved="yes">
         <source xml:space="preserve">Generated</source>
         <target xml:space="preserve">Generated</target>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg943" approved="yes">
+      <trans-unit id="_msg990" approved="yes">
         <source xml:space="preserve">From</source>
         <target xml:space="preserve">From</target>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg944" approved="yes">
+      <trans-unit id="_msg991" approved="yes">
         <source xml:space="preserve">unknown</source>
         <target xml:space="preserve">unknown</target>
         <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg945" approved="yes">
+      <trans-unit id="_msg992" approved="yes">
         <source xml:space="preserve">To</source>
         <target xml:space="preserve">To</target>
         <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg946" approved="yes">
+      <trans-unit id="_msg993" approved="yes">
         <source xml:space="preserve">own address</source>
         <target xml:space="preserve">own address</target>
         <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg947" approved="yes">
+      <trans-unit id="_msg994" approved="yes">
         <source xml:space="preserve">watch-only</source>
         <target xml:space="preserve">watch-only</target>
         <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg948" approved="yes">
+      <trans-unit id="_msg995" approved="yes">
         <source xml:space="preserve">label</source>
         <target xml:space="preserve">label</target>
         <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg949" approved="yes">
+      <trans-unit id="_msg996" approved="yes">
         <source xml:space="preserve">Credit</source>
         <target xml:space="preserve">Credit</target>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
@@ -5234,105 +5483,105 @@ https://www.transifex.com/projects/p/dash/</target>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
-        <trans-unit id="_msg950[0]" approved="yes">
+        <trans-unit id="_msg997[0]" approved="yes">
           <source xml:space="preserve">matures in %n more block(s)</source>
           <target xml:space="preserve">matures in %n more block</target>
         </trans-unit>
-        <trans-unit id="_msg950[1]" approved="yes">
+        <trans-unit id="_msg997[1]" approved="yes">
           <source xml:space="preserve">matures in %n more block(s)</source>
           <target xml:space="preserve">matures in %n more blocks</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg951" approved="yes">
+      <trans-unit id="_msg998" approved="yes">
         <source xml:space="preserve">not accepted</source>
         <target xml:space="preserve">not accepted</target>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg952" approved="yes">
+      <trans-unit id="_msg999" approved="yes">
         <source xml:space="preserve">Debit</source>
         <target xml:space="preserve">Debit</target>
         <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg953" approved="yes">
+      <trans-unit id="_msg1000" approved="yes">
         <source xml:space="preserve">Total debit</source>
         <target xml:space="preserve">Total debit</target>
         <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg954" approved="yes">
+      <trans-unit id="_msg1001" approved="yes">
         <source xml:space="preserve">Total credit</source>
         <target xml:space="preserve">Total credit</target>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg955" approved="yes">
+      <trans-unit id="_msg1002" approved="yes">
         <source xml:space="preserve">Transaction fee</source>
         <target xml:space="preserve">Transaction fee</target>
         <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg956" approved="yes">
+      <trans-unit id="_msg1003" approved="yes">
         <source xml:space="preserve">Net amount</source>
         <target xml:space="preserve">Net amount</target>
         <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg957" approved="yes">
+      <trans-unit id="_msg1004" approved="yes">
         <source xml:space="preserve">Message</source>
         <target xml:space="preserve">Message</target>
         <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg958" approved="yes">
+      <trans-unit id="_msg1005" approved="yes">
         <source xml:space="preserve">Comment</source>
         <target xml:space="preserve">Comment</target>
         <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg959" approved="yes">
+      <trans-unit id="_msg1006" approved="yes">
         <source xml:space="preserve">Transaction ID</source>
         <target xml:space="preserve">Transaction ID</target>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg960" approved="yes">
+      <trans-unit id="_msg1007" approved="yes">
         <source xml:space="preserve">Output index</source>
         <target xml:space="preserve">Output index</target>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg961" approved="yes">
+      <trans-unit id="_msg1008" approved="yes">
         <source xml:space="preserve">Transaction total size</source>
         <target xml:space="preserve">Transaction total size</target>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg962" approved="yes">
+      <trans-unit id="_msg1009" approved="yes">
         <source xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <target xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</target>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg963" approved="yes">
+      <trans-unit id="_msg1010" approved="yes">
         <source xml:space="preserve">Debug information</source>
         <target xml:space="preserve">Debug information</target>
         <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg964" approved="yes">
+      <trans-unit id="_msg1011" approved="yes">
         <source xml:space="preserve">Transaction</source>
         <target xml:space="preserve">Transaction</target>
         <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg965" approved="yes">
+      <trans-unit id="_msg1012" approved="yes">
         <source xml:space="preserve">Inputs</source>
         <target xml:space="preserve">Inputs</target>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg966" approved="yes">
+      <trans-unit id="_msg1013" approved="yes">
         <source xml:space="preserve">Amount</source>
         <target xml:space="preserve">Amount</target>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg967" approved="yes">
+      <trans-unit id="_msg1014" approved="yes">
         <source xml:space="preserve">true</source>
         <target xml:space="preserve">true</target>
         <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg968" approved="yes">
+      <trans-unit id="_msg1015" approved="yes">
         <source xml:space="preserve">false</source>
         <target xml:space="preserve">false</target>
         <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
@@ -5342,7 +5591,7 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../forms/transactiondescdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg969" approved="yes">
+      <trans-unit id="_msg1016" approved="yes">
         <source xml:space="preserve">This pane shows a detailed description of the transaction</source>
         <target xml:space="preserve">This pane shows a detailed description of the transaction</target>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
@@ -5351,7 +5600,7 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../transactiondescdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg970" approved="yes">
+      <trans-unit id="_msg1017" approved="yes">
         <source xml:space="preserve">Details for %1</source>
         <target xml:space="preserve">Details for %1</target>
         <context-group purpose="location"><context context-type="linenumber">21</context></context-group>
@@ -5360,538 +5609,538 @@ https://www.transifex.com/projects/p/dash/</target>
   </body></file>
   <file original="../transactiontablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionTableModel">
-      <trans-unit id="_msg971" approved="yes">
+      <trans-unit id="_msg1018" approved="yes">
         <source xml:space="preserve">Date</source>
         <target xml:space="preserve">Date</target>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg972" approved="yes">
+      <trans-unit id="_msg1019" approved="yes">
         <source xml:space="preserve">Type</source>
         <target xml:space="preserve">Type</target>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg973" approved="yes">
+      <trans-unit id="_msg1020" approved="yes">
         <source xml:space="preserve">Address / Label</source>
         <target xml:space="preserve">Address / Label</target>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
-        <trans-unit id="_msg974[0]" approved="yes">
+        <trans-unit id="_msg1021[0]" approved="yes">
           <source xml:space="preserve">Open for %n more block(s)</source>
           <target xml:space="preserve">Open for %n more block</target>
         </trans-unit>
-        <trans-unit id="_msg974[1]" approved="yes">
+        <trans-unit id="_msg1021[1]" approved="yes">
           <source xml:space="preserve">Open for %n more block(s)</source>
           <target xml:space="preserve">Open for %n more blocks</target>
         </trans-unit>
       </group>
-      <trans-unit id="_msg975" approved="yes">
+      <trans-unit id="_msg1022" approved="yes">
         <source xml:space="preserve">Open until %1</source>
         <target xml:space="preserve">Open until %1</target>
         <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg976" approved="yes">
+      <trans-unit id="_msg1023" approved="yes">
         <source xml:space="preserve">Unconfirmed</source>
         <target xml:space="preserve">Unconfirmed</target>
         <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg977" approved="yes">
+      <trans-unit id="_msg1024" approved="yes">
         <source xml:space="preserve">Abandoned</source>
         <target xml:space="preserve">Abandoned</target>
         <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg978" approved="yes">
+      <trans-unit id="_msg1025" approved="yes">
         <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
         <target xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</target>
         <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg979" approved="yes">
+      <trans-unit id="_msg1026" approved="yes">
         <source xml:space="preserve">Confirmed (%1 confirmations)</source>
         <target xml:space="preserve">Confirmed (%1 confirmations)</target>
         <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg980" approved="yes">
+      <trans-unit id="_msg1027" approved="yes">
         <source xml:space="preserve">Conflicted</source>
         <target xml:space="preserve">Conflicted</target>
         <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg981" approved="yes">
+      <trans-unit id="_msg1028" approved="yes">
         <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
         <target xml:space="preserve">Immature (%1 confirmations, will be available after %2)</target>
         <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg982" approved="yes">
+      <trans-unit id="_msg1029" approved="yes">
         <source xml:space="preserve">Generated but not accepted</source>
         <target xml:space="preserve">Generated but not accepted</target>
         <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg983" approved="yes">
+      <trans-unit id="_msg1030" approved="yes">
         <source xml:space="preserve">verified via InstantSend</source>
         <target xml:space="preserve">verified via InstantSend</target>
         <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg984" approved="yes">
+      <trans-unit id="_msg1031" approved="yes">
         <source xml:space="preserve">locked via ChainLocks</source>
         <target xml:space="preserve">locked via ChainLocks</target>
         <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg985" approved="yes">
+      <trans-unit id="_msg1032" approved="yes">
         <source xml:space="preserve">Received with</source>
         <target xml:space="preserve">Received with</target>
         <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg986" approved="yes">
+      <trans-unit id="_msg1033" approved="yes">
         <source xml:space="preserve">Received from</source>
         <target xml:space="preserve">Received from</target>
         <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg987" approved="yes">
+      <trans-unit id="_msg1034" approved="yes">
         <source xml:space="preserve">Received via %1</source>
         <target xml:space="preserve">Received via %1</target>
         <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg988" approved="yes">
+      <trans-unit id="_msg1035" approved="yes">
         <source xml:space="preserve">Sent to</source>
         <target xml:space="preserve">Sent to</target>
         <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg989" approved="yes">
+      <trans-unit id="_msg1036" approved="yes">
         <source xml:space="preserve">Payment to yourself</source>
         <target xml:space="preserve">Payment to yourself</target>
         <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg990" approved="yes">
+      <trans-unit id="_msg1037" approved="yes">
         <source xml:space="preserve">Mined</source>
         <target xml:space="preserve">Mined</target>
         <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg991" approved="yes">
+      <trans-unit id="_msg1038" approved="yes">
         <source xml:space="preserve">%1 Mixing</source>
         <target xml:space="preserve">%1 Mixing</target>
         <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg992" approved="yes">
+      <trans-unit id="_msg1039" approved="yes">
         <source xml:space="preserve">%1 Collateral Payment</source>
         <target xml:space="preserve">%1 Collateral Payment</target>
         <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg993" approved="yes">
+      <trans-unit id="_msg1040" approved="yes">
         <source xml:space="preserve">%1 Make Collateral Inputs</source>
         <target xml:space="preserve">%1 Make Collateral Inputs</target>
         <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg994" approved="yes">
+      <trans-unit id="_msg1041" approved="yes">
         <source xml:space="preserve">%1 Create Denominations</source>
         <target xml:space="preserve">%1 Create Denominations</target>
         <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg995" approved="yes">
+      <trans-unit id="_msg1042" approved="yes">
         <source xml:space="preserve">%1 Send</source>
         <target xml:space="preserve">%1 Send</target>
         <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg996" approved="yes">
+      <trans-unit id="_msg1043" approved="yes">
         <source xml:space="preserve">watch-only</source>
         <target xml:space="preserve">watch-only</target>
         <context-group purpose="location"><context context-type="linenumber">464</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg997" approved="yes">
+      <trans-unit id="_msg1044" approved="yes">
         <source xml:space="preserve">(n/a)</source>
         <target xml:space="preserve">(n/a)</target>
         <context-group purpose="location"><context context-type="linenumber">482</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg998" approved="yes">
+      <trans-unit id="_msg1045" approved="yes">
         <source xml:space="preserve">(no label)</source>
         <target xml:space="preserve">(no label)</target>
-        <context-group purpose="location"><context context-type="linenumber">713</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">715</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg999" approved="yes">
+      <trans-unit id="_msg1046" approved="yes">
         <source xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</source>
         <target xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</target>
-        <context-group purpose="location"><context context-type="linenumber">752</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1000" approved="yes">
-        <source xml:space="preserve">Date and time that the transaction was received.</source>
-        <target xml:space="preserve">Date and time that the transaction was received.</target>
         <context-group purpose="location"><context context-type="linenumber">754</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1001" approved="yes">
-        <source xml:space="preserve">Type of transaction.</source>
-        <target xml:space="preserve">Type of transaction.</target>
+      <trans-unit id="_msg1047" approved="yes">
+        <source xml:space="preserve">Date and time that the transaction was received.</source>
+        <target xml:space="preserve">Date and time that the transaction was received.</target>
         <context-group purpose="location"><context context-type="linenumber">756</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1002" approved="yes">
-        <source xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</source>
-        <target xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</target>
+      <trans-unit id="_msg1048" approved="yes">
+        <source xml:space="preserve">Type of transaction.</source>
+        <target xml:space="preserve">Type of transaction.</target>
         <context-group purpose="location"><context context-type="linenumber">758</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1003" approved="yes">
-        <source xml:space="preserve">User-defined intent/purpose of the transaction.</source>
-        <target xml:space="preserve">User-defined intent/purpose of the transaction.</target>
+      <trans-unit id="_msg1049" approved="yes">
+        <source xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</source>
+        <target xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</target>
         <context-group purpose="location"><context context-type="linenumber">760</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1004" approved="yes">
+      <trans-unit id="_msg1050" approved="yes">
+        <source xml:space="preserve">User-defined intent/purpose of the transaction.</source>
+        <target xml:space="preserve">User-defined intent/purpose of the transaction.</target>
+        <context-group purpose="location"><context context-type="linenumber">762</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1051" approved="yes">
         <source xml:space="preserve">Amount removed from or added to balance.</source>
         <target xml:space="preserve">Amount removed from or added to balance.</target>
-        <context-group purpose="location"><context context-type="linenumber">762</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">764</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../transactionview.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionView">
-      <trans-unit id="_msg1005" approved="yes">
+      <trans-unit id="_msg1052" approved="yes">
         <source xml:space="preserve">All</source>
         <target xml:space="preserve">All</target>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1006" approved="yes">
+      <trans-unit id="_msg1053" approved="yes">
         <source xml:space="preserve">Today</source>
         <target xml:space="preserve">Today</target>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1007" approved="yes">
+      <trans-unit id="_msg1054" approved="yes">
         <source xml:space="preserve">This week</source>
         <target xml:space="preserve">This week</target>
         <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1008" approved="yes">
+      <trans-unit id="_msg1055" approved="yes">
         <source xml:space="preserve">This month</source>
         <target xml:space="preserve">This month</target>
         <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1009" approved="yes">
+      <trans-unit id="_msg1056" approved="yes">
         <source xml:space="preserve">Last month</source>
         <target xml:space="preserve">Last month</target>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1010" approved="yes">
+      <trans-unit id="_msg1057" approved="yes">
         <source xml:space="preserve">This year</source>
         <target xml:space="preserve">This year</target>
         <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1011" approved="yes">
-        <source xml:space="preserve">Range...</source>
-        <target xml:space="preserve">Range...</target>
+      <trans-unit id="_msg1058">
+        <source xml:space="preserve">Range…</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1012" approved="yes">
+      <trans-unit id="_msg1059" approved="yes">
         <source xml:space="preserve">Most Common</source>
         <target xml:space="preserve">Most Common</target>
         <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1013" approved="yes">
+      <trans-unit id="_msg1060" approved="yes">
         <source xml:space="preserve">Received with</source>
         <target xml:space="preserve">Received with</target>
         <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1014" approved="yes">
+      <trans-unit id="_msg1061" approved="yes">
         <source xml:space="preserve">Sent to</source>
         <target xml:space="preserve">Sent to</target>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1015" approved="yes">
+      <trans-unit id="_msg1062" approved="yes">
         <source xml:space="preserve">%1 Send</source>
         <target xml:space="preserve">%1 Send</target>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1016" approved="yes">
+      <trans-unit id="_msg1063" approved="yes">
         <source xml:space="preserve">%1 Make Collateral Inputs</source>
         <target xml:space="preserve">%1 Make Collateral Inputs</target>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1017" approved="yes">
+      <trans-unit id="_msg1064" approved="yes">
         <source xml:space="preserve">%1 Create Denominations</source>
         <target xml:space="preserve">%1 Create Denominations</target>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1018" approved="yes">
+      <trans-unit id="_msg1065" approved="yes">
         <source xml:space="preserve">%1 Mixing</source>
         <target xml:space="preserve">%1 Mixing</target>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1019" approved="yes">
+      <trans-unit id="_msg1066" approved="yes">
         <source xml:space="preserve">%1 Collateral Payment</source>
         <target xml:space="preserve">%1 Collateral Payment</target>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1020" approved="yes">
+      <trans-unit id="_msg1067" approved="yes">
         <source xml:space="preserve">To yourself</source>
         <target xml:space="preserve">To yourself</target>
         <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1021" approved="yes">
+      <trans-unit id="_msg1068" approved="yes">
         <source xml:space="preserve">Mined</source>
         <target xml:space="preserve">Mined</target>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1022" approved="yes">
+      <trans-unit id="_msg1069" approved="yes">
         <source xml:space="preserve">Other</source>
         <target xml:space="preserve">Other</target>
         <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1023" approved="yes">
+      <trans-unit id="_msg1070" approved="yes">
         <source xml:space="preserve">Enter address, transaction id, or label to search</source>
         <target xml:space="preserve">Enter address, transaction id, or label to search</target>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1024" approved="yes">
+      <trans-unit id="_msg1071" approved="yes">
         <source xml:space="preserve">Min amount</source>
         <target xml:space="preserve">Min amount</target>
         <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1025" approved="yes">
+      <trans-unit id="_msg1072" approved="yes">
         <source xml:space="preserve">Abandon transaction</source>
         <target xml:space="preserve">Abandon transaction</target>
         <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1026" approved="yes">
+      <trans-unit id="_msg1073" approved="yes">
         <source xml:space="preserve">Resend transaction</source>
         <target xml:space="preserve">Resend transaction</target>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1027" approved="yes">
+      <trans-unit id="_msg1074" approved="yes">
         <source xml:space="preserve">Copy address</source>
         <target xml:space="preserve">Copy address</target>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1028" approved="yes">
+      <trans-unit id="_msg1075" approved="yes">
         <source xml:space="preserve">Copy label</source>
         <target xml:space="preserve">Copy label</target>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1029" approved="yes">
+      <trans-unit id="_msg1076" approved="yes">
         <source xml:space="preserve">Copy amount</source>
         <target xml:space="preserve">Copy amount</target>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1030" approved="yes">
+      <trans-unit id="_msg1077" approved="yes">
         <source xml:space="preserve">Copy transaction ID</source>
         <target xml:space="preserve">Copy transaction ID</target>
         <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1031" approved="yes">
+      <trans-unit id="_msg1078" approved="yes">
         <source xml:space="preserve">Copy raw transaction</source>
         <target xml:space="preserve">Copy raw transaction</target>
         <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1032" approved="yes">
+      <trans-unit id="_msg1079" approved="yes">
         <source xml:space="preserve">Copy full transaction details</source>
         <target xml:space="preserve">Copy full transaction details</target>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1033" approved="yes">
+      <trans-unit id="_msg1080" approved="yes">
         <source xml:space="preserve">Edit address label</source>
         <target xml:space="preserve">Edit address label</target>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1034" approved="yes">
+      <trans-unit id="_msg1081" approved="yes">
         <source xml:space="preserve">Show transaction details</source>
         <target xml:space="preserve">Show transaction details</target>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1035" approved="yes">
+      <trans-unit id="_msg1082" approved="yes">
         <source xml:space="preserve">Show address QR code</source>
         <target xml:space="preserve">Show address QR code</target>
         <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1036" approved="yes">
+      <trans-unit id="_msg1083" approved="yes">
         <source xml:space="preserve">Export Transaction History</source>
         <target xml:space="preserve">Export Transaction History</target>
         <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1037">
+      <trans-unit id="_msg1084" approved="yes">
         <source xml:space="preserve">Comma separated file</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Comma separated file</target>
         <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</note>
       </trans-unit>
-      <trans-unit id="_msg1038" approved="yes">
+      <trans-unit id="_msg1085" approved="yes">
         <source xml:space="preserve">Confirmed</source>
         <target xml:space="preserve">Confirmed</target>
         <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1039" approved="yes">
+      <trans-unit id="_msg1086" approved="yes">
         <source xml:space="preserve">Watch-only</source>
         <target xml:space="preserve">Watch-only</target>
         <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1040" approved="yes">
+      <trans-unit id="_msg1087" approved="yes">
         <source xml:space="preserve">Date</source>
         <target xml:space="preserve">Date</target>
         <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1041" approved="yes">
+      <trans-unit id="_msg1088" approved="yes">
         <source xml:space="preserve">Type</source>
         <target xml:space="preserve">Type</target>
         <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1042" approved="yes">
+      <trans-unit id="_msg1089" approved="yes">
         <source xml:space="preserve">Label</source>
         <target xml:space="preserve">Label</target>
         <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1043" approved="yes">
+      <trans-unit id="_msg1090" approved="yes">
         <source xml:space="preserve">Address</source>
         <target xml:space="preserve">Address</target>
         <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1044" approved="yes">
+      <trans-unit id="_msg1091" approved="yes">
         <source xml:space="preserve">ID</source>
         <target xml:space="preserve">ID</target>
         <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1045" approved="yes">
+      <trans-unit id="_msg1092" approved="yes">
         <source xml:space="preserve">Exporting Failed</source>
         <target xml:space="preserve">Exporting Failed</target>
         <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1046" approved="yes">
+      <trans-unit id="_msg1093" approved="yes">
         <source xml:space="preserve">There was an error trying to save the transaction history to %1.</source>
         <target xml:space="preserve">There was an error trying to save the transaction history to %1.</target>
         <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1047" approved="yes">
+      <trans-unit id="_msg1094" approved="yes">
         <source xml:space="preserve">Exporting Successful</source>
         <target xml:space="preserve">Exporting Successful</target>
         <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1048" approved="yes">
+      <trans-unit id="_msg1095" approved="yes">
         <source xml:space="preserve">The transaction history was successfully saved to %1.</source>
         <target xml:space="preserve">The transaction history was successfully saved to %1.</target>
         <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1049" approved="yes">
+      <trans-unit id="_msg1096" approved="yes">
         <source xml:space="preserve">QR code</source>
         <target xml:space="preserve">QR code</target>
-        <context-group purpose="location"><context context-type="linenumber">577</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">574</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1050" approved="yes">
+      <trans-unit id="_msg1097" approved="yes">
         <source xml:space="preserve">Range:</source>
         <target xml:space="preserve">Range:</target>
-        <context-group purpose="location"><context context-type="linenumber">620</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">617</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1051" approved="yes">
+      <trans-unit id="_msg1098" approved="yes">
         <source xml:space="preserve">to</source>
         <target xml:space="preserve">to</target>
-        <context-group purpose="location"><context context-type="linenumber">629</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">626</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletframe.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletFrame">
-      <trans-unit id="_msg1052" approved="yes">
+      <trans-unit id="_msg1099" approved="yes">
         <source xml:space="preserve">No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <target xml:space="preserve">No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</target>
-        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1053" approved="yes">
+      <trans-unit id="_msg1100" approved="yes">
         <source xml:space="preserve">Create a new wallet</source>
         <target xml:space="preserve">Create a new wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletmodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletModel">
-      <trans-unit id="_msg1054" approved="yes">
+      <trans-unit id="_msg1101" approved="yes">
         <source xml:space="preserve">Send Coins</source>
         <target xml:space="preserve">Send Coins</target>
-        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1055" approved="yes">
+      <trans-unit id="_msg1102" approved="yes">
         <source xml:space="preserve">default wallet</source>
         <target xml:space="preserve">default wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">602</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">587</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletview.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletView">
-      <trans-unit id="_msg1056" approved="yes">
+      <trans-unit id="_msg1103" approved="yes">
         <source xml:space="preserve">&amp;Export</source>
         <target xml:space="preserve">&amp;Export</target>
         <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1057" approved="yes">
+      <trans-unit id="_msg1104" approved="yes">
         <source xml:space="preserve">Export the data in the current tab to a file</source>
         <target xml:space="preserve">Export the data in the current tab to a file</target>
         <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1058" approved="yes">
+      <trans-unit id="_msg1105" approved="yes">
         <source xml:space="preserve">Selected amount:</source>
         <target xml:space="preserve">Selected amount:</target>
         <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1059">
+      <trans-unit id="_msg1106" approved="yes">
         <source xml:space="preserve">Unable to decode PSBT from clipboard (invalid base64)</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Unable to decode PSBT from clipboard (invalid base64)</target>
         <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1060" approved="yes">
+      <trans-unit id="_msg1107" approved="yes">
         <source xml:space="preserve">Load Transaction Data</source>
         <target xml:space="preserve">Load Transaction Data</target>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1061" approved="yes">
+      <trans-unit id="_msg1108" approved="yes">
         <source xml:space="preserve">Partially Signed Transaction (*.psbt)</source>
         <target xml:space="preserve">Partially Signed Transaction (*.psbt)</target>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1062">
+      <trans-unit id="_msg1109" approved="yes">
         <source xml:space="preserve">Unable to decode PSBT</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Unable to decode PSBT</target>
         <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1063">
+      <trans-unit id="_msg1110" approved="yes">
         <source xml:space="preserve">Wallet Data</source>
-        <target xml:space="preserve"></target>
+        <target xml:space="preserve">Wallet Data</target>
         <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
         <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
-      <trans-unit id="_msg1064" approved="yes">
+      <trans-unit id="_msg1111" approved="yes">
         <source xml:space="preserve">Error</source>
         <target xml:space="preserve">Error</target>
         <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1065" approved="yes">
+      <trans-unit id="_msg1112" approved="yes">
         <source xml:space="preserve">PSBT file must be smaller than 100 MiB</source>
         <target xml:space="preserve">PSBT file must be smaller than 100 MiB</target>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1066" approved="yes">
+      <trans-unit id="_msg1113" approved="yes">
         <source xml:space="preserve">Backup Wallet</source>
         <target xml:space="preserve">Backup Wallet</target>
         <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1067" approved="yes">
+      <trans-unit id="_msg1114" approved="yes">
         <source xml:space="preserve">Backup Failed</source>
         <target xml:space="preserve">Backup Failed</target>
         <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1068" approved="yes">
+      <trans-unit id="_msg1115" approved="yes">
         <source xml:space="preserve">There was an error trying to save the wallet data to %1.</source>
         <target xml:space="preserve">There was an error trying to save the wallet data to %1.</target>
         <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1069" approved="yes">
+      <trans-unit id="_msg1116" approved="yes">
         <source xml:space="preserve">Backup Successful</source>
         <target xml:space="preserve">Backup Successful</target>
         <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1070" approved="yes">
+      <trans-unit id="_msg1117" approved="yes">
         <source xml:space="preserve">The wallet data was successfully saved to %1.</source>
         <target xml:space="preserve">The wallet data was successfully saved to %1.</target>
         <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1071" approved="yes">
+      <trans-unit id="_msg1118" approved="yes">
         <source xml:space="preserve">Cancel</source>
         <target xml:space="preserve">Cancel</target>
         <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
@@ -5900,1155 +6149,1280 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../dashstrings.cpp" datatype="cpp" source-language="en" target-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="dash-core">
-      <trans-unit id="_msg1072" approved="yes">
+      <trans-unit id="_msg1119" approved="yes">
         <source xml:space="preserve">Error: Listening for incoming connections failed (listen returned error %s)</source>
         <target xml:space="preserve">Error: Listening for incoming connections failed (listen returned error %s)</target>
-        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1073" approved="yes">
+      <trans-unit id="_msg1120" approved="yes">
         <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <target xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</target>
-        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1074" approved="yes">
+      <trans-unit id="_msg1121" approved="yes">
         <source xml:space="preserve">This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
         <target xml:space="preserve">This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1075" approved="yes">
+      <trans-unit id="_msg1122" approved="yes">
         <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <target xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</target>
-        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1076" approved="yes">
+      <trans-unit id="_msg1123" approved="yes">
         <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <target xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</target>
-        <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1077" approved="yes">
+      <trans-unit id="_msg1124" approved="yes">
         <source xml:space="preserve">Already have that input.</source>
         <target xml:space="preserve">Already have that input.</target>
-        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1078" approved="yes">
+      <trans-unit id="_msg1125" approved="yes">
         <source xml:space="preserve">Collateral not valid.</source>
         <target xml:space="preserve">Collateral not valid.</target>
-        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1079" approved="yes">
+      <trans-unit id="_msg1126" approved="yes">
         <source xml:space="preserve">Corrupted block database detected</source>
         <target xml:space="preserve">Corrupted block database detected</target>
-        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1080" approved="yes">
+      <trans-unit id="_msg1127" approved="yes">
         <source xml:space="preserve">Do you want to rebuild the block database now?</source>
         <target xml:space="preserve">Do you want to rebuild the block database now?</target>
-        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1081" approved="yes">
+      <trans-unit id="_msg1128" approved="yes">
         <source xml:space="preserve">Done loading</source>
         <target xml:space="preserve">Done loading</target>
-        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1082" approved="yes">
+      <trans-unit id="_msg1129" approved="yes">
         <source xml:space="preserve">Entries are full.</source>
         <target xml:space="preserve">Entries are full.</target>
-        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1083" approved="yes">
+      <trans-unit id="_msg1130" approved="yes">
         <source xml:space="preserve">Error initializing block database</source>
         <target xml:space="preserve">Error initializing block database</target>
-        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1084" approved="yes">
+      <trans-unit id="_msg1131" approved="yes">
         <source xml:space="preserve">Error initializing wallet database environment %s!</source>
         <target xml:space="preserve">Error initializing wallet database environment %s!</target>
-        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1085" approved="yes">
+      <trans-unit id="_msg1132" approved="yes">
         <source xml:space="preserve">Error loading block database</source>
         <target xml:space="preserve">Error loading block database</target>
-        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1086" approved="yes">
+      <trans-unit id="_msg1133" approved="yes">
         <source xml:space="preserve">Error opening block database</source>
         <target xml:space="preserve">Error opening block database</target>
-        <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1087" approved="yes">
+      <trans-unit id="_msg1134" approved="yes">
         <source xml:space="preserve">Error reading from database, shutting down.</source>
         <target xml:space="preserve">Error reading from database, shutting down.</target>
-        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1088" approved="yes">
+      <trans-unit id="_msg1135">
+        <source xml:space="preserve">Error: Missing checksum</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1136">
+        <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1137">
+        <source xml:space="preserve">Error: Unable to write record to new wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1138" approved="yes">
         <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
         <target xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</target>
-        <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1089" approved="yes">
+      <trans-unit id="_msg1139" approved="yes">
         <source xml:space="preserve">-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <target xml:space="preserve">-maxtxfee is set very high! Fees this large could be paid on a single transaction.</target>
         <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1090" approved="yes">
+      <trans-unit id="_msg1140" approved="yes">
         <source xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
         <target xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same.</target>
-        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">30</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1091" approved="yes">
+      <trans-unit id="_msg1141" approved="yes">
         <source xml:space="preserve">Found unconfirmed denominated outputs, will wait till they confirm to continue.</source>
         <target xml:space="preserve">Found unconfirmed denominated outputs, will wait till they confirm to continue.</target>
-        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1092" approved="yes">
+      <trans-unit id="_msg1142" approved="yes">
         <source xml:space="preserve">Invalid -socketevents (&apos;%s&apos;) specified. Only these modes are supported: %s</source>
         <target xml:space="preserve">Invalid -socketevents (&apos;%s&apos;) specified. Only these modes are supported: %s</target>
-        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1093" approved="yes">
+      <trans-unit id="_msg1143" approved="yes">
         <source xml:space="preserve">Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <target xml:space="preserve">Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</target>
-        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1094" approved="yes">
+      <trans-unit id="_msg1144" approved="yes">
         <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
         <target xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</target>
-        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1095" approved="yes">
+      <trans-unit id="_msg1145" approved="yes">
         <source xml:space="preserve">Transaction index can&apos;t be disabled with governance validation enabled. Either start with -disablegovernance command line switch or enable transaction index.</source>
         <target xml:space="preserve">Transaction index can&apos;t be disabled with governance validation enabled. Either start with -disablegovernance command line switch or enable transaction index.</target>
-        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1096" approved="yes">
-        <source xml:space="preserve">Can&apos;t mix: no compatible inputs found!</source>
-        <target xml:space="preserve">Can&apos;t mix: no compatible inputs found!</target>
-        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1097" approved="yes">
-        <source xml:space="preserve">Entry exceeds maximum size.</source>
-        <target xml:space="preserve">Entry exceeds maximum size.</target>
-        <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1098" approved="yes">
-        <source xml:space="preserve">Found enough users, signing ( waiting %s )</source>
-        <target xml:space="preserve">Found enough users, signing ( waiting %s )</target>
-        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1099" approved="yes">
-        <source xml:space="preserve">Found enough users, signing ...</source>
-        <target xml:space="preserve">Found enough users, signing ...</target>
-        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1100" approved="yes">
-        <source xml:space="preserve">Importing...</source>
-        <target xml:space="preserve">Importing...</target>
-        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1101" approved="yes">
-        <source xml:space="preserve">Incompatible mode.</source>
-        <target xml:space="preserve">Incompatible mode.</target>
-        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1102" approved="yes">
-        <source xml:space="preserve">Incompatible version.</source>
-        <target xml:space="preserve">Incompatible version.</target>
-        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1103" approved="yes">
-        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <target xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</target>
-        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1104" approved="yes">
-        <source xml:space="preserve">Input is not valid.</source>
-        <target xml:space="preserve">Input is not valid.</target>
-        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1105" approved="yes">
-        <source xml:space="preserve">Insufficient funds.</source>
-        <target xml:space="preserve">Insufficient funds.</target>
-        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1106" approved="yes">
-        <source xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</source>
-        <target xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1107" approved="yes">
-        <source xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
-        <target xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</target>
-        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1108" approved="yes">
-        <source xml:space="preserve">Invalid minimum number of spork signers specified with -minsporkkeys</source>
-        <target xml:space="preserve">Invalid minimum number of spork signers specified with -minsporkkeys</target>
-        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1109" approved="yes">
-        <source xml:space="preserve">Loading banlist...</source>
-        <target xml:space="preserve">Loading banlist...</target>
-        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1110" approved="yes">
-        <source xml:space="preserve">Lock is already in place.</source>
-        <target xml:space="preserve">Lock is already in place.</target>
-        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1111" approved="yes">
-        <source xml:space="preserve">Mixing in progress...</source>
-        <target xml:space="preserve">Mixing in progress...</target>
-        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1112" approved="yes">
-        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
-        <target xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1113" approved="yes">
-        <source xml:space="preserve">No Masternodes detected.</source>
-        <target xml:space="preserve">No Masternodes detected.</target>
-        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1114" approved="yes">
-        <source xml:space="preserve">No compatible Masternode found.</source>
-        <target xml:space="preserve">No compatible Masternode found.</target>
-        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1115" approved="yes">
-        <source xml:space="preserve">Not enough funds to mix.</source>
-        <target xml:space="preserve">Not enough funds to mix.</target>
-        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1116" approved="yes">
-        <source xml:space="preserve">Not in the Masternode list.</source>
-        <target xml:space="preserve">Not in the Masternode list.</target>
-        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1117" approved="yes">
-        <source xml:space="preserve">Submitted to masternode, waiting in queue %s</source>
-        <target xml:space="preserve">Submitted to masternode, waiting in queue %s</target>
-        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1118" approved="yes">
-        <source xml:space="preserve">Synchronization finished</source>
-        <target xml:space="preserve">Synchronization finished</target>
-        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1119" approved="yes">
-        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
-        <target xml:space="preserve">Unable to start HTTP server. See debug log for details.</target>
-        <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1120" approved="yes">
-        <source xml:space="preserve">Unknown response.</source>
-        <target xml:space="preserve">Unknown response.</target>
-        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1121" approved="yes">
-        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
-        <target xml:space="preserve">User Agent comment (%s) contains unsafe characters.</target>
-        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1122" approved="yes">
-        <source xml:space="preserve">Verifying wallet(s)...</source>
-        <target xml:space="preserve">Verifying wallet(s)...</target>
-        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1123" approved="yes">
-        <source xml:space="preserve">Will retry...</source>
-        <target xml:space="preserve">Will retry...</target>
-        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1124" approved="yes">
-        <source xml:space="preserve">Can&apos;t find random Masternode.</source>
-        <target xml:space="preserve">Can&apos;t find random Masternode.</target>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1125" approved="yes">
+      <trans-unit id="_msg1146" approved="yes">
+        <source xml:space="preserve">Can&apos;t mix: no compatible inputs found!</source>
+        <target xml:space="preserve">Can&apos;t mix: no compatible inputs found!</target>
+        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1147" approved="yes">
+        <source xml:space="preserve">Entry exceeds maximum size.</source>
+        <target xml:space="preserve">Entry exceeds maximum size.</target>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1148" approved="yes">
+        <source xml:space="preserve">Found enough users, signing ( waiting %s )</source>
+        <target xml:space="preserve">Found enough users, signing ( waiting %s )</target>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1149" approved="yes">
+        <source xml:space="preserve">Incompatible mode.</source>
+        <target xml:space="preserve">Incompatible mode.</target>
+        <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1150" approved="yes">
+        <source xml:space="preserve">Incompatible version.</source>
+        <target xml:space="preserve">Incompatible version.</target>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1151" approved="yes">
+        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
+        <target xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</target>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1152" approved="yes">
+        <source xml:space="preserve">Input is not valid.</source>
+        <target xml:space="preserve">Input is not valid.</target>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1153" approved="yes">
+        <source xml:space="preserve">Insufficient funds.</source>
+        <target xml:space="preserve">Insufficient funds.</target>
+        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1154" approved="yes">
+        <source xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</source>
+        <target xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1155" approved="yes">
+        <source xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
+        <target xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1156" approved="yes">
+        <source xml:space="preserve">Invalid minimum number of spork signers specified with -minsporkkeys</source>
+        <target xml:space="preserve">Invalid minimum number of spork signers specified with -minsporkkeys</target>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1157" approved="yes">
+        <source xml:space="preserve">Lock is already in place.</source>
+        <target xml:space="preserve">Lock is already in place.</target>
+        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1158" approved="yes">
+        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
+        <target xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1159" approved="yes">
+        <source xml:space="preserve">No Masternodes detected.</source>
+        <target xml:space="preserve">No Masternodes detected.</target>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1160" approved="yes">
+        <source xml:space="preserve">No compatible Masternode found.</source>
+        <target xml:space="preserve">No compatible Masternode found.</target>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1161" approved="yes">
+        <source xml:space="preserve">Not enough funds to mix.</source>
+        <target xml:space="preserve">Not enough funds to mix.</target>
+        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1162" approved="yes">
+        <source xml:space="preserve">Not in the Masternode list.</source>
+        <target xml:space="preserve">Not in the Masternode list.</target>
+        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1163">
+        <source xml:space="preserve">Pruning blockstore…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1164">
+        <source xml:space="preserve">Replaying blocks…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1165">
+        <source xml:space="preserve">Rescanning…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1166">
+        <source xml:space="preserve">Starting network threads…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1167" approved="yes">
+        <source xml:space="preserve">Submitted to masternode, waiting in queue %s</source>
+        <target xml:space="preserve">Submitted to masternode, waiting in queue %s</target>
+        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1168" approved="yes">
+        <source xml:space="preserve">Synchronization finished</source>
+        <target xml:space="preserve">Synchronization finished</target>
+        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1169">
+        <source xml:space="preserve">Synchronizing blockchain…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1170">
+        <source xml:space="preserve">Synchronizing governance objects…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1171" approved="yes">
+        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
+        <target xml:space="preserve">Unable to start HTTP server. See debug log for details.</target>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1172" approved="yes">
+        <source xml:space="preserve">Unknown response.</source>
+        <target xml:space="preserve">Unknown response.</target>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1173" approved="yes">
+        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
+        <target xml:space="preserve">User Agent comment (%s) contains unsafe characters.</target>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1174" approved="yes">
+        <source xml:space="preserve">Can&apos;t find random Masternode.</source>
+        <target xml:space="preserve">Can&apos;t find random Masternode.</target>
+        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1175" approved="yes">
         <source xml:space="preserve">%s can&apos;t be lower than %s</source>
         <target xml:space="preserve">%s can&apos;t be lower than %s</target>
-        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1126" approved="yes">
+      <trans-unit id="_msg1176" approved="yes">
         <source xml:space="preserve">%s is idle.</source>
         <target xml:space="preserve">%s is idle.</target>
-        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1127" approved="yes">
+      <trans-unit id="_msg1177" approved="yes">
         <source xml:space="preserve">Can&apos;t mix while sync in progress.</source>
         <target xml:space="preserve">Can&apos;t mix while sync in progress.</target>
-        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1128" approved="yes">
+      <trans-unit id="_msg1178" approved="yes">
         <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
         <target xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1129" approved="yes">
+      <trans-unit id="_msg1179" approved="yes">
         <source xml:space="preserve">Invalid script detected.</source>
         <target xml:space="preserve">Invalid script detected.</target>
-        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1130" approved="yes">
+      <trans-unit id="_msg1180" approved="yes">
         <source xml:space="preserve">%s file contains all private keys from this wallet. Do not share it with anyone!</source>
         <target xml:space="preserve">%s file contains all private keys from this wallet. Do not share it with anyone!</target>
         <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1131" approved="yes">
+      <trans-unit id="_msg1181" approved="yes">
         <source xml:space="preserve">Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
         <target xml:space="preserve">Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</target>
-        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1132" approved="yes">
-        <source xml:space="preserve">Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</source>
-        <target xml:space="preserve">Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</target>
-        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1133" approved="yes">
-        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <target xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</target>
-        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1134" approved="yes">
-        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <target xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</target>
-        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1135" approved="yes">
-        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <target xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</target>
-        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1136" approved="yes">
-        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
-        <target xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</target>
-        <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1137" approved="yes">
-        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
-        <target xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</target>
-        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1138" approved="yes">
-        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <target xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</target>
-        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1139">
-        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it. Please call keypoolrefill first.</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1140" approved="yes">
-        <source xml:space="preserve">WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
-        <target xml:space="preserve">WARNING! Failed to replenish keypool, please unlock your wallet to do so.</target>
-        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1141" approved="yes">
-        <source xml:space="preserve">Wallet is locked, can&apos;t replenish keypool! Automatic backups and mixing are disabled, please unlock your wallet to replenish keypool.</source>
-        <target xml:space="preserve">Wallet is locked, can&apos;t replenish keypool! Automatic backups and mixing are disabled, please unlock your wallet to replenish keypool.</target>
-        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1142" approved="yes">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to change -timestampindex</source>
-        <target xml:space="preserve">You need to rebuild the database using -reindex to change -timestampindex</target>
-        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1143" approved="yes">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <target xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</target>
-        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1144" approved="yes">
-        <source xml:space="preserve">%s failed</source>
-        <target xml:space="preserve">%s failed</target>
-        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1145" approved="yes">
-        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
-        <target xml:space="preserve">-maxmempool must be at least %d MB</target>
-        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1146" approved="yes">
-        <source xml:space="preserve">Automatic backups disabled</source>
-        <target xml:space="preserve">Automatic backups disabled</target>
-        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1147" approved="yes">
-        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <target xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</target>
-        <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1148" approved="yes">
-        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
-        <target xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</target>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1149" approved="yes">
-        <source xml:space="preserve">Could not find asmap file %s</source>
-        <target xml:space="preserve">Could not find asmap file %s</target>
-        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1150" approved="yes">
-        <source xml:space="preserve">Could not parse asmap file %s</source>
-        <target xml:space="preserve">Could not parse asmap file %s</target>
-        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1151" approved="yes">
-        <source xml:space="preserve">ERROR! Failed to create automatic backup</source>
-        <target xml:space="preserve">ERROR! Failed to create automatic backup</target>
-        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1152" approved="yes">
-        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
-        <target xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</target>
-        <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1153" approved="yes">
-        <source xml:space="preserve">Error upgrading evo database</source>
-        <target xml:space="preserve">Error upgrading evo database</target>
-        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1154" approved="yes">
-        <source xml:space="preserve">Error: Disk space is low for %s</source>
-        <target xml:space="preserve">Error: Disk space is low for %s</target>
-        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1155">
-        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1156" approved="yes">
-        <source xml:space="preserve">Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <target xml:space="preserve">Error: failed to add socket to epollfd (epoll_ctl returned error %s)</target>
-        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1157" approved="yes">
-        <source xml:space="preserve">Exceeded max tries.</source>
-        <target xml:space="preserve">Exceeded max tries.</target>
-        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1158" approved="yes">
-        <source xml:space="preserve">Failed to commit EvoDB</source>
-        <target xml:space="preserve">Failed to commit EvoDB</target>
-        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1159" approved="yes">
-        <source xml:space="preserve">Failed to create backup %s!</source>
-        <target xml:space="preserve">Failed to create backup %s!</target>
-        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1160" approved="yes">
-        <source xml:space="preserve">Failed to create backup, error: %s</source>
-        <target xml:space="preserve">Failed to create backup, error: %s</target>
-        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1161" approved="yes">
-        <source xml:space="preserve">Failed to delete backup, error: %s</source>
-        <target xml:space="preserve">Failed to delete backup, error: %s</target>
-        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1162" approved="yes">
-        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
-        <target xml:space="preserve">Failed to rescan the wallet during initialization</target>
-        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1163" approved="yes">
-        <source xml:space="preserve">Failed to verify database</source>
-        <target xml:space="preserve">Failed to verify database</target>
-        <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1164" approved="yes">
-        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
-        <target xml:space="preserve">Ignoring duplicate -wallet %s.</target>
-        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1165" approved="yes">
-        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
-        <target xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1166" approved="yes">
-        <source xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</source>
-        <target xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1167" approved="yes">
-        <source xml:space="preserve">Invalid masternodeblsprivkey. Please see documentation.</source>
-        <target xml:space="preserve">Invalid masternodeblsprivkey. Please see documentation.</target>
-        <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1168" approved="yes">
-        <source xml:space="preserve">Loading block index...</source>
-        <target xml:space="preserve">Loading block index...</target>
-        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1169" approved="yes">
-        <source xml:space="preserve">Loading wallet...</source>
-        <target xml:space="preserve">Loading wallet...</target>
-        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1170" approved="yes">
-        <source xml:space="preserve">Masternode queue is full.</source>
-        <target xml:space="preserve">Masternode queue is full.</target>
-        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1171" approved="yes">
-        <source xml:space="preserve">Masternode:</source>
-        <target xml:space="preserve">Masternode:</target>
-        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1172" approved="yes">
-        <source xml:space="preserve">Missing input transaction information.</source>
-        <target xml:space="preserve">Missing input transaction information.</target>
-        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1173" approved="yes">
-        <source xml:space="preserve">No errors detected.</source>
-        <target xml:space="preserve">No errors detected.</target>
-        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1174" approved="yes">
-        <source xml:space="preserve">No matching denominations found for mixing.</source>
-        <target xml:space="preserve">No matching denominations found for mixing.</target>
-        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1175">
-        <source xml:space="preserve">No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1176" approved="yes">
-        <source xml:space="preserve">Not compatible with existing transactions.</source>
-        <target xml:space="preserve">Not compatible with existing transactions.</target>
-        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1177" approved="yes">
-        <source xml:space="preserve">Not enough file descriptors available.</source>
-        <target xml:space="preserve">Not enough file descriptors available.</target>
-        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1178" approved="yes">
-        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
-        <target xml:space="preserve">Prune cannot be configured with a negative value.</target>
-        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1179" approved="yes">
-        <source xml:space="preserve">Prune mode is incompatible with -disablegovernance=false.</source>
-        <target xml:space="preserve">Prune mode is incompatible with -disablegovernance=false.</target>
-        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1180" approved="yes">
-        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
-        <target xml:space="preserve">Prune mode is incompatible with -txindex.</target>
-        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1181" approved="yes">
-        <source xml:space="preserve">Pruning blockstore...</source>
-        <target xml:space="preserve">Pruning blockstore...</target>
-        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1182" approved="yes">
-        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <target xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</target>
-        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+        <source xml:space="preserve">Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</source>
+        <target xml:space="preserve">Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</target>
+        <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1183" approved="yes">
-        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <target xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</target>
-        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <target xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1184" approved="yes">
-        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
-        <target xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</target>
-        <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
+        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <target xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</target>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1185" approved="yes">
-        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <target xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</target>
-        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
+        <target xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</target>
+        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1186" approved="yes">
-        <source xml:space="preserve">Section [%s] is not recognized.</source>
-        <target xml:space="preserve">Section [%s] is not recognized.</target>
-        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
+        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
+        <target xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</target>
+        <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1187" approved="yes">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
-        <target xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</target>
-        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
+        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
+        <target xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</target>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1188" approved="yes">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
-        <target xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</target>
-        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
+        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
+        <target xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</target>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1189" approved="yes">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
-        <target xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</target>
-        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
+        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it. Please call keypoolrefill first.</source>
+        <target xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it. Please call keypoolrefill first.</target>
+        <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1190" approved="yes">
-        <source xml:space="preserve">Synchronizing blockchain...</source>
-        <target xml:space="preserve">Synchronizing blockchain...</target>
-        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+        <source xml:space="preserve">WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
+        <target xml:space="preserve">WARNING! Failed to replenish keypool, please unlock your wallet to do so.</target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1191" approved="yes">
-        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
-        <target xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</target>
-        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+        <source xml:space="preserve">Wallet is locked, can&apos;t replenish keypool! Automatic backups and mixing are disabled, please unlock your wallet to replenish keypool.</source>
+        <target xml:space="preserve">Wallet is locked, can&apos;t replenish keypool! Automatic backups and mixing are disabled, please unlock your wallet to replenish keypool.</target>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1192" approved="yes">
-        <source xml:space="preserve">This is expected because you are running a pruned node.</source>
-        <target xml:space="preserve">This is expected because you are running a pruned node.</target>
-        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -timestampindex</source>
+        <target xml:space="preserve">You need to rebuild the database using -reindex to change -timestampindex</target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1193" approved="yes">
-        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
-        <target xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</target>
-        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <target xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</target>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1194" approved="yes">
-        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
-        <target xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</target>
-        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
+        <source xml:space="preserve">%s failed</source>
+        <target xml:space="preserve">%s failed</target>
+        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1195" approved="yes">
-        <source xml:space="preserve">Transaction amounts must not be negative</source>
-        <target xml:space="preserve">Transaction amounts must not be negative</target>
-        <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
+        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
+        <target xml:space="preserve">-maxmempool must be at least %d MB</target>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1196" approved="yes">
-        <source xml:space="preserve">Transaction has too long of a mempool chain</source>
-        <target xml:space="preserve">Transaction has too long of a mempool chain</target>
-        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
+        <source xml:space="preserve">Automatic backups disabled</source>
+        <target xml:space="preserve">Automatic backups disabled</target>
+        <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1197" approved="yes">
-        <source xml:space="preserve">Transaction must have at least one recipient</source>
-        <target xml:space="preserve">Transaction must have at least one recipient</target>
-        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <target xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</target>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1198" approved="yes">
-        <source xml:space="preserve">Transaction too large</source>
-        <target xml:space="preserve">Transaction too large</target>
-        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
+        <target xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</target>
+        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1199" approved="yes">
-        <source xml:space="preserve">Trying to connect...</source>
-        <target xml:space="preserve">Trying to connect...</target>
-        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+        <source xml:space="preserve">Could not find asmap file %s</source>
+        <target xml:space="preserve">Could not find asmap file %s</target>
+        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1200" approved="yes">
-        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
-        <target xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</target>
-        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+        <source xml:space="preserve">Could not parse asmap file %s</source>
+        <target xml:space="preserve">Could not parse asmap file %s</target>
+        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1201" approved="yes">
-        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
-        <target xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</target>
-        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+        <source xml:space="preserve">ERROR! Failed to create automatic backup</source>
+        <target xml:space="preserve">ERROR! Failed to create automatic backup</target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1202" approved="yes">
-        <source xml:space="preserve">Unable to generate initial keys</source>
-        <target xml:space="preserve">Unable to generate initial keys</target>
-        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
+        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
+        <target xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</target>
+        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1203" approved="yes">
-        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
-        <target xml:space="preserve">Unknown -blockfilterindex value %s.</target>
-        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
+        <source xml:space="preserve">Error upgrading evo database</source>
+        <target xml:space="preserve">Error upgrading evo database</target>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1204">
-        <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
+        <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1205" approved="yes">
-        <source xml:space="preserve">Upgrading UTXO database</source>
-        <target xml:space="preserve">Upgrading UTXO database</target>
-        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+        <source xml:space="preserve">Error: Disk space is low for %s</source>
+        <target xml:space="preserve">Error: Disk space is low for %s</target>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1206" approved="yes">
-        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
-        <target xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</target>
-        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+      <trans-unit id="_msg1206">
+        <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1207" approved="yes">
-        <source xml:space="preserve">Wasn&apos;t able to create wallet backup folder %s!</source>
-        <target xml:space="preserve">Wasn&apos;t able to create wallet backup folder %s!</target>
-        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      <trans-unit id="_msg1207">
+        <source xml:space="preserve">Error: Got key that was not hex: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1208" approved="yes">
-        <source xml:space="preserve">You can not start a masternode with wallet enabled.</source>
-        <target xml:space="preserve">You can not start a masternode with wallet enabled.</target>
-        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+      <trans-unit id="_msg1208">
+        <source xml:space="preserve">Error: Got value that was not hex: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1209" approved="yes">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to change -addressindex</source>
-        <target xml:space="preserve">You need to rebuild the database using -reindex to change -addressindex</target>
-        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
+        <target xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</target>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1210" approved="yes">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to change -spentindex</source>
-        <target xml:space="preserve">You need to rebuild the database using -reindex to change -spentindex</target>
-        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
+        <source xml:space="preserve">Exceeded max tries.</source>
+        <target xml:space="preserve">Exceeded max tries.</target>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1211" approved="yes">
-        <source xml:space="preserve">no mixing available.</source>
-        <target xml:space="preserve">no mixing available.</target>
-        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+        <source xml:space="preserve">Failed to commit EvoDB</source>
+        <target xml:space="preserve">Failed to commit EvoDB</target>
+        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1212" approved="yes">
-        <source xml:space="preserve">see debug.log for details.</source>
-        <target xml:space="preserve">see debug.log for details.</target>
-        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
+        <source xml:space="preserve">Failed to create backup %s!</source>
+        <target xml:space="preserve">Failed to create backup %s!</target>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1213" approved="yes">
+        <source xml:space="preserve">Failed to create backup, error: %s</source>
+        <target xml:space="preserve">Failed to create backup, error: %s</target>
+        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1214" approved="yes">
+        <source xml:space="preserve">Failed to delete backup, error: %s</source>
+        <target xml:space="preserve">Failed to delete backup, error: %s</target>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1215" approved="yes">
+        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
+        <target xml:space="preserve">Failed to rescan the wallet during initialization</target>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1216" approved="yes">
+        <source xml:space="preserve">Failed to verify database</source>
+        <target xml:space="preserve">Failed to verify database</target>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1217">
+        <source xml:space="preserve">Found enough users, signing…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1218" approved="yes">
+        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
+        <target xml:space="preserve">Ignoring duplicate -wallet %s.</target>
+        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1219" approved="yes">
+        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
+        <target xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1220" approved="yes">
+        <source xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</source>
+        <target xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1221" approved="yes">
+        <source xml:space="preserve">Invalid masternodeblsprivkey. Please see documentation.</source>
+        <target xml:space="preserve">Invalid masternodeblsprivkey. Please see documentation.</target>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1222" approved="yes">
+        <source xml:space="preserve">Masternode queue is full.</source>
+        <target xml:space="preserve">Masternode queue is full.</target>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1223" approved="yes">
+        <source xml:space="preserve">Masternode:</source>
+        <target xml:space="preserve">Masternode:</target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1224" approved="yes">
+        <source xml:space="preserve">Missing input transaction information.</source>
+        <target xml:space="preserve">Missing input transaction information.</target>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1225">
+        <source xml:space="preserve">Mixing in progress…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1226" approved="yes">
+        <source xml:space="preserve">No errors detected.</source>
+        <target xml:space="preserve">No errors detected.</target>
+        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1227" approved="yes">
+        <source xml:space="preserve">No matching denominations found for mixing.</source>
+        <target xml:space="preserve">No matching denominations found for mixing.</target>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1228" approved="yes">
+        <source xml:space="preserve">No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
+        <target xml:space="preserve">No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</target>
+        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1229" approved="yes">
+        <source xml:space="preserve">Not compatible with existing transactions.</source>
+        <target xml:space="preserve">Not compatible with existing transactions.</target>
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1230" approved="yes">
+        <source xml:space="preserve">Not enough file descriptors available.</source>
+        <target xml:space="preserve">Not enough file descriptors available.</target>
+        <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1231" approved="yes">
+        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
+        <target xml:space="preserve">Prune cannot be configured with a negative value.</target>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1232" approved="yes">
+        <source xml:space="preserve">Prune mode is incompatible with -disablegovernance=false.</source>
+        <target xml:space="preserve">Prune mode is incompatible with -disablegovernance=false.</target>
+        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1233" approved="yes">
+        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
+        <target xml:space="preserve">Prune mode is incompatible with -txindex.</target>
+        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1234" approved="yes">
+        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <target xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</target>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1235" approved="yes">
+        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <target xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</target>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1236" approved="yes">
+        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
+        <target xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</target>
+        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1237" approved="yes">
+        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <target xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</target>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1238" approved="yes">
+        <source xml:space="preserve">Section [%s] is not recognized.</source>
+        <target xml:space="preserve">Section [%s] is not recognized.</target>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1239" approved="yes">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
+        <target xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</target>
+        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1240" approved="yes">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
+        <target xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</target>
+        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1241" approved="yes">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
+        <target xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</target>
+        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1242" approved="yes">
+        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
+        <target xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</target>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1243" approved="yes">
+        <source xml:space="preserve">This is expected because you are running a pruned node.</source>
+        <target xml:space="preserve">This is expected because you are running a pruned node.</target>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1244" approved="yes">
+        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
+        <target xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</target>
+        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1245" approved="yes">
+        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
+        <target xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</target>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1246">
+        <source xml:space="preserve">Topping up keypool…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1247" approved="yes">
+        <source xml:space="preserve">Transaction amounts must not be negative</source>
+        <target xml:space="preserve">Transaction amounts must not be negative</target>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1248" approved="yes">
+        <source xml:space="preserve">Transaction has too long of a mempool chain</source>
+        <target xml:space="preserve">Transaction has too long of a mempool chain</target>
+        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1249" approved="yes">
+        <source xml:space="preserve">Transaction must have at least one recipient</source>
+        <target xml:space="preserve">Transaction must have at least one recipient</target>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1250" approved="yes">
+        <source xml:space="preserve">Transaction too large</source>
+        <target xml:space="preserve">Transaction too large</target>
+        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1251" approved="yes">
+        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
+        <target xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</target>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1252" approved="yes">
+        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
+        <target xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</target>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1253" approved="yes">
+        <source xml:space="preserve">Unable to generate initial keys</source>
+        <target xml:space="preserve">Unable to generate initial keys</target>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1254">
+        <source xml:space="preserve">Unable to open %s for writing</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1255" approved="yes">
+        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
+        <target xml:space="preserve">Unknown -blockfilterindex value %s.</target>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1256" approved="yes">
+        <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
+        <target xml:space="preserve">Unknown new rules activated (versionbit %i)</target>
+        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1257" approved="yes">
+        <source xml:space="preserve">Upgrading UTXO database</source>
+        <target xml:space="preserve">Upgrading UTXO database</target>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1258">
+        <source xml:space="preserve">Verifying blocks…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1259">
+        <source xml:space="preserve">Verifying wallet(s)…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1260" approved="yes">
+        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
+        <target xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</target>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1261" approved="yes">
+        <source xml:space="preserve">Wasn&apos;t able to create wallet backup folder %s!</source>
+        <target xml:space="preserve">Wasn&apos;t able to create wallet backup folder %s!</target>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1262">
+        <source xml:space="preserve">Wiping wallet transactions…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1263" approved="yes">
+        <source xml:space="preserve">You can not start a masternode with wallet enabled.</source>
+        <target xml:space="preserve">You can not start a masternode with wallet enabled.</target>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1264" approved="yes">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -addressindex</source>
+        <target xml:space="preserve">You need to rebuild the database using -reindex to change -addressindex</target>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1265" approved="yes">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -spentindex</source>
+        <target xml:space="preserve">You need to rebuild the database using -reindex to change -spentindex</target>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1266" approved="yes">
+        <source xml:space="preserve">no mixing available.</source>
+        <target xml:space="preserve">no mixing available.</target>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1267" approved="yes">
+        <source xml:space="preserve">see debug.log for details.</source>
+        <target xml:space="preserve">see debug.log for details.</target>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1268" approved="yes">
         <source xml:space="preserve">The %s developers</source>
         <target xml:space="preserve">The %s developers</target>
         <context-group purpose="location"><context context-type="linenumber">12</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1214" approved="yes">
+      <trans-unit id="_msg1269" approved="yes">
         <source xml:space="preserve">%s uses exact denominated amounts to send funds, you might simply need to mix some more coins.</source>
         <target xml:space="preserve">%s uses exact denominated amounts to send funds, you might simply need to mix some more coins.</target>
         <context-group purpose="location"><context context-type="linenumber">19</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1215" approved="yes">
-        <source xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <target xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</target>
+      <trans-unit id="_msg1270">
+        <source xml:space="preserve">Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1216" approved="yes">
-        <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <target xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</target>
-        <context-group purpose="location"><context context-type="linenumber">30</context></context-group>
+      <trans-unit id="_msg1271" approved="yes">
+        <source xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <target xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</target>
+        <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1217" approved="yes">
-        <source xml:space="preserve">Error loading %s: You can&apos;t enable HD on an already existing non-HD wallet</source>
-        <target xml:space="preserve">Error loading %s: You can&apos;t enable HD on an already existing non-HD wallet</target>
+      <trans-unit id="_msg1272">
+        <source xml:space="preserve">Cannot upgrade a non HD wallet from version %i to version %i which is non-HD wallet. Use upgradetohd RPC</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1218" approved="yes">
+      <trans-unit id="_msg1273" approved="yes">
+        <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <target xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</target>
+        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1274" approved="yes">
+        <source xml:space="preserve">Error loading %s: You can&apos;t enable HD on an already existing non-HD wallet</source>
+        <target xml:space="preserve">Error loading %s: You can&apos;t enable HD on an already existing non-HD wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1275" approved="yes">
         <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <target xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</target>
-        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1219" approved="yes">
+      <trans-unit id="_msg1276">
+        <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1277">
+        <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1278">
+        <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1279">
+        <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1280" approved="yes">
         <source xml:space="preserve">Incorrect or no devnet genesis block found. Wrong datadir for devnet specified?</source>
         <target xml:space="preserve">Incorrect or no devnet genesis block found. Wrong datadir for devnet specified?</target>
-        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1220" approved="yes">
-        <source xml:space="preserve">Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <target xml:space="preserve">Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</target>
-        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      <trans-unit id="_msg1281">
+        <source xml:space="preserve">Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1221" approved="yes">
-        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <target xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</target>
-        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
+      <trans-unit id="_msg1282">
+        <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1222" approved="yes">
-        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <target xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</target>
+      <trans-unit id="_msg1283">
+        <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1284">
+        <source xml:space="preserve">No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1285">
+        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1223" approved="yes">
-        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
-        <target xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</target>
+      <trans-unit id="_msg1286">
+        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1224" approved="yes">
-        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <target xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</target>
-        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
+      <trans-unit id="_msg1287" approved="yes">
+        <source xml:space="preserve">Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
+        <target xml:space="preserve">Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</target>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1225" approved="yes">
-        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <target xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</target>
-        <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
+      <trans-unit id="_msg1288" approved="yes">
+        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
+        <target xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</target>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1226" approved="yes">
-        <source xml:space="preserve">%s is not a valid backup folder!</source>
-        <target xml:space="preserve">%s is not a valid backup folder!</target>
-        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+      <trans-unit id="_msg1289">
+        <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1227" approved="yes">
-        <source xml:space="preserve">%s is set very high!</source>
-        <target xml:space="preserve">%s is set very high!</target>
-        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1228" approved="yes">
-        <source xml:space="preserve">%s request incomplete:</source>
-        <target xml:space="preserve">%s request incomplete:</target>
+      <trans-unit id="_msg1290" approved="yes">
+        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
+        <target xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</target>
         <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1229" approved="yes">
-        <source xml:space="preserve">-devnet can only be specified once</source>
-        <target xml:space="preserve">-devnet can only be specified once</target>
-        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1230" approved="yes">
-        <source xml:space="preserve">-port must be specified when -devnet and -listen are specified</source>
-        <target xml:space="preserve">-port must be specified when -devnet and -listen are specified</target>
+      <trans-unit id="_msg1291" approved="yes">
+        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
+        <target xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</target>
         <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1231" approved="yes">
-        <source xml:space="preserve">-rpcport must be specified when -devnet and -server are specified</source>
-        <target xml:space="preserve">-rpcport must be specified when -devnet and -server are specified</target>
-        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
+      <trans-unit id="_msg1292" approved="yes">
+        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
+        <target xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1232" approved="yes">
-        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details</source>
-        <target xml:space="preserve">A fatal internal error occurred, see debug.log for details</target>
-        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+      <trans-unit id="_msg1293">
+        <source xml:space="preserve">Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1233" approved="yes">
-        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
-        <target xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
+      <trans-unit id="_msg1294">
+        <source xml:space="preserve">Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1234" approved="yes">
-        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
-        <target xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</target>
-        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1235" approved="yes">
-        <source xml:space="preserve">Change index out of range</source>
-        <target xml:space="preserve">Change index out of range</target>
-        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1236" approved="yes">
-        <source xml:space="preserve">Copyright (C)</source>
-        <target xml:space="preserve">Copyright (C)</target>
-        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1237" approved="yes">
-        <source xml:space="preserve">Disk space is too low!</source>
-        <target xml:space="preserve">Disk space is too low!</target>
-        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1238" approved="yes">
-        <source xml:space="preserve">Error loading %s</source>
-        <target xml:space="preserve">Error loading %s</target>
+      <trans-unit id="_msg1295" approved="yes">
+        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
+        <target xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</target>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1239" approved="yes">
-        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
-        <target xml:space="preserve">Error loading %s: Wallet corrupted</target>
-        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+      <trans-unit id="_msg1296">
+        <source xml:space="preserve">%s -- Incorrect seed, it should be a hex string</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1240" approved="yes">
-        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
-        <target xml:space="preserve">Error loading %s: Wallet requires newer version of %s</target>
-        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
+      <trans-unit id="_msg1297" approved="yes">
+        <source xml:space="preserve">%s is not a valid backup folder!</source>
+        <target xml:space="preserve">%s is not a valid backup folder!</target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1241" approved="yes">
-        <source xml:space="preserve">Error loading %s: You can&apos;t disable HD on an already existing HD wallet</source>
-        <target xml:space="preserve">Error loading %s: You can&apos;t disable HD on an already existing HD wallet</target>
-        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1242" approved="yes">
-        <source xml:space="preserve">Error upgrading chainstate database</source>
-        <target xml:space="preserve">Error upgrading chainstate database</target>
-        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1243" approved="yes">
-        <source xml:space="preserve">Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <target xml:space="preserve">Error: failed to add socket to kqueuefd (kevent returned error %s)</target>
-        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1244" approved="yes">
-        <source xml:space="preserve">Failed to clear fulfilled requests cache at %s</source>
-        <target xml:space="preserve">Failed to clear fulfilled requests cache at %s</target>
+      <trans-unit id="_msg1298" approved="yes">
+        <source xml:space="preserve">%s is set very high!</source>
+        <target xml:space="preserve">%s is set very high!</target>
         <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1245" approved="yes">
-        <source xml:space="preserve">Failed to clear governance cache at %s</source>
-        <target xml:space="preserve">Failed to clear governance cache at %s</target>
+      <trans-unit id="_msg1299" approved="yes">
+        <source xml:space="preserve">%s request incomplete:</source>
+        <target xml:space="preserve">%s request incomplete:</target>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1246" approved="yes">
-        <source xml:space="preserve">Failed to clear masternode cache at %s</source>
-        <target xml:space="preserve">Failed to clear masternode cache at %s</target>
+      <trans-unit id="_msg1300" approved="yes">
+        <source xml:space="preserve">-devnet can only be specified once</source>
+        <target xml:space="preserve">-devnet can only be specified once</target>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1247" approved="yes">
-        <source xml:space="preserve">Failed to find mixing queue to join</source>
-        <target xml:space="preserve">Failed to find mixing queue to join</target>
-        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
+      <trans-unit id="_msg1301" approved="yes">
+        <source xml:space="preserve">-port must be specified when -devnet and -listen are specified</source>
+        <target xml:space="preserve">-port must be specified when -devnet and -listen are specified</target>
+        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1248" approved="yes">
-        <source xml:space="preserve">Failed to load fulfilled requests cache from %s</source>
-        <target xml:space="preserve">Failed to load fulfilled requests cache from %s</target>
-        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+      <trans-unit id="_msg1302" approved="yes">
+        <source xml:space="preserve">-rpcport must be specified when -devnet and -server are specified</source>
+        <target xml:space="preserve">-rpcport must be specified when -devnet and -server are specified</target>
+        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1249" approved="yes">
-        <source xml:space="preserve">Failed to load governance cache from %s</source>
-        <target xml:space="preserve">Failed to load governance cache from %s</target>
-        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
+      <trans-unit id="_msg1303" approved="yes">
+        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details</source>
+        <target xml:space="preserve">A fatal internal error occurred, see debug.log for details</target>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1250" approved="yes">
-        <source xml:space="preserve">Failed to load masternode cache from %s</source>
-        <target xml:space="preserve">Failed to load masternode cache from %s</target>
-        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1251" approved="yes">
-        <source xml:space="preserve">Failed to load sporks cache from %s</source>
-        <target xml:space="preserve">Failed to load sporks cache from %s</target>
+      <trans-unit id="_msg1304" approved="yes">
+        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
+        <target xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</target>
         <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1252" approved="yes">
-        <source xml:space="preserve">Failed to start a new mixing queue</source>
-        <target xml:space="preserve">Failed to start a new mixing queue</target>
+      <trans-unit id="_msg1305" approved="yes">
+        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
+        <target xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</target>
         <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1253" approved="yes">
-        <source xml:space="preserve">Incorrect -rescan mode, falling back to default value</source>
-        <target xml:space="preserve">Incorrect -rescan mode, falling back to default value</target>
+      <trans-unit id="_msg1306" approved="yes">
+        <source xml:space="preserve">Change index out of range</source>
+        <target xml:space="preserve">Change index out of range</target>
+        <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1307" approved="yes">
+        <source xml:space="preserve">Copyright (C)</source>
+        <target xml:space="preserve">Copyright (C)</target>
+        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1308" approved="yes">
+        <source xml:space="preserve">Disk space is too low!</source>
+        <target xml:space="preserve">Disk space is too low!</target>
         <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1254" approved="yes">
-        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
-        <target xml:space="preserve">Initialization sanity check failed. %s is shutting down.</target>
-        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
+      <trans-unit id="_msg1309">
+        <source xml:space="preserve">Dump file %s does not exist.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1255" approved="yes">
-        <source xml:space="preserve">Inputs vs outputs size mismatch.</source>
-        <target xml:space="preserve">Inputs vs outputs size mismatch.</target>
-        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1256" approved="yes">
-        <source xml:space="preserve">Invalid &apos;%s&apos;. Allowed values: 128, 160, 192, 224, 256.</source>
-        <target xml:space="preserve">Invalid &apos;%s&apos;. Allowed values: 128, 160, 192, 224, 256.</target>
-        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1257" approved="yes">
-        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
-        <target xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</target>
+      <trans-unit id="_msg1310">
+        <source xml:space="preserve">Error creating %s</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1258" approved="yes">
-        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
-        <target xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
+      <trans-unit id="_msg1311" approved="yes">
+        <source xml:space="preserve">Error loading %s</source>
+        <target xml:space="preserve">Error loading %s</target>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1259" approved="yes">
-        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
-        <target xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+      <trans-unit id="_msg1312" approved="yes">
+        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
+        <target xml:space="preserve">Error loading %s: Wallet corrupted</target>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1260" approved="yes">
-        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
-        <target xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
+      <trans-unit id="_msg1313" approved="yes">
+        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
+        <target xml:space="preserve">Error loading %s: Wallet requires newer version of %s</target>
+        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1261" approved="yes">
-        <source xml:space="preserve">Invalid spork address specified with -sporkaddr</source>
-        <target xml:space="preserve">Invalid spork address specified with -sporkaddr</target>
+      <trans-unit id="_msg1314" approved="yes">
+        <source xml:space="preserve">Error loading %s: You can&apos;t disable HD on an already existing HD wallet</source>
+        <target xml:space="preserve">Error loading %s: You can&apos;t disable HD on an already existing HD wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1315">
+        <source xml:space="preserve">Error reading next record from wallet database</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1316" approved="yes">
+        <source xml:space="preserve">Error upgrading chainstate database</source>
+        <target xml:space="preserve">Error upgrading chainstate database</target>
         <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1262" approved="yes">
-        <source xml:space="preserve">Loading P2P addresses...</source>
-        <target xml:space="preserve">Loading P2P addresses...</target>
-        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      <trans-unit id="_msg1317">
+        <source xml:space="preserve">Loading P2P addresses…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1263" approved="yes">
-        <source xml:space="preserve">Prune mode is incompatible with -coinstatsindex.</source>
-        <target xml:space="preserve">Prune mode is incompatible with -coinstatsindex.</target>
+      <trans-unit id="_msg1318">
+        <source xml:space="preserve">Loading banlist…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1319">
+        <source xml:space="preserve">Loading block index…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1320">
+        <source xml:space="preserve">Loading wallet…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1321" approved="yes">
+        <source xml:space="preserve">Failed to clear fulfilled requests cache at %s</source>
+        <target xml:space="preserve">Failed to clear fulfilled requests cache at %s</target>
+        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1322" approved="yes">
+        <source xml:space="preserve">Failed to clear governance cache at %s</source>
+        <target xml:space="preserve">Failed to clear governance cache at %s</target>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1323" approved="yes">
+        <source xml:space="preserve">Failed to clear masternode cache at %s</source>
+        <target xml:space="preserve">Failed to clear masternode cache at %s</target>
+        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1324" approved="yes">
+        <source xml:space="preserve">Failed to find mixing queue to join</source>
+        <target xml:space="preserve">Failed to find mixing queue to join</target>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1325" approved="yes">
+        <source xml:space="preserve">Failed to load fulfilled requests cache from %s</source>
+        <target xml:space="preserve">Failed to load fulfilled requests cache from %s</target>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1326" approved="yes">
+        <source xml:space="preserve">Failed to load governance cache from %s</source>
+        <target xml:space="preserve">Failed to load governance cache from %s</target>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1327" approved="yes">
+        <source xml:space="preserve">Failed to load masternode cache from %s</source>
+        <target xml:space="preserve">Failed to load masternode cache from %s</target>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1264" approved="yes">
-        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <target xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</target>
-        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+      <trans-unit id="_msg1328" approved="yes">
+        <source xml:space="preserve">Failed to load sporks cache from %s</source>
+        <target xml:space="preserve">Failed to load sporks cache from %s</target>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1265" approved="yes">
-        <source xml:space="preserve">Replaying blocks...</source>
-        <target xml:space="preserve">Replaying blocks...</target>
-        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      <trans-unit id="_msg1329" approved="yes">
+        <source xml:space="preserve">Failed to start a new mixing queue</source>
+        <target xml:space="preserve">Failed to start a new mixing queue</target>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1266" approved="yes">
-        <source xml:space="preserve">Rescanning...</source>
-        <target xml:space="preserve">Rescanning...</target>
-        <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
+      <trans-unit id="_msg1330">
+        <source xml:space="preserve">Importing…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1267" approved="yes">
-        <source xml:space="preserve">Session not complete!</source>
-        <target xml:space="preserve">Session not complete!</target>
-        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      <trans-unit id="_msg1331" approved="yes">
+        <source xml:space="preserve">Incorrect -rescan mode, falling back to default value</source>
+        <target xml:space="preserve">Incorrect -rescan mode, falling back to default value</target>
+        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1268" approved="yes">
-        <source xml:space="preserve">Session timed out.</source>
-        <target xml:space="preserve">Session timed out.</target>
+      <trans-unit id="_msg1332" approved="yes">
+        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
+        <target xml:space="preserve">Initialization sanity check failed. %s is shutting down.</target>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1269" approved="yes">
-        <source xml:space="preserve">Signing transaction failed</source>
-        <target xml:space="preserve">Signing transaction failed</target>
-        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+      <trans-unit id="_msg1333" approved="yes">
+        <source xml:space="preserve">Inputs vs outputs size mismatch.</source>
+        <target xml:space="preserve">Inputs vs outputs size mismatch.</target>
+        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1270" approved="yes">
-        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
-        <target xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</target>
+      <trans-unit id="_msg1334" approved="yes">
+        <source xml:space="preserve">Invalid &apos;%s&apos;. Allowed values: 128, 160, 192, 224, 256.</source>
+        <target xml:space="preserve">Invalid &apos;%s&apos;. Allowed values: 128, 160, 192, 224, 256.</target>
+        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1335" approved="yes">
+        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</target>
         <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1271" approved="yes">
+      <trans-unit id="_msg1336" approved="yes">
+        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1337" approved="yes">
+        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1338" approved="yes">
+        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
+        <target xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1339" approved="yes">
+        <source xml:space="preserve">Invalid spork address specified with -sporkaddr</source>
+        <target xml:space="preserve">Invalid spork address specified with -sporkaddr</target>
+        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1340" approved="yes">
+        <source xml:space="preserve">Prune mode is incompatible with -coinstatsindex.</source>
+        <target xml:space="preserve">Prune mode is incompatible with -coinstatsindex.</target>
+        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1341" approved="yes">
+        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <target xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</target>
+        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1342" approved="yes">
+        <source xml:space="preserve">Session not complete!</source>
+        <target xml:space="preserve">Session not complete!</target>
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1343" approved="yes">
+        <source xml:space="preserve">Session timed out.</source>
+        <target xml:space="preserve">Session timed out.</target>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1344" approved="yes">
+        <source xml:space="preserve">Signing transaction failed</source>
+        <target xml:space="preserve">Signing transaction failed</target>
+        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1345" approved="yes">
+        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
+        <target xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</target>
+        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1346" approved="yes">
         <source xml:space="preserve">Last queue was created too recently.</source>
         <target xml:space="preserve">Last queue was created too recently.</target>
-        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1272" approved="yes">
+      <trans-unit id="_msg1347" approved="yes">
         <source xml:space="preserve">%s corrupt. Try using the wallet tool dash-wallet to salvage or restoring a backup.</source>
         <target xml:space="preserve">%s corrupt. Try using the wallet tool dash-wallet to salvage or restoring a backup.</target>
         <context-group purpose="location"><context context-type="linenumber">13</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1273" approved="yes">
+      <trans-unit id="_msg1348" approved="yes">
         <source xml:space="preserve">Last successful action was too recent.</source>
         <target xml:space="preserve">Last successful action was too recent.</target>
-        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1274" approved="yes">
-        <source xml:space="preserve">Starting network threads...</source>
-        <target xml:space="preserve">Starting network threads...</target>
-        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1275" approved="yes">
-        <source xml:space="preserve">Synchronizing governance objects...</source>
-        <target xml:space="preserve">Synchronizing governance objects...</target>
-        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1276" approved="yes">
-        <source xml:space="preserve">The source code is available from %s.</source>
-        <target xml:space="preserve">The source code is available from %s.</target>
-        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1277" approved="yes">
-        <source xml:space="preserve">The specified config file %s does not exist</source>
-        <target xml:space="preserve">The specified config file %s does not exist</target>
-        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1278" approved="yes">
-        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
-        <target xml:space="preserve">The transaction amount is too small to pay the fee</target>
-        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1279" approved="yes">
-        <source xml:space="preserve">This is experimental software.</source>
-        <target xml:space="preserve">This is experimental software.</target>
-        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1280" approved="yes">
-        <source xml:space="preserve">Topping up keypool...</source>
-        <target xml:space="preserve">Topping up keypool...</target>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1281" approved="yes">
+      <trans-unit id="_msg1349" approved="yes">
+        <source xml:space="preserve">The source code is available from %s.</source>
+        <target xml:space="preserve">The source code is available from %s.</target>
+        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1350" approved="yes">
+        <source xml:space="preserve">The specified config file %s does not exist</source>
+        <target xml:space="preserve">The specified config file %s does not exist</target>
+        <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1351" approved="yes">
+        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
+        <target xml:space="preserve">The transaction amount is too small to pay the fee</target>
+        <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1352" approved="yes">
+        <source xml:space="preserve">This is experimental software.</source>
+        <target xml:space="preserve">This is experimental software.</target>
+        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1353" approved="yes">
         <source xml:space="preserve">Transaction amount too small</source>
         <target xml:space="preserve">Transaction amount too small</target>
-        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1282" approved="yes">
+      <trans-unit id="_msg1354" approved="yes">
         <source xml:space="preserve">Transaction created successfully.</source>
         <target xml:space="preserve">Transaction created successfully.</target>
-        <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1283" approved="yes">
+      <trans-unit id="_msg1355" approved="yes">
         <source xml:space="preserve">Transaction fees are too high.</source>
         <target xml:space="preserve">Transaction fees are too high.</target>
-        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1284" approved="yes">
+      <trans-unit id="_msg1356" approved="yes">
         <source xml:space="preserve">Transaction not valid.</source>
         <target xml:space="preserve">Transaction not valid.</target>
-        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1285" approved="yes">
+      <trans-unit id="_msg1357">
+        <source xml:space="preserve">Trying to connect…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1358" approved="yes">
         <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
         <target xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</target>
-        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1286" approved="yes">
+      <trans-unit id="_msg1359" approved="yes">
         <source xml:space="preserve">Unable to locate enough mixed funds for this transaction.</source>
         <target xml:space="preserve">Unable to locate enough mixed funds for this transaction.</target>
-        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1287" approved="yes">
+      <trans-unit id="_msg1360" approved="yes">
         <source xml:space="preserve">Unable to locate enough non-denominated funds for this transaction.</source>
         <target xml:space="preserve">Unable to locate enough non-denominated funds for this transaction.</target>
-        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1288" approved="yes">
+      <trans-unit id="_msg1361" approved="yes">
         <source xml:space="preserve">Unable to sign spork message, wrong key?</source>
         <target xml:space="preserve">Unable to sign spork message, wrong key?</target>
-        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1289" approved="yes">
+      <trans-unit id="_msg1362" approved="yes">
         <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <target xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</target>
-        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1290" approved="yes">
+      <trans-unit id="_msg1363" approved="yes">
         <source xml:space="preserve">Unknown state: id = %u</source>
         <target xml:space="preserve">Unknown state: id = %u</target>
-        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1291" approved="yes">
+      <trans-unit id="_msg1364" approved="yes">
         <source xml:space="preserve">Unsupported logging category %s=%s.</source>
         <target xml:space="preserve">Unsupported logging category %s=%s.</target>
-        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1292" approved="yes">
+      <trans-unit id="_msg1365" approved="yes">
         <source xml:space="preserve">Upgrading txindex database</source>
         <target xml:space="preserve">Upgrading txindex database</target>
-        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1293" approved="yes">
-        <source xml:space="preserve">Verifying blocks...</source>
-        <target xml:space="preserve">Verifying blocks...</target>
-        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1294" approved="yes">
+      <trans-unit id="_msg1366" approved="yes">
         <source xml:space="preserve">Very low number of keys left: %d</source>
         <target xml:space="preserve">Very low number of keys left: %d</target>
-        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1295" approved="yes">
+      <trans-unit id="_msg1367" approved="yes">
         <source xml:space="preserve">Wallet is locked.</source>
         <target xml:space="preserve">Wallet is locked.</target>
-        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1296" approved="yes">
+      <trans-unit id="_msg1368" approved="yes">
         <source xml:space="preserve">Warning: can&apos;t use %s and %s together, will prefer %s</source>
         <target xml:space="preserve">Warning: can&apos;t use %s and %s together, will prefer %s</target>
-        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1297" approved="yes">
+      <trans-unit id="_msg1369" approved="yes">
         <source xml:space="preserve">Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <target xml:space="preserve">Warning: incorrect parameter %s, path must exist! Using default path.</target>
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1298" approved="yes">
-        <source xml:space="preserve">Wiping wallet transactions...</source>
-        <target xml:space="preserve">Wiping wallet transactions...</target>
-        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+      <trans-unit id="_msg1370">
+        <source xml:space="preserve">Will retry…</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1299" approved="yes">
+      <trans-unit id="_msg1371" approved="yes">
         <source xml:space="preserve">You are starting with governance validation disabled.</source>
         <target xml:space="preserve">You are starting with governance validation disabled.</target>
-        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1300" approved="yes">
+      <trans-unit id="_msg1372" approved="yes">
         <source xml:space="preserve">You can not disable governance validation on a masternode.</source>
         <target xml:space="preserve">You can not disable governance validation on a masternode.</target>
-        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1301" approved="yes">
+      <trans-unit id="_msg1373" approved="yes">
         <source xml:space="preserve">Your entries added successfully.</source>
         <target xml:space="preserve">Your entries added successfully.</target>
-        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
       </trans-unit>
     </group>
   </body></file>

--- a/src/qt/locale/dash_es.ts
+++ b/src/qt/locale/dash_es.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Solicitar pagos (genera códigos QR y URIs de Dash)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Opciones…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Cifrar billetera…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Copia de seguridad de la billetera…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Cambiar contraseña…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Desbloquear billetera</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Firmar &amp;mensaje…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Verificar mensaje…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Direcciones de envío</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Direcciones de recepción</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Abrir &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Abrir billetera</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Abrir una billetera</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Cerrar billetera...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Mostrar información acerca de Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Opciones...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;Acerca de %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Mostrar u ocultar la ventana principal</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Cifrar billetera…</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Cifrar las llaves privadas que pertenezcan a su billetera</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Copia de seguridad de la billetera...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Crear copia de seguridad de la billetera en otra ubicación</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Cambiar contraseña…</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cambiar la contraseña utilizada para el cifrado de la billetera</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Desbloquear billetera</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>&amp;Bloquear billetera</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Firmar &amp;mensaje...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Firmar mensajes con sus direcciones Dash para demostrar que le pertenecen</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Verificar mensaje...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Mostrar la lista de direcciones de recepción y etiquetas</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Abrir &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Opciones de consola de comandos</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>Mostrar información sobre %1</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>Crear billetera...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>Actividad de red deshabilitada</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Sincronizando encabezados (%1)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Sincronizando con la red…</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indexando los bloques en el disco...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Procesando los bloques en el disco...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Reindexando bloques en disco...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Conectando con los pares...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>%n bloques procesados del histórico de transacciones</numerusform><numerusform>%n bloques procesados del histórico de transacciones</numerusform><numerusform>%n bloques procesados del histórico de transacciones</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 por detrás</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Poniendo al día...</translation>
+        <source>Close Wallet…</source>
+        <translation>Cerrar billetera…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Crear billetera…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Sincronizando encabezados (%1)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Sincronizando con la red…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indexando los bloques en el disco…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Procesando los bloques en el disco…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Reindexando bloques en disco…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Conectando con los pares…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Poniendo al día…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>Mensaje original:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Creando billetera &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Creando billetera &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>Crear</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>Al ser la primera vez que se ejecuta el programa, puede elegir donde %1 almacenará sus datos.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Cuando haga click en OK, %1 se empezará a descargar la %4 cadena de bloques completa (%2GB) empezando por la transacción más antigua en %3 cuando se publicó %4 originalmente.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>La sincronización inicial demanda muchos recursos y podría revelar problemas de hardware que no se han notado previamente. Cada vez que ejecuta %1, continuará descargando a partir del punto anterior.</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>Copiar punto de garantía</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Actualizando...</translation>
+        <source>Please wait…</source>
+        <translation>Por favor espera…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Actualizando…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>Filtrar por cualquier propiedad (ej. dirección o hash protx)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Por favor espera...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Información adicional para Masternode DIP3 %1</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>Número de bloque restantes</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Desconocido...</translation>
+        <source>Unknown…</source>
+        <translation>Desconocido…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>calculando…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>Aumento de progreso por hora</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>calculando...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Tiempo estimado restante hasta sincronización</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>Ocultar</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Desconocido. Sincronización de encabezados (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Desconocido. Sincronización de encabezados (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>billetera predeterminada</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Abriendo billetera &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Abriendo billetera &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>Las opciones configuradas en este cuadro de diálogo se reemplazan por la línea de comando o en el archivo de configuración:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Ocultar el icono de la bandeja del sistema.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;Ocultar icono de bandeja</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Minimizar en lugar de salir de la aplicación cuando la ventana esté cerrada. Cuando esta opción está habilitada, la aplicación se cerrará solo después de seleccionar Salir en el menú.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>El idioma de la interfaz de usuario puede establecerse aquí. Esta configuración tendrá efecto tras reiniciar %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>¿Idioma no disponible o traducción incompleta? Contribuye a la traducción aquí:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' no es un URI válido. Usa 'dash:'.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Dirección de pago no válida %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>¡No se puede interpretar la URI! Esto puede deberse a una dirección Dash inválida o a parámetros de URI mal formados.</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Agente del Usuario</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Enviado</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Recibido</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Error: %1 CSS file(s) faltando en -custom-css-dir camino.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 no se ha cerrado de forma segura todavía...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 no se ha cerrado de forma segura todavía…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Código QR</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Guardar Imagen...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Guardar Imagen…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Guardar Imagen...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Guardar Imagen…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Seleccione un par para ver información detallada.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Dirección</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Servicios</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Puntuación de Exclusión</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>vía %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>nunca</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Entrante</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Salientes</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Regular</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Copiar cantidad</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,8 +2722,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Copiar &amp;Dirección</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Guardar Imagen...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Guardar Imagen…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Características de Coin Control</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Entradas...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>seleccionadas automáticamente</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Polvo:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Entradas…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Después de comisión:</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Comisión por Transacción:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Elegir...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(La comisión inteligente no está aún inicializada. Esto habitualmente tarda unos pocos bloques…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Usando el fallbackfee puede resultar en enviar una transacción que tome varias horas o días (o nunca) para confirmar. Considere elegir su comisión manualmente o espere hasta que haya validado la cadena completa.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Elegir…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Personalizada:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(La comisión inteligente no está aún inicializada. Esto habitualmente tarda unos pocos bloques...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 se esta cerrando...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 se esta cerrando…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Este año</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Rango...</translation>
+        <source>Range…</source>
+        <translation>Rango…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Se encontraron suficientes usuarios, firmando (esperando %s)</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Se encontraron suficientes usuarios, firmando...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Importando...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Modo incompatible.</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Número mínimo inválido de firmantes de spork especificados con -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Cargando lista de excluidos...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>El bloqueo ya está activo.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Mezclado en curso...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>No esta en la lista de Masternodes.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Podando almacén de bloques</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Reproducción de bloques…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Reexplorando…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Iniciando funciones de red…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Enviado al masternode, esperando en cola %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>La sincronización finalizó</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Sincronizando cadena de bloques…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Sincronizando objetos de gobernanza…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>El comentario del Agente de Usuario (%s) contiene caracteres inseguros.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Verificando billetera(s)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Se volverá a intentar...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Error: el espacio en disco es bajo para %s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Error: no se pudo agregar el socket a epollfd (epoll_ctl returned error %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Se superó el máximo de intentos.</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>No se pudo volver a escanear la billetera durante la inicialización</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Se encontraron suficientes usuarios, firmando…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>Permiso P2P no válido: '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Llave privada de Masternode inválida. Por favor ver la documentación.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Cargando el índice de bloques...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Cargando billetera...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>La cola del masternode está llena.</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Información ausente en la transacción de entrada.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Mezclado en curso…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>El modo recorte es incompatible con -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Podando almacén de bloques</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>La sección [%s] no se reconoce</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Dirección de billetera especificada "%s" no es un directorio</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Sincronizando cadena de bloques...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Transacción demasiado grande</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Intentando conectar...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>No se ha podido conectar con %s en este equipo. %s es posible que este todavia en ejecución.</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Actualizando la base de datos UTXO</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Verificando bloques…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Verificando billetera(s)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Error actualizando la base de datos chainstate</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Error: no se pudo agregar el socket a kqueuefd (kevent returned error %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Cargando direcciones P2P …</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Cargando lista de excluidos…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Cargando el índice de bloques…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Cargando billetera…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Error al iniciar una nueva cola de mezclado</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Importando…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Modo de reescaneo incorrecto, retrocediendo al valor predeterminado</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>La dirección de spork especificada con -sporkaddr es invalida</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Cargando direcciones P2P ...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Reduciendo -maxconnections de %d a %d, debido a limitaciones del sistema.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Reproducción de bloques...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Reexplorando...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>La última acción exitosa era demasiado reciente.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Iniciando funciones de red...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Sincronizando objetos de gobernanza...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>El código fuente esta disponible desde %s.</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>La transacción no es válida.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Intentando conectar…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Actualización de la base de datos txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Verificando bloques...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Queda muy poca cantidad de llaves: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Advertencia: parámetro %s incorrecto, ¡la ruta debe existir! Usando ruta predeterminada.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Se volverá a intentar…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_fi.ts
+++ b/src/qt/locale/dash_fi.ts
@@ -47,7 +47,7 @@
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>Vi&amp;e...</translation>
+        <translation>Vi&amp;e…</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Pyydä maksuja (Luo QR koodit ja Dash: URIt)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Asetukset…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Salaa Lompakko…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Varmuuskopioi Lompakko…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Vaihda Salasana…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Avaa Lukitus…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>&amp;Allekirjoita Viesti…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Tarkista Viesti…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Lähettävät Osoitteet</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Vastaanottavat Osoitteet</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Avaa &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Avaa Lompakko</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Avaa lompakko</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Sulje Lompakko...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Näytä tietoja QT:sta</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Asetukset...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;Tietoja %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Näytä tai piilota pääikkuna</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Salaa Lompakko...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Salaa yksityiset avaimet jotka kuuluvat lompakkoosi</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Varmuuskopioi Lompakko...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Varmuuskopioi lompakko toiseen paikkaan</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Vaihda Salasana...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Vaihda lompakon salaukseen käytettävä salasana</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Avaa Lukitus...</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>&amp;Lukitse Lompakko</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>&amp;Allekirjoita Viesti...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Allekirjoita viestit Dash osoitteillasi todistaaksesi että omistat ne</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Tarkista Viesti...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Näytä vastaanottamiseen käytettyjen osoitteiden ja nimien lista</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Avaa &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Komentorivin valinnat</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>Näytä tietoja %1</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>Luo Lompakko...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>Verkkotoiminnot ei käytössä</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Synkronoidaan otsikoita (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Synkronoidaan verkkoon...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indeksoidaan lohkoja levyllä...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Käsitellään lohkoja levyllä...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Uudelleen indeksoidaan lohkoja...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Kytkeydytään peers...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>Käsitelty %n lohko(a) tapahtumahistoriasta.</numerusform><numerusform>Käsitelty %n lohko(a) tapahtumahistoriasta.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 jäljessä</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Saavutetaan verkkoa...</translation>
+        <source>Close Wallet…</source>
+        <translation>Sulje Lompakko…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Luo Lompakko…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Synkronoidaan otsikoita (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Synkronoidaan verkkoon…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indeksoidaan lohkoja levyllä…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Käsitellään lohkoja levyllä…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Uudelleen indeksoidaan lohkoja…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Kytkeydytään peers…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Saavutetaan verkkoa…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>Alkuperäinen viesti:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Luodaan Lompakko &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Luodaan Lompakko &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>Luo</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>Tämä on ensimmäinen kerta, kun %1 on käynnistetty, joten voit valita datahakemiston paikan.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Kun klikkaat OK, %1 alkaa latautua ja prosessoida %4 lohkoketjua (%2GB) alkaen esimmäisestä siirtotapahtumasta %3 kun %4 ensi kerran käynnistettiin.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Tämä ensimmäinen synkronointi on vaativa, ja saattaa paljastaa laitteisto-ongelmia tietokoneessasi joita ei aikaisemmin ole huomattu. Aina kun käynnistät %1, jatkuu latautuminen siitä mihin se jäi aikaisemmin.</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>Kopioi Vakuus Lähtöpiste</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Päivitetään...</translation>
+        <source>Please wait…</source>
+        <translation>Odota…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Päivitetään…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>Suodata minkä tahansa ominaisuuden (esim. osoite tai protx tarkiste) mukaan</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Odota...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Masternode DIP3 lisätietoja %1</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>Lohkoja jäljellä</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Tuntematon...</translation>
+        <source>Unknown…</source>
+        <translation>Tuntematon…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>lasketaan…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>Edistymisen kasvu per tunti</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>lasketaan...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Synkronoinnin jäljellä oleva aika</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>Piilota</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Tuntematon. Synkronoidaan otsikoita (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Tuntematon. Synkronoidaan otsikoita (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>oletus lompakko</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Avataan Lompakko &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Avataan Lompakko &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>Asetukset tässä dialogissa ylikirjoitetaan joko komentorivin tai asetustiedostosta:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Piilota kuvake tehtäväpalkista.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>Piilota tehtäväpalkin kuvake</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Ikkunaa suljettaessa pienennä ohjelman ikkuna lopettamatta itse ohjelmaa. Kun tämä asetus on valittuna, ohjelman voi sulkea vain valitsemalla Lopeta ohjelman valikosta.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>Tässä voit määritellä käyttöliittymän kielen. Muutokset astuvat voimaan seuraavan kerran, kun %1 käynnistetään.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Puuttuuko sopiva kieli tai käännös on kesken? Auta käännöstyössä täällä:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' ei ole validi URI. Käytä sen sijaan 'dash:'.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Virheellinen maksuosoite %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI:a ei voida jäsentää! Tämä voi johtua virheellisestä Dash osoitteesta tai virheellisestä URI:n muuttujasta. </translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Käyttäjäohjelma</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Lähetetty</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Vastaanotettu</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Virhe: %1 CSS tiedosto(t) puuttuu custom-css-dir polusta.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 ei vielä sulkeutunut turvallisesti...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 ei vielä sulkeutunut turvallisesti…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QR Koodi</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>&amp;Tallenna Kuva</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Tallenna Kuva...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Tallenna Kuva…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Valitse peer nähdäksesi tarkempia tietoja.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Suunta</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Palvelut</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Estopisteet</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>kautta %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>ei koskaan</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Saapuva</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Lähtevä</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Normaali</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>Tuntematon</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Kopioi määrä</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,7 +2722,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Kopioi &amp;Osoite</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>&amp;Tallenna Kuva</translation>
     </message>
     <message>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Kolikkokontrolli ominaisuudet</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Sisääntulot...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>automaattisesti valitut</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tomu:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Sisääntulot…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Siirtomaksun jälkeen:</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Siirtomaksu:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Valitse...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Älykästä siirtomaksua ei ole alustettu vielä. Tämä kestää yleensä muutaman lohkon…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Fallbackfee:n käyttö saattaa aiheuttaa että maksutapahtuman vahvistus kestää useita tunteja tai päiviä (tai ei koskaan). Harkitse että valitset siirtomaksun manuaalisesti tai odota että lohkoketju on täysin vahvistettu.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Valitse…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Mukautettu:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Älykästä siirtomaksua ei ole alustettu vielä. Tämä kestää yleensä muutaman lohkon...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 sulkeutuu...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 sulkeutuu…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3273,7 +3238,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
-        <translation>Tarkista &amp;Viesti...</translation>
+        <translation>Tarkista &amp;Viesti…</translation>
     </message>
     <message>
         <source>Reset all verify message fields</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tänä vuonna</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Arvoalue...</translation>
+        <source>Range…</source>
+        <translation>Arvoalue…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -3903,7 +3868,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation>&amp;Vie...</translation>
+        <translation>&amp;Vie…</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Löytyi tarpeeksi käyttäjiä, kirjaudutaan ( odotetaan %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Löytyi tarpeeksi käyttäjiä, kirjaudutaan ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Tuodaan...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Yhteensopimaton tila.</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Virheellinen minimi määrä spork allekirjoittajia määritelty -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Ladataan estolistaa...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>On jo lukittu.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Sekoitus käynnissä...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ei ole Masternodet listassa.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Karsitaan lohkoja…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Toistetaan lohkoja…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Skannataan uudelleen…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Käynnistetään verkkoa…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Lähetetty masternodelle, odotetaan jonossa %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Synkronointi valmis</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Synkronoidaan lohkoketju…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Ladataan hallinnon objekteja…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Käyttäjä toimijan kommentti (%s) sisältää ei suositeltuja merkkejä.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Tarkistetaan lompakko(ja)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Yritetään uudelleen...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4262,10 +4227,6 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Virhe: Levytila on alhainen %s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Virhe: socket lisäys epollfd:ään epäonnistui (epoll_ctl palautti virheen %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Maksimi yritykset ylitetty.</translation>
     </message>
@@ -4290,6 +4251,10 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Lompakon uudelleen skannaaminen epäonnistui alustuksen aikana</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Löytyi tarpeeksi käyttäjiä, kirjaudutaan…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>Virheellinen P2P oikeus: '%s'</translation>
     </message>
@@ -4302,14 +4267,6 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Virheellinen masternodeblsprivkey. Katso lisätietoja dokumentaatiosta.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Ladataan lohkoindeksiä...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Ladataan lompakkoa...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Masternode jono on täysi.</translation>
     </message>
@@ -4320,6 +4277,10 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Puuttuva siirtotapahtuman tieto.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Sekoitus käynnissä…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4350,10 +4311,6 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Karsintatila on epäyhteensopiva -txindex kanssa.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Karsitaan lohkoja...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>Osio [%s] ei ole tunnistettavissa.</translation>
     </message>
@@ -4368,10 +4325,6 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Määritelty -walletdir "%s" ei ole hakemisto</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Synkronoidaan lohkoketju...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4406,10 +4359,6 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Siirtotapahtuma on liian iso</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Yritetään kytkeytyä...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Kytkeytyminen kohteeseen %s ei onnistu tällä tietokoneella. %s on luultavasti jo käynnissä.</translation>
     </message>
@@ -4428,6 +4377,14 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Päivitetään UTXO tietokantaa</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Tarkistetaan lohkoja…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Tarkistetaan lompakko(ja)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4578,8 +4535,20 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Virhe ketjutilan tietokannan päivityksessä</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Virhe: socket lisäys kqueuefd:ään epäonnistui (kevent palautti virheen %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Ladataan P2P osoitteita…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Ladataan estolistaa…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Ladataan lohkoindeksiä…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Ladataan lompakkoa…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4618,6 +4587,10 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Uuden sekoitusjonon käynnistys ei onnistunut</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Tuodaan…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Virheellinen -rescan moodi, palataan takaisin oletusarvoon</translation>
     </message>
@@ -4646,20 +4619,8 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Virheellinen spork osoite määritelty -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Ladataan P2P osoitteita...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Vähennetään -maxconnections %d -&gt; %d, järjestelmän rajoituksien takia.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Toistetaan lohkoja...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Skannataan uudelleen...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4690,14 +4651,6 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Viimeinen onnistunut tapahtuma oli liian äskettäin.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Käynnistetään verkkoa...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Ladataan hallinnon objekteja...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>Lähdekoodi löytyy %s.</translation>
     </message>
@@ -4724,6 +4677,10 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>Siirtotapahtuma ei ole voimassa.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Yritetään kytkeytyä…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4758,10 +4715,6 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
         <translation>Päivitetään txindex tietokantaa</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Tarkistetaan lohkoja...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Osoitteita vähän jäljellä: %d</translation>
     </message>
@@ -4776,6 +4729,10 @@ Vähennä uakommenttien määrää tai kokoa.</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Varoitus: väärä parametri %s, tiedostopolku on oltava olemassa! Käytetään oletuspolkua.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Yritetään uudelleen…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_fr.ts
+++ b/src/qt/locale/dash_fr.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Demande de paiements (génère des QR-codes et des URIs Dash)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Options…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Chiffrer le portefeuille…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>Sauvegarder le &amp;portefeuille…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Changer la phrase de passe…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Déverrouiller le portefeuille</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>&amp;Signer le message…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Vérifier un message…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>Envoyer des adresses</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Recevoir des adresses</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Ouvrir une &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Ouvrir le portefeuille</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Ouvrir un portefeuille</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Fermer le portefeuille…</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Afficher des informations sur Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Options...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>À &amp;propos de %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Afficher ou masquer la fenêtre principale</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Chiffrer le portefeuille...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Chiffrer les clefs privées de votre portefeuille</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>Sauvegarder le &amp;portefeuille...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Sauvegarder le portefeuille vers un autre emplacement</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Changer la phrase de passe...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Modifier la phrase de passe utilisée pour le chiffrement du portefeuille</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Déverrouiller le portefeuille</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>&amp;Verrouiller le portefeuille</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>&amp;Signer le message...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Signer les messages avec votre adresses Dash pour prouver que vous en êtes l'auteur</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Vérifier un message...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Afficher la liste d'adresses de réception et d'étiquettes utilisées</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Ouvrir une &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>Options de ligne de &amp;commande</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>Afficher les informations sur %1</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>Créer un portefeuille…</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>Activité réseau désactivée</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Synchronisation des en-têtes (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Synchronisation avec le réseau en cours...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indexation des blocs sur le disque...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Traitement des blocs sur le disque...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Réindexation des blocs sur le disque...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Connexion aux pairs...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform> Traités %n bloc(s) de l'historique des transactions.</numerusform><numerusform> Traités %n bloc(s) de l'historique des transactions.</numerusform><numerusform> Traités %n bloc(s) de l'historique des transactions.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 en retard</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Rattrapage en cours...</translation>
+        <source>Close Wallet…</source>
+        <translation>Fermer le portefeuille…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Créer un portefeuille…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Synchronisation des en-têtes (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Synchronisation avec le réseau en cours…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indexation des blocs sur le disque…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Traitement des blocs sur le disque…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Réindexation des blocs sur le disque…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Connexion aux pairs…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Rattrapage en cours…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>Message d'origine :</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Création du portefeuille &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Création du portefeuille &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>Créer</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>Puisque c’est la première fois que le logiciel est lancé, vous pouvez choisir où %1 stockera ses données.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Quand vous cliquerez sur Valider, %1 commencera à télécharger et à traiter l’intégralité de la chaîne de blocs %4 (%2 Go) en débutant avec les transactions les plus anciennes de %3, quand %4 a été lancé initialement.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>La synchronisation initiale est très exigeante et pourrait exposer des problèmes matériels dans votre ordinateur passés inaperçus auparavant. Chaque fois que vous exécuterez %1, le téléchargement reprendra où il s’était arrêté.</translation>
     </message>
@@ -1287,7 +1286,11 @@
         <translation>Copier sortie caution</translation>
     </message>
     <message>
-        <source>Updating...</source>
+        <source>Please wait…</source>
+        <translation>Veuillez patienter…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
         <translation>Mise à jour en cours…</translation>
     </message>
     <message>
@@ -1323,10 +1326,6 @@
         <translation>Filtrer selon tout critère (par ex. : adresse ou empreinte protx)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Veuillez patienter…</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Infos supplémentaires pour le masternode DIP3 %1</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>Nombre de blocs restants</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Inconnu...</translation>
+        <source>Unknown…</source>
+        <translation>Inconnu…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>en cours de calcul…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>Avancement par heure</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>en cours de calcul...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Temps restant estimé avant synchronisation</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>Masquer</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Inconnu. Synchronisation d'en-têtes (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Inconnu. Synchronisation d'en-têtes (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>portefeuille par défaut</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Ouverture du portefeuille &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Ouverture du portefeuille &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>Les options choisies dans ce dialogue sont remplacées par la ligne de commande ou dans le fichier de configuration :</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Masquer l'icône de la barre d'état système.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>Masquer l'icône de la barre d'état</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Minimiser l'application (au lieu de la quitter) quand la fenêtre est fermée. Si cette option est activée, l'application se fermera uniquement en passant par le menu Quitter.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>La langue de l’interface utilisateur peut être définie ici. Ce réglage sera pris en compte après redémarrage de %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Langage manquant ou traduction incomplète ? Participez aux traductions ici :
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' n'est pas un URI valide. Utilisez 'dash:' à la place.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Adresse de paiement %1 invalide</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>L'URI ne peut être analysée ! Cela peut provenir d'une adresse Dash invalide, ou de paramètres d'URI mal composés.</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Agent utilisateur</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Envoyé</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Reçu</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Erreur : %1 fichier(s) CSS manquant dans le chemin -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 ne s’est pas encore arrêté en toute sécurité...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 ne s’est pas encore arrêté en toute sécurité…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Code QR</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Enregistrer l’image...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Enregistrer l’image…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Sauvegarder l'image...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Sauvegarder l'image…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Choisir un pair pour voir les informations détaillées.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Direction</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Version</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Services</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Score de bannissement</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>via %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>jamais</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Arrivant</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Sortant</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Normal</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>Inconnus</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Copier le montant</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,8 +2722,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Copier l'&amp;adresse</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Sauvegarder l'image...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Sauvegarder l'image…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Fonctions de contrôle des pièces</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Entrées...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>choisi automatiquement</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Poussière:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Entrées…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Après les frais :</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Frais de transaction :</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Choisissez...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Les frais intelligents ne sont pas encore disponibles. Cette fonction apparaît d'habitude après quelques blocs…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Utiliser les frais de repli peut allonger le temps de confirmation d'une transaction (jusqu'à plusieurs heures, ou jours, voire jamais). Envisagez de choisir vos frais manuellement, ou bien attendez la validation complète de la blockchain.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Choisissez…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Personnalisé :</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Les frais intelligents ne sont pas encore disponibles. Cette fonction apparaît d'habitude après quelques blocs...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>Arrêt de %1...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>Arrêt de %1…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Cette année</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Intervalle...</translation>
+        <source>Range…</source>
+        <translation>Intervalle…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nombre suffisant d'utilisateurs trouvé, signature ( attente %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Nombre suffisant d'utilisateurs trouvé, signature ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Importation...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Mode incompatible.</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Le nombre minimal de signataires spork spécifié avec -minsporkkeys est invalide</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Chargement de la liste de bannissement...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Verrou déjà en place.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Mélange en cours...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Absent de la liste des masternodes.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Élagage  du stockage de blocs…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Retraitement des blocs…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Nouvelle analyse…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Démarrage des processus réseau…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Soumis au masternode, dans la file d'attente %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>La synchronisation est terminée</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Synchronisation de la blockchain…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Synchronisation des objets de gouvernance…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Le commentaire User Agent (%s) contient des caractères dangereux.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Vérification du ou des portefeuille(s)…</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Va réessayer ...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Erreur : l'espace-disque est trop bas pour %s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Erreur : impossible d'ajouter le socket à epollfd (epoll_ctl a renvoyé l'erreur %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Le nombre maximal d'essais est dépassé.</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Échec de la réinspection du portefeuille pendant le démarrage</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Nombre suffisant d'utilisateurs trouvé, signature…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>Autorisation P2P invalide : '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>masternodeblsprivkey invalide. Veuillez vous référer à la documentation.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Chargement de l’index des blocs...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Chargement du portefeuille...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>La file d'attente du masternode est pleine.</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Informations de transaction entrante manquantes.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Mélange en cours…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Le mode Élaguer est incompatible avec -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Élagage  du stockage de blocs...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>La section [%s] n'est pas reconnue.</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Le -walletdir spécifié "%s" n'est pas un répertoire</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Synchronisation de la blockchain…</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Transaction trop volumineuse</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Tentative de connexion...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Impossible de se lier à %s sur cet ordinateur. %s fonctionne probablement déjà.</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Mise à niveau de la base de données UTXO</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Vérification des blocs en cours…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Vérification du ou des portefeuille(s)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Erreur de mise à niveau de la base de données d’état de la chaîne</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Erreur : impossible d'ajouter le socket à kqueuefd (kevent a renvoyé l'erreur %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Chargement des adresses P2P…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Chargement de la liste de bannissement…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Chargement de l’index des blocs…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Chargement du portefeuille…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Impossible de démarrer une nouvelle file de mélange</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Importation…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Mode -rescan incorrect, retour à la valeur par défaut</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>L'adresse spork spécifiée avec -sporkaddr est invalide</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Chargement des adresses P2P...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Réduction de -maxconnections de %d à %d, en raison de limitations du système.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Retraitement des blocs…</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Nouvelle analyse...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>La dernière action réussie est trop récente.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Démarrage des processus réseau...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Synchronisation des objets de gouvernance...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>Le code source se trouve sur %s.</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>Transaction invalide.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Tentative de connexion…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Mise à jour de la base de données txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Vérification des blocs en cours...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Très peu de clefs restantes : %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Attention : paramètre %s incorrect, le chemin doit exister ! Utilisation du chemin par défaut.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Va réessayer …</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_it.ts
+++ b/src/qt/locale/dash_it.ts
@@ -312,6 +312,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -338,6 +341,42 @@
         <translation>Richieste di pagamenti (genera codici QR e dash: URLs)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Opzioni…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Cifra il portafoglio…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Backup Wallet…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Cambia la Passphrase…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Sblocca Portafoglio</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Firma &amp;messaggio…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Verifica messaggio…</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation>&amp;Carica PSBT dal file…</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation>Carica PSBT dagli appunti…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Indirizzi di invio</translation>
     </message>
@@ -346,16 +385,16 @@
         <translation>&amp;Indirizzi di ricezione</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Apri &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Portafoglio aperto</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Apri un portafoglio</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Chiudi Portafoglio...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -414,10 +453,6 @@
         <translation>Mostra informazioni su Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Opzioni...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;Informazioni su %1</translation>
     </message>
@@ -438,32 +473,16 @@
         <translation>Mostra o nascondi la Finestra principale</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Cifra il portafoglio...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Cifra le chiavi private che appartengono al tuo portafoglio</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Backup Wallet...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Effettua il backup del portafoglio</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Cambia la Passphrase...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cambia la passphrase utilizzata per la cifratura del portafoglio</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Sblocca Portafoglio</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -474,24 +493,12 @@
         <translation>&amp;Blocca Wallet</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Firma &amp;messaggio...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Firma i messaggi con il tuo indirizzo Dash per dimostrare che li possiedi</translation>
     </message>
     <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Verifica messaggio...</translation>
-    </message>
-    <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
         <translation>Verificare i messaggi per assicurarsi che sono firmati con gli indirizzi specificati di Dash</translation>
-    </message>
-    <message>
-        <source>&amp;Load PSBT from file...</source>
-        <translation>&amp;Carica PSBT dal file...</translation>
     </message>
     <message>
         <source>&amp;Information</source>
@@ -554,10 +561,6 @@
         <translation>Mostra la lista degli indirizzi di ricezione utilizzati</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Apri &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>Opzioni riga di &amp;comando</translation>
     </message>
@@ -596,10 +599,6 @@
         <translation>Carica transazione Dash parzialmente firmata</translation>
     </message>
     <message>
-        <source>Load PSBT from clipboard...</source>
-        <translation>Carica PSBT dagli appunti...</translation>
-    </message>
-    <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation>Carica la transazione Bitcoin parzialmente firmata dagli appunti</translation>
     </message>
@@ -612,20 +611,12 @@
         <translation>Apri un dash: URI</translation>
     </message>
     <message>
-        <source>Create Wallet...</source>
-        <translation>Crea portafoglio...</translation>
-    </message>
-    <message>
         <source>Create a new wallet</source>
         <translation>Crea un nuovo portafoglio</translation>
     </message>
     <message>
-        <source>Close All Wallets...</source>
-        <translation>Chiudi tutti i Wallet...</translation>
-    </message>
-    <message>
         <source>Close all wallets</source>
-        <translation>Chiudi tutti i Wallet...</translation>
+        <translation>Chiudi tutti i Wallet…</translation>
     </message>
     <message>
         <source>%1 &amp;information</source>
@@ -671,30 +662,6 @@
         <source>Network activity disabled</source>
         <translation>Attività di rete disabilitata</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Sincronizzazione Headers (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Sincronizzazione con la rete in corso...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indicizzando i blocchi su disco...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Elaborazione dei blocchi su disco...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Re-indicizzazione blocchi su disco...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Connessione ai peers</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>Elaborati %n blocchi della cronologia delle transazioni.</numerusform><numerusform>Elaborati %n blocchi della cronologia delle transazioni.</numerusform><numerusform>Elaborati %n blocchi della cronologia delle transazioni.</numerusform></translation>
@@ -704,8 +671,44 @@
         <translation>Indietro di %1</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>In aggiornamento...</translation>
+        <source>Close Wallet…</source>
+        <translation>Chiudi Portafoglio…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Crea portafoglio…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation>Chiudi tutti i Wallet…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Sincronizzazione Headers (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Sincronizzazione con la rete in corso…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indicizzando i blocchi su disco…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Elaborazione dei blocchi su disco…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Re-indicizzazione blocchi su disco…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Connessione ai peers</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>In aggiornamento…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -828,10 +831,6 @@
     <message>
         <source>Original message:</source>
         <translation>Messaggio originale:</translation>
-    </message>
-    <message>
-        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation>Si è verificato un errore irreversibile. %1 non può più continuare in sicurezza e verrà chiuso.</translation>
     </message>
 </context>
 <context>
@@ -1028,8 +1027,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Creazione del portafoglio&lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Creazione del portafoglio&lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1086,7 +1085,7 @@
         <source>Create</source>
         <translation>Creare</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1230,10 +1229,6 @@
         <translation>Dato che questa è la prima volta che il programma viene lanciato, puoi scegliere dove %1 salverà i suoi dati.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Quando fai click su OK, %1 comincerà a scaricare e processare l'intera %4 block chain (%2GB) a partire dalla prime transazioni del %3 quando %4 venne inaugurato.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation>Limita l'archiviazione della blockchain a</translation>
     </message>
@@ -1260,14 +1255,6 @@
     <message>
         <source>Use a custom data directory:</source>
         <translation>Usa una cartella dati personalizzata:</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n GB of free space available</source>
-        <translation><numerusform>%n GB di spazio libero disponibile</numerusform><numerusform>%n GB di spazio libero disponibile</numerusform><numerusform>%n GB di spazio libero disponibile</numerusform></translation>
-    </message>
-    <message numerus="yes">
-        <source>(of %n GB needed)</source>
-        <translation><numerusform>(di %n GB richiesti)</numerusform><numerusform>(di %n GB richiesti)</numerusform><numerusform>(di %n GB richiesti)</numerusform></translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1377,8 +1364,12 @@
         <translation>Copia Collateral Outpoint</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>In aggiornamento...</translation>
+        <source>Please wait…</source>
+        <translation>attendere prego…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>In aggiornamento…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1413,10 +1404,6 @@
         <translation>Filtra per qualsiasi proprietà (es. indirizzo o hash protx)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>attendere prego...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Ulteriori informazioni per DIP3 Masternode %1</translation>
     </message>
@@ -1440,8 +1427,12 @@
         <translation>Numero di blocchi mancanti</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Sconosciuto...</translation>
+        <source>Unknown…</source>
+        <translation>Sconosciuto…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>calcolando…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1456,10 +1447,6 @@
         <translation>Aumento dei progressi per ogni ora</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>calcolando...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Tempo stimato al completamento della sincronizzazione</translation>
     </message>
@@ -1472,8 +1459,8 @@
         <translation>%1 è attualmente in fase di sincronizzazione. Scaricherà intestazioni e blocchi dai peer e li convaliderà fino a raggiungere la punta della blockchain.</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Sconosciuto. Sincronizzazione intestazioni (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Sconosciuto. Sincronizzazione intestazioni (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1502,8 +1489,8 @@
         <translation>portafoglio predefinito</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Apertura Portafoglio &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Apertura Portafoglio &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1703,14 +1690,6 @@
         <translation>Le opzioni impostate in questa finestra di dialogo sono sovrascritte dalla riga di comando o nel file di configurazione:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Nascondi l'icona dalla barra delle applicazioni.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;Nascondi l'icona tray</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Riduci ad icona invece di uscire dall'applicazione quando la finestra viene chiusa. Attivando questa opzione l'applicazione terminerà solo dopo aver selezionato Esci dal menu File.</translation>
     </message>
@@ -1825,12 +1804,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>La lingua dell'interfaccia utente può essere impostata qui. L'impostazione avrà effetto dopo il riavvio %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>La tua lingua manca o la traduzione è incompleta? Contribuisci alla traduzione qui: 
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -2135,8 +2108,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Copia negli appunti</translation>
     </message>
     <message>
-        <source>Save...</source>
-        <translation>Salva...</translation>
+        <source>Save…</source>
+        <translation>Salva…</translation>
     </message>
     <message>
         <source>Close</source>
@@ -2267,10 +2240,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>A causa dell'interruzione del supporto, dovresti richiedere al commerciante di fornirti un URI compatibile con BIP21 o utilizzare un portafoglio che continui a supportare BIP70.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Indirizzo di pagamento non valido: %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>Impossibile interpretare l'URI! La causa puó essere un indirizzo Dash non valido o parametri URI non corretti.</translation>
     </message>
@@ -2283,30 +2252,32 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>User Agent</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Inviato</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Ricevuto</translation>
     </message>
     <message>
-        <source>Peer Id</source>
-        <translation>Peer Id</translation>
-    </message>
-    <message>
         <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation>Indirizzo</translation>
     </message>
     <message>
         <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
         <translation>Network</translation>
     </message>
 </context>
@@ -2449,7 +2420,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Errore: %1 file(s) CSS mancanti nel percorso -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
+        <source>%1 didn't yet exit safely…</source>
         <translation>%1 non è ancora stato chiuso in modo sicuro</translation>
     </message>
     <message>
@@ -2568,14 +2539,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>&amp;Salva Immagine</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>&amp;Salva Immagine</translation>
     </message>
     <message>
@@ -2705,10 +2676,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Select a peer to view detailed information.</source>
         <translation>Seleziona un peer per vedere informazioni dettagliate</translation>
-    </message>
-    <message>
-        <source>Direction</source>
-        <translation>Direzione</translation>
     </message>
     <message>
         <source>Version</source>
@@ -2843,10 +2810,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Servizi</translation>
     </message>
     <message>
-        <source>Ban Score</source>
-        <translation>Punteggio di Ban</translation>
-    </message>
-    <message>
         <source>Connection Time</source>
         <translation>Tempo di connessione</translation>
     </message>
@@ -2963,32 +2926,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Comando in esecuzione senza alcun portafoglio</translation>
     </message>
     <message>
-        <source>(peer id: %1)</source>
-        <translation>(peer id: %1)</translation>
-    </message>
-    <message>
         <source>Executing command using "%1" wallet</source>
         <translation>Comando in esecuzione utilizzando il portafoglio "%1"</translation>
     </message>
     <message>
         <source>via %1</source>
         <translation>via %1</translation>
-    </message>
-    <message>
-        <source>never</source>
-        <translation>mai</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>In entrata</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>In uscita</translation>
-    </message>
-    <message>
-        <source>Outbound block-relay</source>
-        <translation>Block-relay in uscita</translation>
     </message>
     <message>
         <source>Regular</source>
@@ -3006,7 +2949,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>Sconosciuto</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -3105,12 +3048,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Copia l'importo</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <source>Request payment to ...</source>
-        <translation>Richiedi il pagamento a...</translation>
+        <source>Request payment to …</source>
+        <translation>Richiedi il pagamento a…</translation>
     </message>
     <message>
         <source>Address:</source>
@@ -3141,7 +3084,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Copia &amp;Indirizzo</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>&amp;Salva Immagine</translation>
     </message>
     <message>
@@ -3195,10 +3138,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Funzionalità di Coin Control</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Input...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>selezionato automaticamente</translation>
     </message>
@@ -3227,6 +3166,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Infinitesimale:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Input…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Dopo Commissione:</translation>
     </message>
@@ -3247,16 +3190,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Commissione della transazione:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Scegli...</translation>
-    </message>
-    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
         <translation>Quando il volume delle transazioni è inferiore allo spazio nei blocchi, i miner e i nodi di inoltro possono applicare una commissione minima. Pagare solo questa tariffa minima va bene, ma tieni presente che ciò può comportare una transazione mai confermata una volta che c'è più richiesta di transazioni precipitose di quanto la rete possa elaborare.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation>Una commissione troppo bassa potrebbe comportare una transazione mai confermata (leggi il tooltip)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Commissione intelligente non ancora inizializzata. Normalmente richiede un'attesa di alcuni blocchi…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -3273,6 +3216,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>L'utilizzo del fallbackfee può comportare che una transazione richiederà diverse ore o giorni (o molto di  più) per essere confermata. Prendi in considerazione la possibilità di scegliere la tariffa manualmente o attendi fino a quando non avrai convalidato la catena completa.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Scegli…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -3293,10 +3240,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Personalizzata:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Commissione intelligente non ancora inizializzata. Normalmente richiede un'attesa di alcuni blocchi...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3451,10 +3394,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>oppure</translation>
     </message>
     <message>
-        <source>To review recipient list click "Show Details..."</source>
-        <translation>Per rivedere l'elenco dei destinatari facendo clic su "Mostra dettagli..."</translation>
-    </message>
-    <message>
         <source>Confirm send coins</source>
         <translation>Conferma l'invio di dash</translation>
     </message>
@@ -3481,6 +3420,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Send</source>
         <translation>Invia</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation>Per rivedere l'elenco dei destinatari facendo clic su "Mostra dettagli…"</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
@@ -3626,8 +3569,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>Arresto di %1 in corso...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>Arresto di %1 in corso…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -4160,8 +4103,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Quest'anno</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Intervallo...</translation>
+        <source>Range…</source>
+        <translation>Intervallo…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4560,14 +4503,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Trovati utenti sufficienti, firma (in attesa di %s)</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Trovati utenti sufficienti, firma ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Importazione...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Modalità incompatibile</translation>
     </message>
@@ -4600,16 +4535,8 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Numero minimo non valido di firmatari di spork specificato con -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Caricamento lista dei bloccati...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Il blocco è già presente.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Mixing in corso...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4632,12 +4559,36 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Non si trova nella  lista dei Masternode.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Pruning del blockstore…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Riproduzione di blocchi …</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Ripetizione scansione…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Inizializzazione dei thread di rete…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Inviato al masternode, attendendo in coda %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Sincronizzazione finita</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Sincronizzazione blockchain…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Sincronizzazione degli oggetti di governance …</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4650,14 +4601,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Il commento del User Agent (%s) contiene caratteri non sicuri.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Derifica wallet(s)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Ritenterà ...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4788,10 +4731,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Errore: Keypool esaurito, chiamare prima keypoolrefill</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Errore: impossibile aggiungere il socket a epollfd (epoll_ctl ha restituito l'errore %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Numero massimo di tentativi superato.</translation>
     </message>
@@ -4820,6 +4759,10 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Impossibile verificare il database</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Trovati utenti sufficienti, firma…</translation>
+    </message>
+    <message>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation>Duplicato -wallet %s ignorato.</translation>
     </message>
@@ -4836,14 +4779,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Invalid masternodeblsprivkey. Per favore vedi documentazione.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Caricamento dell'indice del blocco...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Caricamento portafoglio...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>La lista dei masternode e' piena.</translation>
     </message>
@@ -4854,6 +4789,10 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
     <message>
         <source>Missing input transaction information.</source>
         <translation>Mancano le informazioni di input della transazione</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Mixing in corso…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4888,10 +4827,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>La modalità prune è incompatibile con l'opzione -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Pruning del blockstore...</translation>
-    </message>
-    <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
         <translation>SQLiteDatabase: Impossibile eseguire l'istruzione per verificare il database: %s</translation>
     </message>
@@ -4924,10 +4859,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>-Walletdir "%s" specificato non è una directory</translation>
     </message>
     <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Sincronizzazione blockchain...</translation>
-    </message>
-    <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
         <translation>Il portafoglio eviterà di pagare meno della tariffa minima di trasmissione.</translation>
     </message>
@@ -4944,6 +4875,10 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Questo è il costo di transazione che pagherai se invii una transazione.</translation>
     </message>
     <message>
+        <source>Topping up keypool…</source>
+        <translation>Ricaricamento del pool di chiavi…</translation>
+    </message>
+    <message>
         <source>Transaction amounts must not be negative</source>
         <translation>Gli importi di transazione non devono essere negativi</translation>
     </message>
@@ -4958,10 +4893,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
     <message>
         <source>Transaction too large</source>
         <translation>Transazione troppo grande</translation>
-    </message>
-    <message>
-        <source>Trying to connect...</source>
-        <translation>cercando di connettersi ...</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
@@ -4988,12 +4919,24 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Aggiornamento del database UTXO</translation>
     </message>
     <message>
+        <source>Verifying blocks…</source>
+        <translation>Verifica blocchi…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Derifica wallet(s)…</translation>
+    </message>
+    <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation>Il portamonete necessita di essere riscritto: riavviare %s per completare</translation>
     </message>
     <message>
         <source>Wasn't able to create wallet backup folder %s!</source>
         <translation>Non è stato possibile creare la cartella di backup del portafoglio %s!</translation>
+    </message>
+    <message>
+        <source>Wiping wallet transactions…</source>
+        <translation>Pulizia delle transazioni del wallet in corso…</translation>
     </message>
     <message>
         <source>You can not start a masternode with wallet enabled.</source>
@@ -5136,8 +5079,20 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Errore durante l'aggiornamento del database chainstate</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Errore: impossibile aggiungere il socket a kqueuefd (kevent ha restituito l'errore %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Caricamento indirizzi P2P…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Caricamento lista dei bloccati…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Caricamento dell'indice del blocco…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Caricamento portafoglio…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -5176,6 +5131,10 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Impossibile avviare una nuova coda di mixaggio</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Importazione…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Modalità -rescan errata, ritorno al valore predefinito</translation>
     </message>
@@ -5212,24 +5171,12 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Indirizzo di spork non valido specificato con -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Caricamento indirizzi P2P...</translation>
-    </message>
-    <message>
         <source>Prune mode is incompatible with -coinstatsindex.</source>
         <translation>La modalità Prune è incompatibile con -coinstatsindex.</translation>
     </message>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Riduzione -maxconnections da %d a %d a causa di limitazioni di sistema.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Riproduzione di blocchi ...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Ripetizione scansione...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -5260,14 +5207,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Ultima azione successo era troppo recente.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Inizializzazione dei thread di rete...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Sincronizzazione degli oggetti di governance ...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>Il codice sorgente è disponibile in %s</translation>
     </message>
@@ -5284,10 +5223,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Questo è un software sperimentale.</translation>
     </message>
     <message>
-        <source>Topping up keypool...</source>
-        <translation>Ricaricamento del pool di chiavi...</translation>
-    </message>
-    <message>
         <source>Transaction amount too small</source>
         <translation>Importo transazione troppo piccolo</translation>
     </message>
@@ -5302,6 +5237,10 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
     <message>
         <source>Transaction not valid.</source>
         <translation>Transazione non valida</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>cercando di connettersi …</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -5336,10 +5275,6 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Aggiornamento del database txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Verifica blocchi...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Il numero di chiavi rimaste è molto basso: %d</translation>
     </message>
@@ -5356,8 +5291,8 @@ Vai su File &gt; Apri Wallet per caricare un Wallet.
         <translation>Attenzione: parametro errato %s, il percorso deve esistere! Utilizzo del percorso predefinito.</translation>
     </message>
     <message>
-        <source>Wiping wallet transactions...</source>
-        <translation>Pulizia delle transazioni del wallet in corso...</translation>
+        <source>Will retry…</source>
+        <translation>Ritenterà …</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_ja.ts
+++ b/src/qt/locale/dash_ja.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>送金を要求 (QRコードとdash:URIを生成)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>オプション… (&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>ウォレットの暗号化… (&amp;E)</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>ウォレットのバックアップ… (&amp;B)</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>パスフレーズの変更… (&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>ウォレットをアンロック…(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>メッセージの署名… (&amp;M)</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>メッセージの検証… (&amp;V)</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>アドレスを送信 (&amp;S)</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>アドレスを受信 (&amp;R)</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>URIを開く… (&amp;U)</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>ウォレットを開く</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>ウォレットを開く</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>ウォレットを閉じる...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Qt についての情報を表示</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>オプション… (&amp;O)</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>%1 について (&amp;A)</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>メインウインドウを表示または非表示</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>ウォレットの暗号化… (&amp;E)</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>あなたのウォレットの秘密鍵を暗号化</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>ウォレットのバックアップ… (&amp;B)</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>ウォレットを他の場所にバックアップ</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>パスフレーズの変更… (&amp;C)</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>ウォレット暗号化のためのパスフレーズを変更</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>ウォレットをアンロック...(&amp;U)</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>ウォレットをロック(&amp;L)</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>メッセージの署名… (&amp;M)</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>あなたがDash アドレスを所有していることを証明するために、あなたのDashアドレスでメッセージに署名してください。</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>メッセージの検証… (&amp;V)</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>過去に使用した受取先アドレスとラベルの一覧を表示</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>URIを開く… (&amp;U)</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>コマンドラインオプション (&amp;C)</translation>
     </message>
@@ -575,10 +574,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>%1の情報を表示する</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>ウォレットを作成する...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -620,30 +615,6 @@
         <source>Network activity disabled</source>
         <translation>ネットワークアクティビティは無効化されました</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>ヘッダーを同期しています (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>ネットワークに同期中…</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>ディスク上のブロックのインデックスを作成中...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>ディスク上のブロックを処理中...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>ディスク上のブロックのインデックスを再作成中…</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>ピアに接続中...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>%n ブロックのトランザクション履歴を処理</numerusform></translation>
@@ -653,7 +624,39 @@
         <translation>%1 遅延</translation>
     </message>
     <message>
-        <source>Catching up...</source>
+        <source>Close Wallet…</source>
+        <translation>ウォレットを閉じる…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>ウォレットを作成する…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>ヘッダーを同期しています (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>ネットワークに同期中…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>ディスク上のブロックのインデックスを作成中…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>ディスク上のブロックを処理中…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>ディスク上のブロックのインデックスを再作成中…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>ピアに接続中…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
         <translation>追跡中…</translation>
     </message>
     <message>
@@ -778,7 +781,7 @@
         <source>Original message:</source>
         <translation>元のメッセージ：</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -973,8 +976,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>ウォレット&lt;b&gt;%1&lt;/b&gt;を作成...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>ウォレット&lt;b&gt;%1&lt;/b&gt;を作成…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1023,7 +1026,7 @@
         <source>Create</source>
         <translation>作成</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>これは本プログラムの最初の起動です。%1 がデータを保存する場所を選択して下さい。</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>OKをクリックすると、%1は完全な%4ブロックチェーン (%2GB) のダウンロードおよび処理を%4が開始された時点の%3から開始します。</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>この初期同期には多大なリソースを消費し、あなたのコンピュータでこれまで見つからなかったハードウェア上の問題が発生する場合があります。%1 を実行する度に、中断された時点からダウンロードを再開します。</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>担保のアウトポイントをコピー</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>更新中...</translation>
+        <source>Please wait…</source>
+        <translation>お待ちください…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>更新中…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>プロパティでのフィルタリング（例：アドレスやProTxハッシュなど）</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>お待ちください...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>DIP3のマスターノード%1の追加情報</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>残りのブロック数</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>不明...</translation>
+        <source>Unknown…</source>
+        <translation>不明…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>計算中…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>一時間毎の進捗の変化</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>計算中...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>同期が完了するまでの推定残り時間</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>非表示</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>不明。ヘッダー(%1、%2%)を同期中...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>不明。ヘッダー(%1、%2%)を同期中…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>デフォルトのウォレット</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;のウォレットを開封中...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;のウォレットを開封中…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>このダイアログで設定されたオプションは、コマンドラインまたは設定ファイルによって上書きされます。</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>システムトレイからアイコンを非表示にします。</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>トレイアイコンを非表示にする(&amp;H)</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>ウィンドウを閉じる際にアプリケーションを終了するのではなく最小化します。このオプションが有効の場合、メニューから終了を選択した場合にのみアプリケーションは閉じられます。</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>ここでユーザーインターフェースの言語を設定できます。設定を反映するには %1 を再起動します。</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>希望の言語がない場合または翻訳に問題がある場合はこちらで翻訳にご協力ください。:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>「dash://」は有効なURIではありません。代わりに「dash:」を使ってください。</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>支払いのアドレス　%1　は無効です</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI を解析できません! これは無効な Dash アドレスあるいは不正な形式の URI パラメーターによって引き起こされた可能性があります。</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>ユーザーエージェント</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>送金しました</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>受け取りました</translation>
     </message>
     </context>
@@ -2138,7 +2123,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>エラー：%1のCSSファイルが-custom-css-dirパスにありません。</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
+        <source>%1 didn't yet exit safely…</source>
         <translation>%1 はまだ安全に終了していません</translation>
     </message>
     <message>
@@ -2249,14 +2234,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QRコード</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>画像を保存...(&amp;S)</translation>
+        <source>&amp;Save Image…</source>
+        <translation>画像を保存…(&amp;S)</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>画像を保存… (&amp;S)</translation>
     </message>
     <message>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>詳細を確認したいピアを選択してください。</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>ディレクション</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>バージョン</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>サービス</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Banスコア</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1経由</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>一度もなし</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>インバウンド</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>アウトバウンド</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>通常</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>不明</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>総額のコピー</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,7 +2722,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>アドレスをコピー(&amp;A)</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
+        <source>&amp;Save Image…</source>
         <translation>画像を保存… (&amp;S)</translation>
     </message>
     <message>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>コインコントロール機能</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>インプット…</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>自動選択</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ダスト：</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>インプット…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>手数料差引後：</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>トランザクション手数料：</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>選択…</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>（スマート手数料はまだ初期化されていません。これには約数ブロックほどかかります…）</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>フォールバックフィーを使用すると、承認に数時間から数日かかる（あるいは承認されない）トランザクションが送信される可能性があります。手数料を手動で選択するか、ブロックチェーン全体の検証が完了するまで待ってください。</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>選択…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>カスタム：</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>（スマート手数料はまだ初期化されていません。これには約数ブロックほどかかります…）</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 をシャットダウンしています...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 をシャットダウンしています…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,7 +3672,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>今年</translation>
     </message>
     <message>
-        <source>Range...</source>
+        <source>Range…</source>
         <translation>期間…</translation>
     </message>
     <message>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>充分なユーザーを発見しました、サインしています ( 待機中 %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>充分なユーザーを発見しました、サインしています </translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>インポートしています…</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>非互換性モード</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-minsporkkeysで指定されたスポーク署名者の最小数が無効です</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>banリストを読み込んでいます...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>すでにロックされています</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>ミキシング中...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>マスターノードリストにありません</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>ブロックストアを剪定しています…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>ブロックをリプレイ中…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>再スキャン中…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>ネットワークのスレッドを起動しています…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>マスターノードにサブミット、待機中 %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>同期完了</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>ブロックチェーンの同期中…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>ガバナンスオブジェクトを同期中…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>ユーザーエージェントのコメント (%s) には安全でない文字が含まれています。</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>ウォレットを検証中…</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>再試行...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>エラー：%sのディスク容量が不足しています</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>エラー：epollfdへのソケットの追加に失敗しました（epoll_ctlは、%sのエラーを返しました）</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>最大試行回数を超えました。</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>初期化中にウォレットの再スキャンに失敗しました</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>充分なユーザーを発見しました、サインしています </translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>無効なP2P許可：「%s」</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>マスターノードBLS秘密鍵が無効です。ドキュメントをお読み下さい。</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>ブロックインデックスを読み込んでいます…</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>ウォレットを読み込んでいます…</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>マスターノードキューがいっぱいです</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>不明なインプットトランザクション情報</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>ミキシング中…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>剪定モードは-txindexと互換性がありません。</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>ブロックストアを剪定しています…</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>[%s]のセクションは認識されません。</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>指定された-walletdirの「%s」はディレクトリではありません</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>ブロックチェーンの同期中…</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>トランザクション量が大きすぎます。</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>接続中です...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>このコンピュータの %s にバインドすることができません。おそらく %s は既に実行されています。</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>UTXOデータベースを更新しています</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>ブロックの検証中…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>ウォレットを検証中…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>チェーンステートデータベースのアップグレードエラー</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>エラー：kqueuefdへのソケットの追加に失敗しました (keventが、%sのエラーを返しました）</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>P2Pアドレスを読み込んでいます…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>banリストを読み込んでいます…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>ブロックインデックスを読み込んでいます…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>ウォレットを読み込んでいます…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>新しいミキシングキューの開始に失敗</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>インポートしています…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>再スキャンモードが正しくないため、デフォルト値に戻ります</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-sporkaddrに指定された無効なスポークアドレスI</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>P2Pアドレスを読み込んでいます...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>システム上の制約から、-maxconnections を %d から %d に削減します。</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>ブロックをリプレイ中…</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>再スキャン中…</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>直近の成功したアクションが最新過ぎでした。</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>ネットワークのスレッドを起動しています...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>ガバナンスオブジェクトを同期中...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>ソースコードは %s より入手可能です。</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>トランザクションが無効です</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>接続中です…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>txindexデータベースのアップグレード</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>ブロックの検証中…</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>非常に少ない数のキー: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>警告：パラメータの%sが正しくありません。パスは必須となります。デフォルトのパスを使用しています。</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>再試行…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_ko.ts
+++ b/src/qt/locale/dash_ko.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>지불 요청하기 (QR코드와 대시 URI가 생성됩니다.)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>옵션(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>지갑 암호화(&amp;E)…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>지갑 백업(&amp;B)…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>암호문 변경(&amp;C)…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>지갑 잠금해제 (&amp;U)</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>메시지 서명…(&amp;M)</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>메시지 검증…(&amp;V)</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>보내기 주소(&amp;S)</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>받기 주소(&amp;R)</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>URI 열기(&amp;U)…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>지갑 열기</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>지갑을 엽니다</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>지갑을 닫습니다...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Qt 정보를 표시합니다</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>옵션(&amp;O)</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>%1 정보(&amp;A)</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>메인창 보이기 또는 숨기기</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>지갑 암호화(&amp;E)...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>지갑에 해당하는 개인 키 암호화하기</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>지갑 백업(&amp;B)...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>지갑을 다른 장소에 백업</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>암호문 변경(&amp;C)...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>지갑 암호화에 사용되는 암호문을 변경합니다</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>지갑 잠금해제 (&amp;U)</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>지갑 잠금(&amp;L)</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>메시지 서명...(&amp;M)</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>본인의 대시 주소임을 증명하기 위하여 메시지에 서명합니다.</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>메시지 검증...(&amp;V)</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>사용한 받기 주소와 라벨을 표시합니다.</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>URI 열기(&amp;U)...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>명령줄 옵션(&amp;C)</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>%1에 관한 정보를 표시합니다</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>지갑을 생성합니다...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>네트워크 활동 정지</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>헤더 동기화중 (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>네트워크와 동기화중...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>디스크에서 블록 색인중...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>디스크에서 블록 처리중...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>디스크에서 블록 다시 색인중...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>피어에 연결중...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>거래 히스토리의 %n 블록을 처리하였습니다.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 전의 정보 처리 중</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>블록 따라잡기...</translation>
+        <source>Close Wallet…</source>
+        <translation>지갑을 닫습니다…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>지갑을 생성합니다…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>헤더 동기화중 (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>네트워크와 동기화중…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>디스크에서 블록 색인중…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>디스크에서 블록 처리중…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>디스크에서 블록 다시 색인중…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>피어에 연결중…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>블록 따라잡기…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>원본 메시지:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>지갑 &lt;b&gt;%1&lt;/b&gt; 생성중...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>지갑 &lt;b&gt;%1&lt;/b&gt; 생성중…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>생성하기</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>프로그램을 처음으로 실행합니다. 어디에 %1 데이터를 저장 할 지 선택할 수 있습니다. </translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>확인을 클릭하면 %1은 모든 %4블록 체인 (%2GB) 장부를 %3 안에 다운로드하고 처리하기 시작합니다.  이는 %4가 시작될 때 생성된 가장 오래된 트랜잭션부터 시작합니다.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>초기 동기화는 매우 오래 걸리며 이전에는 본 적 없는  하드웨어 문제가 발생할 수 있습니다. %1을 실행할 때마다 중단 된 곳에서 다시 계속 다운로드 됩니다.</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>콜래트럴 아웃포인트 복사</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>업데이트 중...</translation>
+        <source>Please wait…</source>
+        <translation>기다려주십시오…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>업데이트 중…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>모든 속성으로 검색하기 (예: 주소 혹은 protx 해시)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>기다려주십시오...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>DIP3 마스터노드 %1에 대한 추가 정보</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>남은 블록의 수</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>알 수 없음...</translation>
+        <source>Unknown…</source>
+        <translation>알 수 없음…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>계산 중…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>시간당 진행 증가율</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>계산 중...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>동기화 완료까지 예상 시간</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>숨기기</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>알 수 없음. 헤더 동기화중 (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>알 수 없음. 헤더 동기화중 (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>기본 지갑</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>지갑 &lt;b&gt;%1&lt;/b&gt; 여는 중...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>지갑 &lt;b&gt;%1&lt;/b&gt; 여는 중…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>이 대화의 옵션 세트는 명령줄에 의해, 혹은 설정 파일에서 중단됩니다:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>시스템 트레이에서 아이콘을 숨깁니다.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>트레이 아이콘 숨김(&amp;H)</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>창이 닫히는 경우 종료하지 않고 축소합니다. 이 옵션을 활성화하면 메뉴에서 종료를 선택하는 경우에만 어플리케이션이 종료됩니다.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>이곳에서 사용자 인터페이스 언어를 설정 할 수 있습니다. 이 설정은 %1을/를 다시 시작할 때 적용됩니다.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>지정하려는 언어가 목록에 없거나 번역이 완성되지 않았다면? 다음의 주소에서 번역을 도와주세요:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' 는 유효하지 않은 URI 입니다. 'dash:' 를 사용하세요.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>유효하지 않은 지불 주소 %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI를 분석할 수 없습니다! 대시 주소가 유효하지 않거나 URI 파라미터 구성에 오류가 존재할 수 있습니다.</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>사용자 에이전트</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>보냄</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>받음</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>오류: %1 CSS 파일이 -custom-css-dir 경로에서 누락되었습니다.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1가 아직 안전하게 종료되지 않았습니다...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1가 아직 안전하게 종료되지 않았습니다…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>이미지 저장(&amp;S)...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>이미지 저장(&amp;S)…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>이미지 저장(&amp;S)...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>이미지 저장(&amp;S)…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>자세한 정보를 보려면 피어를 선택하세요.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>방향</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>버전</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>서비스</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>밴 스코어</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1 경유</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>없음</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>인바운드</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>아웃바운드</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>일반</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>알 수 없음</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>거래액 복사</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,8 +2722,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>주소 복사(&amp;A)</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>이미지 저장(&amp;S)...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>이미지 저장(&amp;S)…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>코인 컨트롤 기능</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>입력...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>자동 선택</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>더스트:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>입력…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>수수료 이후:</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>거래 수수료:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>선택...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Smart fee가 아직 초기화 되지 않았습니다. 이 과정에는 수 블록이 소요됩니다…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>폴백수수료(fallbackfee)를 사용하는 경우 거래를 전송하는 데 수 시간, 수 일이 소요되거나 거래가 전송되지 않을 수 있습니다. 수수료를 수동으로 선택하시거나 완전한 블록체인에 승인할 때 까지 기다리실 것을 권장합니다.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>선택…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>사용자 정의:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Smart fee가 아직 초기화 되지 않았습니다. 이 과정에는 수 블록이 소요됩니다...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 을/를 종료 중입니다...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 을/를 종료 중입니다…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>올 해</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>범위...</translation>
+        <source>Range…</source>
+        <translation>범위…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>충분한 사용자를 감지하였습니다. 신호를 보내는 중입니다. ( %s 기다리기 )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>충분한 사용자를 감지하였습니다. 신호를 보내는 중입니다...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>가져오는 중...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>호환 불가 모드</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-minsporkkeys로 지정된 스포크 서명자의 최소 숫자가 유효하지 않습니다.</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>추방 리스트를 불러오는 중...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>이미 잠금 상태입니다.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>믹싱이 진행 중입니다...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>마스터노드 리스트에 없습니다.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>블록 데이터를 축소 중입니다..</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>블록 재실행 중…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>다시 스캔 중…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>네트워크 스레드 시작중…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>마스터노드에 제출, 대기열에서 기다리는 중 %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>동기화가 끝났습니다.</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>블록체인 동기화 중…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>거버넌스 객체 동기화중…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>사용자 정의 코멘트 (%s)에 안전하지 못한 글자가 포함되어 있습니다.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>지갑(들)을 검증 중...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>다시 시도할 예정입니다...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>에러: %s를 위한 디스크 공간이 부족합니다</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>오류: epollfd에 소켓을 추가하는 데 실패하였습니다 (epoll_ctl 반환 오류 %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>최대 시도 횟수를 초과하였습니다.</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>초기치 설정 중 지갑을 재 스캔하는 데 실패하였습니다</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>충분한 사용자를 감지하였습니다. 신호를 보내는 중입니다…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>유효하지 않은 P2P 허용: '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>유효하지 않은 masternodeblsprivkey 입니다. 문서를 확인하세요.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>블록 인덱스를 불러오는 중...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>지갑을 불러오는 중...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>마스터노드 대기열이 가득 찼습니다.</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>누락된 입력값 거래 정보</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>믹싱이 진행 중입니다…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>블록 축소 모드는 -txindex와 호환되지 않습니다.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>블록 데이터를 축소 중입니다..</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>섹션 [%s]이 인식되지 않습니다.</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>지정된 -walletdir "%s" 은/는 디렉토리가 아닙니다.</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>블록체인 동기화 중...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>거래액이 너무 큽니다</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>연결 시도 중...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>이 컴퓨터의 %s에 바인딩 할 수 없습니다. %s이 이미 실행 중인 것으로 보입니다.</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>UTXO 데이터베이스 업그레이드</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>블록 검증 중…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>지갑(들)을 검증 중…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>체인 상태 데이터베이스 업그레이드 중 오류가 발생했습니다.</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>오류: kqeuefd에 소켓을 추가하는 데 실패하였습니다 (kevent 반환 오류 %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>P2P 주소 불러오는 중…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>추방 리스트를 불러오는 중…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>블록 인덱스를 불러오는 중…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>지갑을 불러오는 중…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>새로운 믹싱 대기열을 시작하는 데 실패하였습니다.</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>가져오는 중…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>잘못된 -rescan 모드, 기본 값으로 돌아갑니다</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-sporkaddr로 지정된 스포크 주소가 유효하지 않습니다.</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>P2P 주소 불러오는 중...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>시스템 상 한계로 인하여 -maxconnections를 %d 에서 %d로 줄였습니다.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>블록 재실행 중...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>다시 스캔 중...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>지난 성공적 액션이 너무 최신입니다.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>네트워크 스레드 시작중...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>거버넌스 객체 동기화중...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>소스 코드는 %s 에서 확인하실 수 있습니다.</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>거래가 유효하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>연결 시도 중…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>txindex 데이터베이스 업그레이드</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>블록 검증 중...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>매우 적은 숫자의 키가 남았습니다: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>경고: 잘못된 %s 파라미터입니다. 경로가 필요합니다! 디폴트 경로를 이용합니다.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>다시 시도할 예정입니다…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_nl.ts
+++ b/src/qt/locale/dash_nl.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Vraag betaling aan (genereert QR-codes en Dash: URI's)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Opties…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Versleutel portemonnee…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Backup portemonnee…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Wijzig wachtwoordzin…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Ontgrendel portemonnee…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Onderteken &amp;bericht</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Verifieer handtekening</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Verzendadressen</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Ontvangstadressen</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Open &amp;URI</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>portemonnee openen</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Open een portemonnee</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Portemonnee sluiten...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Toon informatie over Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Opties...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;Over %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Toon of verberg het hoofdscherm</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Versleutel portemonnee...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Versleutel de geheime sleutels die behoren tot uw portemonnee</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Backup portemonnee...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Backup portemonnee naar een andere locatie</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Wijzig wachtwoordzin...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Wijzig de wachtwoordzin die wordt gebruikt voor portemonneeversleuteling</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Ontgrendel portemonnee...</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>&amp;Portemonnee vergrendelen</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Onderteken &amp;bericht</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Onderteken berichten met uw Dashadressen om te bewijzen dat u deze adressen bezit.</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Verifieer handtekening</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Toon de lijst met gebruikte ontvangstadressen en labels</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Open &amp;URI</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Command-line opties</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>Toon informatie over %1</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>Portemonnee aanmaken...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>Netwerkactiviteit is uitgeschakeld</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Kopteksten synchroniseren (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Synchroniseren met het netwerk...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Bezig met indexeren van blocks op harde schijf...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Bezig met verwerken van blocks op harde schijf...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Bezig met herindexeren van blocks op harde schijf...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Verbinden met peers...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>%n blok van transactiehistorie verwerkt.</numerusform><numerusform>%n blocks van transactiehistorie verwerkt.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 achter</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Aan het bijwerken...</translation>
+        <source>Close Wallet…</source>
+        <translation>Portemonnee sluiten…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Portemonnee aanmaken…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Kopteksten synchroniseren (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Synchroniseren met het netwerk…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Bezig met indexeren van blocks op harde schijf…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Bezig met verwerken van blocks op harde schijf…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Bezig met herindexeren van blocks op harde schijf…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Verbinden met peers…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Aan het bijwerken…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>Originele bericht:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Portemonnee &lt;b&gt;%1&lt;/b&gt; wordt aangemaakt...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Portemonnee &lt;b&gt;%1&lt;/b&gt; wordt aangemaakt…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>Aanmaken</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>Omdat dit de eerste keer is dat het programma gestart is, kunt u nu kiezen waar %1 de data moet opslaan.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Als u op OK klikt, dan zal %1 beginnen met downloaden en verwerken van de volledige %4 blokketen (%2GB) startend met de eerste transacties in %3 toen %4 initeel werd gestart.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Deze initiële synchronisatie is heel veeleisend, en kan hardware problemen met uw computer blootleggen die voorheen onopgemerkt bleven. Elke keer dat %1 gebruikt word, zal verdergegaan worden waar gebleven is.</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>Kopieer Onderpand Outpoint</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Bezig met bijwerken...</translation>
+        <source>Please wait…</source>
+        <translation>Wachten aub…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Bezig met bijwerken…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>Filter op elke eigenschap (bv. adres of protx hash)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Wachten aub...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Extra informatie voor DIP3-masternode %1</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>Aantal blocks resterend.</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Onbekend...</translation>
+        <source>Unknown…</source>
+        <translation>Onbekend…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>Berekenen…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>Vooruitgang per uur</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>Berekenen...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Geschatte tijd tot volledig synchroon</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>Verbergen</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Onbekend. Kopteksten synchroniseren (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Onbekend. Kopteksten synchroniseren (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>standaard portemonnee</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Portemonnee &lt;b&gt;%1&lt;/b&gt; wordt geopend...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Portemonnee &lt;b&gt;%1&lt;/b&gt; wordt geopend…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>Opties die in dit dialoogvenster worden ingesteld, worden overschreven door de opdrachtregel(CLI) of in het configuratiebestand:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Verberg het pictogram in het systeemvak.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;Verberg het pictogram in het systeemvak</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Minimaliseren in plaats van de applicatie af te sluiten wanneer het venster is afgesloten. Als deze optie is ingeschakeld, zal de toepassing pas worden afgesloten na het selecteren van Exit in het menu.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>De taal van de gebruikersinterface kan hier ingesteld worden. Deze instelling zal pas van kracht worden nadat %1 herstart wordt.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Is een een taal te kort of een vertaling onvolledig ? Help de vertaling hier: 
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1979,10 +1964,6 @@ Om te mixen moeten andere gebruikers exact dezelfde denominaties inbrengen.</tra
         <translation>'dash://' is geen geldige URI. Gebruik in plaats daarvan 'dash:'.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Ongeldig betalingsadres %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI kan niet verwerkt worden! Dit kan het gevolg zijn van een ongeldig Dash adres of misvormde URI parameters.</translation>
     </message>
@@ -1995,18 +1976,22 @@ Om te mixen moeten andere gebruikers exact dezelfde denominaties inbrengen.</tra
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>User Agent</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Verstuurd</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Ontvangen</translation>
     </message>
     </context>
@@ -2139,8 +2124,8 @@ Om te mixen moeten andere gebruikers exact dezelfde denominaties inbrengen.</tra
         <translation>Fout: %1 CSS-bestand(en) ontbreken in het pad -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 sloot nog niet veilig af...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 sloot nog niet veilig af…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2250,15 +2235,15 @@ Om te mixen moeten andere gebruikers exact dezelfde denominaties inbrengen.</tra
         <translation>QR-code</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Sla afbeelding op...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Sla afbeelding op…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Sla afbeelding op...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Sla afbeelding op…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2384,10 +2369,6 @@ Om te mixen moeten andere gebruikers exact dezelfde denominaties inbrengen.</tra
         <translation>Selecteer een peer om details te bekijken</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Richting</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
@@ -2494,10 +2475,6 @@ Om te mixen moeten andere gebruikers exact dezelfde denominaties inbrengen.</tra
     <message>
         <source>Services</source>
         <translation>Services</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Verbanningscore</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2624,18 +2601,6 @@ Om te mixen moeten andere gebruikers exact dezelfde denominaties inbrengen.</tra
         <translation>via %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>nooit</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Inkomend</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Uitgaand</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Regulier</translation>
     </message>
@@ -2651,7 +2616,7 @@ Om te mixen moeten andere gebruikers exact dezelfde denominaties inbrengen.</tra
         <source>Unknown</source>
         <translation>onbekend</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2747,7 +2712,7 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2759,8 +2724,8 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Kopieer &amp;adres</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Sla afbeelding op...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Sla afbeelding op…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2813,10 +2778,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Coin controleopties</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Inputs...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>automatisch geselecteerd</translation>
     </message>
@@ -2845,6 +2806,10 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Stof:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Inputs…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Na vergoeding:</translation>
     </message>
@@ -2865,8 +2830,8 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Transactiekosten</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Kies...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Slimme kosten zijn nog niet geïnitialiseerd Dit duurt meestal een paar blocks …)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2883,6 +2848,10 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Het gebruik van de terugval vergoeding kan resulteren in het verzenden van een transactie die enkele uren of dagen (of nooit) duurt om te bevestigen. Overweeg uw tarief handmatig te kiezen of wacht tot u de volledige keten hebt gevalideerd.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Kies…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2903,10 +2872,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
     <message>
         <source>Custom:</source>
         <translation>Aangepast:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Slimme kosten zijn nog niet geïnitialiseerd Dit duurt meestal een paar blocks ...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3179,8 +3144,8 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 is aan het afsluiten...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 is aan het afsluiten…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3709,8 +3674,8 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Dit jaar</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Bereik...</translation>
+        <source>Range…</source>
+        <translation>Bereik…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4047,14 +4012,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Voldoende gebruikers gevonden, aan het ondertekenen ( wacht %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Voldoende gebruikers gevonden, aan het ondertekenen ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Importeren...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Incompatibele modus.</translation>
     </message>
@@ -4087,16 +4044,8 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Ongeldig minumum aantal spork ondertekenaars zoals ingesteld met -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Verbanningslijst aan het laden...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Vergrendeling is al op zijn plaats.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Bezig met mixen...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4119,12 +4068,36 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Niet in de Masternode lijst.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Terugsnoeien blockstore…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Replaying blocks…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Opnieuw scannen…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Netwerkthread starten…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Ingediend bij masternode, wachten in de wachtrij %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Synchronisatie voltooid</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Blokketen aan het synchronizeren…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Synchroniseren governance objecten…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4137,14 +4110,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>User Agentcommentaar (%s) bevat onveilige karakters.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Portemonnee(s) verifiëren..... </translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Opnieuw aan het proberen...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4263,10 +4228,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Fout: Schijfruimte is laag voor %s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Fout: kan geen socket toevoegen aan epollfd (epoll_ctl geeft fout %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Maximum aantal pogingen overschreden.</translation>
     </message>
@@ -4291,6 +4252,10 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Het herscannen van de portemonnee is mislukt tijdens het initialiseren</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Voldoende gebruikers gevonden, aan het ondertekenen…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>Ongeldige P2P machtiging: '%s'</translation>
     </message>
@@ -4303,14 +4268,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Ongeldige masternodeblsprivkey. Zie documentatie.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Laden blokindex...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Laden portemonnee...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Masternode wachtrij is vol.</translation>
     </message>
@@ -4321,6 +4278,10 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
     <message>
         <source>Missing input transaction information.</source>
         <translation>De input transactieinformatie ontbreekt.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Bezig met mixen…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4351,10 +4312,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Terugsnoeimodus is niet compatibel met -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Terugsnoeien blockstore...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>Sectie [%s] wordt niet herkend.</translation>
     </message>
@@ -4369,10 +4326,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Opgegeven -walletdir "%s" is geen map</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Blokketen aan het synchronizeren...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4407,10 +4360,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Transactie te groot</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Proberen te verbinden...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Niet in staat om %s te verbinden op deze computer. %s draait waarschijnlijk al.</translation>
     </message>
@@ -4429,6 +4378,14 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Upgraden UTXO-database</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>blocks aan het controleren…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Portemonnee(s) verifiëren….. </translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4579,8 +4536,20 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Fout bij het upgraden van de ketenstaat database</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Fout: kan socket niet toevoegen aan kqueuefd (kevent geeft fout %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>P2P-adressen aan het laden…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Verbanningslijst aan het laden…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Laden blokindex…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Laden portemonnee…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4619,6 +4588,10 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Het is niet gelukt om een nieuwe mixwachtrij te starten</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Importeren…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Onjuiste -rescan modus, er wordt terug gevallen op de standaardwaarde</translation>
     </message>
@@ -4647,20 +4620,8 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Ongeldig sporkadres opgegeven met -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>P2P-adressen aan het laden...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Verminder -maxconnections van %d naar %d, vanwege systeembeperkingen.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Replaying blocks...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Opnieuw scannen...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4691,14 +4652,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Vorige succesvolle actie is te recent.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Netwerkthread starten...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Synchroniseren governance objecten...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>De broncode is beschikbaar van %s.</translation>
     </message>
@@ -4725,6 +4678,10 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
     <message>
         <source>Transaction not valid.</source>
         <translation>Transactie is niet geldig.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Proberen te verbinden…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4759,10 +4716,6 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
         <translation>Upgraden txindex database</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>blocks aan het controleren...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Het aantal resterende sleutels is heel laag: %d</translation>
     </message>
@@ -4777,6 +4730,10 @@ Nota: Het bericht zal niet verzonden worden met de betaling over het Dash netwer
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Waarschuwing: onjuiste parameter %s, pad moet bestaan! Standaard pad wordt gebruikt</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Opnieuw aan het proberen…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_pl.ts
+++ b/src/qt/locale/dash_pl.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Poproś o płatności (generuje kod QR oraz dash: link)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Opcje…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>Zaszyfruj Portf&amp;el</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>Wykonaj kopię zapasową…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Zmień hasło…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>Odblok&amp;uj Portfel</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Podpisz wiado&amp;mość…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Zweryfikuj wiadomość…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Adresy wysyłające</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Adresy odbiorcze</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Otwórz &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Otwórz Portfel</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Otwórz portfel</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Zamknij Portfel...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Pokaż informacje o Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Opcje...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;O %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Pokazuje lub ukrywa główne okno</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>Zaszyfruj Portf&amp;el</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Szyfruj klucze prywatne, dla twojego portfela</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>Wykonaj kopię zapasową...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Zapisz kopię zapasową portfela w innym miejscu</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Zmień hasło...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Zmień hasło użyte do zaszyfrowania portfela</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>Odblok&amp;uj Portfel</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>Zab&amp;lokuj Porftel</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Podpisz wiado&amp;mość...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Podpisz wiadomości swoim adresem Dash, aby udowodnić, że jesteś ich właścicielem. </translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Zweryfikuj wiadomość...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Pokaż listę użytych adresów odbiorczych i etykiety</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Otwórz &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Opcje konsoli</translation>
     </message>
@@ -586,10 +585,6 @@
         <translation>Otwórz dash: URI</translation>
     </message>
     <message>
-        <source>Create Wallet...</source>
-        <translation>Stwórz Portfel...</translation>
-    </message>
-    <message>
         <source>Create a new wallet</source>
         <translation>Stwórz nowy portfel</translation>
     </message>
@@ -629,30 +624,6 @@
         <source>Network activity disabled</source>
         <translation>Aktywność sieci jest wyłączona</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Synchronizacja nagłówków (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Synchronizacja z siecią...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indeksowanie bloków na dysku...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Przetwarzanie bloków na dysku...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Ponowne indeksowanie bloków na dysku...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Łączenie z peerami</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>Pobrano %n blok z historią transakcji.</numerusform><numerusform>Pobranych zostało %n bloki z historią transakcji.</numerusform><numerusform>Pobranych zostało %n bloków z historią transakcji.</numerusform><numerusform>Pobrano %n bloków z historią transakcji.</numerusform></translation>
@@ -662,8 +633,40 @@
         <translation>%1 wstecz</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Pobieranie bloków ...</translation>
+        <source>Close Wallet…</source>
+        <translation>Zamknij Portfel…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Stwórz Portfel…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Synchronizacja nagłówków (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Synchronizacja z siecią…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indeksowanie bloków na dysku…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Przetwarzanie bloków na dysku…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Ponowne indeksowanie bloków na dysku…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Łączenie z peerami</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Pobieranie bloków …</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -787,7 +790,7 @@
         <source>Original message:</source>
         <translation>Oryginalna wiadomość:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -982,8 +985,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Tworzenie Portfela &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Tworzenie Portfela &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1032,7 +1035,7 @@
         <source>Create</source>
         <translation>Stwórz</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1176,10 +1179,6 @@
         <translation>Ponieważ jest to pierwsze uruchomienie programu, możesz wybrać gdzie %1 będzie przechowywał swoje dane.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Gdy naciśniesz OK, %1 zacznie się pobieranie i przetwarzanie całego %4 łańcucha bloków (%2GB) zaczynając od najwcześniejszych transakcji w %3 gdy %4 został uruchomiony. </translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Wstępna synchronizacja jest bardzo wymagająca i może ujawnić wcześniej niezauważone problemy sprzętowe. Za każdym uruchomieniem %1 pobieranie będzie kontynuowane od miejsca w którym zostało zatrzymane.</translation>
     </message>
@@ -1303,8 +1302,12 @@
         <translation>Skopiuj Collateral punkt wyjscia</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>aktualizowanie...</translation>
+        <source>Please wait…</source>
+        <translation>Poczekaj chwilę…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>aktualizowanie…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1339,10 +1342,6 @@
         <translation>Filtruj według dowolnej właściwości (np. adres lub protx hash)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Poczekaj chwilę...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Dodatkowe informacje dla DIP3 Masternode %1</translation>
     </message>
@@ -1366,8 +1365,12 @@
         <translation>Ilość pozostałych bloków</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Nieznany...</translation>
+        <source>Unknown…</source>
+        <translation>Nieznany…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>obliczanie…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1382,10 +1385,6 @@
         <translation>Wzrost postępu na godzinę</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>obliczanie...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Przybliżony czas do synchronizacji</translation>
     </message>
@@ -1394,8 +1393,8 @@
         <translation>Ukryj</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Nieznany. Synchronizowanie Nagłówków (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Nieznany. Synchronizowanie Nagłówków (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1424,8 +1423,8 @@
         <translation>domyślny portfel</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Otwieranie Portfela &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Otwieranie Portfela &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1583,14 +1582,6 @@
         <translation>Opcje ustawione w tym oknie są zastępowane przez wiersz poleceń lub w pliku konfiguracyjnym:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Ukryj ikonę na pasku zadań.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>Ukryj ikonę na pasku zadań</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Minimalizuje zamiast zakończyć działanie programu przy zamknięciu okna. Kiedy ta opcja jest włączona, program zakończy działanie po wybraniu Zamknij w menu.</translation>
     </message>
@@ -1697,12 +1688,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>Tu możesz ustawić język interfejsu. Zmiana stanie się aktywna po ponownym uruchomieniu %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Dash Core nie został przetłumaczony na Twój język? Tłumaczenie jest niepełne lub niepoprawne? Możesz pomóc nam tłumaczyć tutaj:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -2014,10 +1999,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ze względu na wycofanie wsparcia należy poprosić sprzedawcę o dostarczenie identyfikatora URI zgodnego z BIP21 lub skorzystać z portfela, który nadal obsługuje BIP70.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Nieprawidłowy adres płatności %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI nie może zostać przeanalizowany! Mogło to być spowodowane przez niewłaściwy adres Dash lub niewłaściwe parametry URI</translation>
     </message>
@@ -2030,18 +2011,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Agent użytkownika</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Wysłany</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Otrzymany</translation>
     </message>
     </context>
@@ -2174,8 +2159,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Błąd: nie można znaleźć %1 plik(ów) CSS na ścieżce -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 jeszcze się bezpiecznie nie zamknął...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 jeszcze się bezpiecznie nie zamknął…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2285,15 +2270,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Kod QR</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Zapisz obraz...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Zapisz obraz…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Zapisz obraz...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Zapisz obraz…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2419,10 +2404,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Wybierz peera aby zobaczyć jego szczegółowe informacje.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Kierunek</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
@@ -2529,10 +2510,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Usługi</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>zablokuj wynik</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2659,22 +2636,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>przez %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>nigdy</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>przychodzące</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>wychodzące</translation>
-    </message>
-    <message>
-        <source>Outbound block-relay</source>
-        <translation>Wychodzący przekaźnik blokowy</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Regularny</translation>
     </message>
@@ -2690,7 +2651,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>nieznane</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2789,7 +2750,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Kopiuj kwotę</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2801,8 +2762,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Kopiuj &amp;Adres</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Zapisz obraz...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Zapisz obraz…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2855,10 +2816,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Funkcje sterowania monetami</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Wejścia...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>zaznaczone automatycznie</translation>
     </message>
@@ -2887,6 +2844,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Pył</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Wejścia…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Po opłacie:</translation>
     </message>
@@ -2907,16 +2868,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Opłata za transakcję:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Wybierz...</translation>
-    </message>
-    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
         <translation>Gdy wolumen transakcji jest mniejszy niż miejsce w blokach, górnicy oraz węzły przekazujące mogą narzucić minimalną opłatę. Płacenie tylko tej minimalnej opłaty jest w porządku, ale należy pamiętać, że może to spowodować, że transakcja nigdy nie zostanie potwierdzone gdy pojawi się większe zapotrzebowanie na transakcje Dash, niż sieć może przetworzyć.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation>Zbyt niska opłata może spowodować, że transakcja nigdy nie zostanie potwierdzona (przeczytaj wskazówkę)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Opłata smart nie została jeszcze zainicjonowana. Zazwyczaj zajmuje to kilka bloków…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2933,6 +2894,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Używając opcji fallbackfee może sprawić, że transakcja nie zostanie potwierdzona przez kilka godzin, dni, lub nigdy. Pomyśl nad ręcznym wybraniem wysokości opłaty, lub poczekaj pełną walidację łańcucha.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Wybierz…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2953,10 +2918,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Niestandardowo:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Opłata smart nie została jeszcze zainicjonowana. Zazwyczaj zajmuje to kilka bloków...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3107,10 +3068,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>lub</translation>
     </message>
     <message>
-        <source>To review recipient list click "Show Details..."</source>
-        <translation>Aby przejrzeć listę odbiorców, kliknij „Pokaż szczegóły…”</translation>
-    </message>
-    <message>
         <source>Confirm send coins</source>
         <translation>Potwierdź wysyłanie monet</translation>
     </message>
@@ -3121,6 +3078,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Send</source>
         <translation>Wyślij</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation>Aby przejrzeć listę odbiorców, kliknij „Pokaż szczegóły…”</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
@@ -3261,8 +3222,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 się zamyka...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 się zamyka…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3791,8 +3752,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>W tym roku</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Zakres...</translation>
+        <source>Range…</source>
+        <translation>Zakres…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4149,14 +4110,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Znaleziono wystarczającą ilość użytkowników, trwa podoposywanie ( poczekaj %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Znaleziono wystarczającą ilość użytkowników, zapisuje ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Importuje...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Niekompatybilny tryb.</translation>
     </message>
@@ -4189,16 +4142,8 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Nieważna  minimalna liczba osób podpisujących sporka ustawiona z -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Ładuję listę blokowanych...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Transakcja została już zamknięta.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>W trakcie mieszania...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4221,12 +4166,36 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Nie istnieje na liście masternodów.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Kasuję stare bloki …</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Odtwarzanie bloków …</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Ponowne skanowanie…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Uruchamianie wątków sieciowych…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Przesłano do masterdnoda, czekaj na swoją kolej %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Synchronizacja zakończona</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Synchronizuje blockchain…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Synchronizuję obiekty zarządzania…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4239,14 +4208,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Komentarz agenta użytkownika (%s) zawiera znaki które nie są bezpieczne.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Weryfikuje portfel(e)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Spróbuje ponownie...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4365,10 +4326,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Błąd: Nie ma wystarczająco miejsca na dysku dla %s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Błąd: Nie powiodło się dodanie socket do epollfd (epll_ctl zwróciło błąd %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Przekroczona została maksymalna liczba prób</translation>
     </message>
@@ -4397,6 +4354,10 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Nie udało się zweryfikować bazy danych</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Znaleziono wystarczającą ilość użytkowników, zapisuje…</translation>
+    </message>
+    <message>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation>Ignorowanie duplikatu -portfel %s.</translation>
     </message>
@@ -4413,14 +4374,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Niewłaściwy masternodeblsprivkey. Sprawdź dokumentacje.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Wczytuję indeks bloków</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Ładuję portfel...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Kolejka masternodów jest pełna.</translation>
     </message>
@@ -4431,6 +4384,10 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
     <message>
         <source>Missing input transaction information.</source>
         <translation>Brak informacji o transakcji wejściowej.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>W trakcie mieszania…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4459,10 +4416,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation>Tryb obcinania jest niekompatybilny z -txindex.</translation>
-    </message>
-    <message>
-        <source>Pruning blockstore...</source>
-        <translation>Kasuję stare bloki ...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -4497,10 +4450,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Wyznaczona komenda -walletdir "%s" nie jest katalogiem danych</translation>
     </message>
     <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Synchronizuje blockchain...</translation>
-    </message>
-    <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
         <translation>Portfel będzie unikał płacenia mniejszej niż przekazana opłaty.</translation>
     </message>
@@ -4533,10 +4482,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Za duża transakcja</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Staram się połączyć</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Nie można przywiązać do %s na tym komputerze. %s prawdopodobnie jest już uruchomiony.</translation>
     </message>
@@ -4555,6 +4500,14 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Aktualizowanie bazy danych UTXO</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Weryfikacja bloków…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Weryfikuje portfel(e)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4705,8 +4658,20 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Błąd ładowania bazy bloków</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Błąd: Nie powiodło się dodanie socket do kqueuefd (kevent zwróciło błąd %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Wczytywanie adresów P2P…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Ładuję listę blokowanych…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Wczytuję indeks bloków</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Ładuję portfel…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4745,6 +4710,10 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Próba stworzenia kolejki do mieszania monet zakończyła się niepowodzeniem</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Importuje…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Nieprawidłowy tryb -rescan, powrót do wartości domyślnie.</translation>
     </message>
@@ -4773,20 +4742,8 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Nieważny adres spork ustawiony z -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Wczytywanie adresów P2P...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Zmniejsz -maxconnections z %d do %d, z powodu ograniczeń systemowych.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Odtwarzanie bloków ...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Ponowne skanowanie...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4817,14 +4774,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Za mało czasu upłynęło od ostatniej udanej transakcji.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Uruchamianie wątków sieciowych...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Synchronizuję obiekty zarządzania...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>Kod źródłowy dostępny jest z %s.</translation>
     </message>
@@ -4851,6 +4800,10 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
     <message>
         <source>Transaction not valid.</source>
         <translation>Transakcja niewłaściwa.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Staram się połączyć</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4885,10 +4838,6 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
         <translation>Aktualizowanie bazy danych txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Weryfikacja bloków...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Pozostało bardzo mało kluczy: %d</translation>
     </message>
@@ -4903,6 +4852,10 @@ Przejdź do Plik &gt; Otwórz portfel, aby załadować portfel.
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Uwaga: błędne parametry %s, ścieżka musi być poprawna! Używając domyślnie ścieżki.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Spróbuje ponownie…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_pt.ts
+++ b/src/qt/locale/dash_pt.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Solicitações de pagamentos (gera códigos QR e Dash: URIs)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Opções…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Criptografar Carteira…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>Fazer &amp;Backup da Carteira…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>Alterar frase de segurança</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Desbloquear carteira…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Assinar &amp;Mensagem…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Verificar mensagem…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Endereços de envio</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Endereços de recebimento</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Abrir &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Abrir Carteira</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Abrir uma carteira</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Fechar Carteira...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Exibe informações sobre Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Opções...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;Sobre %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Mostrar ou esconder a Janela Principal.</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Criptografar Carteira...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Criptografar as chaves privadas que pertencem à sua carteira</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>Fazer &amp;Backup da Carteira...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Faça o Backup da carteira para outro local</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>Alterar frase de segurança</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Mudar a frase de segurança utilizada na criptografia da carteira</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Desbloquear carteira...</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>Bloquear carteira</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Assinar &amp;Mensagem...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Assine mensagens com seus endereços Dash para provar que você é dono delas</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Verificar mensagem...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Mostrar a lista de endereços de recebimento usados ​​e rótulos</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Abrir &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>Opções de linha de &amp;comando</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>Mostrar informação sobre %1</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>Criar Carteira...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>Atividade da rede disativada</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Sincronizando cabeçahos (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Sincronizando com a rede...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indexando blocos no disco...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Processando blocos no disco...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Reindexando blocos no disco...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Conectando...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>Processados %n blocos do histórico de transações.</numerusform><numerusform>Processados %n blocos do histórico de transações.</numerusform><numerusform>Processados %n blocos do histórico de transações.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 atrás</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Recuperando o atraso ...</translation>
+        <source>Close Wallet…</source>
+        <translation>Fechar Carteira…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Criar Carteira…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Sincronizando cabeçahos (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Sincronizando com a rede…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indexando blocos no disco…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Processando blocos no disco…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Reindexando blocos no disco…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Conectando…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Recuperando o atraso …</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>Mensagem original:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Criando Carteira &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Criando Carteira &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>Criar</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>Como essa é a primeira vez que o programa é executado, você pode escolher onde %1 armazenará seus dados.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Quando clicar OK, %1 vai começar a descarregar e processar a cadeia de blocos %4 completa (%2GB) começando com as transações mais antigas em %3 quando a %4 foi inicialmente lançada.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Esta sincronização inicial é muito exigente, e pode expor problemas com o seu computador que previamente podem ter passado despercebidos. Cada vez que corre %1, este vai continuar a descarregar de onde deixou. </translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>Copiar Outpoint Collateral</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Atualizando...</translation>
+        <source>Please wait…</source>
+        <translation>Por favor, aguarde…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Atualizando…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>Filtrar por qualquer propriedade (por exemplo, endereço ou hash protx)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Por favor, aguarde...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Informações adicionais para DIP3 Masternode %1</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>Número de blocos que faltam</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Desconhecido...</translation>
+        <source>Unknown…</source>
+        <translation>Desconhecido…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>calculando</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>Aumento do progresso por hora</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>calculando</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Tempo estimado para sincronizar</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>Esconder</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Desconhecido. Sincronizando cabeçalhos (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Desconhecido. Sincronizando cabeçalhos (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>carteira padrão</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Abrindo Carteira&lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Abrindo Carteira&lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>As opções definidas nesta caixa de diálogo são substituídas pela linha de comando ou no arquivo de configuração:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Ocultar o ícone da bandeja do sistema.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;Esconder ícone</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Minimizar em vez de sair do aplicativo quando a janela for fechada. Quando esta opção está ativada, o aplicativo só será fechado selecionando Sair no menu.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>O idioma da interface pode ser definido aqui. Essa configuração terá efeito após reiniciar o %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Idioma inexistente ou tradução incompleta? Contribua com a tradução aqui:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' não é uma URL válida. Use 'dash:' como alternativa.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Endereço de pagamento inválido %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>A URI não pode ser analisada! Isto pode ser causado por um endereço inválido ou um parâmetro URI malformado.</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>User Agent</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Enviado</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Recebido</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Erro: %1 arquivo(s) CSS ausente(s) no caminho -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 ainda não terminou com segurança...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 ainda não terminou com segurança…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Código QR</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Salvar Imagem...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Salvar Imagem…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Salvar Imagem...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Salvar Imagem…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Selecione um ponto para ver informações detalhadas.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Direção</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Serviços</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Banir pontuação</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>por %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>nunca</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Entrada</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Saída</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Usual</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>Desconhecido</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,8 +2722,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Copiar Endereço</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Salvar Imagem...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Salvar Imagem…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Opções de Controle da Moeda</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Entradas...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>automaticamente selecionado</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Poeira:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Entradas…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Depois da taxa:</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Taxa de transação</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Escolha...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Smart fee não iniciado. Isso requer alguns blocos…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Usar o fallbackfee pode resultar no envio de uma transação que levará várias horas ou dias (ou nunca) para confirmação. Considere escolher sua taxa manualmente ou espere até que você tenha validado a cadeia completa.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Escolha…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Personalizado:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Smart fee não iniciado. Isso requer alguns blocos...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 está desligando...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 está desligando…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Esse ano</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Intervalo...</translation>
+        <source>Range…</source>
+        <translation>Intervalo…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Encontrou usuários suficientes, assinando ( esperando %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Encontrou usuários suficientes, assinando ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Importando...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Modo incompatível.</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Número mínimo inválido de assinantes do spork especificados com -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Carregando lista de banidos...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Bloqueio já está no lugar.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Mixing em progresso...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Não está na lista de Masternode.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Podando (pruning) os blocos existentes…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Reproduzindo blocos…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Escaneando…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Iniciando threads de rede…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Enviado para o masternode, esperando na fila %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Sincronização finalizada</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Sincronizando o blockchain…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Sincronizando objetos de governança ….</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Comentário User Agent (%s) contém caracteres inseguros.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Verificando carteira(s)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Será feita nova tentativa...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Erro: Espaço em disco está pequeno para %s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Erro: falha ao adicionar socket ao epollfd (epoll_ctl retornou erro %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Tentativas máximas excedidas.</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Falha ao verificar novamente a carteira durante a inicialização</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Encontrou usuários suficientes, assinando…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>Permissão P2P inválida: '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Masternodeblsprivkey invalido. Por favor, veja a documentação.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Carregando índice de blocos...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Carregando carteira...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>A fila do masternode está cheia.</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Falta informação da transação de entrada.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Mixing em progresso…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>O modo prune é incompatível com -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Podando (pruning) os blocos existentes...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>A seção [%s] não é reconhecida.</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>O diretório especificado -walletdir "%s" não é um diretório</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Sincronizando o blockchain...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Transação muito grande</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Tentando se conectar...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Impossível vincular a %s neste computador. O %s provavelmente já está rodando.</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Atualizando banco de dados UTXO</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Verificando blocos…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Verificando carteira(s)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Erro ao atualizar banco de dados do chainstate</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Erro: falha ao adicionar socket ao kqueuefd (kevent retornou erro %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>A carregar endereços de P2P…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Carregando lista de banidos…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Carregando índice de blocos…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Carregando carteira…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Falha ao iniciar uma nova fila de mistura</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Importando…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Modo -rescan incorreto, retornando ao valor padrão</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Endereço de spork inválido especificado com -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>A carregar endereços de P2P...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Reduzindo -maxconnections de %d para %d, devido à limitações do sistema.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Reproduzindo blocos...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Escaneando...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>A última acção é muito recente.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Iniciando threads de rede...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Sincronizando objetos de governança ....</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>O código fonte está disponível pelo %s.</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>Transação inválida.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Tentando se conectar…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Atualizando o banco de dados txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Verificando blocos...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Número muito baixo de chaves restantes: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Aviso: parâmetro %s incorreto, o caminho deve existir! Usando o caminho padrão.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Será feita nova tentativa…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_ro.ts
+++ b/src/qt/locale/dash_ro.ts
@@ -1,4 +1,4 @@
-<TS language="ro" version="2.1">
+<TS version="2.1" language="ro">
 <context>
     <name>AddressBookPage</name>
     <message>
@@ -74,10 +74,6 @@
         <translation>Acestea sunt adresele tale Dash pentru efectuarea platilor. Intotdeauna verifica atent suma de plata si adresa beneficiarului inainte de a trimite monede.</translation>
     </message>
     <message>
-        <source>These are your Dash addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation>Acestea sunt adresele tale Dash pentru receptionarea platilor. Este recomandat sa folosesti mereu o adresa noua pentru primirea platilor.</translation>
-    </message>
-    <message>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copiază adresa</translation>
     </message>
@@ -102,16 +98,13 @@
         <translation>Exportă listă de adrese</translation>
     </message>
     <message>
-        <source>Comma separated file (*.csv)</source>
-        <translation>Fisier .csv cu separator - virgula</translation>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation>A apărut o eroare la salvarea listei de adrese la %1. Vă rugăm să încercaţi din nou.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
         <translation>Export nereusit</translation>
-    </message>
-    <message>
-        <source>There was an error trying to save the address list to %1. Please try again.</source>
-        <translation>A apărut o eroare la salvarea listei de adrese la %1. Vă rugăm să încercaţi din nou.</translation>
     </message>
 </context>
 <context>
@@ -151,10 +144,6 @@
         <translation>Repetaţi noua frază de acces</translation>
     </message>
     <message>
-        <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Introduceţi noua parolă a portofelului electronic.&lt;br/&gt;Vă rugăm să folosiţi o parolă de&lt;b&gt;minimum 10 caractere aleatoare&lt;/b&gt;, sau &lt;b&gt;minimum 8 cuvinte&lt;/b&gt;.</translation>
-    </message>
-    <message>
         <source>Encrypt wallet</source>
         <translation>Criptare portofel</translation>
     </message>
@@ -171,20 +160,8 @@
         <translation>Deblocare portofel</translation>
     </message>
     <message>
-        <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
-        <translation>Această acţiune necesită introducerea parolei de acces pentru decriptarea portofelului.</translation>
-    </message>
-    <message>
-        <source>Decrypt wallet</source>
-        <translation>Decriptare portofel</translation>
-    </message>
-    <message>
         <source>Change passphrase</source>
         <translation>Schimbă fraza de acces</translation>
-    </message>
-    <message>
-        <source>Enter the old passphrase and new passphrase to the wallet.</source>
-        <translation>Introduceţi vechea şi noua parolă pentru portofel.</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
@@ -231,10 +208,6 @@
         <translation>Fraza de acces introdusă pentru decriptarea portofelului a fost incorectă.</translation>
     </message>
     <message>
-        <source>Wallet decryption failed</source>
-        <translation>Decriptarea portofelului a esuat.</translation>
-    </message>
-    <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Parola portofelului a fost schimbata.</translation>
     </message>
@@ -258,23 +231,10 @@
     <name>BitcoinAmountField</name>
     </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
-    <message>
-        <source>A fatal error occurred. Dash Core can no longer continue safely and will quit.</source>
-        <translation>A apărut o eroare fatală. Dash Core nu mai poate continua în siguranță și se va opri.</translation>
-    </message>
-    <message>
-        <source>Dash Core</source>
-        <translation>Dash Core</translation>
-    </message>
-    <message>
-        <source>Wallet</source>
-        <translation>Portofel</translation>
-    </message>
-    <message>
-        <source>Node</source>
-        <translation>Nod</translation>
-    </message>
     <message>
         <source>&amp;Overview</source>
         <translation>&amp;Imagine de ansamblu</translation>
@@ -298,6 +258,38 @@
     <message>
         <source>Request payments (generates QR codes and dash: URIs)</source>
         <translation>Cereţi plăţi (generează coduri QR şi Dash-uri: URls)</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Opţiuni…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>Cript&amp;ează portofelul…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Fă o copie de siguranță a  portofelului…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>S&amp;chimbă parola…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Deblochează portofelul</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Semnează &amp;mesaj…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Verifică mesaj…</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation>Deschide &amp;URI…</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -324,20 +316,12 @@
         <translation>Închide aplicaţia</translation>
     </message>
     <message>
-        <source>Show information about Dash Core</source>
-        <translation>Arată informații despre Dash Core</translation>
-    </message>
-    <message>
         <source>About &amp;Qt</source>
         <translation>Despre &amp;Qt</translation>
     </message>
     <message>
         <source>Show information about Qt</source>
         <translation>Arată informaţii despre Qt</translation>
-    </message>
-    <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Opţiuni...</translation>
     </message>
     <message>
         <source>&amp;About %1</source>
@@ -356,32 +340,16 @@
         <translation>Arată sau ascunde fereastra principală</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>Cript&amp;ează portofelul...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Criptează cheile private ale portofelului dvs.</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Fă o copie de siguranță a  portofelului...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Creează o copie de rezervă a portofelului într-o locaţie diferită</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>S&amp;chimbă parola...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Schimbă fraza de acces folosită pentru criptarea portofelului</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Deblochează portofelul</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -392,16 +360,8 @@
         <translation>Blochează portofelul</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Semnează &amp;mesaj...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Semnaţi mesaje cu adresa dvs. Dash pentru a dovedi că vă aparţin</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Verifică mesaj...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -418,10 +378,6 @@
     <message>
         <source>&amp;Debug console</source>
         <translation>&amp;Consola pentru debug </translation>
-    </message>
-    <message>
-        <source>Open debugging console</source>
-        <translation>Deshide consola pentru debugging</translation>
     </message>
     <message>
         <source>&amp;Network Monitor</source>
@@ -464,28 +420,12 @@
         <translation>Afișează backup-urile create în mod automat în portofel</translation>
     </message>
     <message>
-        <source>&amp;Sending addresses...</source>
-        <translation>Adrese de trimitere...</translation>
-    </message>
-    <message>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Arată lista de adrese trimise şi etichetele folosite.</translation>
     </message>
     <message>
-        <source>&amp;Receiving addresses...</source>
-        <translation>&amp;Adrese de primire...</translation>
-    </message>
-    <message>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Arată lista de adrese pentru primire şi etichetele</translation>
-    </message>
-    <message>
-        <source>Open &amp;URI...</source>
-        <translation>Deschide &amp;URI...</translation>
-    </message>
-    <message>
-        <source>Open a dash: URI or payment request</source>
-        <translation>Deschidere Dash: o adresa URI sau o cerere de plată</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
@@ -508,10 +448,6 @@
         <translation>&amp;Setări</translation>
     </message>
     <message>
-        <source>&amp;Tools</source>
-        <translation>&amp;Unelte</translation>
-    </message>
-    <message>
         <source>&amp;Help</source>
         <translation>A&amp;jutor</translation>
     </message>
@@ -527,30 +463,6 @@
         <source>Network activity disabled</source>
         <translation>Activitatea retelei a fost oprita.</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Se sincronizeaza Header-ele (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Se sincronizează cu reţeaua...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Se indexează blocurile pe disc...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Se proceseaza blocurile pe disc...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Se reindexează blocurile pe disc...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Se conecteaza cu alte noduri...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>%n block procesat de istorie a tranzacțiilor</numerusform><numerusform>%n block-uri procesate de istorie a tranzacțiilor</numerusform><numerusform>Processed %n blocks of transaction history.</numerusform></translation>
@@ -560,8 +472,32 @@
         <translation>%1 în urmă</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Se actualizează...</translation>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Se sincronizeaza Header-ele (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Se sincronizează cu reţeaua…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Se indexează blocurile pe disc…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Se proceseaza blocurile pe disc…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Se reindexează blocurile pe disc…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Se conecteaza cu alte noduri…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Se actualizează…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -669,7 +605,7 @@
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portofelul este &lt;b&gt;criptat&lt;/b&gt; iar în momentul de faţă este &lt;b&gt;blocat&lt;/b&gt;</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -838,6 +774,12 @@
     </message>
 </context>
 <context>
+    <name>CreateWalletActivity</name>
+    </context>
+<context>
+    <name>CreateWalletDialog</name>
+    </context>
+<context>
     <name>EditAddressDialog</name>
     <message>
         <source>Edit Address</source>
@@ -876,10 +818,6 @@
         <translation>Adresa introdusă "%1" nu este o adresă Dash validă</translation>
     </message>
     <message>
-        <source>The entered address "%1" is already in the address book.</source>
-        <translation>Adresa introdusă "%1" se află deja în lista de adrese.</translation>
-    </message>
-    <message>
         <source>Could not unlock wallet.</source>
         <translation>Portofelul nu a putut fi deblocat.</translation>
     </message>
@@ -912,14 +850,13 @@
     </message>
 </context>
 <context>
+    <name>GovernanceList</name>
+    </context>
+<context>
     <name>HelpMessageDialog</name>
     <message>
         <source>version</source>
         <translation>versiune</translation>
-    </message>
-    <message>
-        <source>(%1-bit)</source>
-        <translation>(%1-bit)</translation>
     </message>
     <message>
         <source>About %1</source>
@@ -945,10 +882,6 @@
         <translation>Deoarece este prima lansare a programului poți alege unde %1 va stoca datele sale.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Cand apasati OK, %1 va incepe descarcarea si procesarea intregului %4 blockchain (%2GB) incepand cu cele mai vechi tranzactii din %3 de la lansarea initiala a %4.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Sincronizarea initiala necesita foarte multe resurse, si poate releva probleme de hardware ale computerului care anterior au trecut neobservate. De fiecare data cand rulati %1, descarcarea va continua de unde a fost intrerupta.</translation>
     </message>
@@ -963,6 +896,14 @@
     <message>
         <source>Use a custom data directory:</source>
         <translation>Foloseşte un dosar de date personalizat:</translation>
+    </message>
+    <message>
+        <source>%1 GB of free space available</source>
+        <translation>%1 GB de spațiu liber disponibil</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation>(din %1 GB necesar)</translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -988,14 +929,6 @@
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
-    <message>
-        <source>%1 GB of free space available</source>
-        <translation>%1 GB de spațiu liber disponibil</translation>
-    </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation>(din %1 GB necesar)</translation>
-    </message>
 </context>
 <context>
     <name>MasternodeList</name>
@@ -1006,10 +939,6 @@
     <message>
         <source>Status</source>
         <translation>Stare</translation>
-    </message>
-    <message>
-        <source>0</source>
-        <translation>0</translation>
     </message>
     <message>
         <source>Filter List:</source>
@@ -1131,8 +1060,12 @@
         <translation>Numarul de blocuri ramase</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Necunoscut...</translation>
+        <source>Unknown…</source>
+        <translation>Necunoscut…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>calculeaza…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1147,10 +1080,6 @@
         <translation>Cresterea progresului per ora</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>calculeaza...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Timp estimat pana la sincronizare</translation>
     </message>
@@ -1158,11 +1087,7 @@
         <source>Hide</source>
         <translation>Ascunde</translation>
     </message>
-    <message>
-        <source>Unknown. Syncing Headers (%1)...</source>
-        <translation>Necunoscut. Se sincronizeaza headerele (%1)...</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1170,22 +1095,13 @@
         <translation>Deschide URI</translation>
     </message>
     <message>
-        <source>Open payment request from URI or file</source>
-        <translation>Deschideţi cerere de plată prin intermediul adresei URI sau a fişierului</translation>
-    </message>
-    <message>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
-    <message>
-        <source>Select payment request file</source>
-        <translation>Selectaţi fişierul cerere de plată</translation>
-    </message>
-    <message>
-        <source>Select payment request file to open</source>
-        <translation>Selectati care fisier de cerere de plata va fi deschis</translation>
-    </message>
 </context>
+<context>
+    <name>OpenWalletActivity</name>
+    </context>
 <context>
     <name>OptionsDialog</name>
     <message>
@@ -1199,10 +1115,6 @@
     <message>
         <source>Size of &amp;database cache</source>
         <translation>Mărimea bazei de &amp;date cache</translation>
-    </message>
-    <message>
-        <source>MB</source>
-        <translation>MB</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
@@ -1317,10 +1229,6 @@
         <translation>Tor</translation>
     </message>
     <message>
-        <source>Connect to the Dash network through a separate SOCKS5 proxy for Tor hidden services.</source>
-        <translation>Conectare la reteaua Dash printr-un proxy SOCKS5 separat pentru serviciile TOR ascunse.</translation>
-    </message>
-    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Afişează doar un icon in tray la ascunderea ferestrei</translation>
     </message>
@@ -1345,12 +1253,6 @@
         <translation>Limba interfeţei utilizatorului poate fi setată aici. Această setare va avea efect după repornirea %1.</translation>
     </message>
     <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Limba lipsă sau traducerea incompletă? Ajută contribuind traduceri aici:
-https://www.transifex.com/projects/p/dash/</translation>
-    </message>
-    <message>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unitatea de măsură pentru afişarea sumelor:</translation>
     </message>
@@ -1361,10 +1263,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Decimal digits</source>
         <translation>Zecimale</translation>
-    </message>
-    <message>
-        <source>Active command-line options that override above options:</source>
-        <translation>Opţiuni linie de comandă active care oprimă opţiunile de mai sus:</translation>
     </message>
     <message>
         <source>Reset all client options to default.</source>
@@ -1599,6 +1497,9 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
 </context>
 <context>
+    <name>PSBTOperationsDialog</name>
+    </context>
+<context>
     <name>PaymentServer</name>
     <message>
         <source>Payment request error</source>
@@ -1613,14 +1514,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Gestionare URI</translation>
     </message>
     <message>
-        <source>Payment request fetch URL is invalid: %1</source>
-        <translation>URL-ul cererii de plată preluat nu este valid: %1</translation>
-    </message>
-    <message>
-        <source>Invalid payment address %1</source>
-        <translation>Adresă pentru plată invalidă %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI nu poate fi analizat! Acest lucru poate fi cauzat de o adresă Dash invalidă sau parametri URI deformaţi.</translation>
     </message>
@@ -1628,91 +1521,31 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Payment request file handling</source>
         <translation>Manipulare fişier cerere de plată</translation>
     </message>
-    <message>
-        <source>Payment request file cannot be read! This can be caused by an invalid payment request file.</source>
-        <translation>Fişierul cerere de plată nu poate fi citit! Cauza poate fi un fişier cerere de plată nevalid.</translation>
-    </message>
-    <message>
-        <source>Payment request rejected</source>
-        <translation>Cerere de plată refuzată</translation>
-    </message>
-    <message>
-        <source>Payment request network doesn't match client network.</source>
-        <translation>Cererea de plată din reţea nu se potriveşte cu clientul din reţea</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation>Cerere de plată expirata</translation>
-    </message>
-    <message>
-        <source>Payment request is not initialized.</source>
-        <translation>Cererea de plată nu este iniţializată.</translation>
-    </message>
-    <message>
-        <source>Unverified payment requests to custom payment scripts are unsupported.</source>
-        <translation>Cererile nesecurizate către scripturi personalizate de plăți nu sunt suportate</translation>
-    </message>
-    <message>
-        <source>Invalid payment request.</source>
-        <translation>Cerere de plată invalidă.</translation>
-    </message>
-    <message>
-        <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation>Suma cerută de plată de %1 este prea mică (considerată praf).</translation>
-    </message>
-    <message>
-        <source>Refund from %1</source>
-        <translation>Rambursare de la %1</translation>
-    </message>
-    <message>
-        <source>Payment request %1 is too large (%2 bytes, allowed %3 bytes).</source>
-        <translation>Cererea de plată %1 este prea mare (%2 octeţi, permis %3 octeţi).</translation>
-    </message>
-    <message>
-        <source>Error communicating with %1: %2</source>
-        <translation>Eroare la comunicarea cu %1: %2</translation>
-    </message>
-    <message>
-        <source>Payment request cannot be parsed!</source>
-        <translation>Cererea de plată nu poate fi analizată!</translation>
-    </message>
-    <message>
-        <source>Bad response from server %1</source>
-        <translation>Răspuns greşit de la server %1</translation>
-    </message>
-    <message>
-        <source>Network request error</source>
-        <translation>Eroare în cererea de reţea</translation>
-    </message>
-    <message>
-        <source>Payment acknowledged</source>
-        <translation>Plată acceptată</translation>
-    </message>
 </context>
 <context>
     <name>PeerTableModel</name>
     <message>
-        <source>NodeId</source>
-        <translation>NodeID</translation>
-    </message>
-    <message>
-        <source>Node/Service</source>
-        <translation>Nod/Serviciu</translation>
-    </message>
-    <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Agent utilizator</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     </context>
 <context>
+    <name>Proposal</name>
+    </context>
+<context>
+    <name>ProposalModel</name>
+    </context>
+<context>
     <name>QObject</name>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 nu a fost inchis in siguranta...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 nu a fost inchis in siguranta…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -1784,21 +1617,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
 </context>
 <context>
-    <name>QObject::QObject</name>
-    <message>
-        <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation>Eroare: Directorul de date specificat "%1" nu există.</translation>
-    </message>
-    <message>
-        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
-        <translation>Eroare: Nu se poate parsa fișierul de configurare: %1. Utilizează numai sintaxa cheie=valoare.</translation>
-    </message>
-    <message>
-        <source>Error: %1</source>
-        <translation>Eroare: %1</translation>
-    </message>
-    </context>
-<context>
     <name>QRDialog</name>
     <message>
         <source>QR-Code Title</source>
@@ -1809,38 +1627,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Salvează imaginea...</translation>
-    </message>
-    <message>
-        <source>Error creating QR Code.</source>
-        <translation>Eroare la crearea Codului QR</translation>
-    </message>
-</context>
-<context>
-    <name>QRGeneralImageWidget</name>
-    <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Salvează imaginea...</translation>
-    </message>
-    <message>
-        <source>&amp;Copy Image</source>
-        <translation>&amp;Copiaza Imaginea</translation>
-    </message>
-    <message>
-        <source>Save QR Code</source>
-        <translation>Salvează codul QR</translation>
-    </message>
-    <message>
-        <source>PNG Image (*.png)</source>
-        <translation>Imagine de tip PNG (*.png)</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Salvează imaginea…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Salvează imaginea...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Salvează imaginea…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -1850,11 +1645,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Save QR Code</source>
         <translation>Salvează codul QR</translation>
     </message>
-    <message>
-        <source>PNG Image (*.png)</source>
-        <translation>Imagine de tip PNG (*.png)</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1902,24 +1693,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Fişier jurnal depanare</translation>
     </message>
     <message>
-        <source>Current number of blocks</source>
-        <translation>Numărul curent de blocuri</translation>
-    </message>
-    <message>
         <source>Client version</source>
         <translation>Versiune client</translation>
     </message>
     <message>
-        <source>Using BerkeleyDB version</source>
-        <translation>Foloseşte BerkeleyDB versiunea</translation>
-    </message>
-    <message>
         <source>Block chain</source>
         <translation>Lanţ de blocuri</translation>
-    </message>
-    <message>
-        <source>Number of Masternodes</source>
-        <translation>Număr de Masternode-uri</translation>
     </message>
     <message>
         <source>Memory Pool</source>
@@ -1966,14 +1745,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Selectaţi un partener pentru a vedea informaţiile detaliate.</translation>
     </message>
     <message>
-        <source>Whitelisted</source>
-        <translation>Whitelisted</translation>
-    </message>
-    <message>
-        <source>Direction</source>
-        <translation>Direcţie</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>versiune</translation>
     </message>
@@ -1988,10 +1759,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Synced Blocks</source>
         <translation>Blocuri Sincronizate</translation>
-    </message>
-    <message>
-        <source>Wallet Path</source>
-        <translation>Traiectoria Portofelului</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2024,10 +1791,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Servicii</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Scor Ban</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2066,42 +1829,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Repararea Portofelului</translation>
     </message>
     <message>
-        <source>Salvage wallet</source>
-        <translation>Salvează portofelul</translation>
-    </message>
-    <message>
-        <source>Recover transactions 1</source>
-        <translation>Recuperează tranzacții 1</translation>
-    </message>
-    <message>
-        <source>Recover transactions 2</source>
-        <translation>Recuperează tranzacții 2</translation>
-    </message>
-    <message>
-        <source>Upgrade wallet format</source>
-        <translation>Actualizează formatul portofelului</translation>
-    </message>
-    <message>
-        <source>The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockhain files or missing/obsolete transactions.</source>
-        <translation>Butoanele de mai jos vor reporni portofelul cu opțiuni din linia de comandă pentru a repara portofelul, pentru a rezolva problemele cu fișierele blocate corupte sau cu tranzacțiile care lipsesc / sunt vechi.</translation>
-    </message>
-    <message>
-        <source>-salvagewallet: Attempt to recover private keys from a corrupt wallet.dat.</source>
-        <translation>-salvagewallet: Încearcă să recuperezi cheile private de la un wallet.dat. corupt</translation>
-    </message>
-    <message>
-        <source>-zapwallettxes=1: Recover transactions from blockchain (keep meta-data, e.g. account owner).</source>
-        <translation>-zapwallettxes=1: Recuperează tranzacții din blockchain (păstrează meta-data, ex: proprietarul contului).</translation>
-    </message>
-    <message>
-        <source>-zapwallettxes=2: Recover transactions from blockchain (drop meta-data).</source>
-        <translation>-zapwallettxes=2: Recuperează tranzacții din blockchain (șterge meta-data).</translation>
-    </message>
-    <message>
-        <source>-upgradewallet: Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself!)</source>
-        <translation>-upgradewallet: Actualizează portofelul la ultimul format la pornire. (Notă: aceasta nu este o actualizare a portofelului în sine!)</translation>
-    </message>
-    <message>
         <source>Wallet repair options.</source>
         <translation>Opțiuni de reparație a portofelului</translation>
     </message>
@@ -2112,6 +1839,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>-reindex: Rebuild block chain index from current blk000??.dat files.</source>
         <translation>-reindexează: Reconstruiește index-ul block chain din fișierele curente blk000??.dat.</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Nu</translation>
     </message>
     <message>
         <source>&amp;Disconnect</source>
@@ -2170,38 +1901,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Total: %1 (Activat: %2)</translation>
     </message>
     <message>
-        <source>(node id: %1)</source>
-        <translation>(node id: %1)</translation>
-    </message>
-    <message>
         <source>via %1</source>
         <translation>via %1</translation>
-    </message>
-    <message>
-        <source>never</source>
-        <translation>niciodată</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Intrare</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Ieşire</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation>Da</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation>Nu</translation>
     </message>
     <message>
         <source>Unknown</source>
         <translation>necunoscut</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2235,10 +1942,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Amount:</source>
         <translation>Sum&amp;a:</translation>
-    </message>
-    <message>
-        <source>&amp;Request payment</source>
-        <translation>&amp;Cerere plată</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
@@ -2284,13 +1987,9 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Copiază suma</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
-    <message>
-        <source>QR Code</source>
-        <translation>Cod QR</translation>
-    </message>
     <message>
         <source>Copy &amp;URI</source>
         <translation>Copiază &amp;URl</translation>
@@ -2300,8 +1999,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Copiază &amp;adresa</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Salvează imaginea...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Salvează imaginea…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2310,34 +2009,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Payment information</source>
         <translation>Informaţiile plată</translation>
-    </message>
-    <message>
-        <source>URI</source>
-        <translation>URI</translation>
-    </message>
-    <message>
-        <source>Address</source>
-        <translation>Adresa</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation>Cantitate</translation>
-    </message>
-    <message>
-        <source>Label</source>
-        <translation>Etichetă</translation>
-    </message>
-    <message>
-        <source>Message</source>
-        <translation>Mesaj</translation>
-    </message>
-    <message>
-        <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation>URI rezultat este prea lung, încearcă să reduci textul pentru etichetă / mesaj.</translation>
-    </message>
-    <message>
-        <source>Error encoding URI into QR Code.</source>
-        <translation>Eroare la codarea URl-ului în cod QR.</translation>
     </message>
 </context>
 <context>
@@ -2382,10 +2053,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Caracteristici control ale monedei</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Intrări</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>Selectie automatică</translation>
     </message>
@@ -2414,6 +2081,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Praf:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Intrări</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>După taxe:</translation>
     </message>
@@ -2434,12 +2105,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Taxă tranzacţie:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Alegeţi...</translation>
-    </message>
-    <message>
-        <source>collapse fee-settings</source>
-        <translation>inchide setarile de taxare</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Taxa smart nu este inca initializata. Aceasta poate dura cateva blocuri…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2450,16 +2117,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Dacă taxa vamală este stabilită la 1000 de duffi și tranzacția are doar 250 de octeți, atunci "per kilobyte" plătește doar 250 de duffi în taxă,&lt;br /&gt;în timp ce "cel puțin" plătește 1000 de duffi. Pentru tranzacțiile mai mari decât un kilobyte, ambele plătesc cu kilobyte.</translation>
     </message>
     <message>
-        <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks.&lt;br /&gt;But be aware that this can end up in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
-        <translation>Plata numai a taxei minime este ok, atâta timp cât există un volum mai mic de tranzacții decât spațiul din block-uri.&lt;br /&gt;Dar trebuie să știi că acest lucru se poate încheia într-o tranzacție care nu se confirmă odată ce există mai multă cerere pentru tranzacții dash decât poate procesa rețeaua.</translation>
-    </message>
-    <message>
         <source>per kilobyte</source>
         <translation>per kilooctet</translation>
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Utilizarea fallbackfee-ului poate duce la trimiterea unei tranzacții care va dura mai multe ore sau zile (sau niciodată) pentru confirmare. Ia în considerare alegerea manuală a taxei sau așteaptă până când ai validat lanțul complet.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Alegeţi…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2470,20 +2137,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ascunde</translation>
     </message>
     <message>
-        <source>(read the tooltip)</source>
-        <translation>(citeste tooltip)</translation>
-    </message>
-    <message>
         <source>Recommended:</source>
         <translation>Recomandat:</translation>
     </message>
     <message>
         <source>Custom:</source>
         <translation>Personalizat:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Taxa smart nu este inca initializata. Aceasta poate dura cateva blocuri...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -2558,14 +2217,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Sigur doriţi să trimiteţi?</translation>
     </message>
     <message>
-        <source>are added as transaction fee</source>
-        <translation>se adaugă ca și comision de tranzacție</translation>
-    </message>
-    <message>
-        <source>Total Amount = &lt;b&gt;%1&lt;/b&gt;&lt;br /&gt;= %2</source>
-        <translation>Suma Totală = &lt;b&gt;%1&lt;/b&gt;&lt;br /&gt;= %2</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;(%1 of %2 entries displayed)&lt;/b&gt;</source>
         <translation>&lt;b&gt;(%1 of %2 înregistrările afișate)&lt;/b&gt;</translation>
     </message>
@@ -2614,20 +2265,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Creare tranzacţie nereuşită!</translation>
     </message>
     <message>
-        <source>The transaction was rejected with the following reason: %1</source>
-        <translation>Tranzactia a fost refuzata pentru urmatorul motiv: %1</translation>
-    </message>
-    <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation> O taxă mai mare de %1 este considerată o taxă absurd de mare </translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation>Cerere de plată expirata</translation>
-    </message>
-    <message>
-        <source>Pay only the required fee of %1</source>
-        <translation>Plăteşte doar taxa solicitata de %1</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -2656,10 +2295,6 @@ https://www.transifex.com/projects/p/dash/</translation>
 </context>
 <context>
     <name>SendCoinsEntry</name>
-    <message>
-        <source>This is a normal payment.</source>
-        <translation>Aceasta este o tranzacţie normală.</translation>
-    </message>
     <message>
         <source>Pay &amp;To:</source>
         <translation>Plăteşte că&amp;tre:</translation>
@@ -2732,22 +2367,11 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
-    <message>
-        <source>Enter a label for this address to add it to your address book</source>
-        <translation>Introdu o etichetă pentru această adresă pentru a fi adăugată în lista ta de adrese</translation>
-    </message>
-</context>
-<context>
-    <name>SendConfirmationDialog</name>
-    <message>
-        <source>Yes</source>
-        <translation>Da</translation>
-    </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
+        <source>%1 is shutting down…</source>
         <translation>%1 se închide</translation>
     </message>
     <message>
@@ -2895,13 +2519,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
 </context>
 <context>
-    <name>SplashScreen</name>
-    <message>
-        <source>[testnet]</source>
-        <translation>[testnet]</translation>
-    </message>
-</context>
-<context>
     <name>TrafficGraphWidget</name>
     <message>
         <source>KB/s</source>
@@ -3037,10 +2654,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction total size</source>
         <translation>Dimensiune totala tranzacţie</translation>
-    </message>
-    <message>
-        <source>Merchant</source>
-        <translation>Comerciant</translation>
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
@@ -3216,8 +2829,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Anul acesta</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Interval...</translation>
+        <source>Range…</source>
+        <translation>Interval…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -3276,10 +2889,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Copiaza toate detaliile tranzacţiei</translation>
     </message>
     <message>
-        <source>Edit label</source>
-        <translation>Editează eticheta</translation>
-    </message>
-    <message>
         <source>Show transaction details</source>
         <translation>Arată detaliile tranzacţiei</translation>
     </message>
@@ -3290,10 +2899,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Export Transaction History</source>
         <translation>Export istoric tranzacţii</translation>
-    </message>
-    <message>
-        <source>Comma separated file (*.csv)</source>
-        <translation>Fisier .csv cu separator - virgula</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -3360,19 +2965,18 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
 </context>
 <context>
+    <name>WalletController</name>
+    </context>
+<context>
     <name>WalletFrame</name>
-    <message>
-        <source>No wallet has been loaded.</source>
-        <translation>Nu a fost încărcat nici un portofel.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
         <translation>Trimite monede</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>WalletView</name>
     <message>
@@ -3390,10 +2994,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Backup Wallet</source>
         <translation>Backup portofelul electronic</translation>
-    </message>
-    <message>
-        <source>Wallet Data (*.dat)</source>
-        <translation>Date portofel (*.dat)</translation>
     </message>
     <message>
         <source>Backup Failed</source>
@@ -3423,20 +3023,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Aceasta este o versiune de test preliminară - vă asumaţi riscul folosind-o - nu folosiţi pentru minerit sau aplicaţiile comercianţilor</translation>
     </message>
     <message>
-        <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
-        <translation>Atenţie: Reţeaua nu pare să fie de acord în totalitate! Aparent nişte mineri au probleme.</translation>
-    </message>
-    <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Atenţie: Aparent, nu sîntem de acord cu toţi partenerii noştri! Va trebui să faceţi o actualizare, sau alte noduri necesită actualizare.</translation>
     </message>
     <message>
         <source>Already have that input.</source>
         <translation>Această intrare deja există.</translation>
-    </message>
-    <message>
-        <source>Cannot downgrade wallet</source>
-        <translation>Nu se poate retrograda portofelul</translation>
     </message>
     <message>
         <source>Collateral not valid.</source>
@@ -3479,14 +3071,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Eroare la citirea bazei de date. Oprire.</translation>
     </message>
     <message>
-        <source>Error</source>
-        <translation>Eroare</translation>
-    </message>
-    <message>
-        <source>Error: Disk space is low!</source>
-        <translation>Eroare: Spaţiu pe disc redus!</translation>
-    </message>
-    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Am esuat ascultarea pe orice port. Folositi -listen=0 daca vreti asta.</translation>
     </message>
@@ -3511,28 +3095,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Intrarea depășește dimensiunea maximă.</translation>
     </message>
     <message>
-        <source>Failed to load fulfilled requests cache from</source>
-        <translation>Nu a reușit să se încarce cache-ul cererilor îndeplinite de la</translation>
-    </message>
-    <message>
-        <source>Failed to load governance cache from</source>
-        <translation>Nu a reușit să se încarce cache-ul guvernării de la</translation>
-    </message>
-    <message>
-        <source>Failed to load masternode cache from</source>
-        <translation>Nu a reușit să se încarce cache-ul masternode-urilor de la</translation>
-    </message>
-    <message>
         <source>Found enough users, signing ( waiting %s )</source>
         <translation>S-au găsit suficienți utilizatori, semnând (așteptând %s )</translation>
-    </message>
-    <message>
-        <source>Found enough users, signing ...</source>
-        <translation>S-au găsit suficienți utilizatori, semnând ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Import...</translation>
     </message>
     <message>
         <source>Incompatible mode.</source>
@@ -3545,10 +3109,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Incorect sau nici un bloc de geneza găsit. Directorul de retea greşit?</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Informaţie</translation>
     </message>
     <message>
         <source>Input is not valid.</source>
@@ -3571,28 +3131,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Număr minim de semnatari spork specificat cu -minsporkkeys nu este valabil. </translation>
     </message>
     <message>
-        <source>Keypool ran out, please call keypoolrefill first</source>
-        <translation>Keypool epuizat, folositi intai functia keypoolrefill</translation>
-    </message>
-    <message>
-        <source>Loading banlist...</source>
-        <translation>Încărcare banlist...</translation>
-    </message>
-    <message>
-        <source>Loading fulfilled requests cache...</source>
-        <translation>Încărcarea cache-ului de cereri îndeplinite ...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Încărcarea cache-ului masternode-ului</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Blocarea este deja în vigoare.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Amestecare în curs ...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -3615,12 +3155,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nu este în lista Masternode</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Reductie blockstore…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Redirecționarea block-urilor …</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Rescanare…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Se pornesc threadurile retelei…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Trimis la masternode, așteaptă la coadă %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Sincronizarea s-a terminat</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Sincronizarea blockchain-ului…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Sincronizarea obiectelor de guvernare…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -3631,28 +3195,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Răspuns necunoscut.</translation>
     </message>
     <message>
-        <source>Unsupported argument -benchmark ignored, use -debug=bench.</source>
-        <translation>Argumentul nesuportat -benchmark este ignorat, folositi debug=bench.</translation>
-    </message>
-    <message>
-        <source>Unsupported argument -debugnet ignored, use -debug=net.</source>
-        <translation>Argument nesuportat -debugnet ignorat, folosiţi -debug=net.</translation>
-    </message>
-    <message>
-        <source>Unsupported argument -tor found, use -onion.</source>
-        <translation>Argument nesuportat -tor găsit, folosiţi -onion.</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Comentariul (%s) al Agentului Utilizator contine caractere nesigure.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Verificare portofelului (rilor) ...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Se va reîncerca...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -3675,10 +3219,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%s fișierul conține toate cheile private din acest portofel. Nu le împărtăși nimănui!</translation>
     </message>
     <message>
-        <source>-masternode option is deprecated and ignored, specifying -masternodeblsprivkey is enough to start this node as a masternode.</source>
-        <translation>- optiunea masternode este dezaprobata si ignorata - specificarea masternodeblsprivkey-ului este suficienta pentru a porni acest nod ca si un masternode.</translation>
-    </message>
-    <message>
         <source>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
         <translation>Nu s-a reușit crearea unui backup, fișierul există deja! Acest lucru s-ar putea întâmpla dacă ai repornit portofelul în mai puțin de 60 de secunde. Poți continua dacă eşti de acord cu asta.</translation>
     </message>
@@ -3695,10 +3235,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Reductie: ultima sincronizare merge dincolo de datele reductiei. Trebuie sa faceti -reindex (sa descarcati din nou intregul blockchain in cazul unui nod redus)</translation>
     </message>
     <message>
-        <source>Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.</source>
-        <translation>Rescanarile nu sunt posibile in modul redus. Va trebui sa folositi -reindex, ceea ce va descarca din nou intregul blockchain.</translation>
-    </message>
-    <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation>Baza de date a blocurilor contine un bloc ce pare a fi din viitor. Acest lucru poate fi cauzat de setarea incorecta a datei si orei in computerul dvs. Reconstruiti baza de date a blocurilor doar daca sunteti sigur ca data si ora calculatorului dvs sunt corecte.</translation>
     </message>
@@ -3711,24 +3247,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Lungimea totala a sirului versiunii retelei (%i) depaseste lungimea maxima (%i). Reduceti numarul sa dimensiunea uacomments. </translation>
     </message>
     <message>
-        <source>Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported.</source>
-        <translation>S-a gasit un argument -socks nesuportat. Setarea versiunii SOCKS nu mai este posibila, sunt suportate doar proxiurile SOCKS5.</translation>
-    </message>
-    <message>
-        <source>Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay.</source>
-        <translation>Se ignora argumentul nesuportat -whitelistalwaysrelay, folositi -whitelistrelay si/sau -whitelistforcerelay.</translation>
-    </message>
-    <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
         <translation>AVERTIZARE! Nu s-a reușit reîncărcarea keypool-ului, deblochează portofelul pentru a face acest lucru.</translation>
     </message>
     <message>
         <source>Wallet is locked, can't replenish keypool! Automatic backups and mixing are disabled, please unlock your wallet to replenish keypool.</source>
         <translation>Portofelul este blocat, nu poate fi completat keypool-ul! Backupurile automate și amestecarea sunt dezactivate, deblochează portofelul pentru a completa keypool-ul.</translation>
-    </message>
-    <message>
-        <source>Warning: Unknown block versions being mined! It's possible unknown rules are in effect</source>
-        <translation>Atentie: se mineaza blocuri cu versiune necunoscuta! Este posibil sa fie in vigoare reguli necunoscute.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to change -timestampindex</source>
@@ -3751,10 +3275,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>EROARE! Backup-ul automat a eșuat</translation>
     </message>
     <message>
-        <source>Error: A fatal internal error occurred, see debug.log for details</source>
-        <translation>Eroare: S-a produs o eroare interna fatala, vedeti debug.log pentru detalii</translation>
-    </message>
-    <message>
         <source>Failed to create backup %s!</source>
         <translation>Crearea backup-ului a eșuat %s!</translation>
     </message>
@@ -3767,8 +3287,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ștergerea backup-ului a eșuat, eroare: %s</translation>
     </message>
     <message>
-        <source>Failed to load sporks cache from</source>
-        <translation>Nu s-a putut încărca cache-ul sporks din</translation>
+        <source>Found enough users, signing…</source>
+        <translation>S-au găsit suficienți utilizatori, semnând…</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
@@ -3777,26 +3297,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Invalid masternodeblsprivkey. Please see documentation.</source>
         <translation>masternodeblsprivkey nu este valabil. Consultă documentația.</translation>
-    </message>
-    <message>
-        <source>Loading block index...</source>
-        <translation>Încarc indice bloc...</translation>
-    </message>
-    <message>
-        <source>Loading governance cache...</source>
-        <translation>Se încarcă cache-ul de guvernanță...</translation>
-    </message>
-    <message>
-        <source>Loading sporks cache...</source>
-        <translation>Se încarcă cache-ul sporks...</translation>
-    </message>
-    <message>
-        <source>Loading wallet... (%3.2f %%)</source>
-        <translation>Se încarcă portofelul... (%3.2f %%)</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Încarc portofel...</translation>
     </message>
     <message>
         <source>Masternode queue is full.</source>
@@ -3809,6 +3309,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Lipsesc informațiile despre tranzacțiile de intrare.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Amestecare în curs …</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -3833,14 +3337,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation>Modul redus este incompatibil cu -txindex.</translation>
-    </message>
-    <message>
-        <source>Pruning blockstore...</source>
-        <translation>Reductie blockstore...</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Sincronizarea blockchain-ului...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -3871,10 +3367,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tranzacţie prea mare</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Se încearcă conectarea...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Nu se poate efectua legatura la %s pe acest computer. %s probabil ruleaza deja.</translation>
     </message>
@@ -3883,12 +3375,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Actualizarea bazei de date UTXO</translation>
     </message>
     <message>
-        <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation>Portofelul trebuie rescris: reporneşte %s pentru finalizare</translation>
+        <source>Verifying blocks…</source>
+        <translation>Se verifică blocurile…</translation>
     </message>
     <message>
-        <source>Warning: unknown new rules activated (versionbit %i)</source>
-        <translation>Atentie: se activeaza reguli noi necunoscute (versionbit %i)</translation>
+        <source>Verifying wallet(s)…</source>
+        <translation>Verificare portofelului (rilor) …</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation>Portofelul trebuie rescris: reporneşte %s pentru finalizare</translation>
     </message>
     <message>
         <source>Wasn't able to create wallet backup folder %s!</source>
@@ -3907,20 +3403,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Trebuie să reconstruiești baza de date utilizând -reindex pentru a schimba -spentindex</translation>
     </message>
     <message>
-        <source>You need to rebuild the database using -reindex to change -txindex</source>
-        <translation>Trebuie să reconstruiești baza de date utilizând -reindex pentru a schimba -txindex</translation>
-    </message>
-    <message>
         <source>no mixing available.</source>
         <translation>mixing nu este valabil</translation>
     </message>
     <message>
         <source>see debug.log for details.</source>
         <translation>vezi debug.log pentru detalii.</translation>
-    </message>
-    <message>
-        <source>Dash Core</source>
-        <translation>Dash Core</translation>
     </message>
     <message>
         <source>The %s developers</source>
@@ -3963,24 +3451,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Aceasta este taxa de tranzactie pe care este posibil sa o platiti daca estimarile de taxe nu sunt disponibile.</translation>
     </message>
     <message>
-        <source>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit %s and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</source>
-        <translation>Acest produs include software dezvoltat de OpenSSL Project pentru a fi folosit in Toolkitul OpenSSL %s, software criptografic scris de Eric Young si software UPnP scris de Thomas Bernard. </translation>
-    </message>
-    <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation>Imposibil de redat block-urile. Va trebui să reconstruiți baza de date folosind -reindex-chainstate.</translation>
-    </message>
-    <message>
-        <source>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
-        <translation>Atenţie: fişierul portofelului este corupt, date salvate! Fişierul %s a fost salvat ca %s in %s; dacă balanta sau tranzactiile sunt incorecte ar trebui să restauraţi dintr-o copie de siguranţă.</translation>
-    </message>
-    <message>
-        <source>%d of last 100 blocks have unexpected version</source>
-        <translation>%d din ultimele 100 de blocuri au versiune neașteptată</translation>
-    </message>
-    <message>
-        <source>%s corrupt, salvage failed</source>
-        <translation>%s corupt, salvare nereuşită</translation>
     </message>
     <message>
         <source>%s is not a valid backup folder!</source>
@@ -4031,12 +3503,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Eroare la încărcare %s: Nu poți dezactiva HD pe un portofel HD deja existent</translation>
     </message>
     <message>
-        <source>Error loading wallet %s. Duplicate -wallet filename specified.</source>
-        <translation>Eroare la încărcarea portofelului %s. Numele de fișier duplicat -wallet specificat.</translation>
-    </message>
-    <message>
         <source>Error upgrading chainstate database</source>
         <translation>Eroare la actualizarea bazei de date chainstate</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation>Încărcare adrese P2P…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Încărcare banlist…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Încarc indice bloc…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Încarc portofel…</translation>
     </message>
     <message>
         <source>Failed to find mixing queue to join</source>
@@ -4045,6 +3529,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Failed to start a new mixing queue</source>
         <translation>Nu a reușit să pornească un nou queue de amestecare</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation>Import…</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
@@ -4071,20 +3559,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Adresa spork nevalidă specificată cu -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Încărcare adrese P2P...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Se micsoreaza -maxconnections de la %d la %d, datorita limitarilor de sistem.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Redirecționarea block-urilor ...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Rescanare...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4097,14 +3573,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Signing transaction failed</source>
         <translation>Nu s-a reuşit semnarea tranzacţiei</translation>
-    </message>
-    <message>
-        <source>Starting network threads...</source>
-        <translation>Se pornesc threadurile retelei...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Sincronizarea obiectelor de guvernare...</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -4135,8 +3603,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tranzacția nu este validă.</translation>
     </message>
     <message>
-        <source>Transaction too large for fee policy</source>
-        <translation>Tranzacţia are suma prea mare pentru a beneficia de gratuitate</translation>
+        <source>Trying to connect…</source>
+        <translation>Se încearcă conectarea…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4159,10 +3627,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Categorie de înregistrare neacceptată %s=%s.</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Se verifică blocurile...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Un număr foarte scăzut de chei rămase: %d</translation>
     </message>
@@ -4171,16 +3635,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Portofel blocat.</translation>
     </message>
     <message>
-        <source>Warning</source>
-        <translation>Avertisment</translation>
+        <source>Will retry…</source>
+        <translation>Se va reîncerca…</translation>
     </message>
     <message>
         <source>Your entries added successfully.</source>
         <translation>Intrările tale au fost adăugate cu succes.</translation>
-    </message>
-    <message>
-        <source>Zapping all transactions from wallet...</source>
-        <translation>Şterge toate tranzacţiile din portofel...</translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/dash_ru.ts
+++ b/src/qt/locale/dash_ru.ts
@@ -312,6 +312,17 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation>Произошла критическая ошибка. Дальнейшая безопасная работа %1 невозможна, программа будет закрыта.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation>Внутренняя ошибка</translation>
+    </message>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -338,6 +349,42 @@
         <translation>Запросить платежи (создать QR-коды и dash: URI)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Параметры…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>За&amp;шифровать кошелёк…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Сделать резервную копию кошелька…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Изменить пароль…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Разблокировать кошелёк…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>П&amp;одписать сообщение…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Проверить сообщение…</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation>&amp;Загрузить PSBT из файла…</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation>Загрузить PSBT из буфера обмена…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>Адреса &amp;отправки</translation>
     </message>
@@ -346,16 +393,16 @@
         <translation>Адреса &amp;получения</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>Открыть &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Открыть кошелёк</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Открыть кошелёк</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Закрыть кошелёк...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -414,10 +461,6 @@
         <translation>Показать информацию о Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Параметры...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;О %1</translation>
     </message>
@@ -438,32 +481,16 @@
         <translation>Показать или скрыть главное окно</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>За&amp;шифровать кошелёк...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Зашифровать закрытые ключи, содержащиеся в вашем кошельке</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Сделать резервную копию кошелька...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Сделать резервную копию кошелька в другом месте</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Изменить пароль...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Изменить пароль шифрования кошелька</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Разблокировать кошелёк...</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -474,24 +501,12 @@
         <translation>За&amp;блокировать кошелёк</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>П&amp;одписать сообщение...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Подписать сообщения вашими адресами Dash, чтобы доказать, что вы ими владеете</translation>
     </message>
     <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Проверить сообщение...</translation>
-    </message>
-    <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
         <translation>Проверить сообщения, чтобы удостовериться, что они были подписаны определёнными адресами Dash</translation>
-    </message>
-    <message>
-        <source>&amp;Load PSBT from file...</source>
-        <translation>&amp;Загрузить PSBT из файла...</translation>
     </message>
     <message>
         <source>&amp;Information</source>
@@ -554,10 +569,6 @@
         <translation>Показать список использованных адресов получения и их меток</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Открыть &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Параметры командной строки</translation>
     </message>
@@ -596,10 +607,6 @@
         <translation>Загрузить частично подписанную транзакцию Dash</translation>
     </message>
     <message>
-        <source>Load PSBT from clipboard...</source>
-        <translation>Загрузить PSBT из буфера обмена...</translation>
-    </message>
-    <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation>Загрузить частично подписанную транзакцию Dash из буфера обмена</translation>
     </message>
@@ -612,16 +619,8 @@
         <translation>Открыть dash: URI</translation>
     </message>
     <message>
-        <source>Create Wallet...</source>
-        <translation>Создать кошелёк...</translation>
-    </message>
-    <message>
         <source>Create a new wallet</source>
         <translation>Создать новый кошелёк</translation>
-    </message>
-    <message>
-        <source>Close All Wallets...</source>
-        <translation>Закрыть все кошельки...</translation>
     </message>
     <message>
         <source>Close all wallets</source>
@@ -671,30 +670,6 @@
         <source>Network activity disabled</source>
         <translation>Сетевая активность отключена</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Синхронизация заголовков (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Синхронизация с сетью...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Индексация блоков на диске...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Обработка блоков на диске...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Идёт переиндексация блоков на диске...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Подключение к пирам...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>Обработан 1 блок из истории транзакций.</numerusform><numerusform>Обработано %n блока из истории транзакций.</numerusform><numerusform>Обработано %n блоков из истории транзакций.</numerusform><numerusform>Обработано %n блоков из истории транзакций.</numerusform></translation>
@@ -704,8 +679,44 @@
         <translation>%1 позади</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Синхронизируется...</translation>
+        <source>Close Wallet…</source>
+        <translation>Закрыть кошелёк…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Создать кошелёк…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation>Закрыть все кошельки…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Синхронизация заголовков (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Синхронизация с сетью…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Индексация блоков на диске…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Обработка блоков на диске…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Идёт переиндексация блоков на диске…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Подключение к пирам…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Синхронизируется…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -828,10 +839,6 @@
     <message>
         <source>Original message:</source>
         <translation>Изначальное сообщение:</translation>
-    </message>
-    <message>
-        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation>Произошла критическая ошибка. Дальнейшая безопасная работа %1 невозможна, программа будет закрыта.</translation>
     </message>
 </context>
 <context>
@@ -1028,8 +1035,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Создается кошелёк&lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Создается кошелёк&lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1086,7 +1093,7 @@
         <source>Create</source>
         <translation>Создать</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1230,10 +1237,6 @@
         <translation>Так как вы впервые запустили программу, вы можете выбрать, где %1 будет хранить данные.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>После нажатия OK, %1 начнет скачивать и проверять всю цепочку блоков %4 (%2ГБ), начиная с самых ранних транзакций %3, т.е. со времени запуска проекта %4.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation>Ограничить хранение цепочки блоков</translation>
     </message>
@@ -1250,6 +1253,10 @@
         <translation>Начальная синхронизация требует много ресурсов и, возможно, обнаружит проблемы с Вашим компьютером, которых Вы ранее не замечали. Каждый раз, когда Вы запускаете %1, скачивание будет продолжено с того места, где оно было остановлено в прошлый раз.</translation>
     </message>
     <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation>После нажатия OK, %1 начнет скачивать и проверять всю цепочку блоков %4 (%2 ГБ), начиная с самых ранних транзакций %3, т.е. со времени запуска проекта %4.</translation>
+    </message>
+    <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
         <translation>Если Вы выбрали ограниченное хранение цепочки блоков (удаление старых блоков), исторические данные все равно будут скачаны и проверены, после чего они будут удалены для уменьшения размера хранимых данных.</translation>
     </message>
@@ -1261,17 +1268,17 @@
         <source>Use a custom data directory:</source>
         <translation>Использовать другой каталог данных:</translation>
     </message>
-    <message numerus="yes">
-        <source>%n GB of free space available</source>
-        <translation><numerusform>доступно %n ГБ свободного места</numerusform><numerusform>доступно %n ГБ свободного места</numerusform><numerusform>доступно %n ГБ свободного места</numerusform><numerusform>доступно %n ГБ свободного места</numerusform></translation>
+    <message>
+        <source>%1 GB of free space available</source>
+        <translation>доступно %1 ГБ свободного места</translation>
     </message>
-    <message numerus="yes">
-        <source>(of %n GB needed)</source>
-        <translation><numerusform>(из требующихся %n ГБ)</numerusform><numerusform>(из требующихся %n ГБ)</numerusform><numerusform>(из требующихся %n ГБ)</numerusform><numerusform>(из требующихся %n ГБ)</numerusform></translation>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation>(из требующихся %1 ГБ)</translation>
     </message>
-    <message numerus="yes">
-        <source>(%n GB needed for full chain)</source>
-        <translation><numerusform>(из %n ГБ, требующегося для полной цепочки блоков)</numerusform><numerusform>(из %n ГБ, требующихся для полной цепочки блоков)</numerusform><numerusform>(из %n ГБ, требующихся для полной цепочки блоков)</numerusform><numerusform>(из %n ГБ, требующихся для полной цепочки блоков)</numerusform></translation>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation>(из %1 ГБ, требующихся для полной цепочки блоков)</translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1386,8 +1393,12 @@
         <translation>Скопировать залоговый выход</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Обновляется...</translation>
+        <source>Please wait…</source>
+        <translation>Пожалуйста, подождите…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Обновляется…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1422,10 +1433,6 @@
         <translation>Фильтровать по любому значению (например, по адресу или по хешу регистрационной транзакции)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Пожалуйста, подождите...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Дополнительная информация для DIP3 мастерноды %1</translation>
     </message>
@@ -1449,8 +1456,12 @@
         <translation>Количество оставшихся блоков</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Неизвестно...</translation>
+        <source>Unknown…</source>
+        <translation>Неизвестно…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>рассчитывается…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1465,10 +1476,6 @@
         <translation>Увеличение прогресса за час</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>рассчитывается...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Оставшееся время, приблизительно</translation>
     </message>
@@ -1481,8 +1488,8 @@
         <translation>%1 синхронизируется.  Он будет скачивать заголовки и блоки от пиров и проверять их, пока не достигнет вершины цепочки блоков.</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Неизвестно. Синхронизация заголовков (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Неизвестно. Синхронизация заголовков (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1511,8 +1518,8 @@
         <translation>кошелек по умолчанию</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Открывается кошелёк&lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Открывается кошелёк&lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1544,6 +1551,14 @@
     <message>
         <source>&amp;Appearance</source>
         <translation>&amp;Внешний вид</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation>Показать иконку в системном лотке.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation>&amp;Показать иконку в системном лотке</translation>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
@@ -1708,16 +1723,14 @@
         <translation>Показывает, используется ли указанный по умолчанию SOCKS5 прокси для подключения к пирам этого типа сети.</translation>
     </message>
     <message>
+        <source>Language missing or translation incomplete? Help contributing translations here:
+https://explore.transifex.com/dash/dash/</source>
+        <translation>Нет Вашего языка или перевод неполон? Помогите нам сделать перевод лучше:
+https://explore.transifex.com/dash/dash/</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
         <translation>Настройки, указанные в этом диалоге, перекрываются командной строкой либо файлом настроек:</translation>
-    </message>
-    <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Скрыть иконку в системном лотке.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>Скрыть &amp;иконку в системном лотке</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
@@ -1834,12 +1847,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>Здесь можно выбрать язык интерфейса. Настройки вступят в силу после перезапуска %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Нет Вашего языка или перевод неполон? Помогите нам сделать перевод лучше:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -2144,8 +2151,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Скопировать в буфер обмена</translation>
     </message>
     <message>
-        <source>Save...</source>
-        <translation>Сохранить...</translation>
+        <source>Save…</source>
+        <translation>Сохранить…</translation>
     </message>
     <message>
         <source>Close</source>
@@ -2276,10 +2283,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>В связи с прекращением поддержки следует запросить у мерчанта URI, совместимый с BIP21, или использовать кошелек, который продолжает поддерживать BIP70.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Неверный адрес платежа %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>Не удалось разобрать URI! Возможно указан некорректный адрес Dash либо параметры URI сформированы неверно.</translation>
     </message>
@@ -2292,30 +2295,42 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>User Agent</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Пинг</translation>
     </message>
     <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation>Пир</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation>Тип</translation>
+    </message>
+    <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Отправлено</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Получено</translation>
     </message>
     <message>
-        <source>Peer Id</source>
-        <translation>Id пира</translation>
-    </message>
-    <message>
         <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation>Адрес</translation>
     </message>
     <message>
         <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
         <translation>Сеть</translation>
     </message>
 </context>
@@ -2458,8 +2473,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ошибка: не удалось обнаружить %1 CSS файл(ов) в папке -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 еще не завершил работу...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 еще не завершил работу…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2488,6 +2503,16 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Internal</source>
         <translation>Внутренний</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
+        <translation>Входящее</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
+        <translation>Исходящее</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -2577,15 +2602,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QR-код</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Сохранить изображение...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Сохранить изображение…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Сохранить изображение...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Сохранить изображение…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2716,10 +2741,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Выберите пира для просмотра детализированной информации.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Направление</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
@@ -2734,6 +2755,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Synced Blocks</source>
         <translation>Синхронизированные блоки</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation>Последний блок</translation>
+    </message>
+    <message>
+        <source>Last Transaction</source>
+        <translation>Последняя транзакция</translation>
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
@@ -2848,12 +2877,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Разрешения</translation>
     </message>
     <message>
-        <source>Services</source>
-        <translation>Сервисы</translation>
+        <source>Direction/Type</source>
+        <translation>Направление/тип</translation>
     </message>
     <message>
-        <source>Ban Score</source>
-        <translation>Очки бана</translation>
+        <source>Services</source>
+        <translation>Сервисы</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2902,6 +2931,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>-reindex: Rebuild block chain index from current blk000??.dat files.</source>
         <translation>-reindex: Перестроить индекс цепочки блоков из текущих файлов blk000??.dat.</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation>От</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Нет</translation>
     </message>
     <message>
         <source>&amp;Disconnect</source>
@@ -2972,32 +3009,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Выполнение команд без какого либо кошелька</translation>
     </message>
     <message>
-        <source>(peer id: %1)</source>
-        <translation>(id пира: %1)</translation>
-    </message>
-    <message>
         <source>Executing command using "%1" wallet</source>
         <translation>Выполнение команд, используя "%1" кошелек</translation>
     </message>
     <message>
+        <source>(peer: %1)</source>
+        <translation>(id пира: %1)</translation>
+    </message>
+    <message>
         <source>via %1</source>
         <translation>через %1</translation>
-    </message>
-    <message>
-        <source>never</source>
-        <translation>никогда</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Входящие</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Исходящие</translation>
-    </message>
-    <message>
-        <source>Outbound block-relay</source>
-        <translation>Исходящая ретрансляция блоков</translation>
     </message>
     <message>
         <source>Regular</source>
@@ -3014,6 +3035,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Unknown</source>
         <translation>Неизвестно</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation>Никогда</translation>
     </message>
 </context>
 <context>
@@ -3114,12 +3139,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Скопировать сумму</translation>
     </message>
-</context>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation>Не удается разблокировать кошелёк.</translation>
+    </message>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <source>Request payment to ...</source>
-        <translation>Запросить платёж на ...</translation>
+        <source>Request payment to …</source>
+        <translation>Запросить платёж на …</translation>
     </message>
     <message>
         <source>Address:</source>
@@ -3150,8 +3179,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Копировать &amp;адрес</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Сохранить изображение...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Сохранить изображение…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -3204,10 +3233,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Функции контроля монет</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Входы...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>выбраны автоматически</translation>
     </message>
@@ -3236,6 +3261,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Пыль:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Входы…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>После комиссии:</translation>
     </message>
@@ -3256,16 +3285,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Комиссия транзакции:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Выбрать...</translation>
-    </message>
-    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
         <translation>Когда объем транзакций меньше, чем место в блоках, майнеры, а также узлы ретрансляции могут установить минимальную комиссию. Платить минимальную комиссию вполне нормально, но следует учитывать, что это может привести к тому, что транзакция никогда не будет подтверждена. В случае, если спрос на Dash-транзакции будет превышать спрос, который может обработать сеть.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation>Слишком низкая комиссия может привести к тому, что транзакция не будет подтверждена (читайте всплывающую подсказку)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Расчет "умной" комиссии еще не доступен. Обычно требуется подождать несколько блоков…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -3282,6 +3311,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Использование fallbackfee может привести к тому, что для подтверждения транзакции потребуется несколько часов или дней (или она вообще никогда не подтвердится). Лучше укажите комиссию вручную или дождитесь полной синхронизации.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Выбрать…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -3302,10 +3335,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Вручную:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Расчет "умной" комиссии еще не доступен. Обычно требуется подождать несколько блоков...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3460,10 +3489,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>или</translation>
     </message>
     <message>
-        <source>To review recipient list click "Show Details..."</source>
-        <translation>Для просмотра списка получателей нажмите кнопку "Show Details...".</translation>
-    </message>
-    <message>
         <source>Confirm send coins</source>
         <translation>Подтвердите отправку монет</translation>
     </message>
@@ -3490,6 +3515,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Send</source>
         <translation>Отправить</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation>Для просмотра списка получателей нажмите кнопку "Show Details…".</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
@@ -3635,8 +3664,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 выключается...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 выключается…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -4169,8 +4198,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>В этом году</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Промежуток...</translation>
+        <source>Range…</source>
+        <translation>Промежуток…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4569,14 +4598,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Найдено достаточное количество участников, подписываем ( ожидание %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Найдено достаточное количество участников, подписываем ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Импорт ...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Несовместимый режим.</translation>
     </message>
@@ -4609,16 +4630,8 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Некорректное минимальное количество подписантов спорков, указанное в -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Загрузка списка заблокированных...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Установлена блокировка.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Выполняется перемешивание...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4641,12 +4654,36 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Отсутствует в списке мастернод.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Удаление старых блоков…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Повтор блоков…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Сканирование…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Запуск сетевых потоков…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Отправлено на мастерноду, ожидаем в очереди %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Синхронизация завершена</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Синхронизация блокчейна…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Синхронизация объектов управления…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4659,14 +4696,6 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Комментарий User Agent  (%s) содержит небезопасные символы.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Проверка кошелька(ов)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Попробуем еще раз...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4797,10 +4826,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Ошибка: Не осталось ключей, пожалуйста, выполните команду keypoolrefill</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Ошибка: не удалось добавить сокет в epollfd (epoll_ctl вернул ошибку %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Превышено максимальное количество попыток.</translation>
     </message>
@@ -4829,6 +4854,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Ошибка проверки базы данных</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Найдено достаточное количество участников, подписываем…</translation>
+    </message>
+    <message>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation>Игнорирование дублирования -wallet %s.</translation>
     </message>
@@ -4845,14 +4874,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Некорректный masternodeblsprivkey. Пожалуйста, ознакомьтесь с документацией.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Загрузка индекса блоков...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Загрузка кошелька...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Очередь на мастерноде переполнена.</translation>
     </message>
@@ -4863,6 +4884,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Missing input transaction information.</source>
         <translation>Отсутствует информация о входной транзакции.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Выполняется перемешивание…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4897,10 +4922,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Режим удаления блоков несовместим с -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Удаление старых блоков...</translation>
-    </message>
-    <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
         <translation>SQLiteDatabase: Не удалось выполнить запрос для проверки базы данных: %s</translation>
     </message>
@@ -4933,10 +4954,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Указанный -walletdir "%s" не является директорией</translation>
     </message>
     <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Синхронизация блокчейна...</translation>
-    </message>
-    <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
         <translation>Кошелек не будет платить комиссию меньше, чем необходимо для передачи. </translation>
     </message>
@@ -4953,6 +4970,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Это комиссия, которую Вы заплатите, если отправите транзакцию.</translation>
     </message>
     <message>
+        <source>Topping up keypool…</source>
+        <translation>Пополняем пул ключей…</translation>
+    </message>
+    <message>
         <source>Transaction amounts must not be negative</source>
         <translation>Сумма транзакции не может быть отрицательной</translation>
     </message>
@@ -4967,10 +4988,6 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Transaction too large</source>
         <translation>Транзакция слишком большая</translation>
-    </message>
-    <message>
-        <source>Trying to connect...</source>
-        <translation>Попытка соединения...</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
@@ -4997,12 +5014,24 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Обновление базы UTXO</translation>
     </message>
     <message>
+        <source>Verifying blocks…</source>
+        <translation>Проверка блоков…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Проверка кошелька(ов)…</translation>
+    </message>
+    <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation>Необходимо перезаписать кошелёк: перезапустите %s для завершения операции</translation>
     </message>
     <message>
         <source>Wasn't able to create wallet backup folder %s!</source>
         <translation>Не удалось создать папку для резервной копии кошелька %s!</translation>
+    </message>
+    <message>
+        <source>Wiping wallet transactions…</source>
+        <translation>Стираем транзакции из кошелька…</translation>
     </message>
     <message>
         <source>You can not start a masternode with wallet enabled.</source>
@@ -5145,8 +5174,20 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Ошибка обновления базы данных состояний цепочки</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Ошибка: не удалось добавить сокет в kqueuefd (kevent вернул ошибку %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Загрузка P2P адресов…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Загрузка списка заблокированных…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Загрузка индекса блоков…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Загрузка кошелька…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -5185,6 +5226,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Не удалось создать очередь перемешивания</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Импорт …</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Некорректное значение -rescan, будет использовано значение по умолчанию</translation>
     </message>
@@ -5221,24 +5266,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>В -sporkaddr указан некорректный адрес</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Загрузка P2P адресов...</translation>
-    </message>
-    <message>
         <source>Prune mode is incompatible with -coinstatsindex.</source>
         <translation>Режим удаления блоков несовместим с -coinstatsindex.</translation>
     </message>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Настройка -maxconnections снижена с %d до %d из-за ограничений системы.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Повтор блоков...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Сканирование...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -5269,14 +5302,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Последнее успешное действие было слишком недавно.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Запуск сетевых потоков...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Синхронизация объектов управления...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>Исходный код доступен по адресу %s.</translation>
     </message>
@@ -5293,10 +5318,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Это экспериментальное ПО.</translation>
     </message>
     <message>
-        <source>Topping up keypool...</source>
-        <translation>Пополняем пул ключей...</translation>
-    </message>
-    <message>
         <source>Transaction amount too small</source>
         <translation>Сумма транзакции слишком мала</translation>
     </message>
@@ -5311,6 +5332,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Transaction not valid.</source>
         <translation>Транзакция некорректна.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Попытка соединения…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -5345,10 +5370,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Обновление базы txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Проверка блоков...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Осталось очень мало ключей: %d</translation>
     </message>
@@ -5365,8 +5386,8 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Внимание: некорректный параметр %s, путь должен существовать! Будет использован путь по умолчанию.</translation>
     </message>
     <message>
-        <source>Wiping wallet transactions...</source>
-        <translation>Стираем транзакции из кошелька...</translation>
+        <source>Will retry…</source>
+        <translation>Попробуем еще раз…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_sk.ts
+++ b/src/qt/locale/dash_sk.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,12 +331,44 @@
         <translation>Vyžiadať platby (vygeneruje QR kódy a Dash: URI)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Možnosti…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Zašifrovať peňaženku…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Zálohovať peňaženku…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Zmena hesla…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Odomknúť peňaženku</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Podpísať &amp;správu…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Overiť správu…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Odosielacie adresy</translation>
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
         <translation>&amp;Prijímacie adresy</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation>Otvoriť &amp;URI…</translation>
     </message>
     <message>
         <source>Open Wallet</source>
@@ -344,12 +379,8 @@
         <translation>Otvoriť peňaženku</translation>
     </message>
     <message>
-        <source>Close Wallet...</source>
-        <translation>Zatvoriť Peňaženku...</translation>
-    </message>
-    <message>
         <source>Close wallet</source>
-        <translation>Zatvoriť peňaženku...</translation>
+        <translation>Zatvoriť peňaženku…</translation>
     </message>
     <message>
         <source>No wallets available</source>
@@ -404,10 +435,6 @@
         <translation>Zobrazit informácie o Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Možnosti...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;O %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Zobraziť alebo skryť hlavné okno</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Zašifrovať peňaženku...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Zašifruj súkromné kľúče ktoré patria do vašej peňaženky</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Zálohovať peňaženku...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Zálohovať peňaženku na iné miesto</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Zmena hesla...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Zmeniť heslo použité na šifrovanie peňaženky</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Odomknúť peňaženku</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>&amp;Zamknúť peňaženku</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Podpísať &amp;správu...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Podpísať správy s vašimi Dash adresami ako dôkaz že ich vlastníte</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Overiť správu...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Zobraziť zoznam použitých prijímacích adries a ich popisov</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>Otvoriť &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Možnosti príkazového riadku</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>Zobraziť informácie o %1</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>Vytvoriť peňaženku...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>Sieťová aktivita zakázaná</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Synchronizujú sa hlavičky (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Synchronizácia so sieťou...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Indexujem bloky na disku...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Spracovávam bloky na disku...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Reindexujú sa bloky na disku...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Pripája sa k partnerom...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>Spracovaný jeden blok transakčnej histórie.</numerusform><numerusform>Spracované %n bloky transakčnej histórie.</numerusform><numerusform>Spracovaných %n blokov transakčnej histórie.</numerusform><numerusform>Spracovaných %n blokov transakčnej histórie.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 pozadu</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Sťahujem...</translation>
+        <source>Close Wallet…</source>
+        <translation>Zatvoriť Peňaženku…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Vytvoriť peňaženku…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Synchronizujú sa hlavičky (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Synchronizácia so sieťou…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Indexujem bloky na disku…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Spracovávam bloky na disku…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Reindexujú sa bloky na disku…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Pripája sa k partnerom…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Sťahujem…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>Pôvodná správa:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Vytvára sa peňaženka &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Vytvára sa peňaženka &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>Vytvoriť</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>Keďže toto je prvé spustenie programu, môžete si vybrať, kam %1 bude ukladať vaše údaje.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Keď kliknete na OK tak %1 začne sťahovanie a spracuje celý %4 blockchain (%2GB) počnúc najmladšími transakciami v %3 keď sa %4 prvý krát spustil.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Počiatočná synchronizácia je veľmi náročná a môže odhaliť hardvérové problémy vo vašom počítači o ktorých ste do teraz nevedeli. Vždy keď zapnete %1 tak sa sťahovanie začne presne tam kde bolo pred vypnutím.</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>Kopírovať zábezpeku Outpoint</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Aktualizuje sa...</translation>
+        <source>Please wait…</source>
+        <translation>Prosím čakajte…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Aktualizuje sa…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>Filtrovať podľa ľubovoľnej vlastnosti (napr. adresa alebo protx hash)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Prosím čakajte...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Ďalšie informácie pre DIP3 Masternode %1</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>Počet zostávajúcich blokov</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Neznáme...</translation>
+        <source>Unknown…</source>
+        <translation>Neznáme…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>počíta sa…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>Prírastok postupu za hodinu</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>počíta sa...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Odhad času pre dokončenie synchronizácie</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>Skryť</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Neznáme. Synchronizujú sa hlavičky (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Neznáme. Synchronizujú sa hlavičky (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>predvolená peňaženka</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>Otvára sa peňaženka &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>Otvára sa peňaženka &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>Možnosti nastavené v tomto dialógovom okne sú prepísané príkazovým riadkom alebo v konfiguračnom súbore:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Skryť ikonu zo systémovej lišty.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;Skryť ikonu v oblasti oznámení</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Minimalizovať namiesto ukončenia aplikácie keď sa okno zavrie. Keď je zvolená táto možnosť, aplikácia sa zavrie len po zvolení Ukončiť v menu.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>Jazyk uživateľského rozhrania sa dá nastaviť tu. Toto nastavenie sa uplatní až po reštarte %1.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Chýbajúci alebo nekompletný preklad? Pomôžte nám tu:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>„dash://“ nie je platný URI. Namiesto toho použite „dash:“.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>Neplatná adresa platby %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI sa nedá analyzovať! Toto môže byť spôsobené neplatnou Dash adresou, alebo nesprávnym tvarom URI parametrov.</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Agent používateľa</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Odozva</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Odoslané</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Prijaté</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Chyba: %1 CSS súbor(ov) chýba v ceste -custom-css-dir.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 nebol ešte bezpečne ukončený...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 nebol ešte bezpečne ukončený…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QR kód</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Uložiť obrázok...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Uložiť obrázok…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Uložiť obrázok...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Uložiť obrázok…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Pre detailné informácie vyberte partnerský uzol.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Smer</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Verzia</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Služby</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Skóre zákazu</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>cez %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>nikdy</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Vstupné</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Výstupné</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Pravidelné</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>Neznáme</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Kopírovať sumu</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,8 +2722,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Kopírovať &amp;adresu</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Uložiť obrázok...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Uložiť obrázok…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Možnosti "Kontroly mincí"</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Vstupy...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>automaticky vybraté</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Prach:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Vstupy…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Po poplatku:</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Transakčný poplatok</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Vybrať...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Inteligentný poplatok nebol ešte inicializovaný. Obvykle to trvá nekoľko blokov…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Používanie fallbackfee môže mať za následok odoslanie transakcie, ktorá sa bude potvrdzovať niekoľko hodín alebo dní (prípadne nikdy). Zvážte možnosť výberu poplatku ručne alebo počkajte, než potvrdíte kompletný reťazec blokov.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Vybrať…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Vlastné:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Inteligentný poplatok nebol ešte inicializovaný. Obvykle to trvá nekoľko blokov...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 sa vypína...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 sa vypína…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3249,7 +3214,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
-        <translation>&amp;Overiť správu...</translation>
+        <translation>&amp;Overiť správu…</translation>
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tento rok</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Rozsah...</translation>
+        <source>Range…</source>
+        <translation>Rozsah…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -3874,7 +3839,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
-        <translation>Zatvoriť peňaženku...</translation>
+        <translation>Zatvoriť peňaženku…</translation>
     </message>
     <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nájdený dostatok používateľov, pospisuje sa ( čakanie %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Nájdený dostatok používateľov, pospisuje sa ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Importuje sa...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Nekompatibilný mód.</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Neplatný minimálny počet spork podpisovateľov určených pomocou -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Načítavam banlist...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Zámok je už na mieste.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Prebieha miešanie...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nie je v zozname Masternode.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Redukovanie blockstore…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Prebieha nahratie blokov …</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Znova prehľadávam…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Spúšťajú sa sieťové vlákna…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Odoslané na masternode, čaká vo fronte %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Synchronizácia dokončená</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Synchronizuje sa blockchain…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Synchronizujú sa objekty správy…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Komentár u typu klienta (%s) obsahuje riskantné znaky.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Overuje sa peňaženka(y)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Skúsime znovu...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Chyba: Miesta na disku pre %s je málo</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Chyba: Nepodaril sa pridať soket do epollfd (epoll_ctl vrátil chybu %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Prekročený maximálny počet pokusov.</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Počas inicializácie sa nepodarilo znova naskenovať peňaženku</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Nájdený dostatok používateľov, pospisuje sa…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>Neplatné povolenie P2P: '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Neplatný masternodeblsprivkey. Pozrite si dokumentáciu.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Načítavanie zoznamu blokov...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Načítavanie peňaženky...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Fronta Masternode je plná</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Chýbajú vstupy transakčnej informácie.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Prebieha miešanie…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Orezávanie nie je kompatibilné s -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Redukovanie blockstore...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>Sekcia [%s] nie je rozpoznaná.</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Zadaný -walletdir "%s" nie je adresár</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Synchronizuje sa blockchain...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Transakcia je príliš veľká</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Pokúšame sa pripojiť...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Nedá sa pripojiť k %s na tomto počítači. %s už pravdepodobne beží.</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>Vylepšuje sa databáza neminutých výstupov (UTXO)</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Overovanie blokov…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Overuje sa peňaženka(y)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Chyba pri vylepšení databáze reťzcov blokov</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Chyba: Nepodaril sa pridať soket do kqueuefd (kevent vrátil chybu %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>Načítavam P2P adresy…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Načítavam banlist…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Načítavanie zoznamu blokov…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Načítavanie peňaženky…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nepodarilo sa spustiť novú frontu miešania</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>Importuje sa…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Nesprávny -rescan režim, vracia sa späť k predvolenej hodnote</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Neplatná spork adresa určená pomocou -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Načítavam P2P adresy…</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Obmedzuje sa -maxconnections z %d na %d kvôli systémovým obmedzeniam.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Prebieha nahratie blokov ...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Znova prehľadávam...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Posledná akcia bola pred chvíľou.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Spúšťajú sa sieťové vlákna...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Synchronizujú sa objekty správy...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>Zdrojový kód je dostupný z %s</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>Neplatná transakcia.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Pokúšame sa pripojiť…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Aktualizácia databázy txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Overovanie blokov...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Zostáva veľmi málo kľúčov: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Upozornenie: nesprávny parameter %s, cesta musí existovať! Použije sa predvolené cesta.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Skúsime znovu…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_th.ts
+++ b/src/qt/locale/dash_th.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>เรียกเก็บการชำระเงิน (สร้างคิว อาร์ โค้ด QR codes และแหล่งที่มาของ Dash: URIs)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;ตัวเลือก…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;เข้ารหัสกระเป๋าสตางค์</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;สำรองกระเป๋าสตางค์…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;เปลี่ยนวลีรหัสผ่าน…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;ปลดล็อคกระเป๋าสตางค์</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>การลงนาม &amp;ข้อความ…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;ยืนยันข้อความ…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;ส่งที่อยู่</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>รับที่อยู่</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>เปิด &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>เปิดกระเป๋าสตางค์</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>เปิดกระเป๋า</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>ปิดกระเป๋าสตางค์ ...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>แสดงข้อมูล เกี่ยวกับ Qt</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;ตัวเลือก...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>&amp;เกี่ยวกับ %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>แสดง หรือ ซ่อน หน้าหลัก</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;เข้ารหัสกระเป๋าสตางค์</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>เข้ารหัส private keys สำหรับกระเป๋าสตางค์ของท่าน</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;สำรองกระเป๋าสตางค์...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>สำรองกระเป๋าเงินไปยังที่เก็บอื่น</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;เปลี่ยนวลีรหัสผ่าน...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>เปลี่ยนรหัสผ่านที่ใช้สำหรับการเข้าถึงรหัสลับของกระเป๋าสตางค์</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;ปลดล็อคกระเป๋าสตางค์</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>ล็อคกระเป๋าสตางค์</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>การลงนาม &amp;ข้อความ...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>ลงชื่อด้วยที่อยู่ Dash ของคุณเพื่อแสดงว่าคุณคือเจ้าของบัญชีนี้จริง</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;ยืนยันข้อความ...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>แสดงรายการที่อยู่ผู้รับและป้ายชื่อที่ใช้ไปแล้ว</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>เปิด &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;ตัวเลือก Command-line</translation>
     </message>
@@ -586,10 +585,6 @@
         <translation>เปิด Dash: URI</translation>
     </message>
     <message>
-        <source>Create Wallet...</source>
-        <translation>สร้างกระเป๋าสตางค์ ...</translation>
-    </message>
-    <message>
         <source>Create a new wallet</source>
         <translation>สร้างกระเป๋าเงินใหม่</translation>
     </message>
@@ -629,30 +624,6 @@
         <source>Network activity disabled</source>
         <translation>ปิดการใช้งานเครือข่ายแล้ว</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>กำลังซิงค์ส่วนหัว (%1%) ...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>กำลังซิงค์กับเครือข่าย ...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>การกำลังสร้างดัชนีของบล็อก ในดิสก์...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>กำลังดำเนินการกับบล็อกในดิสก์...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>กำลังทำดัชนี ที่เก็บบล็อก ใหม่ ในดิสก์...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>เชื่อมต่อกับ Peers</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>ประมวลผล %n บล็อคของประวัติการทำธุรกรรม</numerusform></translation>
@@ -662,7 +633,39 @@
         <translation>%1 ตามหลัง</translation>
     </message>
     <message>
-        <source>Catching up...</source>
+        <source>Close Wallet…</source>
+        <translation>ปิดกระเป๋าสตางค์ …</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>สร้างกระเป๋าสตางค์ …</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>กำลังซิงค์ส่วนหัว (%1%) …</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>กำลังซิงค์กับเครือข่าย …</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>การกำลังสร้างดัชนีของบล็อก ในดิสก์…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>กำลังดำเนินการกับบล็อกในดิสก์…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>กำลังทำดัชนี ที่เก็บบล็อก ใหม่ ในดิสก์…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>เชื่อมต่อกับ Peers</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
         <translation>กำลังอัพเดต</translation>
     </message>
     <message>
@@ -787,7 +790,7 @@
         <source>Original message:</source>
         <translation>ข้อความต้นฉบับ:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -982,8 +985,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>การสร้างกระเป๋าเงิน &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>การสร้างกระเป๋าเงิน &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1032,7 +1035,7 @@
         <source>Create</source>
         <translation>สร้าง</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1176,10 +1179,6 @@
         <translation>นี่เป็นการรันโปรแกรมครั้งแรก ท่านสามารถเลือก ว่าจะเก็บข้อมูลไว้ที่ %1</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>เมื่อคุณกด OK %1 จะเริ่มดาวน์โหลดและดำเนินการเต็ม %4 ของ block chain (%2GB) เริ่มต้นด้วยการทำธุรกรรมแรกสุดใน %3 เมื่อ %4 เริ่มดำเนินการในขั้นต้น</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>การซิงโครไนซ์ในขั้นต้นนี้เป็นที่ต้องการอย่างมาก และอาจจะปรากฏปัญหาของฮ​าร์ดแวร์กับคอมพิวเตอร์ของคุณที่อาจจะไม่ได้สังเกตมาก่อน ในแต่ละครั้งคุณดำเนินการ %1 มันจะดำเนินการดาวน์โหลดที่ค้างไว้</translation>
     </message>
@@ -1303,8 +1302,12 @@
         <translation>Copy Collateral Outpoint</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>กำลังอัพเดต...</translation>
+        <source>Please wait…</source>
+        <translation>กรุณารอสักครู่…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>กำลังอัพเดต…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1339,10 +1342,6 @@
         <translation>กรองตามทรัพย์สินต่าง ๆ  (เช่นที่อยู่หรือ protx hash)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>กรุณารอสักครู่...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>ข้อมูลเพิ่มเติมสำหรับ DIP3 Masternode %1</translation>
     </message>
@@ -1366,8 +1365,12 @@
         <translation>จำนวนบล็อกที่เหลือ</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>ไม่ทราบ...</translation>
+        <source>Unknown…</source>
+        <translation>ไม่ทราบ…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>กำลังคำนวณ…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1382,10 +1385,6 @@
         <translation>เพิ่มความคืบหน้าต่อชั่วโมง</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>กำลังคำนวณ...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>เวลาโดยประมาณที่เหลือจนกว่าจะซิงค์</translation>
     </message>
@@ -1394,8 +1393,8 @@
         <translation>ซ่อน</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>ไม่ทราบการซิงค์ส่วนหัว (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>ไม่ทราบการซิงค์ส่วนหัว (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1424,8 +1423,8 @@
         <translation>กระเป๋าเงินเริ่มต้น</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>เปิดกระเป๋า &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>เปิดกระเป๋า &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1583,14 +1582,6 @@
         <translation>ตัวเลือกที่ตั้งไว้ในกล่องโต้ตอบนี้จะถูกแทนที่โดยบรรทัดคำสั่งหรือในไฟล์กำหนดค่า:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>ซ่อนไอคอนจาก System tray</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;ซ่อนไอคอน tray </translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>มินิไมซ์แอพ แทนการออกจากแอพพลิเคชั่น เมื่อวินโดว์ได้รับการปิด เมื่อเลือกตัวเลือกนี้ แอพพลิเคชั่น จะถูกปิด ก็ต่อเมื่อ มีการเลือกเมนู Exit/ออกจากระบบ เท่านั้น</translation>
     </message>
@@ -1697,12 +1688,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>สามารถตั้งค่า User interface language ได้ที่นี่ การตั้งค่านี้จะมีผลหลังจากรีสตาร์ท %1</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>ภาษาขาดหายไปหรือการแปลไม่สมบูรณ์ใช่หรือไม่?  สามารถช่วยแปลเพิ่มเติมได้ที่นี่:   
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -2014,10 +1999,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>เนื่องจากการสนับสนุนถูกยกเลิก คุณควรขอให้ผู้ค้าจัดเตรียม URI ที่เข้ากันได้กับ BIP21 หรือใช้กระเป๋าเงินที่รองรับ BIP70 ต่อไป</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>ที่อยู่การชำระเงินไม่ถูกต้อง %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>ไม่สามารถประมวลผล URI ได้สำเร็จ ! ซึ่งอาจเกิดจากที่อยู่ Dash ไม่ถูกต้องหรือพารามิเตอร์ URI ที่มีรูปแบบไม่ถูกต้อง</translation>
     </message>
@@ -2030,18 +2011,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>ตัวแทนผู้ใช้</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>ส่ง</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>ได้รับ</translation>
     </message>
     </context>
@@ -2174,8 +2159,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ข้อผิดพลาด:%1 CSS file(s) หายไปในเส้นทาง -custom-css-dir</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 ยังไม่สามารถออกจากระบบได้อย่างปลอดภัย ...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 ยังไม่สามารถออกจากระบบได้อย่างปลอดภัย …</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2285,15 +2270,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>โค้ด QR</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;บันทึกรูปภาพ...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;บันทึกรูปภาพ…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;บันทึกรูปภาพ...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;บันทึกรูปภาพ…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2419,10 +2404,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>เลือก Peer เพื่อดูรายละเอียด</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>ทิศทาง</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>เวอร์ชั่น</translation>
     </message>
@@ -2529,10 +2510,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>บริการ</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Ban Score</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2659,22 +2636,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>via %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>ไม่เคย</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>ขาเข้า</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>ขาออก</translation>
-    </message>
-    <message>
-        <source>Outbound block-relay</source>
-        <translation>Outbound block-relay</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>ปกติ</translation>
     </message>
@@ -2690,7 +2651,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>ไม่ทราบ</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2789,7 +2750,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>คัดลอกจำนวน</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2801,8 +2762,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>คัดลอก &amp;ที่อยู่</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;บันทึกรูปภาพ...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;บันทึกรูปภาพ…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2855,10 +2816,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>คุณสมบัติการควบคุมเหรียญ</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>ปัจจัยการผลิต...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>เลือกโดยอัตโนมัติ</translation>
     </message>
@@ -2887,6 +2844,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>เศษ:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>ปัจจัยการผลิต…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>ส่วนที่เหลือจากค่าธรรมเนียม:</translation>
     </message>
@@ -2907,16 +2868,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ค่าธรรมเนียมการทำธุรกรรม:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>เลือก...</translation>
-    </message>
-    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
         <translation>เมื่อมีปริมาณธุรกรรมน้อยกว่าพื้นที่ในบล็อก นักขุดและโหนดรีเลย์อาจบังคับใช้ค่าธรรมเนียมขั้นต่ำ การจ่ายเฉพาะค่าธรรมเนียมขั้นต่ำนี้ถือว่าใช้ได้ แต่โปรดทราบว่าสิ่งนี้อาจส่งผลให้ธุรกรรมไม่ได้รับการยืนยันเมื่อมีความต้องการธุรกรรม Dash มากกว่าที่เครือข่ายจะสามารถดำเนินการได้</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation>ค่าธรรมเนียมที่ต่ำเกินไปอาจทำให้ธุรกรรมไม่ได้รับการยืนยัน (อ่านคำแนะนำเครื่องมือ)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(ค่าธรรมเนียมยังไม่ถูกเก็บ โดยปกติจะใช้สองสามบล็อค … )</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2933,6 +2894,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>การใช้ fallbackfee อาจส่งผลให้การส่งธุรกรรมที่ต้องใช้เวลาหลายชั่วโมงหรือหลายวัน (หรือไม่) เพื่อยืนยัน พิจารณาเลือกค่าธรรมเนียมด้วยตนเองหรือรอจนกว่าคุณจะได้ตรวจสอบความสมบูรณ์ของสายโซ่</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>เลือก…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2953,10 +2918,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>กำหนดเอง:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(ค่าธรรมเนียมยังไม่ถูกเก็บ โดยปกติจะใช้สองสามบล็อค ... )</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3107,10 +3068,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>หรือ</translation>
     </message>
     <message>
-        <source>To review recipient list click "Show Details..."</source>
-        <translation>หากต้องการตรวจสอบรายชื่อผู้รับ คลิก "แสดงรายละเอียด..."</translation>
-    </message>
-    <message>
         <source>Confirm send coins</source>
         <translation>ยืนยันการส่งเหรียญ</translation>
     </message>
@@ -3121,6 +3078,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Send</source>
         <translation>ส่ง</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation>หากต้องการตรวจสอบรายชื่อผู้รับ คลิก "แสดงรายละเอียด…"</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
@@ -3261,8 +3222,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 กำลังปิด...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 กำลังปิด…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3791,8 +3752,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ปีนี้</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>ช่วง...</translation>
+        <source>Range…</source>
+        <translation>ช่วง…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4146,15 +4107,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Found enough users, signing ( waiting %s )</source>
-        <translation>พบผู้ใช้เพียงพอ, กำลังลงนาม...  ( กำลังรอ %s )</translation>
-    </message>
-    <message>
-        <source>Found enough users, signing ...</source>
-        <translation>พบผู้ใช้เพียงพอ, กำลังลงนาม...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>กำลังนำเข้า...</translation>
+        <translation>พบผู้ใช้เพียงพอ, กำลังลงนาม…  ( กำลังรอ %s )</translation>
     </message>
     <message>
         <source>Incompatible mode.</source>
@@ -4189,16 +4142,8 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>จำนวนขั้นต่ำ spork signers ไม่ถูกต้องระบุด้วย -minsporkkeys</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>กำลังโหลดรายการต้องห้าม</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>ล็อกอยู่ในตำแหน่งแล้ว</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>อยู่ระหว่างการผสม...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4221,12 +4166,36 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>ไม่อยู่ในรายการ Masternode</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>กำลังตัด blockstore …</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>กำลัง reply blocks…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>กำลังสแกนใหม่…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>เริ่มต้นเธรดเครือข่าย ..</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>ส่งไปยัง masternode กำลังรอคิว %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>การซิงโครไนซ์สิ้นเสร็จ</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>กำลังซิงโครไนซ์ blockchain…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>กำลังปรับเทียบออบเจคการกำกับ …</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4239,14 +4208,6 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>ตัวแทนผู้ใช้แสดงความคิดเห็น (%s) มีอักขระที่ไม่ปลอดภัย</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>กำลังตรวจสอบ wallet(s)...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>จะลองใหม่ ...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4365,10 +4326,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>ข้อผิดพลาด: พื้นที่ดิสก์ต่ำสำหรับ %s</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>ข้อผิดพลาด: ล้มเหลวในการเพิ่ม socket to epollfd (epoll_ctl returned error %s) </translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>เกินความพยายามสูงสุด</translation>
     </message>
@@ -4397,6 +4354,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>ตรวจสอบฐานข้อมูลไม่สำเร็จ</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>พบผู้ใช้เพียงพอ, กำลังลงนาม…</translation>
+    </message>
+    <message>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation>ละเว้น duplicate -wallet %s.</translation>
     </message>
@@ -4413,14 +4374,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>masternodeprivkey ไม่ถูกต้อง โปรดดูเอกสารประกอบ</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>กำลังโหลดดัชนีบล็อก ...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>กำลังโหลด Wallet ...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>คิว Masternode เต็ม</translation>
     </message>
@@ -4431,6 +4384,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Missing input transaction information.</source>
         <translation>อินพุตข้อมูลธุรกรรมขาดหายไป</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>อยู่ระหว่างการผสม…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4459,10 +4416,6 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation>โหมด Prune ไม่สามารถใช้ได้กับ -txtindex ได้</translation>
-    </message>
-    <message>
-        <source>Pruning blockstore...</source>
-        <translation>กำลังตัด blockstore ...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -4497,10 +4450,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>-walletdir "%s" ที่ระบุไม่ใช่ไดเรกทอรี่</translation>
     </message>
     <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>กำลังซิงโครไนซ์ blockchain...</translation>
-    </message>
-    <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
         <translation>กระเป๋าสตางค์นี้จะหลีกเลี่ยงการจ่ายเงินน้อยกว่าค่าโอนขั้นต่ำ</translation>
     </message>
@@ -4533,10 +4482,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>ธุรกรรมมีขนาดใหญ่เกินไป</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>กำลังพยายามเชื่อมต่อ ...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>ไม่สามารถผูกกับ %s คอมพิวเตอร์เครื่องนี้ได้  %s อาจกำลังทำงานอยู่แล้ว</translation>
     </message>
@@ -4555,6 +4500,14 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Upgrading UTXO database</source>
         <translation>การอัพเกรดฐานข้อมูล UTXO</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>กำลังตรวจสอบบล็อค …</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>กำลังตรวจสอบ wallet(s)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4705,8 +4658,20 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>เกิดข้อผิดพลาดในการอัพเกรดฐานข้อมูล chainstate</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>ข้อผิดพลาด: ล้มเหลวในการเพิ่ม socket to kqueuefd (kevent returned error %s) </translation>
+        <source>Loading P2P addresses…</source>
+        <translation>กำลังโหลดที่อยู่ P2P …</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>กำลังโหลดรายการต้องห้าม</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>กำลังโหลดดัชนีบล็อก …</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>กำลังโหลด Wallet …</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4745,6 +4710,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>ไม่สามารถเริ่มคิวการผสมใหม่</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>กำลังนำเข้า…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>โหมด -rescan ไม่ถูกต้อง ถอยกลับไปในค่าเริ่มต้น</translation>
     </message>
@@ -4773,20 +4742,8 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>ที่อยู่ spork ที่ระบุด้วย -sporkaddr ไม่ถูกต้อง</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>กำลังโหลดที่อยู่ P2P ...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>ลดการเชื่อมต่อสูงสุดจาก %d ถึง %d เนื่องจากข้อจำกัดของระบบ</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>กำลัง reply blocks...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>กำลังสแกนใหม่...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4817,14 +4774,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>การกระทำที่ประสบความสำเร็จล่าสุดเป็นข้อมูลล่าสุด</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>เริ่มต้นเธรดเครือข่าย ..</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>กำลังปรับเทียบออบเจคการกำกับ ...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>ซอร์สโค้ดที่ใช้ได้จาก %s</translation>
     </message>
@@ -4851,6 +4800,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Transaction not valid.</source>
         <translation>ธุรกรรมไม่ถูกต้อง</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>กำลังพยายามเชื่อมต่อ …</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4885,10 +4838,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>การอัพเกรดฐานข้อมูล txindex</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>กำลังตรวจสอบบล็อค ...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>จำนวนคีย์ที่เหลืออยู่ต่ำมาก: %d</translation>
     </message>
@@ -4903,6 +4852,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>คำเตือน: ปัจจัยที่กำหนดไม่ถูกต้อง %s, เส้นทางต้องมี! ใช้เส้นทางเริ่มต้น</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>จะลองใหม่ …</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_tr.ts
+++ b/src/qt/locale/dash_tr.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>Ödeme talep et (QR kodu ve Dash URI'si oluşturur)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Seçenekler…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Cüzdanı Şifrele…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Cüzdanı Yedekle…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>&amp;Parolayı Değiştir…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>Cüzdanı &amp;Kilitle…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>&amp;İleti imzala…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>İletiyi &amp;kontrol et…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;Gönderilen adresler</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;Alıcı adresler</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>&amp;URI Aç…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>Açık Cüzdan</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>Cüzdanı Aç</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>Kapalı Cüzdan...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>Qt hakkında bilgi göster</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Seçenekler...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>%1 &amp;Hakkında</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>Ana pencereyi göster ya da gizle</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Cüzdanı Şifrele...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Cüzdanınıza ait özel anahtarları şifreleyin</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Cüzdanı Yedekle...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Cüzdanı diğer bir konumda yedekle</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Parolayı Değiştir...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cüzdan şifrelemesi için kullanılan parolayı değiştir</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>Cüzdanı &amp;Kilitle...</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>Cüzdanı &amp;Kilitle</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>&amp;İleti imzala...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>İletileri adreslerin size ait olduğunu ispatlamak için Dash adresleri ile imzala</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>İletiyi &amp;kontrol et...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>Kullanılmış alım adresleri ve etiketlerin listesini göster</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>&amp;URI Aç...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;Komut satırı seçenekleri</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>%1 ile ilgili bilgileri göster</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>Cüzdan Oluştur...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>Ağ etkinliği devre dışı bırakıldı</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Üstbilgiler Senkronize Ediliyor (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Ağ ile senkronize ediliyor...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Bloklar diske indeksleniyor...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Bloklar diske işleniyor...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Diskteki bloklar yeniden indeksleniyor...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Eşlere bağlanılıyor...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>İşlem geçmişindeki %n blok işlendi.</numerusform><numerusform>İşlem geçmişindeki %n blok işlendi.</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>%1 geride</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Aralık kapatılıyor...</translation>
+        <source>Close Wallet…</source>
+        <translation>Kapalı Cüzdan…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>Cüzdan Oluştur…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Üstbilgiler Senkronize Ediliyor (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Ağ ile senkronize ediliyor…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Bloklar diske indeksleniyor…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Bloklar diske işleniyor…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Diskteki bloklar yeniden indeksleniyor…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Eşlere bağlanılıyor…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Aralık kapatılıyor…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>Orijinal mesaj:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>&lt;b&gt;%1&lt;/b&gt; Cüzdan Oluşturuluyor...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt; Cüzdan Oluşturuluyor…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>Oluştur</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>Bu programın ilk kez başlatılmasından dolayı %1 yazılımının verilerini nerede saklayacağını seçebilirsiniz.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Tamam'a tıkladığınızda, %1, bütün %4 blok zincirini (%2GB) %4 ilk olarak yayınlandığında %3'deki en erken işlemlerden  indirmeye ve işlemeye başlayacaktır.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Bu başlangıç senkronizasyonu çok zorlayıcıdır ve bilgisayarınızdaki daha önce fark edilmemiş olan donanım sorunlarını ortaya çıkarabilir. %1'i her çalıştırdığınızda, kaldığı yerden devam edecektir.</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>Teminat Çıkış Noktasını Kopyala</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Güncelleştiriyor...</translation>
+        <source>Please wait…</source>
+        <translation>Lütfen bekleyin…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Güncelleştiriyor…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>Herhangi bir özelliğe göre filtreleyin (ör. adres veya protx hash'ı)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Lütfen bekleyin...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>DIP3 Ana Düğümü %1 için ek bilgi</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>Kalan blok sayısı</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Bilinmiyor...</translation>
+        <source>Unknown…</source>
+        <translation>Bilinmiyor…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>hesaplanıyor…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>Saat başı ilerleme artışı</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>hesaplanıyor...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Senkronize edilene kadar kalan tahmini süre</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>Gizle</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>Bilinmeyen. Başlıklar Senkronize Ediliyor (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>Bilinmeyen. Başlıklar Senkronize Ediliyor (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>varsayılan cüzdan</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>&lt;b&gt;%1&lt;/b&gt; Cüzdan Açılıyor...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt; Cüzdan Açılıyor…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>Bu iletişim kutusunda ayarlanan seçenekler, komut satırı veya yapılandırma dosyası tarafından geçersiz kılınır:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Simgeyi sistem çubuğunda gizle.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;Sistem çubuğu simgesini gizle</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>Pencere kapatıldığında uygulamadan çıkmak yerine uygulamayı küçültür. Bu seçenek etkinleştirildiğinde, uygulama sadece menüden çıkış seçildiğinde kapanacaktır.</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>Kullanıcı arayüzünün dili burada belirtilebilir. Bu ayar %1 tekrar başlatıldığında etkinleşecektir.</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Diliniz mevcut değil veya çeviri eksik mi? Buradan çevirilere katkıda bulunun:
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' geçerli bir URI değil. Bunun yerine 'dash:' kullanın.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>%1 ödeme adresi geçersizdir</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI ayrıştırılamıyor! Bunun nedeni geçersiz bir Dash adresi veya hatalı biçimlendirilmiş URI değişkenleri olabilir.</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>Kullanıcı Yazılımı</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Gönderildi</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Alındı</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Hata: -custom-css-dir yolunda %1 CSS dosyas(lar)ı eksik.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1  henüz güvenli bir şekilde çıkış yapmamıştır...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1  henüz güvenli bir şekilde çıkış yapmamıştır…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QR Kodu</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>Resmi ka&amp;ydet...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>Resmi ka&amp;ydet…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>Resmi ka&amp;ydet...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>Resmi ka&amp;ydet…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ayrıntılı bilgi görmek için bir eş seçin.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>Yön</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>Servisler</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>Yasaklama Skoru</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1 vasıtasıyla</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>asla</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Gelen</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Giden</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>Düzenli</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>bilinmiyor</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Tutarı kopyala</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,8 +2722,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Adresi kopyala</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>Resmi ka&amp;ydet...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>Resmi ka&amp;ydet…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Para kontrolü özellikleri</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Girdiler...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>otomatik seçilmiş</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Toz:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Girdiler…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Ücretten sonra:</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>İşlem ücreti:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Seç...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Zeki ücret henüz başlatılmadı. Bu genelde birkaç blok alır…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Fallbackfee kullanmak, bir işlemin teyit edilmesinin satler veya günler almasına (ve hiçbir zaman teyit edilememesine) neden olabilir. Ücreti elle seçmeyi veya tüm zincirin onaylanmasını beklemeyi göz önünde bulundurun.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Seç…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>Özel:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Zeki ücret henüz başlatılmadı. Bu genelde birkaç blok alır...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 kapanıyor...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 kapanıyor…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,7 +3672,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Bu yıl</translation>
     </message>
     <message>
-        <source>Range...</source>
+        <source>Range…</source>
         <translation>Tarih Aralığı</translation>
     </message>
     <message>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Yeterli kullanıcı bulundu, imzalanıyor ( %s bekleniyor )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Yeterli kullanıcı bulundu, imzalanıyor ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>İçe aktarılıyor...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>Uyumsuz mod.</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-minsporkkeys ile belirtilmiş geçersiz minimum spork imzacısı sayısı</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>Yasaklama listesi yükleniyor...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Kilit zaten yerinde.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Karışım devam ediyor...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ana düğüm listesinde yok.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Blockstore budanıyor…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Tekrarlanan bloklar…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Yeniden tarama…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Ağ iş parçacıkları başlatılıyor…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Ana düğüme gönderildi, kuyrukta bekleniyor %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Eşleme bitti</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Blok zinciri eşleniyor…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Yönetim nesneleri eşleniyor…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Kullanıcı Aracı açıklaması (%s) güvensiz karakterler içermektedir.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Cüzdan(lar) doğrulanıyor...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Tekrar denenecek...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Hata: %s için disk alanı yetersiz</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Hata: epollfd'ye soket eklenemedi (epoll_ctl %s hatası verdi)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Maksimum deneme aşıldı.</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Başlatma sırasında cüzdan yeniden taranamadı</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>Yeterli kullanıcı bulundu, imzalanıyor…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>Geçersiz P2P izni: '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Geçersiz masternodeblsprivkey. Lütfen dökümanlara göz atın.</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>Blok indeksi yükleniyor...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Cüzdan yükleniyor...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Ana düğüm kuyruğu dolu.</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Girdi işlem bilgisi eksik.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Karışım devam ediyor…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Budama kipi -txindex ile uyumsuzdur.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Blockstore budanıyor...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>[%s] bölümü tanınmadı.</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Belirtilen -walletdir "%s" dizin değildir</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Blok zinciri eşleniyor...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>İşlem çok büyük</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Bağlanmaya çalışılıyor...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Bu bilgisayarda %s unsuruna bağlanılamadı. %s muhtemelen hâlihazırda çalışmaktadır.</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>UTXO veritabanı yükseltiliyor</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>Bloklar kontrol ediliyor…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Cüzdan(lar) doğrulanıyor…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Zincirdurumu veritabanı yükseltme hatası</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>Hata: kqueuefd'ye soket eklenemedi (kevent %s hatası verdi)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>P2P adresleri yükleniyor…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Yasaklama listesi yükleniyor…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Blok indeksi yükleniyor…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Cüzdan yükleniyor…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Yeni bir karışım kuyruğu başlatılamadı</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>İçe aktarılıyor…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>Yanlış -rescan modu, varsayılan değere geri dönüyor.</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-sporkaddr ile yanlış spork adresi belirtildi</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>P2P adresleri yükleniyor...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Sistem sınırlamaları sebebiyle -maxconnections %d değerinden %d değerine düşürülmüştür.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Tekrarlanan bloklar...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Yeniden tarama...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Son başarılı eylemi çok yakında yapıldı.</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>Ağ iş parçacıkları başlatılıyor...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Yönetim nesneleri eşleniyor...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>Kaynak kod şuradan elde edilebilir: %s.</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>İşlem geçerli değil.</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>Bağlanmaya çalışılıyor…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>txindex veritabanını yükseltme</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Bloklar kontrol ediliyor...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Çok az sayıda anahtar kaldı: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>Uyarı: %s yanlış parametre, yol mevcut olmalı! Varsayılan yol kullanılıyor.</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>Tekrar denenecek…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_vi.ts
+++ b/src/qt/locale/dash_vi.ts
@@ -1,4 +1,4 @@
-<TS language="vi" version="2.1">
+<TS version="2.1" language="vi">
 <context>
     <name>AddressBookPage</name>
     <message>
@@ -74,10 +74,6 @@
         <translation>Đây là các địa chỉ Dash của bạn để gửi thanh toán. Luôn luôn kiểm tra số tiền và địa chỉ nhận trước khi bạn gửi tiền.</translation>
     </message>
     <message>
-        <source>These are your Dash addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation>Đây là các địa chỉ Dash của bạn để nhận thanh toán. Gợi ý là sử dụng một địa chỉ nhận mới cho mỗi giao dịch.</translation>
-    </message>
-    <message>
         <source>&amp;Copy Address</source>
         <translation>&amp;Sao chép Địa chỉ</translation>
     </message>
@@ -102,16 +98,13 @@
         <translation>Kết xuất danh sách Địa chỉ</translation>
     </message>
     <message>
-        <source>Comma separated file (*.csv)</source>
-        <translation>File định dạng phân cách bởi dấu phẩy (*.csv)</translation>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation>Có lỗi xảy ra khi lưu các địa chỉ vào %1. Hãy thử lại.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
         <translation>Kết xuất không thành công</translation>
-    </message>
-    <message>
-        <source>There was an error trying to save the address list to %1. Please try again.</source>
-        <translation>Có lỗi xảy ra khi lưu các địa chỉ vào %1. Hãy thử lại.</translation>
     </message>
 </context>
 <context>
@@ -187,14 +180,6 @@
         <translation>Nhập lại mật khẩu mới</translation>
     </message>
     <message>
-        <source>Show password</source>
-        <translation>Hiển thị mật khẩu</translation>
-    </message>
-    <message>
-        <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Nhập mật khẩu mới cho ví. &lt;br/&gt;Hãy sử dụng mật khẩu có &lt;b&gt;10 hoặc hơn các ký tự ngẫu nhiên&lt;/b&gt;, hay &lt;b&gt;8 từ hoặc nhiều hơn&lt;/b&gt;.</translation>
-    </message>
-    <message>
         <source>Encrypt wallet</source>
         <translation>Mã hoá ví</translation>
     </message>
@@ -211,20 +196,8 @@
         <translation>Mở khoá ví</translation>
     </message>
     <message>
-        <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
-        <translation>Công việc này cần mật khẩu ví của bạn để giải mã ví.</translation>
-    </message>
-    <message>
-        <source>Decrypt wallet</source>
-        <translation>Giải mã ví</translation>
-    </message>
-    <message>
         <source>Change passphrase</source>
         <translation>Đổi mật khẩu</translation>
-    </message>
-    <message>
-        <source>Enter the old passphrase and new passphrase to the wallet.</source>
-        <translation>Hãy nhập vào mật khẩu cũ và mật khẩu mới cho ví của bạn.</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
@@ -271,10 +244,6 @@
         <translation>Mật khẩu bạn nhập để giải mã ví không chính xác.</translation>
     </message>
     <message>
-        <source>Wallet decryption failed</source>
-        <translation>Giải mã ví không thành công</translation>
-    </message>
-    <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Mật khẩu ví đã được đổi thành công.</translation>
     </message>
@@ -302,23 +271,10 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
-    <message>
-        <source>A fatal error occurred. Dash Core can no longer continue safely and will quit.</source>
-        <translation>Có lỗi nghiêm trọng xảy ra. Dash Core không thể tiếp tục một cách an toàn được nên phải thoát ra.</translation>
-    </message>
-    <message>
-        <source>Dash Core</source>
-        <translation>Dash Core</translation>
-    </message>
-    <message>
-        <source>Wallet</source>
-        <translation>Ví</translation>
-    </message>
-    <message>
-        <source>Node</source>
-        <translation>Nút</translation>
-    </message>
     <message>
         <source>&amp;Overview</source>
         <translation>&amp;Tổng thể</translation>
@@ -342,6 +298,38 @@
     <message>
         <source>Request payments (generates QR codes and dash: URIs)</source>
         <translation>Yêu cầu thanh toán (sinh mã QR và dash: URIs)</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation>&amp;Tuỳ chọn…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>&amp;Mã hoá Ví…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>&amp;Sao lưu Ví…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>Đổi &amp;Mật khẩu…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>&amp;Mở khoá Ví…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>Ký vào &amp;thông điệp…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>&amp;Kiểm tra thông điệp…</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation>Mở &amp;URI…</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -368,20 +356,12 @@
         <translation>Thoát ứng dụng</translation>
     </message>
     <message>
-        <source>Show information about Dash Core</source>
-        <translation>Hiển thị thông tin về Dash Core</translation>
-    </message>
-    <message>
         <source>About &amp;Qt</source>
         <translation>Về &amp;QT</translation>
     </message>
     <message>
         <source>Show information about Qt</source>
         <translation>Hiển thị thông tin giới thiệu về Qt</translation>
-    </message>
-    <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;Tuỳ chọn...</translation>
     </message>
     <message>
         <source>&amp;About %1</source>
@@ -400,32 +380,16 @@
         <translation>Hiển thị hoặc ẩn cửa sổ chính</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Mã hoá Ví...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Mã hoá khoá riêng mà thuộc về ví của bạn</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Sao lưu Ví...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>Sao lưu ví vào vị trí khác</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>Đổi &amp;Mật khẩu...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Đổi mật khẩu dùng để mã hoá ví</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>&amp;Mở khoá Ví...</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -436,16 +400,8 @@
         <translation>&amp;Khoá Ví</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Ký vào &amp;thông điệp...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>Ký vào thông điệp với địa chỉ Dash để chứng minh bạn là chủ của chúng</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Kiểm tra thông điệp...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -462,10 +418,6 @@
     <message>
         <source>&amp;Debug console</source>
         <translation>Giao diện gỡ rối</translation>
-    </message>
-    <message>
-        <source>Open debugging console</source>
-        <translation>Mở giao diện gỡ rối</translation>
     </message>
     <message>
         <source>&amp;Network Monitor</source>
@@ -508,28 +460,12 @@
         <translation>Hiển thị những ví được sao lưu tự động</translation>
     </message>
     <message>
-        <source>&amp;Sending addresses...</source>
-        <translation>&amp;Gửi địa chỉ...</translation>
-    </message>
-    <message>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Hiển thị danh sách các địa chỉ đã sử dụng và các nhãn</translation>
     </message>
     <message>
-        <source>&amp;Receiving addresses...</source>
-        <translation>Địa chỉ nhận...</translation>
-    </message>
-    <message>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Hiển thị danh sách các địa chỉ đã sử dụng để nhận và các nhãn</translation>
-    </message>
-    <message>
-        <source>Open &amp;URI...</source>
-        <translation>Mở &amp;URI...</translation>
-    </message>
-    <message>
-        <source>Open a dash: URI or payment request</source>
-        <translation>Mở một dash: URI hoặc một yêu cầu thanh toán</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
@@ -556,10 +492,6 @@
         <translation>&amp;Thiết đặt</translation>
     </message>
     <message>
-        <source>&amp;Tools</source>
-        <translation>&amp;Công cụ</translation>
-    </message>
-    <message>
         <source>&amp;Help</source>
         <translation>&amp;Trợ giúp</translation>
     </message>
@@ -575,30 +507,6 @@
         <source>Network activity disabled</source>
         <translation>Kết nối mạng bị tắt</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Đang đồng bộ phần đầu (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>Đang đồng bộ với mạng lưới...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>Sắp xếp các khối trên đĩa...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>Đang xử lý các khối trên đĩa...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Sắp xếp lại các khối trên đĩa...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>Đang kết nối với các máy ngang hàng...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>Đã xử lý được %n block(s) của lịch sử giao dịch.</numerusform></translation>
@@ -608,8 +516,32 @@
         <translation>%1 đằng sau</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>Đang nạp bộ đệm...</translation>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>Đang đồng bộ phần đầu (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>Đang đồng bộ với mạng lưới…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>Sắp xếp các khối trên đĩa…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>Đang xử lý các khối trên đĩa…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>Sắp xếp lại các khối trên đĩa…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>Đang kết nối với các máy ngang hàng…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>Đang nạp bộ đệm…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -717,7 +649,7 @@
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Ví &lt;b&gt;đã được mã hoá&lt;/b&gt; và hiện tại &lt;b&gt;đã được khoá&lt;/b&gt;</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -877,10 +809,6 @@
         <translation>Một số coin đã được bỏ chọn vì chúng đã được tiêu.</translation>
     </message>
     <message>
-        <source>Some coins were unselected because they do not have enough mixing rounds.</source>
-        <translation>Một số coin đã được bỏ chọn vì chúng chưa đủ số vòng trộn.</translation>
-    </message>
-    <message>
         <source>Show all coins</source>
         <translation>Hiển thị toàn bộ coin</translation>
     </message>
@@ -905,6 +833,12 @@
         <translation>không áp dụng</translation>
     </message>
 </context>
+<context>
+    <name>CreateWalletActivity</name>
+    </context>
+<context>
+    <name>CreateWalletDialog</name>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -944,10 +878,6 @@
         <translation>Địa chỉ vừa nhập "%1" không phải địa chỉ Dash hợp lệ.</translation>
     </message>
     <message>
-        <source>The entered address "%1" is already in the address book.</source>
-        <translation>Địa chỉ vừa nhập "%1" đã có trong danh sách địa chỉ.</translation>
-    </message>
-    <message>
         <source>Could not unlock wallet.</source>
         <translation>Không thể mở khoá ví.</translation>
     </message>
@@ -980,14 +910,13 @@
     </message>
 </context>
 <context>
+    <name>GovernanceList</name>
+    </context>
+<context>
     <name>HelpMessageDialog</name>
     <message>
         <source>version</source>
         <translation>phiên bản</translation>
-    </message>
-    <message>
-        <source>(%1-bit)</source>
-        <translation>(%1-bit)</translation>
     </message>
     <message>
         <source>About %1</source>
@@ -1013,10 +942,6 @@
         <translation>Đây là lần đầu chương trình khởi chạy, bạn có thể chọn nơi %1 sẽ lưu trữ data.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>Khi bạn click OK, %1 sẽ bắt đầu download và process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>Đồng bộ hóa ban đầu này rất đòi hỏi, và có thể phơi bày các sự cố về phần cứng với máy tính của bạn trước đó đã không được chú ý. Mỗi khi bạn chạy %1, nó sẽ tiếp tục tải về nơi nó dừng lại.</translation>
     </message>
@@ -1031,6 +956,14 @@
     <message>
         <source>Use a custom data directory:</source>
         <translation>Sử dụng thư mục dữ liệu tuỳ chọn:</translation>
+    </message>
+    <message>
+        <source>%1 GB of free space available</source>
+        <translation>%1 GB còn trống </translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation>(của %1 GB cần đến)</translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1056,14 +989,6 @@
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
-    <message>
-        <source>%1 GB of free space available</source>
-        <translation>%1 GB còn trống </translation>
-    </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation>(của %1 GB cần đến)</translation>
-    </message>
 </context>
 <context>
     <name>MasternodeList</name>
@@ -1074,10 +999,6 @@
     <message>
         <source>Status</source>
         <translation>Trạng thái</translation>
-    </message>
-    <message>
-        <source>0</source>
-        <translation>0</translation>
     </message>
     <message>
         <source>Filter List:</source>
@@ -1148,8 +1069,12 @@
         <translation>Copy các đầu ra của khoản đặt cọc</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>Đang cập nhật...</translation>
+        <source>Please wait…</source>
+        <translation>Vui lòng đợi…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>Đang cập nhật…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1184,10 +1109,6 @@
         <translation>Lọc bởi bất kỳ thuộc tính nào (ví dụ địa chỉ hoặc protx hash)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>Vui lòng đợi...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>Thông tin thêm về DIP3 Masternode %1</translation>
     </message>
@@ -1211,8 +1132,12 @@
         <translation>Số khối còn lại</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>Không xác định...</translation>
+        <source>Unknown…</source>
+        <translation>Không xác định…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>đang tính…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1227,10 +1152,6 @@
         <translation>Tiến trình tăng lên mỗi giờ</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>đang tính...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>Thời gian ước đoán còn lại để hoàn tất việc đồng bộ</translation>
     </message>
@@ -1238,11 +1159,7 @@
         <source>Hide</source>
         <translation>Ẩn</translation>
     </message>
-    <message>
-        <source>Unknown. Syncing Headers (%1)...</source>
-        <translation>Không xác định. Đang đồng bộ phần đầu (%1)...</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1250,22 +1167,13 @@
         <translation>Mở URI</translation>
     </message>
     <message>
-        <source>Open payment request from URI or file</source>
-        <translation>Mở yêu cầu thanh toán từ URI hoặc file</translation>
-    </message>
-    <message>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
-    <message>
-        <source>Select payment request file</source>
-        <translation>Chọn file yêu cầ thanh toán</translation>
-    </message>
-    <message>
-        <source>Select payment request file to open</source>
-        <translation>Chọn tệp yêu cầu thanh toán để mở</translation>
-    </message>
 </context>
+<context>
+    <name>OpenWalletActivity</name>
+    </context>
 <context>
     <name>OptionsDialog</name>
     <message>
@@ -1279,10 +1187,6 @@
     <message>
         <source>Size of &amp;database cache</source>
         <translation>Kích thước của dữ liệu cache</translation>
-    </message>
-    <message>
-        <source>MB</source>
-        <translation>MB</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
@@ -1335,18 +1239,6 @@
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
         <translation>Hiển thị nếu proxy SOCKS5 mặc định được cung cấp để dùng tiếp cận các thiết bị ngang hàng thông qua loại mạng này.</translation>
-    </message>
-    <message>
-        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor hidden services:</source>
-        <translation>Sử dụng các proxy riêng biệt SOCKS&amp;5 để truy cập các nút ngang hàng trên các dịch vụ ẩn danh Tor:</translation>
-    </message>
-    <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>Ẩn biểu tượng khỏi khay hệ thống.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>Ẩn biểu tượng &amp;khay hệ thống</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
@@ -1425,10 +1317,6 @@
         <translation>Tor</translation>
     </message>
     <message>
-        <source>Connect to the Dash network through a separate SOCKS5 proxy for Tor hidden services.</source>
-        <translation>Kết nối với mạng lưới Dash thông qua các proxy SOCKS5 riêng biệt cho các dịch vụ ẩn danh Tor.</translation>
-    </message>
-    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Chỉ hiển thị biểu tượng ở khai sau khi thu nhỏ cửa sổ.</translation>
     </message>
@@ -1453,12 +1341,6 @@
         <translation>Giao diện ngôn ngữ người dùng có thể được thiết lập tại đây. Tùy chọn này sẽ có hiệu lực sau khi khởi động lại %1.</translation>
     </message>
     <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>Ngôn ngữ ị thiếu hoặc việc dịch chưa hoàn tất? Tham gia dịch giúp tại đây:
-https://www.transifex.com/projects/p/dash/</translation>
-    </message>
-    <message>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Đơn vị &amp;hiển thị số lượng:</translation>
     </message>
@@ -1469,10 +1351,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Decimal digits</source>
         <translation>Số các chữ số thập phân</translation>
-    </message>
-    <message>
-        <source>Active command-line options that override above options:</source>
-        <translation>Kích hoạt các tuỳ chọn dòng lệnh sẽ thay thế cho các tuỳ chọn trên:</translation>
     </message>
     <message>
         <source>Reset all client options to default.</source>
@@ -1715,6 +1593,9 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
 </context>
 <context>
+    <name>PSBTOperationsDialog</name>
+    </context>
+<context>
     <name>PaymentServer</name>
     <message>
         <source>Payment request error</source>
@@ -1729,14 +1610,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>xử lý URI</translation>
     </message>
     <message>
-        <source>Payment request fetch URL is invalid: %1</source>
-        <translation>Yêu cầu thanh toán lấy URL là không hợp lệ: %1</translation>
-    </message>
-    <message>
-        <source>Invalid payment address %1</source>
-        <translation>Địa chỉ thanh toán không hợp lệ %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI không thể phân tích. Nó có thể bởi địa chỉ Dash không hợp lệ hoặc thông số URI dị hình.</translation>
     </message>
@@ -1744,99 +1617,41 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Payment request file handling</source>
         <translation>Thanh toán cần file xử lý</translation>
     </message>
-    <message>
-        <source>Payment request file cannot be read! This can be caused by an invalid payment request file.</source>
-        <translation>Tệp yêu cầu thanh toán không thể đọc được. Nó có thể là nguyên nhân bởi tệp thanh toán không hợp lệ.</translation>
-    </message>
-    <message>
-        <source>Payment request rejected</source>
-        <translation>Yêu cầu giao dịch bị từ chối</translation>
-    </message>
-    <message>
-        <source>Payment request network doesn't match client network.</source>
-        <translation>Mạng yêu cầu thanh toán không tương xứng với mạng của phần mềm.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation>Yêu cầu thanh toán đã hết hạn.</translation>
-    </message>
-    <message>
-        <source>Payment request is not initialized.</source>
-        <translation>Yêu cầu thanh toán không được khởi tạo.</translation>
-    </message>
-    <message>
-        <source>Unverified payment requests to custom payment scripts are unsupported.</source>
-        <translation>Yêu cầu thanh toán chưa được xác minh để tùy chỉnh các kịch bản thanh toán không được hỗ trợ.</translation>
-    </message>
-    <message>
-        <source>Invalid payment request.</source>
-        <translation>Yêu cầu thanh toán không hợp lệ.</translation>
-    </message>
-    <message>
-        <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation>Yêu cầu thanh toán khoản tiền của  %1 là quá nhỏ (được xem là bụi).</translation>
-    </message>
-    <message>
-        <source>Refund from %1</source>
-        <translation>Trả lại từ %1</translation>
-    </message>
-    <message>
-        <source>Payment request %1 is too large (%2 bytes, allowed %3 bytes).</source>
-        <translation>Yêu cầu thanh toán %1 quá lớn (%2 bytes, cho phép %3 bytes)</translation>
-    </message>
-    <message>
-        <source>Error communicating with %1: %2</source>
-        <translation>Lỗi kết nối với %1: %2</translation>
-    </message>
-    <message>
-        <source>Payment request cannot be parsed!</source>
-        <translation>Yêu cầu thanh toán không thể xử lý!</translation>
-    </message>
-    <message>
-        <source>Bad response from server %1</source>
-        <translation>Phản hồi xấu từ máy chủ %1</translation>
-    </message>
-    <message>
-        <source>Network request error</source>
-        <translation>Yêu cầu mạng bị lỗi</translation>
-    </message>
-    <message>
-        <source>Payment acknowledged</source>
-        <translation>Thanh toán được ghi nhận</translation>
-    </message>
 </context>
 <context>
     <name>PeerTableModel</name>
     <message>
-        <source>NodeId</source>
-        <translation>NodeID</translation>
-    </message>
-    <message>
-        <source>Node/Service</source>
-        <translation>Nút/Dịch vụ</translation>
-    </message>
-    <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>User Agent</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>Đã gửi</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>Đã nhận</translation>
     </message>
-</context>
+    </context>
+<context>
+    <name>Proposal</name>
+    </context>
+<context>
+    <name>ProposalModel</name>
+    </context>
 <context>
     <name>QObject</name>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 vẫn chưa thoát an toàn...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 vẫn chưa thoát an toàn…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -1936,49 +1751,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
 </context>
 <context>
-    <name>QObject::QObject</name>
-    <message>
-        <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation>Error: Xác định data directory "%1" không tồn tại.</translation>
-    </message>
-    <message>
-        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
-        <translation>Error: Không thể parse configuration file: %1. Chỉ dùng key=value syntax.</translation>
-    </message>
-    <message>
-        <source>Error: %1</source>
-        <translation>Error: %1</translation>
-    </message>
-    <message>
-        <source>Error: Failed to load application fonts.</source>
-        <translation>Lỗi: Nạp font chữ không thành công.</translation>
-    </message>
-    <message>
-        <source>Error: Specified font-family invalid. Valid values: %1.</source>
-        <translation>Lỗi: Loại font được chọn không hợp lệ Giá trị hợp lệ: %1</translation>
-    </message>
-    <message>
-        <source>Error: Specified font-weight-normal invalid. Valid range %1 to %2.</source>
-        <translation>Lỗi: Độ đậm font chữ dạng thường được chọn không hợp lệ. Khoảng hợp lệ %1 đến %2.</translation>
-    </message>
-    <message>
-        <source>Error: Specified font-weight-bold invalid. Valid range %1 to %2.</source>
-        <translation>Lỗi: Độ đậm font chữ dạng chữ đậm được chọn không hợp lệ. Khoảng hợp lệ %1 đến %2.</translation>
-    </message>
-    <message>
-        <source>Error: Specified font-scale invalid. Valid range %1 to %2.</source>
-        <translation>Lỗi: Cỡ chữ được chọn không hợp lệ. Khoảng hợp lệ %1 đến %2.</translation>
-    </message>
-    <message>
-        <source>Error: Invalid -custom-css-dir path.</source>
-        <translation>Lỗi: Đường dẫn -custom-css-dir không hợp lệ.</translation>
-    </message>
-    <message>
-        <source>Error: %1 CSS file(s) missing in -custom-css-dir path.</source>
-        <translation>Lỗi: %1 File(s) CSS không tìm thấy trong đường dẫn -custom-css-dir.</translation>
-    </message>
-</context>
-<context>
     <name>QRDialog</name>
     <message>
         <source>QR-Code Title</source>
@@ -1989,38 +1761,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Mã QR</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Lưu ảnh...</translation>
-    </message>
-    <message>
-        <source>Error creating QR Code.</source>
-        <translation>Lỗi khi tạo mã QR.</translation>
-    </message>
-</context>
-<context>
-    <name>QRGeneralImageWidget</name>
-    <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Lưu ảnh...</translation>
-    </message>
-    <message>
-        <source>&amp;Copy Image</source>
-        <translation>&amp;Sao chép ảnh</translation>
-    </message>
-    <message>
-        <source>Save QR Code</source>
-        <translation>&amp;Lưu mã QR</translation>
-    </message>
-    <message>
-        <source>PNG Image (*.png)</source>
-        <translation>PNG Image (*.png)</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Lưu ảnh…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Lưu ảnh...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Lưu ảnh…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2030,11 +1779,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Save QR Code</source>
         <translation>&amp;Lưu mã QR</translation>
     </message>
-    <message>
-        <source>PNG Image (*.png)</source>
-        <translation>Ảnh dạng PNG (*.png)</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -2082,24 +1827,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Debug log file</translation>
     </message>
     <message>
-        <source>Current number of blocks</source>
-        <translation>Số khối hiện tại</translation>
-    </message>
-    <message>
         <source>Client version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <source>Using BerkeleyDB version</source>
-        <translation>Sử dụng BerkeleyDB version</translation>
-    </message>
-    <message>
         <source>Block chain</source>
         <translation>Block chain</translation>
-    </message>
-    <message>
-        <source>Number of Masternodes</source>
-        <translation>Số lượng Masternodes</translation>
     </message>
     <message>
         <source>Memory Pool</source>
@@ -2146,14 +1879,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Hãy chọn một máy đồng cấp để xem thông tin chi tiết.</translation>
     </message>
     <message>
-        <source>Whitelisted</source>
-        <translation>Danh sách trắng</translation>
-    </message>
-    <message>
-        <source>Direction</source>
-        <translation>Hướng</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
@@ -2168,10 +1893,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Synced Blocks</source>
         <translation>Các khối đã đồng bộ</translation>
-    </message>
-    <message>
-        <source>Wallet Path</source>
-        <translation>Đường dẫn đến Ví</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2210,10 +1931,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Dịch vụ</translation>
     </message>
     <message>
-        <source>Ban Score</source>
-        <translation>Điểm cấm</translation>
-    </message>
-    <message>
         <source>Connection Time</source>
         <translation>Thời gian kết nối</translation>
     </message>
@@ -2250,42 +1967,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Sửa &amp;Ví</translation>
     </message>
     <message>
-        <source>Salvage wallet</source>
-        <translation>Cứu ví</translation>
-    </message>
-    <message>
-        <source>Recover transactions 1</source>
-        <translation>Phục hồi các giao dịch 1</translation>
-    </message>
-    <message>
-        <source>Recover transactions 2</source>
-        <translation>Phục hồi các giao dịch 2</translation>
-    </message>
-    <message>
-        <source>Upgrade wallet format</source>
-        <translation>Nâng cấp định dạng ví</translation>
-    </message>
-    <message>
-        <source>The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockhain files or missing/obsolete transactions.</source>
-        <translation>Nút dưới đây sẽ khởi động lại ví với tuỳ chọn dòng lệnh để sửa lại ví, sửa lại những vấn đề với các tệp blockchain bị lỗi hoặc các giao dịch bị thiếu/cũ.</translation>
-    </message>
-    <message>
-        <source>-salvagewallet: Attempt to recover private keys from a corrupt wallet.dat.</source>
-        <translation>-salvagewallet: Thử phục hồi khoá riêng từ tệp wallet.dat bị lỗi.</translation>
-    </message>
-    <message>
-        <source>-zapwallettxes=1: Recover transactions from blockchain (keep meta-data, e.g. account owner).</source>
-        <translation>-zapwallettxes=1: Phục hồi các giao dịch từ blockchain (giữ các meta-data, ví dụ: chủ tải khoản).</translation>
-    </message>
-    <message>
-        <source>-zapwallettxes=2: Recover transactions from blockchain (drop meta-data).</source>
-        <translation>-zapwallettxes=2: Phục hồi tất cả các giao dịch từ blockchain (bỏ đi các meta-data).</translation>
-    </message>
-    <message>
-        <source>-upgradewallet: Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself!)</source>
-        <translation>-upgradewallet: Nâng cấp ví lên định dạng mới nhất khi khởi động. (Chú ý: điều này KHÔNG có nghĩa là nâng cấp bản thân phần mềm ví)</translation>
-    </message>
-    <message>
         <source>Wallet repair options.</source>
         <translation>Các tuỳ chọn sửa ví.</translation>
     </message>
@@ -2296,6 +1977,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>-reindex: Rebuild block chain index from current blk000??.dat files.</source>
         <translation>-reindex: Tái lập lại chỉ mục cho chuỗi khối từ tệp hiện tại blk000??.dat</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Không đồng ý</translation>
     </message>
     <message>
         <source>&amp;Disconnect</source>
@@ -2362,38 +2047,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tổng số: %1 (Bật: %2)</translation>
     </message>
     <message>
-        <source>(node id: %1)</source>
-        <translation>(node id: %1)</translation>
-    </message>
-    <message>
         <source>via %1</source>
         <translation>theo %1</translation>
-    </message>
-    <message>
-        <source>never</source>
-        <translation>không bao giờ</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>Kết nối về</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>Kết nối đi</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation>Đồng ý</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation>Không đồng ý</translation>
     </message>
     <message>
         <source>Unknown</source>
         <translation>Không xác định</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2427,10 +2088,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Amount:</source>
         <translation>&amp;Số tiền:</translation>
-    </message>
-    <message>
-        <source>&amp;Request payment</source>
-        <translation>&amp;Yêu cầu thanh toán</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
@@ -2484,13 +2141,9 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>Sao chép số tiền</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
-    <message>
-        <source>QR Code</source>
-        <translation>Mã QR</translation>
-    </message>
     <message>
         <source>Copy &amp;URI</source>
         <translation>Copy &amp;URI</translation>
@@ -2500,8 +2153,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Copy địa chỉ</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>&amp;Lưu ảnh...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>&amp;Lưu ảnh…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2510,34 +2163,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Payment information</source>
         <translation>Thông tin thanh toán</translation>
-    </message>
-    <message>
-        <source>URI</source>
-        <translation>URI</translation>
-    </message>
-    <message>
-        <source>Address</source>
-        <translation>Địa chỉ</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation>Số tiền</translation>
-    </message>
-    <message>
-        <source>Label</source>
-        <translation>Nhãn</translation>
-    </message>
-    <message>
-        <source>Message</source>
-        <translation>Thông điệp</translation>
-    </message>
-    <message>
-        <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation>Kết quả là URI quá dài, hãy thử rút gọn chữ trong nhãn / thông điệp.</translation>
-    </message>
-    <message>
-        <source>Error encoding URI into QR Code.</source>
-        <translation>Lỗi mã hoá URI thành mã QR.</translation>
     </message>
 </context>
 <context>
@@ -2582,10 +2207,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tính năng Kiểm soát Coin</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>Đầu vào...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>tự động chọn</translation>
     </message>
@@ -2614,6 +2235,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Bụi</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>Đầu vào…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>Phí sau:</translation>
     </message>
@@ -2634,12 +2259,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Phí giao dịch</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>Chọn...</translation>
-    </message>
-    <message>
-        <source>collapse fee-settings</source>
-        <translation>Thu gọn các thiết lập về phí</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(Phí khởi tạo thông minh chưa được khởi tạo. Thường thì sẽ mất vài block…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2650,16 +2271,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nếu mức phí tuỳ chỉnh được đặt là 1000 duff và giao dịch chỉ có 250 byte, thì "theo kilobyte" chỉ trả 250 duff cho phí,&lt;br /&gt;trong khi "ít nhất" phải trả 1000 duff. Cho các giao dịch lớn hơn 1 kilobyte thì cả hai đều trả theo kilobyte.</translation>
     </message>
     <message>
-        <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks.&lt;br /&gt;But be aware that this can end up in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
-        <translation>Chỉ trả phí tối thiểu cũng được chỉ khi mà có lượng giao dịch ít hơn không gian trong khối.&lt;br /&gt;Nhưng cần lưu ý là nó có thể xảy ra hiện tượng giao dịch không bao giờ được xác nhận một khi có nhiều nhu cầu giao dash hơn khả năng mà mạng lưới có thể xử lý được.</translation>
-    </message>
-    <message>
         <source>per kilobyte</source>
         <translation>mỗi kilobyte</translation>
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>Sử dụng phí dự phòng có thể dẫn tới việc giao dịch mất đến hàng giờ hoặc hàng ngày (hoặc thậm chí không bao giờ) được xác thực. Hãy cân nhắc tự chọn mức phí hoặc đợi đến khi bạn được chuỗi xác thực hoàn chỉnh.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>Chọn…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2670,20 +2291,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ẩn</translation>
     </message>
     <message>
-        <source>(read the tooltip)</source>
-        <translation>(xem gợi ý)</translation>
-    </message>
-    <message>
         <source>Recommended:</source>
         <translation>Gợi ý:</translation>
     </message>
     <message>
         <source>Custom:</source>
         <translation>Tuỳ chỉnh:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Phí khởi tạo thông minh chưa được khởi tạo. Thường thì sẽ mất vài block...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -2758,14 +2371,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Bạn có chắc mình muốn gửi?</translation>
     </message>
     <message>
-        <source>are added as transaction fee</source>
-        <translation>được thêm vào như là phí giao dịch</translation>
-    </message>
-    <message>
-        <source>Total Amount = &lt;b&gt;%1&lt;/b&gt;&lt;br /&gt;= %2</source>
-        <translation>Tổng số tiền = &lt;b&gt;%1&lt;/b&gt;&lt;br /&gt;= %2</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;(%1 of %2 entries displayed)&lt;/b&gt;</source>
         <translation>&lt;b&gt;(%1 của %2 các thành phần được hiển thị)&lt;/b&gt;</translation>
     </message>
@@ -2814,20 +2419,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tạo giao dịch không thành công!</translation>
     </message>
     <message>
-        <source>The transaction was rejected with the following reason: %1</source>
-        <translation>The transaction đã bị từ chối với lý do sau: %1</translation>
-    </message>
-    <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation>Mức phí cao hơn %1 có thể được xem là mức cao thái quá.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation>Yêu cầu thanh toán đã hết hạn.</translation>
-    </message>
-    <message>
-        <source>Pay only the required fee of %1</source>
-        <translation>Chỉ thanh toán mức phí yêu cầu của %1</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -2856,10 +2449,6 @@ https://www.transifex.com/projects/p/dash/</translation>
 </context>
 <context>
     <name>SendCoinsEntry</name>
-    <message>
-        <source>This is a normal payment.</source>
-        <translation>Đây là giao dịch thông thường.</translation>
-    </message>
     <message>
         <source>Pay &amp;To:</source>
         <translation>Trả &amp;Cho</translation>
@@ -2936,23 +2525,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Memo:</source>
         <translation>Ghi nhớ:</translation>
     </message>
-    <message>
-        <source>Enter a label for this address to add it to your address book</source>
-        <translation>Nhập nhãn cho địa chỉ để thêm nó vào sổ địa chỉ của bạn.</translation>
-    </message>
-</context>
-<context>
-    <name>SendConfirmationDialog</name>
-    <message>
-        <source>Yes</source>
-        <translation>Yes</translation>
-    </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>%1 đang shutting down...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>%1 đang shutting down…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3027,7 +2605,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation>Hãy nhập vào địa chỉ của người nhận, thông điệp (hãy đảm bảo rằng bạn copy cả dấu xuống dòng, dấu cách, dấu tab,... một cách chính xác) và chữ ký bên dưới để kiểm tra thông điệp. Hãy cẩn thận để không đọc thêm vào phần chữ ký mà nó dùng để ký, để tránh bị đánh lừa bởi kiểu tấn công người trung gian. Chú ý đây chỉ để chứng minh chữ ký của bên nhận với địa chỉ đó, nó không thể chứng minh người gửi hoặc bất kỳ giao dich nào!</translation>
+        <translation>Hãy nhập vào địa chỉ của người nhận, thông điệp (hãy đảm bảo rằng bạn copy cả dấu xuống dòng, dấu cách, dấu tab,… một cách chính xác) và chữ ký bên dưới để kiểm tra thông điệp. Hãy cẩn thận để không đọc thêm vào phần chữ ký mà nó dùng để ký, để tránh bị đánh lừa bởi kiểu tấn công người trung gian. Chú ý đây chỉ để chứng minh chữ ký của bên nhận với địa chỉ đó, nó không thể chứng minh người gửi hoặc bất kỳ giao dich nào!</translation>
     </message>
     <message>
         <source>The Dash address the message was signed with</source>
@@ -3108,13 +2686,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Message verified.</source>
         <translation>Thông điệp đã được xác thực.</translation>
-    </message>
-</context>
-<context>
-    <name>SplashScreen</name>
-    <message>
-        <source>[testnet]</source>
-        <translation>[mạng thử]</translation>
     </message>
 </context>
 <context>
@@ -3269,10 +2840,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction total size</source>
         <translation>Tổng kích thước giao dịch</translation>
-    </message>
-    <message>
-        <source>Merchant</source>
-        <translation>Người bán</translation>
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
@@ -3456,8 +3023,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Năm nay</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>Khoảng...</translation>
+        <source>Range…</source>
+        <translation>Khoảng…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -3520,10 +3087,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Sao chép chi tiết đầy đủ về giao dịch</translation>
     </message>
     <message>
-        <source>Edit label</source>
-        <translation>Sửa nhãn</translation>
-    </message>
-    <message>
         <source>Show transaction details</source>
         <translation>Xem chi tiết giao dịch</translation>
     </message>
@@ -3534,10 +3097,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Export Transaction History</source>
         <translation>Kết xuất Lịch sử Giao dịch</translation>
-    </message>
-    <message>
-        <source>Comma separated file (*.csv)</source>
-        <translation>File định dạng phân cách bởi dấu phẩy (*.csv)</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -3604,19 +3163,18 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
 </context>
 <context>
+    <name>WalletController</name>
+    </context>
+<context>
     <name>WalletFrame</name>
-    <message>
-        <source>No wallet has been loaded.</source>
-        <translation>Không có ví nào được nạp.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
         <translation>Gửi tiền</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>WalletView</name>
     <message>
@@ -3634,10 +3192,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Backup Wallet</source>
         <translation>Sao lưu Ví</translation>
-    </message>
-    <message>
-        <source>Wallet Data (*.dat)</source>
-        <translation>Dữ liệu Ví (*.dat)</translation>
     </message>
     <message>
         <source>Backup Failed</source>
@@ -3667,20 +3221,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Đây là phiên bản chưa chính thức - hãy dùng và tự chấp nhận mạo hiểm - đừng dùng để đào coin hoặc các ứng dụng thương mại.</translation>
     </message>
     <message>
-        <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
-        <translation>Cảnh báo: Mạng lưới có vẻ chưa hoàn toàn đồng ý! Một vài máy đào có vẻ như đã kinh nghiệm với những vấn đề này.</translation>
-    </message>
-    <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Cảnh báo: Chúng ta có vẻ không được sự đồng ý một cách đầy đủ từ các đối tác ngang hàng! Bạn cần nâng cấp hoặc các nút khác cần nâng cấp.</translation>
     </message>
     <message>
         <source>Already have that input.</source>
         <translation>Đã có đầu vào đó.</translation>
-    </message>
-    <message>
-        <source>Cannot downgrade wallet</source>
-        <translation>Không thể hạ cấp ví</translation>
     </message>
     <message>
         <source>Collateral not valid.</source>
@@ -3723,14 +3269,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Lỗi đọc từ cơ sở dữ liệu, đang tắt phần mềm.</translation>
     </message>
     <message>
-        <source>Error</source>
-        <translation>Lỗi</translation>
-    </message>
-    <message>
-        <source>Error: Disk space is low!</source>
-        <translation>Lỗi: Dung lượng đĩa thấp!</translation>
-    </message>
-    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Không thành công khi lắng nghe trên các cổng. Sử dụng -listen=0 nếu bạn muốn nó.</translation>
     </message>
@@ -3767,28 +3305,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Đầu vào vượt ngưỡng tối đa. </translation>
     </message>
     <message>
-        <source>Failed to load fulfilled requests cache from</source>
-        <translation>Không thể tải cache yêu cầu đã được thực hiện từ</translation>
-    </message>
-    <message>
-        <source>Failed to load governance cache from</source>
-        <translation>Không thể cache tải dữ liệu governance từ</translation>
-    </message>
-    <message>
-        <source>Failed to load masternode cache from</source>
-        <translation>Không thể tải cache dữ liệu về masternode từ</translation>
-    </message>
-    <message>
         <source>Found enough users, signing ( waiting %s )</source>
         <translation>Đã tìm đủ người dùng, đang ký (vui lòng đợi %s)</translation>
-    </message>
-    <message>
-        <source>Found enough users, signing ...</source>
-        <translation>Đã kiếm đủ người dùng, đang ký ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>Đang nạp...</translation>
     </message>
     <message>
         <source>Incompatible mode.</source>
@@ -3801,10 +3319,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Khối sáng thế không chính xác hoặc không tìm thấy. Sai datadir cho mạng lưới?</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Thông tin</translation>
     </message>
     <message>
         <source>Input is not valid.</source>
@@ -3827,28 +3341,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Số lượng người ký tối thiểu cho spork được chỉ bởi -minsporkkeys không hợp lệ</translation>
     </message>
     <message>
-        <source>Keypool ran out, please call keypoolrefill first</source>
-        <translation>Keypool đã hết, hãy gọi keypoolrefill trước</translation>
-    </message>
-    <message>
-        <source>Loading banlist...</source>
-        <translation>Đang tải danh sách từ chối...</translation>
-    </message>
-    <message>
-        <source>Loading fulfilled requests cache...</source>
-        <translation>Đang tải cache dữ liệu thực hiện...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Đang tải cache cho masternode...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>Khoá đã sẵn sàng.</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>Đang trong quá trình trộn...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -3871,12 +3365,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Không có trong danh sách Masternode.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>Đang xén tỉa các khối lưu trữ…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>Phát lại các khối…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>Đang quét lại…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>Starting network threads…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Đã được gửi cho masternode, đang đợi trong hàng đợi %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Đồng bộ đã hoàn thành</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>Đang đồng bộ blockchain…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>Đang đồng bộ các đối tượng quản trị…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -3887,28 +3405,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Trả lời không xác định.</translation>
     </message>
     <message>
-        <source>Unsupported argument -benchmark ignored, use -debug=bench.</source>
-        <translation>Tuỳ chọn không được hỗ trợ -benchmark, sử dụng -debug=bench.</translation>
-    </message>
-    <message>
-        <source>Unsupported argument -debugnet ignored, use -debug=net.</source>
-        <translation>Tuỳ chọn không được hỗ trợ -debugnet, sử dụng -debug=net.</translation>
-    </message>
-    <message>
-        <source>Unsupported argument -tor found, use -onion.</source>
-        <translation>Tuỳ chọn không được hỗ trợ -tor, hãy sử dụng -onion.</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>Bình luận User Agent (%s) có chứa những ký tự không an toàn.</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>Đang kiểm tra (các) ví...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>Sẽ thử lại...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -3931,10 +3429,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>File %s có chứa tất cả các khoá riêng từ ví này. Không nên chia sẻ nó với bất cứ ai.</translation>
     </message>
     <message>
-        <source>-masternode option is deprecated and ignored, specifying -masternodeblsprivkey is enough to start this node as a masternode.</source>
-        <translation>Tuỳ chọn -masternode không được sử dụng nữa và bị bỏ qua, việc chỉ rõ tham số -masternodeblsprivkey là đủ để khởi động một nút như là một masternode.</translation>
-    </message>
-    <message>
         <source>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
         <translation>Không tạo được file dự phòng, file đã tồn tại rồi! Điều này có thể xảy ra nếu bạn khởi động lại ví trong ít hơn 60 giây. Bạn có thể tiếp tục nếu bạn đồng ý với việc đó.</translation>
     </message>
@@ -3951,10 +3445,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Xén tỉa: việc đồng bộ ví mới đây đã đi quá dữ liệu được xén tỉa. Bạn cần -reindex (download toàn bộ blockchain lần nữa trong trường hợp các nút bị xén tỉa)</translation>
     </message>
     <message>
-        <source>Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.</source>
-        <translation>Rescans là không thể trong chế độ xén tỉa. Bạn cần sử dụng -reindex mà nó sẽ tải xuống toàn bộ blockchain lại.</translation>
-    </message>
-    <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation>Cơ sở dữ liệu khối có chứa một khối mà nó có vẻ sẽ xuất hiện trong tương lai. Điều này có thể là do ngày giờ trên máy tính của bạn được thiết lập không chính xác. Chỉ khi tái lập lại cơ sở dữ liệu khối nếu bạn chắc chắn rằng ngày giờ máy tính của bạn là chính xác.</translation>
     </message>
@@ -3967,14 +3457,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tổng độ dài của chuỗi phiên bản mạng (%i) vượt qua độ dài tối đa (%i). Hãy giảm số hoặc kích thước của uacomments.</translation>
     </message>
     <message>
-        <source>Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported.</source>
-        <translation>Tìm thấy tham số không được hỗ trợ -socks. Thiết lập phiên bản SOCKS không còn hiệu lực nữa, chỉ có proxy SOCKS5 mới được hỗ trợ.</translation>
-    </message>
-    <message>
-        <source>Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay.</source>
-        <translation>Tham số không được hỗ trợ -whitelistalwaysrelay đã bị bỏ qua, hãy sử dụng -whitelistrelay và/hoặc -whitelistforcerelay.</translation>
-    </message>
-    <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
         <translation>CẢNH BÁO: Bổ sung keypool không thành công, hãy mở khoá ví của bạn để làm điều đó.</translation>
     </message>
@@ -3983,20 +3465,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ví đã được khoá, không thể bổ sung keypool! Tự động backups và trộn đã bị tắt, hãy mở khoá ví của bạn để bổ sung keypool.</translation>
     </message>
     <message>
-        <source>Warning: Unknown block versions being mined! It's possible unknown rules are in effect</source>
-        <translation>Cảnh báo: Không xác định được phiên bản khối được đào! Có thể những luật chưa được biết đang có tác động</translation>
-    </message>
-    <message>
         <source>You need to rebuild the database using -reindex to change -timestampindex</source>
         <translation>Bạn cần phải tái lập lại cơ sở dữ liệu sử dụng tham số -reindex để thay đổi -timestampindex</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
         <translation>Bạn cần tái lập lại cơ sở dữ liệu sử dụng -reindex để quay trở lại chế độ không bị xén tỉa. Điều này sẽ làm tải lại toàn bộ blockchain</translation>
-    </message>
-    <message>
-        <source>-litemode is deprecated.</source>
-        <translation>-litemode không được dùng nữa.</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
@@ -4015,28 +3489,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Lỗi nâng cấp cơ sở dữ liệu evo</translation>
     </message>
     <message>
-        <source>Error: A fatal internal error occurred, see debug.log for details</source>
-        <translation>Lỗi: Một lỗi bên trong trầm trọng đã xảy ra, hãy xem file debug.log để biết thêm chi tiết</translation>
-    </message>
-    <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>Lỗi: Không thành công trong việc thêm socket vào epolfd (epoll_ctl trả về lỗi %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>Vượt quá số lần thử tối đa.</translation>
-    </message>
-    <message>
-        <source>Failed to clear fulfilled requests cache at</source>
-        <translation>Không thể xoá bộ nhớ đệm về các yêu cầu đã được thực hiện tại </translation>
-    </message>
-    <message>
-        <source>Failed to clear governance cache at</source>
-        <translation>Không thể xoá bộ đệm quản trị tại </translation>
-    </message>
-    <message>
-        <source>Failed to clear masternode cache at</source>
-        <translation>Không thể xoá bộ đệm masternode tại </translation>
     </message>
     <message>
         <source>Failed to commit EvoDB</source>
@@ -4055,12 +3509,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Không xoá được backup, lỗi: %s</translation>
     </message>
     <message>
-        <source>Failed to load sporks cache from</source>
-        <translation>Thất bại việc tải dữ liệu sporks cache từ</translation>
-    </message>
-    <message>
         <source>Failed to rescan the wallet during initialization</source>
         <translation>Không thể quét lại ví trong quá trình khởi tạo</translation>
+    </message>
+    <message>
+        <source>Found enough users, signing…</source>
+        <translation>Đã kiếm đủ người dùng, đang ký…</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
@@ -4069,34 +3523,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Invalid masternodeblsprivkey. Please see documentation.</source>
         <translation>masternodeblsprivkey không hợp lệ. Hãy xem trong tài liệu.</translation>
-    </message>
-    <message>
-        <source>It has been replaced by -disablegovernance.</source>
-        <translation>Nó đã được thay thế bởi -disablegovernance.</translation>
-    </message>
-    <message>
-        <source>Its replacement -disablegovernance has been forced instead.</source>
-        <translation>Sự thay thế -disablegovernance đã bị buộc phải thực hiện.</translation>
-    </message>
-    <message>
-        <source>Loading block index...</source>
-        <translation>Đang nạp chỉ mục khối...</translation>
-    </message>
-    <message>
-        <source>Loading governance cache...</source>
-        <translation>Đang tải bộ đệm quản trị...</translation>
-    </message>
-    <message>
-        <source>Loading sporks cache...</source>
-        <translation>Đang tải dữ liệu sporks cache...</translation>
-    </message>
-    <message>
-        <source>Loading wallet... (%3.2f %%)</source>
-        <translation>Đang nạp ví... (%3.2f %%)</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>Đang tải ví...</translation>
     </message>
     <message>
         <source>Masternode queue is full.</source>
@@ -4109,6 +3535,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>Thiếu thông tin giao dịch đầu vào.</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>Đang trong quá trình trộn…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4139,10 +3569,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Chế độ Xén-tỉa không tương thích với -txindex.</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>Đang xén tỉa các khối lưu trữ...</translation>
-    </message>
-    <message>
         <source>Specified -walletdir "%s" does not exist</source>
         <translation>Thư mục được chỉ ra -walletdir "%s" không tồn tại</translation>
     </message>
@@ -4153,10 +3579,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>Thư mục được xác định bởi -walletdir "%s" không phải là một thư mục</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>Đang đồng bộ blockchain...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4191,10 +3613,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Giao dịch quá lớn</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>Đang thử kết nối...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>Unable to bind to %s on this computer. %s is probably already running.</translation>
     </message>
@@ -4207,16 +3625,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Upgrading UTXO database</translation>
     </message>
     <message>
-        <source>Wallet %s resides outside wallet directory %s</source>
-        <translation>Ví %s nằm ngoài thư mục ví %s</translation>
+        <source>Verifying blocks…</source>
+        <translation>Đang kiểm tra các khối…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>Đang kiểm tra (các) ví…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation>Wallet needed to be rewritten: restart %s to complete</translation>
-    </message>
-    <message>
-        <source>Warning: unknown new rules activated (versionbit %i)</source>
-        <translation>Cảnh báo: luật mới chưa rõ đã được kích hoạt (versionbit %i)</translation>
     </message>
     <message>
         <source>Wasn't able to create wallet backup folder %s!</source>
@@ -4235,20 +3653,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Bạn cần tái lập lại cơ sở dữ liệu sử dụng -reindex để thay đổi -spentindex</translation>
     </message>
     <message>
-        <source>You need to rebuild the database using -reindex to change -txindex</source>
-        <translation>Bạn cần tái lập lại cơ sở dữ liệu sử dụng -reindex để thay đổi -txindex</translation>
-    </message>
-    <message>
         <source>no mixing available.</source>
         <translation>không có phiên trộn nào sẵn sàng.</translation>
     </message>
     <message>
         <source>see debug.log for details.</source>
         <translation>xem debug.log để biết thêm chi tiết.</translation>
-    </message>
-    <message>
-        <source>Dash Core</source>
-        <translation>Dash Core</translation>
     </message>
     <message>
         <source>The %s developers</source>
@@ -4291,24 +3701,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>This is the transaction fee you may pay when fee estimates are not available.</translation>
     </message>
     <message>
-        <source>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit %s and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</source>
-        <translation>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit %s and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</translation>
-    </message>
-    <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation>Không thể phát lại các khối. Bạn sẽ cần xây dựng lại cơ sở dữ liệu bằng cách sử dụng -reindex-chainstate.</translation>
-    </message>
-    <message>
-        <source>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
-        <translation>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</translation>
-    </message>
-    <message>
-        <source>%d of last 100 blocks have unexpected version</source>
-        <translation>%d của 100 khối cuối cùng có phiên bản không mong đợi</translation>
-    </message>
-    <message>
-        <source>%s corrupt, salvage failed</source>
-        <translation>%s corrupt, salvage failed</translation>
     </message>
     <message>
         <source>%s is not a valid backup folder!</source>
@@ -4359,12 +3753,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Lỗi tải %s: Bạn không thể tắt HD trên một ví đã có HD</translation>
     </message>
     <message>
-        <source>Error loading wallet %s. Duplicate -wallet filename specified.</source>
-        <translation>Lỗi tải ví %s. Tham số -wallet tên file chỉ định bị trùng</translation>
-    </message>
-    <message>
         <source>Error upgrading chainstate database</source>
         <translation>Error upgrading chainstate database</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation>Loading P2P addresses…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>Đang tải danh sách từ chối…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>Đang nạp chỉ mục khối…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>Đang tải ví…</translation>
     </message>
     <message>
         <source>Failed to find mixing queue to join</source>
@@ -4373,6 +3779,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Failed to start a new mixing queue</source>
         <translation>Không thể khởi động được một hàng đợi trộn mới</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation>Đang nạp…</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
@@ -4399,20 +3809,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Địa chỉ spork được chỉ ra không hợp lệ với -sporkaddr</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>Loading P2P addresses...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Giảm -maxconnections từ %d đến %d, bởi vì những giới hạn của hệ thống.</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>Phát lại các khối...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>Đang quét lại...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4425,14 +3823,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Signing transaction failed</source>
         <translation>Thất bại khi ký giao dịch</translation>
-    </message>
-    <message>
-        <source>Starting network threads...</source>
-        <translation>Starting network threads...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>Đang đồng bộ các đối tượng quản trị...</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -4463,8 +3853,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Giao dịch không hợp lệ.</translation>
     </message>
     <message>
-        <source>Transaction too large for fee policy</source>
-        <translation>Giao dịch quá lớn cho chính sách miễn phí</translation>
+        <source>Trying to connect…</source>
+        <translation>Đang thử kết nối…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4487,10 +3877,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Danh mục ghi nhật ký không được hỗ trợ %s=%s.</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>Đang kiểm tra các khối...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>Còn lại số lượg rất ít các khoá: %d</translation>
     </message>
@@ -4499,8 +3885,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Ví đã bị khoá.</translation>
     </message>
     <message>
-        <source>Warning</source>
-        <translation>Cảnh báo</translation>
+        <source>Will retry…</source>
+        <translation>Sẽ thử lại…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>
@@ -4513,10 +3899,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Your entries added successfully.</source>
         <translation>Các đầu vào của bạn đã được thêm vào một cách thành công.</translation>
-    </message>
-    <message>
-        <source>Zapping all transactions from wallet...</source>
-        <translation>Dọn sạch tất cả các giao dịch khỏi ví...</translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/dash_zh_CN.ts
+++ b/src/qt/locale/dash_zh_CN.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>请求付款(生成二维码和Dash付款协议的URI)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>选项(&amp;O)…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>加密钱包(&amp;E)…</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>备份钱包(&amp;B)…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>更改密码(&amp;C)…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>解锁钱包(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>消息签名(&amp;M)…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>验证消息(&amp;V)…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>&amp;发送地址</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>&amp;收款地址</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>打开 &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>打开钱包</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>打开一个钱包</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>关闭钱包...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>显示 Qt 相关信息</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>选项(&amp;O)...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>关于 %1</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>显示或隐藏主窗口</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>加密钱包(&amp;E)...</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>对钱包中的私钥加密</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>备份钱包(&amp;B)...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>备份钱包到其他文件夹</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>更改密码(&amp;C)...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>更改钱包加密口令</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>解锁钱包(&amp;U)</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>锁定钱包(&amp;L)</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>消息签名(&amp;M)...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>使用您的Dash地址进行消息签名以证明对此地址的所有权</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>验证消息(&amp;V)...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>显示用过的接收地址和标签的列表</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>打开 &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>&amp;命令行选项</translation>
     </message>
@@ -586,10 +585,6 @@
         <translation>打开一个dash: URI</translation>
     </message>
     <message>
-        <source>Create Wallet...</source>
-        <translation>创建钱包...</translation>
-    </message>
-    <message>
         <source>Create a new wallet</source>
         <translation>创建一个新钱包</translation>
     </message>
@@ -629,30 +624,6 @@
         <source>Network activity disabled</source>
         <translation>网络活动已禁用</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>同步区块头部 (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>正在与网络同步...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>正在为硬盘中的区块建立索引...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>正在处理硬盘中的区块...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>正在为硬盘中的区块重建索引...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>正在连接到节点……</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>已处理了%n个区块的交易记录。</numerusform></translation>
@@ -662,8 +633,40 @@
         <translation>落后 %1 </translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>更新中...</translation>
+        <source>Close Wallet…</source>
+        <translation>关闭钱包…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>创建钱包…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>同步区块头部 (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>正在与网络同步…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>正在为硬盘中的区块建立索引…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>正在处理硬盘中的区块…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>正在为硬盘中的区块重建索引…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>正在连接到节点……</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>更新中…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -787,7 +790,7 @@
         <source>Original message:</source>
         <translation>原始信息:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -982,8 +985,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>正在创建钱包 &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>正在创建钱包 &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1032,7 +1035,7 @@
         <source>Create</source>
         <translation>创建</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1176,10 +1179,6 @@
         <translation>由于这是第一次启动此程序，您可以选择%1的数据所存储的位置</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>当您点击确认后，%1 将会在 %4 启动时从  %3 中最早的交易开始，下载并处理完整的 %4 区块链 (%2GB)。</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>最初的同步过程是非常吃力的，同时可能会暴露您电脑上的一些硬件方面的小毛病，尽管您可能之前没有注意过。您每运行%1，它就会继续从之前中断的地方下载.</translation>
     </message>
@@ -1303,8 +1302,12 @@
         <translation>复制保证金输出点</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>更新中...</translation>
+        <source>Please wait…</source>
+        <translation>请稍等…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>更新中…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1339,10 +1342,6 @@
         <translation>按任何属性筛选 (例. 地址或protx hash)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>请稍等...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>DIP3 主节点 %1 的额外信息</translation>
     </message>
@@ -1366,8 +1365,12 @@
         <translation>剩余区块数量</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>未知...</translation>
+        <source>Unknown…</source>
+        <translation>未知…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>正在计算…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1382,10 +1385,6 @@
         <translation>每小时进度增加</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>正在计算...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>预计剩余同步时间</translation>
     </message>
@@ -1394,8 +1393,8 @@
         <translation>隐藏</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>未知状态. 同步区块头部 (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>未知状态. 同步区块头部 (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1424,8 +1423,8 @@
         <translation>默认钱包</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>正在打开钱包 &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>正在打开钱包 &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1583,14 +1582,6 @@
         <translation>此对话框中设置的选项被命令行或配置文件覆盖:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>隐藏系统托盘中的图标.</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>&amp;隐藏托盘图标</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>窗口被关闭时最小化而不是退出应用程序。当此选项启用时，应用程序只会在菜单中选择退出时退出。</translation>
     </message>
@@ -1697,12 +1688,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>可以在这里设定用户界面的语言。这个设定在重启 %1 后才会生效。</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>缺少相关语言或翻译不完整？请到这里协助翻译：
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -2014,10 +1999,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>由于终止支持, 您应当要求商家为您提供一个兼容BIP21的URI, 或使用仍支持BIP70的钱包.</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>无效的付款地址 %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>URI不能被解析! 原因可能是无效的Dash地址或URI参数格式错误。</translation>
     </message>
@@ -2030,18 +2011,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>用户代理</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation> Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>发送</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>已接收</translation>
     </message>
     </context>
@@ -2174,7 +2159,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>错误: -custom-css-dir 路径下%1 CSS file(s)丢失.</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
+        <source>%1 didn't yet exit safely…</source>
         <translation>%1 尚未安全退出</translation>
     </message>
     <message>
@@ -2285,15 +2270,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>二维码</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>保存图片(&amp;S)...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>保存图片(&amp;S)…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>保存图片(&amp;S)...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>保存图片(&amp;S)…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2419,10 +2404,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>选择一个节点查看详细信息.</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>方向</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>版本</translation>
     </message>
@@ -2529,10 +2510,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>服务</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>禁止 扣分</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2659,22 +2636,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>经由 %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>永不</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>导入</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>导出</translation>
-    </message>
-    <message>
-        <source>Outbound block-relay</source>
-        <translation>向外区块广播</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>常规</translation>
     </message>
@@ -2690,7 +2651,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2789,7 +2750,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>复制金额</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2801,8 +2762,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>复制地址(&amp;A)</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>保存图片(&amp;S)...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>保存图片(&amp;S)…</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2855,10 +2816,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>交易源地址控制功能</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>输入...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>自动选择</translation>
     </message>
@@ -2887,6 +2844,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>零散金额：</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>输入…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>加上交易费用后:</translation>
     </message>
@@ -2907,16 +2868,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>交易手续费：</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>选择...</translation>
-    </message>
-    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for dash transactions than the network can process.</source>
         <translation>当交易量小于区块空间时, 矿工和中继节点或许会强制收取最低费用. 仅支付最低费用也可以, 但请注意, 一旦Dash交易的需求超出了网络的处理能力, 则会导致这笔交易永远无法被确认.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation>过低的交易手续费也许会导致交易永远无法被确认 (阅读提示信息)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(手续费演算法还没有准备好。通常都要等几个块才可以…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2933,6 +2894,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>使用fallbackfee可能会导致发送一笔需要几个小时或几天(或永远不会)确认的交易. 建议手动选择手续费, 或者等待您完全验证整个区块链后.</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>选择…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2953,10 +2918,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>自定义：</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(手续费演算法还没有准备好。通常都要等几个块才可以...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3107,10 +3068,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>或</translation>
     </message>
     <message>
-        <source>To review recipient list click "Show Details..."</source>
-        <translation>查看收件人列表请点击 "显示详细信息..."</translation>
-    </message>
-    <message>
         <source>Confirm send coins</source>
         <translation>确认发送货币</translation>
     </message>
@@ -3121,6 +3078,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Send</source>
         <translation>发送</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation>查看收件人列表请点击 "显示详细信息…"</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
@@ -3261,8 +3222,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>正在关闭 %1 ...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>正在关闭 %1 …</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3791,8 +3752,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>今年</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>范围...</translation>
+        <source>Range…</source>
+        <translation>范围…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4149,14 +4110,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>用户数已满足，开始签名 (等待 %s)</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>用户数已满足，开始签名 ... </translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>正在导入...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>不兼容模式。</translation>
     </message>
@@ -4189,16 +4142,8 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>无效的最少数叉勺签名人以  -minsporkkeys 标识</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>正在加载黑名单...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>已锁定。</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>正在混合...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4221,12 +4166,36 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>在主节点列表中不存在。</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>正在修剪区块存储…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>重播区块中…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>正在重新扫描…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>正在启动网络线程…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>提交到主节点，在队列 %s 中等待</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>同步完成</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>正在同步区块链…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>正在同步治理对象…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4239,14 +4208,6 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>用户代理评论(%s)包含不安全的字符。</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>验证(多个)钱包中...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>即将重试...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4365,10 +4326,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>错误: %s 磁盘空间不足</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>错误: 无法添加socket到epollfd (epoll_ctl 返回错误 %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>超过最大尝试次数.</translation>
     </message>
@@ -4397,6 +4354,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>验证数据库失败</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>用户数已满足，开始签名…</translation>
+    </message>
+    <message>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation>忽略重复 -钱包 %s.</translation>
     </message>
@@ -4413,14 +4374,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>无效的 masternodeblsprivkey。请阅读文档。</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>正在读取区块索引...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>正在读取钱包...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>主节点列队已满。</translation>
     </message>
@@ -4431,6 +4384,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Missing input transaction information.</source>
         <translation>缺少交易信息的输入数据。</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>正在混合…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4459,10 +4416,6 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation>修剪模式与 -txindex 不兼容。</translation>
-    </message>
-    <message>
-        <source>Pruning blockstore...</source>
-        <translation>正在修剪区块存储...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -4497,10 +4450,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>指定的  -walletdir "%s" 不是一个目录</translation>
     </message>
     <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>正在同步区块链...</translation>
-    </message>
-    <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
         <translation>钱包避免低于最小交易费的支付</translation>
     </message>
@@ -4533,10 +4482,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>交易过大</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>尝试连接中...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>无法在本机绑定 %s 端口。%s 可能已经在运行。</translation>
     </message>
@@ -4555,6 +4500,14 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Upgrading UTXO database</source>
         <translation>升级UTXO数据库</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>验证区块中…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>验证(多个)钱包中…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4705,8 +4658,20 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>升级链状态数据库出错</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>错误: 无法添加socket到kqueuefd (kevent 返回错误 %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>正在加载P2P地址…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>正在加载黑名单…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>正在读取区块索引…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>正在读取钱包…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4745,6 +4710,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>无法开始一个新的混币队列</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>正在导入…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>错误的-rescan模式，恢复到默认值</translation>
     </message>
@@ -4773,20 +4742,8 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>使用 -sporkaddr 指定的spork地址无效</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>正在加载P2P地址...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>因为系统的限制，将 -maxconnections 参数从 %d 降到了 %d</translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>重播区块中...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>正在重新扫描...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4817,14 +4774,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>上一次成功操作才完成。</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>正在启动网络线程...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>正在同步治理对象…</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>源代码可以在 %s 获得。</translation>
     </message>
@@ -4851,6 +4800,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Transaction not valid.</source>
         <translation>交易无效。</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>尝试连接中…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4885,10 +4838,6 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>正在升级交易指数数据库</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>验证区块中...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>尚余少量的密匙：%d</translation>
     </message>
@@ -4903,6 +4852,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>警告：不正确的参数 %s，路径必须存在！请使用预设路径。</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>即将重试…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_zh_TW.ts
+++ b/src/qt/locale/dash_zh_TW.ts
@@ -302,6 +302,9 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
@@ -328,6 +331,34 @@
         <translation>要求付款(產生 QR Code 和達世幣付款協議的 URI)</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation>選項(&amp;O)…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation>加密錢包(&amp;E)</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation>備份錢包(&amp;B)…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation>更改密碼(&amp;C)…</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock Wallet…</source>
+        <translation>解鎖錢包(&amp;U)…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation>簽署訊息(&amp;M)…</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation>驗證訊息(&amp;V)…</translation>
+    </message>
+    <message>
         <source>&amp;Sending addresses</source>
         <translation>發送位址(&amp;S)</translation>
     </message>
@@ -336,16 +367,16 @@
         <translation>收款位址(&amp;R)</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation>開啓 &amp;URI…</translation>
+    </message>
+    <message>
         <source>Open Wallet</source>
         <translation>打開錢包</translation>
     </message>
     <message>
         <source>Open a wallet</source>
         <translation>打開一個錢包</translation>
-    </message>
-    <message>
-        <source>Close Wallet...</source>
-        <translation>關閉錢包...</translation>
     </message>
     <message>
         <source>Close wallet</source>
@@ -404,10 +435,6 @@
         <translation>顯示 Qt 相關資訊</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>選項(&amp;O)...</translation>
-    </message>
-    <message>
         <source>&amp;About %1</source>
         <translation>關於%1(&amp;A)</translation>
     </message>
@@ -428,32 +455,16 @@
         <translation>顯示或隱藏主視窗</translation>
     </message>
     <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>加密錢包(&amp;E)</translation>
-    </message>
-    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>把錢包中的密鑰加密</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>備份錢包(&amp;B)...</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
         <translation>把錢包備份到其它地方</translation>
     </message>
     <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>更改密碼(&amp;C)...</translation>
-    </message>
-    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>更改錢包加密用的密碼</translation>
-    </message>
-    <message>
-        <source>&amp;Unlock Wallet...</source>
-        <translation>解鎖錢包(&amp;U)...</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -464,16 +475,8 @@
         <translation>鎖定錢包(&amp;L)</translation>
     </message>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>簽署訊息(&amp;M)...</translation>
-    </message>
-    <message>
         <source>Sign messages with your Dash addresses to prove you own them</source>
         <translation>用達世幣位址簽署訊息來證明位址是你的</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>驗證訊息(&amp;V)...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dash addresses</source>
@@ -540,10 +543,6 @@
         <translation>顯示已使用過的收款位址和標記的清單</translation>
     </message>
     <message>
-        <source>Open &amp;URI...</source>
-        <translation>開啓 &amp;URI...</translation>
-    </message>
-    <message>
         <source>&amp;Command-line options</source>
         <translation>命令列選項(&amp;C)</translation>
     </message>
@@ -576,10 +575,6 @@
     <message>
         <source>Show information about %1</source>
         <translation>顯示有關%1 的相關信息</translation>
-    </message>
-    <message>
-        <source>Create Wallet...</source>
-        <translation>創建錢包...</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -621,30 +616,6 @@
         <source>Network activity disabled</source>
         <translation>被禁用的網絡活動</translation>
     </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>正在同步開頭 (%1%)...</translation>
-    </message>
-    <message>
-        <source>Synchronizing with network...</source>
-        <translation>正在跟網路進行同步...</translation>
-    </message>
-    <message>
-        <source>Indexing blocks on disk...</source>
-        <translation>正在為磁碟裡的區塊建立索引...</translation>
-    </message>
-    <message>
-        <source>Processing blocks on disk...</source>
-        <translation>正在處理磁碟裡的區塊資料...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>正在為磁碟裡的區塊重建索引...</translation>
-    </message>
-    <message>
-        <source>Connecting to peers...</source>
-        <translation>正在連接其他對等用戶群...</translation>
-    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>已經處理了 %n 個區塊的交易紀錄。</numerusform></translation>
@@ -654,8 +625,40 @@
         <translation>落後 %1</translation>
     </message>
     <message>
-        <source>Catching up...</source>
-        <translation>正在趕進度...</translation>
+        <source>Close Wallet…</source>
+        <translation>關閉錢包…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation>創建錢包…</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation>正在同步開頭 (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation>正在跟網路進行同步…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation>正在為磁碟裡的區塊建立索引…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation>正在處理磁碟裡的區塊資料…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation>正在為磁碟裡的區塊重建索引…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation>正在連接其他對等用戶群…</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation>正在趕進度…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -779,7 +782,7 @@
         <source>Original message:</source>
         <translation>原始信息:</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -974,8 +977,8 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>正在創建錢包 &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>正在創建錢包 &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1024,7 +1027,7 @@
         <source>Create</source>
         <translation>創造</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1164,10 +1167,6 @@
         <translation>因為這是程式第一次啓動，你可以選擇 %1 儲存資料的地方。</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>在你按下「好」之後，%1 就會開始下載並處理整個 %4 區塊鏈(大小是  %2GB)，也就是從 %3 年 %4 剛剛起步時的最初交易開始。</translation>
-    </message>
-    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation>一開始的同步作業非常的耗費資源，並且可能會暴露出之前沒被發現的電腦硬體問題。每次執行 %1 的時候都會繼續先前未完成的下載。</translation>
     </message>
@@ -1287,8 +1286,12 @@
         <translation>複製抵押品出點</translation>
     </message>
     <message>
-        <source>Updating...</source>
-        <translation>更新中...</translation>
+        <source>Please wait…</source>
+        <translation>請稍候…</translation>
+    </message>
+    <message>
+        <source>Updating…</source>
+        <translation>更新中…</translation>
     </message>
     <message>
         <source>ENABLED</source>
@@ -1323,10 +1326,6 @@
         <translation>按任何屬性過濾 (例如 位址 或 protx 哈希值)</translation>
     </message>
     <message>
-        <source>Please wait...</source>
-        <translation>請稍候...</translation>
-    </message>
-    <message>
         <source>Additional information for DIP3 Masternode %1</source>
         <translation>關於DIP3主節點%1 的附加信息</translation>
     </message>
@@ -1350,8 +1349,12 @@
         <translation>尚餘區塊數量</translation>
     </message>
     <message>
-        <source>Unknown...</source>
-        <translation>未知...</translation>
+        <source>Unknown…</source>
+        <translation>未知…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation>計算中…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1366,10 +1369,6 @@
         <translation>每小時進度增加</translation>
     </message>
     <message>
-        <source>calculating...</source>
-        <translation>計算中...</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
         <translation>預計要完成同步的所需時間</translation>
     </message>
@@ -1378,8 +1377,8 @@
         <translation>隱藏</translation>
     </message>
     <message>
-        <source>Unknown. Syncing Headers (%1, %2%)...</source>
-        <translation>未知。 正在同步開頭 (%1, %2%)...</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation>未知。 正在同步開頭 (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -1408,8 +1407,8 @@
         <translation>預設錢包</translation>
     </message>
     <message>
-        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>正在打開錢包 &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation>正在打開錢包 &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
 </context>
 <context>
@@ -1559,14 +1558,6 @@
         <translation>此對話框中設置的選項被命令行或配置文件覆蓋:</translation>
     </message>
     <message>
-        <source>Hide the icon from the system tray.</source>
-        <translation>隱藏系統工具列中的圖示。</translation>
-    </message>
-    <message>
-        <source>&amp;Hide tray icon</source>
-        <translation>隱藏系統工具列圖示(&amp;H)</translation>
-    </message>
-    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>當視窗關閉時，把應用程式縮到最小，而不是結束。當勾選這個選項時，只能夠用選單中的結束來關掉應用程式。</translation>
     </message>
@@ -1669,12 +1660,6 @@
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation>可以在這裡設定使用者介面的語言。這個設定在重啓 %1 後才會生效。</translation>
-    </message>
-    <message>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</source>
-        <translation>缺少相關語言或翻譯不完整？請到這裡協助翻譯
-https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1978,10 +1963,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>'dash://' 不是有效的URI。請用'dash:' 來代替。</translation>
     </message>
     <message>
-        <source>Invalid payment address %1</source>
-        <translation>無效的付款位址 %1</translation>
-    </message>
-    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Dash address or malformed URI parameters.</source>
         <translation>沒辦法解析 URI 位址！可能是因為達世幣位址無效，或是 URI 參數格式錯誤。</translation>
     </message>
@@ -1994,18 +1975,22 @@ https://www.transifex.com/projects/p/dash/</translation>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation>使用者代理</translation>
     </message>
     <message>
         <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
         <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
         <translation>發送</translation>
     </message>
     <message>
         <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
         <translation>已收到</translation>
     </message>
     </context>
@@ -2138,8 +2123,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>錯誤: -custom-css-dir 路徑中缺少 %1 個 CSS 文件。</translation>
     </message>
     <message>
-        <source>%1 didn't yet exit safely...</source>
-        <translation>%1 還沒有安全地結束...</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation>%1 還沒有安全地結束…</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -2249,15 +2234,15 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>QR Code</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>儲存圖片(&amp;S)...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>儲存圖片(&amp;S)…</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>儲存圖片(&amp;S)...</translation>
+        <source>&amp;Save Image…</source>
+        <translation>儲存圖片(&amp;S)…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2383,10 +2368,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>選擇一個對等用戶來查看詳細資訊。</translation>
     </message>
     <message>
-        <source>Direction</source>
-        <translation>方向</translation>
-    </message>
-    <message>
         <source>Version</source>
         <translation>版本</translation>
     </message>
@@ -2493,10 +2474,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Services</source>
         <translation>服務</translation>
-    </message>
-    <message>
-        <source>Ban Score</source>
-        <translation>組別評分</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2623,18 +2600,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>經由 %1</translation>
     </message>
     <message>
-        <source>never</source>
-        <translation>沒有過</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation>進來</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation>出去</translation>
-    </message>
-    <message>
         <source>Regular</source>
         <translation>正常</translation>
     </message>
@@ -2650,7 +2615,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Unknown</source>
         <translation>不明</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -2745,7 +2710,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Copy amount</source>
         <translation>複製金額</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -2757,8 +2722,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>複製位址(&amp;A)</translation>
     </message>
     <message>
-        <source>&amp;Save Image...</source>
-        <translation>儲存圖片...(&amp;S)</translation>
+        <source>&amp;Save Image…</source>
+        <translation>儲存圖片…(&amp;S)</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
@@ -2811,10 +2776,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>錢幣控制功能</translation>
     </message>
     <message>
-        <source>Inputs...</source>
-        <translation>輸入...</translation>
-    </message>
-    <message>
         <source>automatically selected</source>
         <translation>自動選擇</translation>
     </message>
@@ -2843,6 +2804,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>零散錢:</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation>輸入…</translation>
+    </message>
+    <message>
         <source>After Fee:</source>
         <translation>計費後金額:</translation>
     </message>
@@ -2863,8 +2828,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>交易手續費:</translation>
     </message>
     <message>
-        <source>Choose...</source>
-        <translation>選項...</translation>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation>(手續費智慧演算法還沒準備好。通常都要等幾個區塊才行…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2881,6 +2846,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation>使用fallbackfee可能會導致發送一個需要幾個小時或幾天 (或永遠不會) 確認的交易。 考慮手動選擇你的費用，或者等到你已經驗證完整的鏈後。</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation>選項…</translation>
     </message>
     <message>
         <source>Note: Not enough data for fee estimation, using the fallback fee instead.</source>
@@ -2901,10 +2870,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Custom:</source>
         <translation>自訂:</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(手續費智慧演算法還沒準備好。通常都要等幾個區塊才行...)</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -3177,8 +3142,8 @@ https://www.transifex.com/projects/p/dash/</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <source>%1 is shutting down...</source>
-        <translation>正在關閉 %1 中...</translation>
+        <source>%1 is shutting down…</source>
+        <translation>正在關閉 %1 中…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -3707,8 +3672,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>今年</translation>
     </message>
     <message>
-        <source>Range...</source>
-        <translation>指定範圍...</translation>
+        <source>Range…</source>
+        <translation>指定範圍…</translation>
     </message>
     <message>
         <source>Most Common</source>
@@ -4045,14 +4010,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>找到足夠多的用戶，簽署中 (等待  %s )</translation>
     </message>
     <message>
-        <source>Found enough users, signing ...</source>
-        <translation>找到足夠多的用戶，簽署中 ...</translation>
-    </message>
-    <message>
-        <source>Importing...</source>
-        <translation>正在匯入中...</translation>
-    </message>
-    <message>
         <source>Incompatible mode.</source>
         <translation>不兼容的模式。</translation>
     </message>
@@ -4085,16 +4042,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>使用-minsporkkeys 指定的最低叉勺簽名者數目無效</translation>
     </message>
     <message>
-        <source>Loading banlist...</source>
-        <translation>正在載入禁止清單...</translation>
-    </message>
-    <message>
         <source>Lock is already in place.</source>
         <translation>已經鎖定。</translation>
-    </message>
-    <message>
-        <source>Mixing in progress...</source>
-        <translation>正在進行混合...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4117,12 +4066,36 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>不在主節點列表中。</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation>修剪儲存區塊…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation>正在重播區塊…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation>正在重新掃描…</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation>正在啟動網路執行緒…</translation>
+    </message>
+    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>己經提交到主節點，在隊列%s 中等待 </translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>同步完成</translation>
+    </message>
+    <message>
+        <source>Synchronizing blockchain…</source>
+        <translation>正在同步區塊鏈…</translation>
+    </message>
+    <message>
+        <source>Synchronizing governance objects…</source>
+        <translation>正在同步治理對象…</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4135,14 +4108,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>用戶代理註釋 (%s) 包含不安全的字符。</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)...</source>
-        <translation>正在驗證錢包...</translation>
-    </message>
-    <message>
-        <source>Will retry...</source>
-        <translation>將重新嘗試...</translation>
     </message>
     <message>
         <source>Can't find random Masternode.</source>
@@ -4261,10 +4226,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>錯誤: %s 的磁盤空間不足</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
-        <translation>錯誤: 無法將套接字添加到 epollfd (epoll_ctl 傳回錯誤 %s)</translation>
-    </message>
-    <message>
         <source>Exceeded max tries.</source>
         <translation>超過最大嘗試的次數。</translation>
     </message>
@@ -4289,6 +4250,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>初始化期間無法重新掃描錢包</translation>
     </message>
     <message>
+        <source>Found enough users, signing…</source>
+        <translation>用户数已满足，开始签名…</translation>
+    </message>
+    <message>
         <source>Invalid P2P permission: '%s'</source>
         <translation>無效的 P2P 權限: '%s'</translation>
     </message>
@@ -4301,14 +4266,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>無效的masternodeblsprivkey。請參閱文檔。</translation>
     </message>
     <message>
-        <source>Loading block index...</source>
-        <translation>正在載入區塊索引...</translation>
-    </message>
-    <message>
-        <source>Loading wallet...</source>
-        <translation>正在載入錢包資料...</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>主節點隊列已滿。</translation>
     </message>
@@ -4319,6 +4276,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Missing input transaction information.</source>
         <translation>缺少交易信息的輸入資料。</translation>
+    </message>
+    <message>
+        <source>Mixing in progress…</source>
+        <translation>正在進行混合…</translation>
     </message>
     <message>
         <source>No errors detected.</source>
@@ -4349,10 +4310,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>修剪模式與 -txindex 不兼容。</translation>
     </message>
     <message>
-        <source>Pruning blockstore...</source>
-        <translation>修剪儲存區塊...</translation>
-    </message>
-    <message>
         <source>Section [%s] is not recognized.</source>
         <translation>無法識別節 [%s] 。</translation>
     </message>
@@ -4367,10 +4324,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
         <translation>指定的 -walletdir "%s" 不是一個目錄</translation>
-    </message>
-    <message>
-        <source>Synchronizing blockchain...</source>
-        <translation>正在同步區塊鏈...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4405,10 +4358,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>交易太大了</translation>
     </message>
     <message>
-        <source>Trying to connect...</source>
-        <translation>嘗試連接...</translation>
-    </message>
-    <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
         <translation>沒辦法繫結在這台電腦上的 %s 。%s 可能已經在執行了。</translation>
     </message>
@@ -4427,6 +4376,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Upgrading UTXO database</source>
         <translation>正在升級 UTXO 資料庫</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation>正在驗證區塊資料…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation>正在驗證錢包…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4577,8 +4534,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>升級區塊鏈狀態資料庫時發生錯誤</translation>
     </message>
     <message>
-        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
-        <translation>錯誤: 無法將套接字添加到 kqueuefd (kevent 傳回錯誤 %s)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation>正在載入 P2P 位址資料…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation>正在載入禁止清單…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation>正在載入區塊索引…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation>正在載入錢包資料…</translation>
     </message>
     <message>
         <source>Failed to clear fulfilled requests cache at %s</source>
@@ -4617,6 +4586,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>無法開始一個新的混合隊列</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation>正在匯入中…</translation>
+    </message>
+    <message>
         <source>Incorrect -rescan mode, falling back to default value</source>
         <translation>不正確的 -rescan 模式，恢復到預設值</translation>
     </message>
@@ -4645,20 +4618,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>使用參數 -sporkaddr 時指定的spork地址無效</translation>
     </message>
     <message>
-        <source>Loading P2P addresses...</source>
-        <translation>正在載入 P2P 位址資料...</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>由於系統的限制，把-maxconnections 由%d 減至 %d </translation>
-    </message>
-    <message>
-        <source>Replaying blocks...</source>
-        <translation>正在重播區塊...</translation>
-    </message>
-    <message>
-        <source>Rescanning...</source>
-        <translation>正在重新掃描...</translation>
     </message>
     <message>
         <source>Session not complete!</source>
@@ -4689,14 +4650,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>距離上一次成功執行的時間過短。</translation>
     </message>
     <message>
-        <source>Starting network threads...</source>
-        <translation>正在啟動網路執行緒...</translation>
-    </message>
-    <message>
-        <source>Synchronizing governance objects...</source>
-        <translation>正在同步治理對象...</translation>
-    </message>
-    <message>
         <source>The source code is available from %s.</source>
         <translation>原始碼可以在 %s 取得。</translation>
     </message>
@@ -4723,6 +4676,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Transaction not valid.</source>
         <translation>交易無效。</translation>
+    </message>
+    <message>
+        <source>Trying to connect…</source>
+        <translation>嘗試連接…</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -4757,10 +4714,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>正在升級交易指數數據庫</translation>
     </message>
     <message>
-        <source>Verifying blocks...</source>
-        <translation>正在驗證區塊資料...</translation>
-    </message>
-    <message>
         <source>Very low number of keys left: %d</source>
         <translation>尚餘小量的公鑰: %d</translation>
     </message>
@@ -4775,6 +4728,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <translation>警告 : 不正確的參數 %s，路徑必須存在!  請使用預設路徑。</translation>
+    </message>
+    <message>
+        <source>Will retry…</source>
+        <translation>將重新嘗試…</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>


### PR DESCRIPTION
## Issue being fixed or feature implemented
Mostly regular translation updates but with 2 additional fixes:
- ac2e9ea is a backport, without it `make translate` fails to update `dashstrings.cpp` properly (but I couldn't figure out which PR it belongs to 🤷‍♂️ )
- c8333a5 is needed to make it easier to replace all `...` with `…` in `*.ts` files locally to avoid annoying translators (`...` and `…` are visually the same in transifex interface)


## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

