### PR TITLE
fix: avoid voting for the same trigger multiple times

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -748,19 +748,23 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
         const uint256 gov_sb_hash = trigger_opt.value().GetHash();
         if (vote_rec_t voteRecord; trigger_opt.value().GetCurrentMNVotes(mn_activeman.GetOutPoint(), voteRecord)) {
             const auto& strFunc = __func__;
-            ranges::any_of(voteRecord.mapInstances, [&](const auto& voteInstancePair){
+            ranges::any_of(voteRecord.mapInstances, [&](const auto& voteInstancePair) {
                 if (voteInstancePair.first == VOTE_SIGNAL_FUNDING) {
                     if (voteInstancePair.second.eOutcome == VOTE_OUTCOME_YES) {
                         votedFundingYesTriggerHash = gov_sb_hash;
                     }
-                    LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Not voting YES-FUNDING for trigger:%s, we voted %s for it already\n",
-                            strFunc, gov_sb_hash.ToString(), CGovernanceVoting::ConvertOutcomeToString(voteInstancePair.second.eOutcome));
+                    LogPrint(BCLog::GOBJECT, /* Continued */
+                             "CGovernanceManager::%s "
+                             "Not voting YES-FUNDING for trigger:%s, we voted %s for it already\n",
+                             strFunc, gov_sb_hash.ToString(),
+                             CGovernanceVoting::ConvertOutcomeToString(voteInstancePair.second.eOutcome));
                     return true;
                 }
                 return false;
             });
         } else if (VoteFundingTrigger(gov_sb_hash, VOTE_OUTCOME_YES, connman, peerman, mn_activeman)) {
-            LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Voting YES-FUNDING for new trigger:%s success\n", __func__, gov_sb_hash.ToString());
+            LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Voting YES-FUNDING for new trigger:%s success\n", __func__,
+                     gov_sb_hash.ToString());
             votedFundingYesTriggerHash = gov_sb_hash;
         } else {
             LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Voting YES-FUNDING for new trigger:%s failed\n", __func__, gov_sb_hash.ToString());
@@ -786,14 +790,17 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
         }
         if (vote_rec_t voteRecord; govobj->GetCurrentMNVotes(mn_activeman.GetOutPoint(), voteRecord)) {
             const auto& strFunc = __func__;
-            if (ranges::any_of(voteRecord.mapInstances, [&](const auto& voteInstancePair){
-                if (voteInstancePair.first == VOTE_SIGNAL_FUNDING) {
-                    LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Not voting NO-FUNDING for trigger:%s, we voted %s for it already\n",
-                            strFunc, trigger_hash.ToString(), CGovernanceVoting::ConvertOutcomeToString(voteInstancePair.second.eOutcome));
-                    return true;
-                }
-                return false;
-            })) {
+            if (ranges::any_of(voteRecord.mapInstances, [&](const auto& voteInstancePair) {
+                    if (voteInstancePair.first == VOTE_SIGNAL_FUNDING) {
+                        LogPrint(BCLog::GOBJECT, /* Continued */
+                                 "CGovernanceManager::%s "
+                                 "Not voting NO-FUNDING for trigger:%s, we voted %s for it already\n",
+                                 strFunc, trigger_hash.ToString(),
+                                 CGovernanceVoting::ConvertOutcomeToString(voteInstancePair.second.eOutcome));
+                        return true;
+                    }
+                    return false;
+                })) {
                 continue;
             }
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
We just had a sb voting period and I noticed that the network is way too spammy and produces too many votes (10x+ the expected numbers). It turns out that relying on `ProcessVoteAndRelay` on mainnet is not enough because rate-check expires too soon and MNs are able to vote again and again. On testnet it was never an issue because the voting period there is really short.

## What was done?
Check known votes to make sure we never voted earlier.

## How Has This Been Tested?
Run tests, run a MN on mainnet and check logs.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

