### PR TITLE
chore: bump version in core to v22

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_PREREQ([2.69])
 dnl Don't forget to push a corresponding tag when updating any of _CLIENT_VERSION_* numbers
-define(_CLIENT_VERSION_MAJOR, 21)
+define(_CLIENT_VERSION_MAJOR, 22)
 define(_CLIENT_VERSION_MINOR, 0)
-define(_CLIENT_VERSION_BUILD, 2)
+define(_CLIENT_VERSION_BUILD, 0)
 define(_CLIENT_VERSION_IS_RELEASE, false)
 define(_COPYRIGHT_YEAR, 2024)
 define(_COPYRIGHT_HOLDERS,[The %s developers])


### PR DESCRIPTION
## Issue being fixed or feature implemented
Platform is requesting https://github.com/dashpay/dash/pull/6183 be merged into develop, so that they can stop using hacky custom builds (which end up being out of date). 

## What was done?
Bump version to v22.0, allow for breaking changes to be merged in. My plan here is to basically have v22.0 be what v21.1 would have originally been, a large minor version, however now, we can merge in breaking changes too. 

Breaking changes can now be merged in

I don't have a firm timeline yet, but I want this optional smaller v22 to be released relatively quickly compared to normal major versions.  

## How Has This Been Tested?
NA

## Breaking Changes
None, yet!

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

