### PR TITLE
fix: use blocks-only instead of address-only for inventory

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2589,7 +2589,7 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
         }
         ++it;
 
-        if (!peer.m_addr_relay_enabled && NetMessageViolatesBlocksOnly(inv.GetCommand())) {
+        if (peer.m_block_relay_only && NetMessageViolatesBlocksOnly(inv.GetCommand())) {
             // Note that if we receive a getdata for non-block messages
             // from a block-relay-only outbound peer that violate the policy,
             // we skip such getdata messages from this peer


### PR DESCRIPTION
## Issue being fixed or feature implemented
Mobile client (without full blockchain) can't receive transactions before they are mined in the block.

## What was done?
Fixed a condition "is an addr relay" to "not a block relay".
It's an alternate solution for https://github.com/dashpay/dash/pull/6162


## How Has This Been Tested?
Tested with hashengineering - it works!

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone