### PR TITLE
feat: enable EHF activation of MN_RR on mainnet

### DIFF
--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -52,10 +52,6 @@ void CEHFSignalsHandler::UpdatedBlockTip(const CBlockIndex* const pindexNew, boo
         return;
     }
 
-    if (Params().NetworkIDString() == CBaseChainParams::MAIN) {
-        // TODO: v20 will never attempt to create EHF messages on main net; if this is needed it will be done by v20.1 or v21 nodes
-        return;
-    }
     const auto ehfSignals = mnhfman.GetSignalsStage(pindexNew);
     for (const auto& deployment : Params().GetConsensus().vDeployments) {
         // Skip deployments that do not use dip0023
@@ -102,10 +98,6 @@ void CEHFSignalsHandler::trySignEHFSignal(int bit, const CBlockIndex* const pind
 
 void CEHFSignalsHandler::HandleNewRecoveredSig(const CRecoveredSig& recoveredSig)
 {
-    if (Params().NetworkIDString() == CBaseChainParams::MAIN) {
-        // TODO: v20 will never attempt to create EHF messages on main net; if this is needed it will be done by v20.1 or v21 nodes
-        return;
-    }
     if (g_txindex) {
         g_txindex->BlockUntilSyncedToCurrentChain();
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash/issues/6081

## What was done?
Removed a code, that disabled MN_RR activation with EHF on Main Net

## How Has This Been Tested?
This code is tested on devnet, is in process of testing on testnet.


## Breaking Changes
It make MN_RR possible to get active on mainnet.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone