### PR TITLE
test: fix test of withdrawal for more than 1000 dash

### DIFF
--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -223,14 +223,14 @@ class AssetLocksTest(DashTestFramework):
         except JSONRPCException as e:
             assert expected_error in e.error['message']
 
-    def slowly_generate_batch(self, amount):
-        self.log.info(f"Slowly generate {amount} blocks")
-        while amount > 0:
-            self.log.info(f"Generating batch of blocks {amount} left")
-            next = min(10, amount)
-            amount -= next
-            self.bump_mocktime(next)
-            self.nodes[1].generate(next)
+    def slowly_generate_batch(self, count):
+        self.log.info(f"Slowly generate {count} blocks")
+        while count > 0:
+            self.log.info(f"Generating batch of blocks {count} left")
+            batch = min(10, count)
+            count -= batch
+            self.bump_mocktime(batch)
+            self.nodes[1].generate(batch)
             self.sync_all()
 
     def run_test(self):
@@ -381,7 +381,7 @@ class AssetLocksTest(DashTestFramework):
         assert_equal(rawtx_is["chainlock"], False)
         assert not "confirmations" in rawtx
         assert not "confirmations" in rawtx_is
-        # disable back IS
+        self.log.info("Disable back IS")
         self.set_sporks()
 
         assert "assetUnlockTx" in node.getrawtransaction(txid, 1)
@@ -441,7 +441,7 @@ class AssetLocksTest(DashTestFramework):
             inode.reconsiderblock(block_to_reconsider)
         self.validate_credit_pool_balance(locked - 2 * COIN)
 
-        self.log.info("Forcibly mining asset_unlock_tx_too_late and ensure block is invalid...")
+        self.log.info("Forcibly mining asset_unlock_tx_too_late and ensure block is invalid")
         self.create_and_check_block([asset_unlock_tx_too_late], expected_error = "bad-assetunlock-not-active-quorum")
 
         node.generate(1)
@@ -450,7 +450,7 @@ class AssetLocksTest(DashTestFramework):
         self.validate_credit_pool_balance(locked - 2 * COIN)
         self.validate_credit_pool_balance(block_hash=self.block_hash_1, expected=locked)
 
-        self.log.info("Forcibly mine asset_unlock_tx_full and ensure block is invalid...")
+        self.log.info("Forcibly mine asset_unlock_tx_duplicate_index and ensure block is invalid")
         self.create_and_check_block([asset_unlock_tx_duplicate_index], expected_error = "bad-assetunlock-duplicated-index")
 
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

DIP for Credit Pool says:
```
The withdrawal should not be mined if:
* It requests more DASH than the credit pool contains
* It requests more than 1000 DASH
* The credit pool contains more than 1000 DASH, and the withdrawal would result in more than a 10% reduction in the credit pool over the 576-block window
* The credit pool contains less than 1000 DASH, and the withdrawal would result in more than 100 DASH being removed from the pool over the 576-block window
```

Though, current functional test for asset locks improperly test this case, because threshold for big withdrawal happens by 10%, not 1000 dash.


## What was done?
Improvements for functional asset lock test to actually test a limit 1000 dash, not just 10%

## How Has This Been Tested?
See changes

## Breaking Changes
N/A, changes only for tests


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone