### PR TITLE
fix: let internal govobj/vote inv request trackers expire after 60 sec

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -462,7 +462,8 @@ void CGovernanceManager::CheckAndRemove()
         }
     }
 
-    LogPrint(BCLog::GOBJECT, "CGovernanceManager::UpdateCachesAndClean -- %s, m_requested_hash_time size=%d\n", ToString(), m_requested_hash_time.size());
+    LogPrint(BCLog::GOBJECT, "CGovernanceManager::UpdateCachesAndClean -- %s, m_requested_hash_time size=%d\n",
+             ToString(), m_requested_hash_time.size());
 }
 
 const CGovernanceObject* CGovernanceManager::FindConstGovernanceObject(const uint256& nHash) const
@@ -846,10 +847,13 @@ bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
         return false;
     }
 
-    const auto& [_itr, inserted] = m_requested_hash_time.emplace(inv.hash, GetTime<std::chrono::seconds>().count() + RELIABLE_PROPAGATION_TIME);
+    const auto valid_until = GetTime<std::chrono::seconds>().count() + RELIABLE_PROPAGATION_TIME;
+    const auto& [_itr, inserted] = m_requested_hash_time.emplace(inv.hash, valid_until);
 
     if (inserted) {
-        LogPrint(BCLog::GOBJECT, "CGovernanceManager::ConfirmInventoryRequest added %s inv hash to m_requested_hash_time, size=%d\n", MSG_GOVERNANCE_OBJECT ? "object" : "vote", m_requested_hash_time.size());
+        LogPrint(BCLog::GOBJECT, /* Continued */
+                 "CGovernanceManager::ConfirmInventoryRequest added %s inv hash to m_requested_hash_time, size=%d\n",
+                 MSG_GOVERNANCE_OBJECT ? "object" : "vote", m_requested_hash_time.size());
     }
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::ConfirmInventoryRequest reached end, returning true\n");

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -455,7 +455,7 @@ void CGovernanceManager::CheckAndRemove()
     // forget about expired requests
     auto r_it = m_requested_hash_time.begin();
     while (r_it != m_requested_hash_time.end()) {
-        if (r_it->second < nNow) {
+        if (r_it->second < std::chrono::seconds(nNow)) {
             m_requested_hash_time.erase(r_it++);
         } else {
             ++r_it;
@@ -847,7 +847,7 @@ bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
         return false;
     }
 
-    const auto valid_until = GetTime<std::chrono::seconds>().count() + RELIABLE_PROPAGATION_TIME;
+    const auto valid_until = GetTime<std::chrono::seconds>() + std::chrono::seconds(RELIABLE_PROPAGATION_TIME);
     const auto& [_itr, inserted] = m_requested_hash_time.emplace(inv.hash, valid_until);
 
     if (inserted) {

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -853,7 +853,7 @@ bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
     if (inserted) {
         LogPrint(BCLog::GOBJECT, /* Continued */
                  "CGovernanceManager::ConfirmInventoryRequest added %s inv hash to m_requested_hash_time, size=%d\n",
-                 MSG_GOVERNANCE_OBJECT ? "object" : "vote", m_requested_hash_time.size());
+                 inv.type == MSG_GOVERNANCE_OBJECT ? "object" : "vote", m_requested_hash_time.size());
     }
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::ConfirmInventoryRequest reached end, returning true\n");

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -270,7 +270,7 @@ private:
     int nCachedBlockHeight;
     std::map<uint256, CGovernanceObject> mapPostponedObjects;
     hash_s_t setAdditionalRelayObjects;
-    std::map<uint256, int64_t> m_requested_hash_time;
+    std::map<uint256, std::chrono::seconds> m_requested_hash_time;
     bool fRateChecksEnabled;
     std::optional<uint256> votedFundingYesTriggerHash;
     std::map<uint256, std::shared_ptr<CSuperblock>> mapTrigger;

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -270,8 +270,7 @@ private:
     int nCachedBlockHeight;
     std::map<uint256, CGovernanceObject> mapPostponedObjects;
     hash_s_t setAdditionalRelayObjects;
-    std::map<uint256, int64_t> mapRequestedObjects;
-    std::map<uint256, int64_t> mapRequestedVotes;
+    std::map<uint256, int64_t> m_requested_hash_time;
     bool fRateChecksEnabled;
     std::optional<uint256> votedFundingYesTriggerHash;
     std::map<uint256, std::shared_ptr<CSuperblock>> mapTrigger;
@@ -389,13 +388,8 @@ private:
 
     bool ProcessVote(CNode* pfrom, const CGovernanceVote& vote, CGovernanceException& exception, CConnman& connman);
 
-    /// Called to indicate a requested object has been received
-    bool AcceptObjectMessage(const uint256& nHash);
-
-    /// Called to indicate a requested vote has been received
-    bool AcceptVoteMessage(const uint256& nHash);
-
-    static bool AcceptMessage(const uint256& nHash, std::map<uint256, int64_t>& mapHash);
+    /// Called to indicate a requested object or vote has been received
+    bool AcceptMessage(const uint256& nHash);
 
     void CheckOrphanVotes(CGovernanceObject& govobj, PeerManager& peerman);
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -270,8 +270,8 @@ private:
     int nCachedBlockHeight;
     std::map<uint256, CGovernanceObject> mapPostponedObjects;
     hash_s_t setAdditionalRelayObjects;
-    hash_s_t setRequestedObjects;
-    hash_s_t setRequestedVotes;
+    std::map<uint256, int64_t> mapRequestedObjects;
+    std::map<uint256, int64_t> mapRequestedVotes;
     bool fRateChecksEnabled;
     std::optional<uint256> votedFundingYesTriggerHash;
     std::map<uint256, std::shared_ptr<CSuperblock>> mapTrigger;
@@ -395,7 +395,7 @@ private:
     /// Called to indicate a requested vote has been received
     bool AcceptVoteMessage(const uint256& nHash);
 
-    static bool AcceptMessage(const uint256& nHash, hash_s_t& setHash);
+    static bool AcceptMessage(const uint256& nHash, std::map<uint256, int64_t>& mapHash);
 
     void CheckOrphanVotes(CGovernanceObject& govobj, PeerManager& peerman);
 

--- a/test/functional/p2p_governance_invs.py
+++ b/test/functional/p2p_governance_invs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test inv expiration for governance objects/votes
+"""
+
+from test_framework.messages import (
+    CInv,
+    msg_inv,
+    MSG_GOVERNANCE_OBJECT,
+    MSG_GOVERNANCE_OBJECT_VOTE,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import force_finish_mnsync
+
+RELIABLE_PROPAGATION_TIME = 60  # src/governance/governance.cpp
+DATA_CLEANUP_TIME = 5 * 60      # src/init.cpp
+MSG_INV_ADDED = 'CGovernanceManager::ConfirmInventoryRequest added {} inv hash to m_requested_hash_time'
+
+class GovernanceInvsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+        force_finish_mnsync(node)
+        inv = msg_inv([CInv(MSG_GOVERNANCE_OBJECT, 1)])
+        self.test_request_expiration(inv, "object")
+        inv = msg_inv([CInv(MSG_GOVERNANCE_OBJECT_VOTE, 2)])
+        self.test_request_expiration(inv, "vote")
+
+    def test_request_expiration(self, inv, name):
+        msg = MSG_INV_ADDED.format(name)
+        node = self.nodes[0]
+        peer = node.add_p2p_connection(P2PInterface())
+        self.log.info(f"Send dummy governance {name} inv and make sure it's added to requested map")
+        with node.assert_debug_log([msg]):
+            peer.send_message(inv)
+        self.log.info(f"Send dummy governance {name} inv again and make sure it's not added because we know about it already")
+        with node.assert_debug_log([], [msg]):
+            peer.send_message(inv)
+        self.log.info("Force internal cleanup")
+        with node.assert_debug_log(['UpdateCachesAndClean']):
+            node.mockscheduler(DATA_CLEANUP_TIME + 1)
+        self.log.info(f"Send dummy governance {name} inv again and make sure it's not added because we still know about it")
+        with node.assert_debug_log([], [msg]):
+            peer.send_message(inv)
+        self.log.info(f"Bump mocktime, force internal cleanup, send dummy governance {name} inv again and make sure it's accepted again")
+        self.bump_mocktime(RELIABLE_PROPAGATION_TIME + 1, nodes=[node])
+        with node.assert_debug_log(['UpdateCachesAndClean']):
+            node.mockscheduler(DATA_CLEANUP_TIME + 1)
+        with node.assert_debug_log([msg]):
+            peer.send_message(inv)
+        node.disconnect_p2ps()
+
+
+if __name__ == '__main__':
+    GovernanceInvsTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -59,6 +59,8 @@ NODE_HEADERS_COMPRESSED = (1 << 11)
 MSG_TX = 1
 MSG_BLOCK = 2
 MSG_FILTERED_BLOCK = 3
+MSG_GOVERNANCE_OBJECT = 17
+MSG_GOVERNANCE_OBJECT_VOTE = 18
 MSG_CMPCT_BLOCK = 20
 MSG_TYPE_MASK = 0xffffffff >> 2
 
@@ -350,6 +352,8 @@ class CInv:
         MSG_TX: "TX",
         MSG_BLOCK: "Block",
         MSG_FILTERED_BLOCK: "filtered Block",
+        MSG_GOVERNANCE_OBJECT: "Governance Object",
+        MSG_GOVERNANCE_OBJECT_VOTE: "Governance Vote",
         MSG_CMPCT_BLOCK: "CompactBlock",
     }
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -293,6 +293,7 @@ BASE_SCRIPTS = [
     'feature_governance.py --descriptors',
     'feature_governance_cl.py --legacy-wallet',
     'feature_governance_cl.py --descriptors',
+    'p2p_governance_invs.py',
     'rpc_uptime.py',
     'feature_discover.py',
     'wallet_resendwallettransactions.py --legacy-wallet',


### PR DESCRIPTION
## Issue being fixed or feature implemented
Another issue noticed during recent sb voting period. Lots of inv are coming from peers that never send the object/vote they announced. Let's not wait for these forever, 60 seconds should be enough.

## What was done?
Add a "timer" to each request.

## How Has This Been Tested?
Run tests, run a MN on mainnet and check logs.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

