### PR TITLE
feat: add sbom and provenance in release for dockerhub; use jammy; apt remove as possible

### DIFF
--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -65,6 +65,8 @@ jobs:
         context: ./contrib/containers/deploy
         file: ./contrib/containers/deploy/Dockerfile.GitHubActions.Release
         push: true
+        provenance: mode=max
+        sbom: true
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}
         build-args: |

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore"
 
@@ -32,6 +32,14 @@ RUN mach=$(uname -m) \
       && find /tmp/dashcore*/bin -type f ! -name 'dash-qt' -exec cp {} /usr/local/bin \; \
       && rm -rf /tmp/dashcore* \
       && chmod a+x /usr/local/bin/*
+
+RUN apt-get update && \
+    apt list --installed && \
+    apt-get -y purge \
+    wget \
+    ca-certificates \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 USER dash
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Docker provenance refers to the origin and history of Docker images, including how they were built, modified, and by whom. An SBOM (Software Bill of Materials) is a detailed list of all components in a software application, providing transparency about libraries, dependencies, and versions used, which is crucial for security and compliance.

## What was done?
Add SBOM and provenance to docker build; this may allow some level of validation that GitHub actions is actually doing what it says it is.

See this for more information https://docs.docker.com/build/ci/github-actions/attestations/

## How Has This Been Tested?
Building with buildx with sbom and provenance flags locally

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

