### PR TITLE
fix: build with -Wdocumentation - rename param pwallet to wallet

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1332,7 +1332,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
 /**
  * List transactions based on the given criteria.
  *
- * @param  pwallet        The wallet.
+ * @param  wallet         The wallet.
  * @param  wtx            The wallet transaction.
  * @param  nMinDepth      The minimum confirmation depth.
  * @param  fLong          Whether to include the JSON version of the transaction.


### PR DESCRIPTION
## Issue being fixed or feature implemented

CI failures like that:
https://gitlab.com/dashpay/dash/-/jobs/7400661581

It happened due to 2 PRs merged one after each other without rebasing:
 - enabling -Wdocumentation in bitcoin#21631 (#6113)
 - renaming param while doxygen comment is forgotten in #6114


## What was done?
It contains changes from https://github.com/dashpay/dash/pull/6133
Thanks Vijay for spotting issue, this PR is DNM if 6133 will get merged faster.


## How Has This Been Tested?
See CI

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone