### PR TITLE
WIP: feat: immature withdrawal transactions

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -241,7 +241,7 @@ unsigned int CCoinsViewCache::GetCacheSize() const {
 
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
 {
-    if (!tx.IsCoinBase()) {
+    if (!tx.IsCoinBase() && !tx.IsWithdrawal()) {
         for (unsigned int i = 0; i < tx.vin.size(); i++) {
             if (!HaveCoin(tx.vin[i].prevout)) {
                 return false;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -112,7 +112,7 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool 
         bool overwrite = check_for_overwrite ? cache.HaveCoin(COutPoint(txid, i)) : fCoinbase;
         // Coinbase transactions can always be overwritten, in order to correctly
         // deal with the pre-BIP30 occurrences of duplicate coinbase transactions.
-        cache.AddCoin(COutPoint(txid, i), Coin(tx.vout[i], nHeight, fCoinbase), overwrite);
+        cache.AddCoin(COutPoint(txid, i), Coin(tx.vout[i], nHeight, fCoinbase, tx.IsWithdrawal()), overwrite);
     }
 }
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -52,7 +52,7 @@ public:
     //! empty constructor
     Coin() : fCoinBase(false), nHeight(0) { }
 
-    bool IsCoinBase() const {
+    bool RequiresMaturing() const {
         return fCoinBase;
     }
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -76,7 +76,7 @@ public:
         uint32_t code = 0;
         ::Unserialize(s, VARINT(code));
         fWithdrawal = (code & 0x80000000);
-        nHeight = (code >> 1) & 0x7FFFFFFFu;
+        nHeight = (code & 0x7FFFFFFFu) >> 1;
         fCoinBase = code & 1;
         ::Unserialize(s, Using<TxOutCompression>(out));
     }

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -22,6 +22,8 @@ inline unsigned int MaxBlockSigOps(bool fDIP0001Active = true)
 static const unsigned int MAX_TX_EXTRA_PAYLOAD = 10000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
+/** Withdrawal transaction outputs can only be spent after this number of new blocks (network rule) */
+static const int WITHDRAWAL_MATURITY = 576;
 
 /** Flags for nSequence and nLockTime locks */
 /** Interpret sequence numbers as relative lock-time constraints. */

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -183,6 +183,13 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
                 strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
         }
 
+        // If prev is withdrawal, check that it's matured
+        if (coin.IsWithdrawal() && nSpendHeight - coin.nHeight < WITHDRAWAL_MATURITY) {
+            return state.Invalid(TxValidationResult::TX_PREMATURE_SPEND, "bad-txns-premature-spend-of-withdrawal",
+                strprintf("tried to spend withdrawal at depth %d", nSpendHeight - coin.nHeight));
+        }
+
+
         // Check for negative or overflow input values
         nValueIn += coin.out.nValue;
         if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn)) {

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -149,7 +149,7 @@ bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 
             for (uint32_t j = 0; j < tx->vout.size(); ++j) {
                 const CTxOut& out{tx->vout[j]};
-                Coin coin{out, pindex->nHeight, tx->IsCoinBase()};
+                Coin coin{out, pindex->nHeight, tx->IsCoinBase(), tx->IsWithdrawal()};
                 COutPoint outpoint{tx->GetHash(), j};
 
                 // Skip unspendable coins
@@ -426,7 +426,7 @@ bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex
         for (uint32_t j = 0; j < tx->vout.size(); ++j) {
             const CTxOut& out{tx->vout[j]};
             COutPoint outpoint{tx->GetHash(), j};
-            Coin coin{out, pindex->nHeight, tx->IsCoinBase()};
+            Coin coin{out, pindex->nHeight, tx->IsCoinBase(), tx->IsWithdrawal()};
 
             // Skip unspendable coins
             if (coin.out.scriptPubKey.IsUnspendable()) {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -264,6 +264,11 @@ public:
         return nVersion >= SPECIAL_VERSION;
     }
 
+    bool IsWithdrawal() const noexcept
+    {
+        return IsSpecialTxVersion() && nType == TRANSACTION_ASSET_UNLOCK;
+    }
+
     bool HasExtraPayloadField() const noexcept
     {
         return IsSpecialTxVersion() && nType != TRANSACTION_NORMAL;

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -93,9 +93,9 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
 
     CBlockUndo block_undo;
     block_undo.vtxundo.emplace_back();
-    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(500, included_scripts[3]), 1000, true);
-    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(600, included_scripts[4]), 10000, false);
-    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(700, excluded_scripts[3]), 100000, false);
+    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(500, included_scripts[3]), 1000, true, false);
+    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(600, included_scripts[4]), 10000, false, false);
+    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(700, excluded_scripts[3]), 100000, false, false);
 
     BlockFilter block_filter(BlockFilterType::BASIC_FILTER, block, block_undo);
     const GCSFilter& filter = block_filter.GetFilter();
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(blockfilters_json_test)
         for (unsigned int ii = 0; ii < prev_scripts.size(); ii++) {
             std::vector<unsigned char> raw_script = ParseHex(prev_scripts[ii].get_str());
             CTxOut txout(0, CScript(raw_script.begin(), raw_script.end()));
-            tx_undo.vprevout.emplace_back(txout, 0, false);
+            tx_undo.vprevout.emplace_back(txout, 0, false, false);
         }
 
         uint256 prev_filter_header_basic;

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
             // Update the expected result to know about the new output coins
             assert(tx.vout.size() == 1);
             const COutPoint outpoint(tx.GetHash(), 0);
-            result[outpoint] = Coin(tx.vout[0], height, CTransaction(tx).IsCoinBase());
+            result[outpoint] = Coin(tx.vout[0], height, CTransaction(tx).IsCoinBase(), CTransaction(tx).IsWithdrawal());
 
             // Call UpdateCoins on the top cache
             CTxUndo undo;
@@ -729,7 +729,7 @@ BOOST_AUTO_TEST_CASE(ccoins_spend)
     CheckSpendCoins(VALUE1, VALUE2, ABSENT, DIRTY|FRESH, NO_ENTRY   );
 }
 
-static void CheckAddCoinBase(CAmount base_value, CAmount cache_value, CAmount modify_value, CAmount expected_value, char cache_flags, char expected_flags, bool coinbase)
+static void CheckAddCoinBase(CAmount base_value, CAmount cache_value, CAmount modify_value, CAmount expected_value, char cache_flags, char expected_flags, bool coinbase, bool withdrawal)
 {
     SingleEntryCacheTest test(base_value, cache_value, cache_flags);
 
@@ -738,7 +738,7 @@ static void CheckAddCoinBase(CAmount base_value, CAmount cache_value, CAmount mo
     try {
         CTxOut output;
         output.nValue = modify_value;
-        test.cache.AddCoin(OUTPOINT, Coin(std::move(output), 1, coinbase), coinbase);
+        test.cache.AddCoin(OUTPOINT, Coin(std::move(output), 1, coinbase, withdrawal), coinbase);
         test.cache.SelfTest();
         GetCoinsMapEntry(test.cache.map(), result_value, result_flags);
     } catch (std::logic_error&) {
@@ -759,7 +759,7 @@ template <typename... Args>
 static void CheckAddCoin(Args&&... args)
 {
     for (const CAmount base_value : {ABSENT, SPENT, VALUE1})
-        CheckAddCoinBase(base_value, std::forward<Args>(args)...);
+        CheckAddCoinBase(base_value, std::forward<Args>(args)..., false);
 }
 
 BOOST_AUTO_TEST_CASE(ccoins_add)

--- a/src/test/evo_assetlocks_tests.cpp
+++ b/src/test/evo_assetlocks_tests.cpp
@@ -308,6 +308,12 @@ BOOST_FIXTURE_TEST_CASE(evo_assetunlock, TestChain100Setup)
     std::string reason;
     BOOST_CHECK(IsStandardTx(CTransaction(tx), reason));
 
+    {
+        int height = 0;
+        Coin(tx.vout[0], height, CTransaction(tx).IsCoinBase(), CTransaction(tx).IsWithdrawal());
+        // TODO - make unit test for withdrawal!!1
+    }
+
     TxValidationState tx_state;
     std::string strTest;
     BOOST_CHECK_MESSAGE(CheckTransaction(CTransaction(tx), tx_state), strTest);

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -198,7 +198,7 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
                 const CTransaction transaction{random_mutable_transaction};
                 bool is_spent = false;
                 for (const CTxOut& tx_out : transaction.vout) {
-                    if (Coin{tx_out, 0, transaction.IsCoinBase()}.IsSpent()) {
+                    if (Coin{tx_out, 0, transaction.IsCoinBase(), transaction.IsWithdrawal()}.IsSpent()) {
                         is_spent = true;
                     }
                 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -464,8 +464,11 @@ public:
     //! at which height this transaction was included in the active block chain
     int nHeight;
 
+    //! whether transaction is a withdrawal
+    bool fWithdrawal;
+
     //! empty constructor
-    CCoins() : fCoinBase(false), vout(0), nHeight(0) { }
+    CCoins() : fCoinBase(false), vout(0), nHeight(0), fWithdrawal(false) { }
 
     template<typename Stream>
     void Unserialize(Stream &s) {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -546,7 +546,7 @@ bool CCoinsViewDB::Upgrade() {
             COutPoint outpoint(key.second, 0);
             for (size_t i = 0; i < old_coins.vout.size(); ++i) {
                 if (!old_coins.vout[i].IsNull() && !old_coins.vout[i].scriptPubKey.IsUnspendable()) {
-                    Coin newcoin(std::move(old_coins.vout[i]), old_coins.nHeight, old_coins.fCoinBase);
+                    Coin newcoin(std::move(old_coins.vout[i]), old_coins.nHeight, old_coins.fCoinBase, old_coins.fWithdrawal);
                     outpoint.n = i;
                     CoinEntry entry(&outpoint);
                     batch.Write(entry, newcoin);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1046,7 +1046,7 @@ static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& m
     CAmount txfee = 0;
     bool fCheckResult = tx.IsCoinBase() || Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee);
     assert(fCheckResult);
-    UpdateCoins(tx, mempoolDuplicate, std::numeric_limits<int>::max());
+    UpdateCoins(tx, mempoolDuplicate, MEMPOOL_HEIGHT);
 }
 
 void CTxMemPool::check(CChainState& active_chainstate) const

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -767,7 +767,8 @@ void CTxMemPool::removeForReorg(CChainState& active_chainstate, int flags) EXCLU
                 const Coin &coin = active_chainstate.CoinsTip().AccessCoin(txin.prevout);
                 if (m_check_ratio != 0) assert(!coin.IsSpent());
                 unsigned int nMemPoolHeight = active_chainstate.m_chain.Tip()->nHeight + 1;
-                if (coin.IsSpent() || (coin.IsCoinBase() && ((signed long)nMemPoolHeight) - coin.nHeight < COINBASE_MATURITY)) {
+                if (coin.IsSpent() || (coin.IsCoinBase() && ((signed long)nMemPoolHeight) - coin.nHeight < COINBASE_MATURITY) ||
+                        coin.IsWithdrawal() && ((signed long)nMemPoolHeight - coin.nHeight < WITHDRAWAL_MATURITY)) {
                     txToRemove.insert(it);
                     break;
                 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1455,7 +1455,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     CTransactionRef ptx = mempool.get(outpoint.hash);
     if (ptx) {
         if (outpoint.n < ptx->vout.size()) {
-            coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false);
+            coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false, false);
             return true;
         } else {
             return false;
@@ -1467,7 +1467,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 void CCoinsViewMemPool::PackageAddTransaction(const CTransactionRef& tx)
 {
     for (unsigned int n = 0; n < tx->vout.size(); ++n) {
-        m_temp_added.emplace(COutPoint(tx->GetHash(), n), Coin(tx->vout[n], MEMPOOL_HEIGHT, false));
+        m_temp_added.emplace(COutPoint(tx->GetHash(), n), Coin(tx->vout[n], MEMPOOL_HEIGHT, false, tx->IsWithdrawal()));
     }
 }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -44,7 +44,7 @@ class CBLSPublicKey;
 using CBLSLazyPublicKey = CBLSLazyWrapper<CBLSPublicKey>;
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
-static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
+static const uint32_t MEMPOOL_HEIGHT = 0x3FFFFFFF;
 
 struct LockPoints
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1886,6 +1886,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
         // In either case, we need to get the destination address
         CTxDestination address;
 
+         MAYBE SOME FIXES inside GetAmount ? dunno
         if (!ExtractDestination(txout.scriptPubKey, address) && !txout.scriptPubKey.IsUnspendable())
         {
             pwallet->WalletLogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5341,7 +5341,7 @@ bool CWalletTx::IsChainLocked() const
 
 int CWalletTx::GetBlocksToMaturity() const
 {
-    if (!IsCoinBase())
+    if (!IsCoinBase() && !IsWithdrawal())
         return 0;
     int chain_depth = GetDepthInMainChain();
     assert(chain_depth >= 0); // coinbase tx should not be conflicted

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5356,6 +5356,7 @@ int CWalletTx::GetBlocksToMaturity() const
 
 bool CWalletTx::IsImmature() const
 {
+    // note GetBlocksToMaturity is 0 for non-coinbase tx
     return GetBlocksToMaturity() > 0;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5345,11 +5345,13 @@ int CWalletTx::GetBlocksToMaturity() const
         return 0;
     int chain_depth = GetDepthInMainChain();
     assert(chain_depth >= 0); // coinbase tx should not be conflicted
+    // TODO make here condition for withdrawal
     return std::max(0, (COINBASE_MATURITY+1) - chain_depth);
 }
 
 bool CWalletTx::IsImmatureCoinBase() const
 {
+    // TODO make here withdrawal too! rename to IsImmatureTx() ??
     // note GetBlocksToMaturity is 0 for non-coinbase tx
     return GetBlocksToMaturity() > 0;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2993,7 +2993,7 @@ bool CWallet::SignTransaction(CMutableTransaction& tx) const
             return false;
         }
         const CWalletTx& wtx = mi->second;
-        coins[input.prevout] = Coin(wtx.tx->vout[input.prevout.n], wtx.m_confirm.block_height, wtx.IsCoinBase());
+        coins[input.prevout] = Coin(wtx.tx->vout[input.prevout.n], wtx.m_confirm.block_height, wtx.IsCoinBase(), wtx.IsWithdrawal());
     }
     std::map<int, std::string> input_errors;
     return SignTransaction(tx, coins, SIGHASH_ALL, input_errors);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -592,7 +592,7 @@ public:
     const uint256& GetHash() const { return tx->GetHash(); }
     bool IsCoinBase() const { return tx->IsCoinBase(); }
     bool IsWithdrawal() const { return tx->IsWithdrawal(); }
-    bool IsImmatureCoinBase() const;
+    bool IsImmature() const;
 
     // Disable copying of CWalletTx objects to prevent bugs where instances get
     // copied in and out of the mapWallet map, and fields are updated in the

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -591,6 +591,7 @@ public:
     void setConfirmed() { m_confirm.status = CWalletTx::CONFIRMED; }
     const uint256& GetHash() const { return tx->GetHash(); }
     bool IsCoinBase() const { return tx->IsCoinBase(); }
+    bool IsWithdrawal() const { return tx->IsWithdrawal(); }
     bool IsImmatureCoinBase() const;
 
     // Disable copying of CWalletTx objects to prevent bugs where instances get

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -416,6 +416,9 @@ class AssetLocksTest(DashTestFramework):
         self.sync_all()
         self.validate_credit_pool_balance(locked - 2 * COIN)
 
+        self.log.info(f"TXX: {node.getrawtransaction(txid, 1)}")
+        self.log.info(f"blocks: {node.getblockcount()}")
+
         self.log.info("Generating many blocks to make quorum far behind (even still active)...")
         self.slowly_generate_batch(too_late_height - node.getblockcount() - 1)
         self.check_mempool_result(tx=asset_unlock_tx_too_late, result_expected={'allowed': True, 'fees': {'base': Decimal(str(tiny_amount / COIN))}})

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -276,6 +276,7 @@ class AssetLocksTest(DashTestFramework):
         self.test_asset_unlocks(node_wallet, node, pubkey)
         self.test_withdrawal_limits(node_wallet, node, pubkey)
         self.test_mn_rr(node_wallet, node, pubkey)
+        raise False
 
 
     def test_asset_locks(self, node_wallet, node, pubkey):
@@ -352,6 +353,10 @@ class AssetLocksTest(DashTestFramework):
         too_late_height = node.getblockcount() + 48
 
         self.check_mempool_result(tx=asset_unlock_tx, result_expected={'allowed': True, 'fees': {'base': Decimal(str(tiny_amount / COIN))}})
+
+        for vout in node.decoderawtransaction(asset_unlock_tx.serialize().hex())['vout']:
+            node_wallet.importaddress(vout['scriptPubKey']['address'])
+
         self.check_mempool_result(tx=asset_unlock_tx_too_big_fee,
                 result_expected={'allowed': False, 'reject-reason' : 'max-fee-exceeded'})
         self.check_mempool_result(tx=asset_unlock_tx_zero_fee,


### PR DESCRIPTION
## Issue being fixed or feature implemented
To prevent a case of catastrophic failure in case of attack on platform, withdrawals from platform is going to be immature, at least right after release.

## What was done?
Make transaction of withdrawal immature, make a support for it for wallet, for rpc, and for UTXO.


## How Has This Been Tested?
see updates in units tests to fix compatibility.

Though, specific tests fro withdrawals immaturity is WIP

## Breaking Changes
Withdrawals becomes are immature and impossible to spend before 576 blocks are mined, similar to Coin Base transactions

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone