### PR TITLE
feat: aim to have at least 2 onion connections, guard them from eviction

### DIFF
--- a/doc/release-notes-6147.md
+++ b/doc/release-notes-6147.md
@@ -1,0 +1,12 @@
+P2P and Network Changes
+-----------------------
+
+### Improved Onion Connectivity
+
+To enhance censorship resistance and mitigate network partitioning risks, Dash Core now aims to maintain at least two
+outbound onion connections and generally protects these connections from eviction. As a result of the low percentage
+of gossiped addresses being onion nodes, it was often the case where, unless you specify `onlynet=onion`, a node
+would rarely if ever establish any outbound onion connections. This change ensures that nodes which can access the
+onion network maintain a few onion connections. As a result, network messages could continue to propagate across
+the network even if non-onion IPv4 traffic is blocked, reducing the risk of partitioning. Additionally, this update improves
+security by enabling p2p encryption for these peers. (#6147)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2341,6 +2341,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.nMaxConnections = nMaxConnections;
     connOptions.m_max_outbound_full_relay = std::min(MAX_OUTBOUND_FULL_RELAY_CONNECTIONS, connOptions.nMaxConnections);
     connOptions.m_max_outbound_block_relay = std::min(MAX_BLOCK_RELAY_ONLY_CONNECTIONS, connOptions.nMaxConnections-connOptions.m_max_outbound_full_relay);
+    connOptions.m_max_outbound_onion = std::min(MAX_DESIRED_ONION_CONNECTIONS, connOptions.nMaxConnections / 2);
     connOptions.nMaxAddnode = MAX_ADDNODE_CONNECTIONS;
     connOptions.nMaxFeeler = MAX_FEELER_CONNECTIONS;
     connOptions.uiInterface = &uiInterface;

--- a/src/net.h
+++ b/src/net.h
@@ -85,6 +85,8 @@ static const int MAX_ADDNODE_CONNECTIONS = 8;
 static const auto INBOUND_EVICTION_PROTECTION_TIME{1s};
 /** Maximum number of block-relay-only outgoing connections */
 static const int MAX_BLOCK_RELAY_ONLY_CONNECTIONS = 2;
+/** Maximum number of onion connections we will try harder to connect to / protect from eviction */
+static const int MAX_DESIRED_ONION_CONNECTIONS = 2;
 /** Maximum number of feeler connections */
 static const int MAX_FEELER_CONNECTIONS = 1;
 /** -listen default */
@@ -873,6 +875,7 @@ public:
         int nMaxConnections = 0;
         int m_max_outbound_full_relay = 0;
         int m_max_outbound_block_relay = 0;
+        int m_max_outbound_onion = 0;
         int nMaxAddnode = 0;
         int nMaxFeeler = 0;
         CClientUIInterface* uiInterface = nullptr;
@@ -905,6 +908,7 @@ public:
         nMaxConnections = connOptions.nMaxConnections;
         m_max_outbound_full_relay = std::min(connOptions.m_max_outbound_full_relay, connOptions.nMaxConnections);
         m_max_outbound_block_relay = connOptions.m_max_outbound_block_relay;
+        m_max_outbound_onion = connOptions.m_max_outbound_onion;
         m_use_addrman_outgoing = connOptions.m_use_addrman_outgoing;
         nMaxAddnode = connOptions.nMaxAddnode;
         nMaxFeeler = connOptions.nMaxFeeler;
@@ -1179,6 +1183,7 @@ public:
 
     size_t GetNodeCount(ConnectionDirection) const;
     size_t GetMaxOutboundNodeCount();
+    size_t GetMaxOutboundOnionNodeCount();
     void GetNodeStats(std::vector<CNodeStats>& vstats) const;
     bool DisconnectNode(const std::string& node);
     bool DisconnectNode(const CSubNet& subnet);
@@ -1514,6 +1519,9 @@ private:
     // How many block-relay only outbound peers we want
     // We do not relay tx or addr messages with these peers
     int m_max_outbound_block_relay;
+
+    // How many onion outbound peers we want; don't care if full or block only; does not increase m_max_outbound
+    int m_max_outbound_onion;
 
     int nMaxAddnode;
     int nMaxFeeler;


### PR DESCRIPTION
## Issue being fixed or feature implemented
In the past I've noticed that even when using `-proxy` over tor, I wouldn't actually gain any onion connections over time. This is even worse when using -onion. Sure it may expose an onion service, but you wouldn't gain any onion connections (in my experience)!

The goal here is to minimize easy-ish censorship and improve network-wide resistance to partitioning. It is not unimaginable that port 9999 could be blocked at large scale. This could potentially result in severe partitioning, and subsequent issues. In an attempt to avoid this, we should always try to have at least 2 outbound onion connections when at all possible. Hopefully this also makes onion addresses gossip better.

This also adds a benefit of p2p encryption for these peers. As a result, there is improved plausible deniability that you produced a transaction, as it is possible you received it over onion and simply rebroadcast it over ipv4.

I don't think there is any real downside to this patch, stuff like masternode / quorum connections will still always happen over ipv4, but with this, blocks and transactions would continue to propogate across the network even if (non-onion) ipv4 traffic was all dropped.

Arguably, it's not **ideal** to send so much traffic over tor, but hopefully as latency is higher, we will generally receive messages over ipv4 first and therefor not request them over the onion connections.


## What was done?
We will always try to get 2 onion nodes (full or block only); and guard them from eviction

## How Has This Been Tested?
Run a node; see over time that you start with 0 onion nodes, and over time you progress to having two of them! 

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

