### PR TITLE
feat: harden all sporks on mainnet to current values

### DIFF
--- a/doc/release-notes-6140.md
+++ b/doc/release-notes-6140.md
@@ -1,0 +1,6 @@
+Mainnet Spork Hardening
+-----------------------
+
+This version hardens all Sporks on mainnet. Sporks remain in effect on all devnets and testnet; however, on mainnet,
+the value of all sporks are hard coded to 0, or 1 for SPORK_21_QUORUM_ALL_CONNECTED. These hardened values match the
+active values historically used on mainnet, so there is no change in the network's functionality.

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -262,6 +262,16 @@ bool CSporkManager::IsSporkActive(SporkId nSporkID) const
 
 SporkValue CSporkManager::GetSporkValue(SporkId nSporkID) const
 {
+    // Harden all sporks on Mainnet
+    if (!Params().IsTestChain()) {
+        switch (nSporkID) {
+            case SPORK_21_QUORUM_ALL_CONNECTED:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+
     LOCK(cs);
 
     if (auto opt_sporkValue = SporkValueIfActive(nSporkID)) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Harden all sporks on the mainnet; they are no longer necessary. Although retaining them might be beneficial in addressing bugs or issues, the greater priority is to protect mainnet by minimizing risks associated with potential centralization or even its perception. Sporks will continue to be valuable for testing on developer networks; however, on mainnet, the risks of maintaining them now outweigh the benefits of retaining them.

## What was done?
Adjust CSporkManager::GetSporkValue to always return 0 for sporks in general and 1 for SPORK_21_QUORUM_ALL_CONNECTED specifically.

## How Has This Been Tested?
Ran main net node with this patch. Sporks show as expected

## Breaking Changes
This is not a breaking change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

