### PR TITLE
feat: keep llmq_50_60 enabled in Devnets

### DIFF
--- a/doc/release-notes-6183.md
+++ b/doc/release-notes-6183.md
@@ -1,0 +1,4 @@
+New functionality
+-----------
+
+- LLMQ type LLMQ_50_60 is enabled for Devnet networks. This is needed when testing on a large Devnet.

--- a/src/llmq/options.cpp
+++ b/src/llmq/options.cpp
@@ -132,7 +132,7 @@ bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, gsl::not_null<con
             return true;
         case Consensus::LLMQType::LLMQ_50_60:
             return !fDIP0024IsActive || !fHaveDIP0024Quorums ||
-                    Params().NetworkIDString() == CBaseChainParams::TESTNET;
+                    Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET;
         case Consensus::LLMQType::LLMQ_TEST_INSTANTSEND:
             return !fDIP0024IsActive || !fHaveDIP0024Quorums ||
                     consensusParams.llmqTypeDIP0024InstantSend == Consensus::LLMQType::LLMQ_TEST_INSTANTSEND;

--- a/src/llmq/options.cpp
+++ b/src/llmq/options.cpp
@@ -131,8 +131,8 @@ bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, gsl::not_null<con
         case Consensus::LLMQType::LLMQ_DEVNET:
             return true;
         case Consensus::LLMQType::LLMQ_50_60:
-            return !fDIP0024IsActive || !fHaveDIP0024Quorums ||
-                    Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET;
+            return !fDIP0024IsActive || !fHaveDIP0024Quorums || Params().NetworkIDString() == CBaseChainParams::TESTNET ||
+                   Params().NetworkIDString() == CBaseChainParams::DEVNET;
         case Consensus::LLMQType::LLMQ_TEST_INSTANTSEND:
             return !fDIP0024IsActive || !fHaveDIP0024Quorums ||
                     consensusParams.llmqTypeDIP0024InstantSend == Consensus::LLMQType::LLMQ_TEST_INSTANTSEND;


### PR DESCRIPTION
## Issue being fixed or feature implemented
LLMQ_50_60 needs to be enabled in Devnets when deploying a larger one.

## What was done?


## How Has This Been Tested?


## Breaking Changes
no


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

