### PR TITLE
fix: help p2p_timeouts to succeed on the my localhost

### DIFF
--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -90,7 +90,7 @@ class TimeoutsTest(BitcoinTestFramework):
 
         with self.nodes[0].assert_debug_log(expected_msgs=expected_timeout_logs):
             self.mock_forward(3)
-            no_verack_node.wait_for_disconnect(timeout=1)
+            no_verack_node.wait_for_disconnect(timeout=2)
             no_version_node.wait_for_disconnect(timeout=1)
             no_send_node.wait_for_disconnect(timeout=1)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Locally on my environment the functional tests `p2p_timeouts.py` fails in 80% runs.

Output:
```
    stdout:
    2024-08-08T05:02:32.216000Z TestFramework (INFO): Initializing test directory /tmp/test_runner_∋_🏃_20240808_120217/p2p_timeouts_0
    2024-08-08T05:02:35.079000Z TestFramework.utils (ERROR): wait_until() failed. Predicate: ''''
            def test_function():
                if check_connected:
                    assert self.is_connected
                return test_function_in()
    '''
    2024-08-08T05:02:35.080000Z TestFramework (ERROR): Assertion failed
    Traceback (most recent call last):
      File "DASH/test/functional/test_framework/test_framework.py", line 159, in main
        self.run_test()
      File "DASH/test/functional/p2p_timeouts.py", line 93, in run_test
        no_verack_node.wait_for_disconnect(timeout=1)
      File "DASH/test/functional/test_framework/p2p.py", line 495, in wait_for_disconnect
        self.wait_until(test_function, timeout=timeout, check_connected=False)
      File "DASH/test/functional/test_framework/p2p.py", line 487, in wait_until
        wait_until_helper(test_function, timeout=timeout, lock=p2p_lock, timeout_factor=self.timeout_factor)
      File "DASH/test/functional/test_framework/util.py", line 267, in wait_until_helper
        raise AssertionError("Predicate {} not true after {} seconds".format(predicate_source, timeout))
    AssertionError: Predicate ''''
            def test_function():
                if check_connected:
                    assert self.is_connected
                return test_function_in()
    ''' not true after 1.0 seconds
    2024-08-08T05:02:35.581000Z TestFramework (INFO): Stopping nodes
    2024-08-08T05:02:36.582000Z TestFramework (WARNING): Not cleaning up dir /tmp/test_runner_∋_🏃_20240808_120217/p2p_timeouts_0
    2024-08-08T05:02:36.582000Z TestFramework (ERROR): Test failed. Test logging available at /tmp/test_runner_∋_🏃_20240808_120217/p2p_timeouts_0/test_framework.log
    2024-08-08T05:02:36.582000Z TestFramework (ERROR):
    2024-08-08T05:02:36.582000Z TestFramework (ERROR): Hint: Call DASH/test/functional/combine_logs.py '/tmp/test_runner_∋_🏃_20240808_120217/p2p_timeouts_0' to consolidate all logs
    2024-08-08T05:02:36.582000Z TestFramework (ERROR):
    2024-08-08T05:02:36.582000Z TestFramework (ERROR): If this failure happened unexpectedly or intermittently, please file a bug and provide a link or upload of the combined log.
    2024-08-08T05:02:36.582000Z TestFramework (ERROR): https://github.com/dashpay/dash/issues
    2024-08-08T05:02:36.582000Z TestFramework (ERROR):

    stderr:

    TEST            | STATUS    | DURATION

    p2p_timeouts.py | ✓ Passed  | 4 s
    p2p_timeouts.py | ✖ Failed  | 4 s
    p2p_timeouts.py | ✖ Failed  | 5 s
    p2p_timeouts.py | ✖ Failed  | 5 s
    p2p_timeouts.py | ✖ Failed  | 6 s
    p2p_timeouts.py | ✖ Failed  | 6 s
    p2p_timeouts.py | ✖ Failed  | 7 s

    ALL             | ✖ Failed  | 37 s (accumulated)
    Runtime: 7 s
```

## What was done?
Increased a timeout to see for first disconnect event +1 second.

## How Has This Been Tested?
100% succeed:
```
$ test/functional/test_runner.py -j20 p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py p2p_timeouts.py 

p2p_timeouts.py | ✓ Passed  | 4 s
p2p_timeouts.py | ✓ Passed  | 5 s
p2p_timeouts.py | ✓ Passed  | 5 s
p2p_timeouts.py | ✓ Passed  | 6 s
p2p_timeouts.py | ✓ Passed  | 6 s
p2p_timeouts.py | ✓ Passed  | 7 s
p2p_timeouts.py | ✓ Passed  | 7 s
p2p_timeouts.py | ✓ Passed  | 8 s
p2p_timeouts.py | ✓ Passed  | 8 s
p2p_timeouts.py | ✓ Passed  | 9 s
p2p_timeouts.py | ✓ Passed  | 9 s
p2p_timeouts.py | ✓ Passed  | 10 s
p2p_timeouts.py | ✓ Passed  | 10 s
p2p_timeouts.py | ✓ Passed  | 11 s
p2p_timeouts.py | ✓ Passed  | 11 s
p2p_timeouts.py | ✓ Passed  | 12 s
```



## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone