### PR TITLE
fix: avoid calling functions that change wallet state inside of `assert(...)`

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -268,17 +268,21 @@ bool LegacyScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, WalletBat
     }
 
     if (!hdChainCurrent.IsNull()) {
-        assert(EncryptHDChain(master_key, m_hd_chain));
-        assert(LoadHDChain(m_hd_chain));
+        bool res = EncryptHDChain(master_key, m_hd_chain);
+        assert(res);
+        res = LoadHDChain(m_hd_chain);
+        assert(res);
 
         CHDChain hdChainCrypted;
-        assert(GetHDChain(hdChainCrypted));
+        res = GetHDChain(hdChainCrypted);
+        assert(res);
 
         // ids should match, seed hashes should not
         assert(hdChainCurrent.GetID() == hdChainCrypted.GetID());
         assert(hdChainCurrent.GetSeedHash() != hdChainCrypted.GetSeedHash());
 
-        assert(AddHDChain(*encrypted_batch, hdChainCrypted));
+        res = AddHDChain(*encrypted_batch, hdChainCrypted);
+        assert(res);
     }
 
     encrypted_batch = nullptr;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Functions that change the state should not be called inside `assert`s

kudos to @kwvg for noticing https://github.com/dashpay/dash/pull/6116#discussion_r1681163803

## What was done?
Move them out

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

