### PR TITLE
refactor: initialize variables in the header instead

### DIFF
--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -22,21 +22,7 @@
 
 #include <string>
 
-CGovernanceObject::CGovernanceObject() :
-    cs(),
-    m_obj{},
-    nDeletionTime(0),
-    fCachedLocalValidity(false),
-    strLocalValidityError(),
-    fCachedFunding(false),
-    fCachedValid(true),
-    fCachedDelete(false),
-    fCachedEndorsed(false),
-    fDirtyCache(true),
-    fExpired(false),
-    fUnparsable(false),
-    mapCurrentMNVotes(),
-    fileVotes()
+CGovernanceObject::CGovernanceObject()
 {
     // PARSE JSON DATA STORAGE (VCHDATA)
     LoadData();
@@ -44,19 +30,7 @@ CGovernanceObject::CGovernanceObject() :
 
 CGovernanceObject::CGovernanceObject(const uint256& nHashParentIn, int nRevisionIn, int64_t nTimeIn, const uint256& nCollateralHashIn, const std::string& strDataHexIn) :
     cs(),
-    m_obj{nHashParentIn, nRevisionIn, nTimeIn, nCollateralHashIn, strDataHexIn},
-    nDeletionTime(0),
-    fCachedLocalValidity(false),
-    strLocalValidityError(),
-    fCachedFunding(false),
-    fCachedValid(true),
-    fCachedDelete(false),
-    fCachedEndorsed(false),
-    fDirtyCache(true),
-    fExpired(false),
-    fUnparsable(false),
-    mapCurrentMNVotes(),
-    fileVotes()
+    m_obj{nHashParentIn, nRevisionIn, nTimeIn, nCollateralHashIn, strDataHexIn}
 {
     // PARSE JSON DATA STORAGE (VCHDATA)
     LoadData();

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -28,7 +28,8 @@ CGovernanceObject::CGovernanceObject()
     LoadData();
 }
 
-CGovernanceObject::CGovernanceObject(const uint256& nHashParentIn, int nRevisionIn, int64_t nTimeIn, const uint256& nCollateralHashIn, const std::string& strDataHexIn) :
+CGovernanceObject::CGovernanceObject(const uint256& nHashParentIn, int nRevisionIn, int64_t nTimeIn,
+                                     const uint256& nCollateralHashIn, const std::string& strDataHexIn) :
     cs(),
     m_obj{nHashParentIn, nRevisionIn, nTimeIn, nCollateralHashIn, strDataHexIn}
 {

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -103,37 +103,37 @@ private:
     Governance::Object m_obj;
 
     /// time this object was marked for deletion
-    int64_t nDeletionTime;
+    int64_t nDeletionTime{0};
 
 
     /// is valid by blockchain
-    bool fCachedLocalValidity;
+    bool fCachedLocalValidity{false};
     std::string strLocalValidityError;
 
     // VARIOUS FLAGS FOR OBJECT / SET VIA MASTERNODE VOTING
 
     /// true == minimum network support has been reached for this object to be funded (doesn't mean it will for sure though)
-    bool fCachedFunding;
+    bool fCachedFunding{false};
 
     /// true == minimum network has been reached flagging this object as a valid and understood governance object (e.g, the serialized data is correct format, etc)
-    bool fCachedValid;
+    bool fCachedValid{true};
 
     /// true == minimum network support has been reached saying this object should be deleted from the system entirely
-    bool fCachedDelete;
+    bool fCachedDelete{false};
 
     /** true == minimum network support has been reached flagging this object as endorsed by an elected representative body
      * (e.g. business review board / technical review board /etc)
      */
-    bool fCachedEndorsed;
+    bool fCachedEndorsed{false};
 
     /// object was updated and cached values should be updated soon
-    bool fDirtyCache;
+    bool fDirtyCache{true};
 
     /// Object is no longer of interest
-    bool fExpired;
+    bool fExpired{false};
 
     /// Failed to parse object data
-    bool fUnparsable;
+    bool fUnparsable{false};
 
     vote_m_t mapCurrentMNVotes;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Don't initialize via initializer lists when avoidable

## What was done?
Initialize in the header

## How Has This Been Tested?
building

## Breaking Changes
None

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

