### PR TITLE
refactor: use `=` with ENV in dockerfiles

### DIFF
--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -65,8 +65,8 @@ RUN apt-get update && apt-get install $APT_ARGS \
     make \
     tk-dev \
     xz-utils
-ENV PYENV_ROOT "/usr/local/pyenv"
-ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+ENV PYENV_ROOT="/usr/local/pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN curl https://pyenv.run | bash \
     && pyenv update \
     && pyenv install $PYTHON_VERSION \
@@ -92,8 +92,8 @@ ARG USER_ID=1000
 ARG GROUP_ID=1000
 
 # add user with specified (or default) user/group ids
-ENV USER_ID ${USER_ID}
-ENV GROUP_ID ${GROUP_ID}
+ENV USER_ID=${USER_ID}
+ENV GROUP_ID=${GROUP_ID}
 RUN groupadd -g ${GROUP_ID} dash
 RUN useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash
 
@@ -117,12 +117,12 @@ RUN apt-get update && apt-get install $APT_ARGS \
 ARG CPPCHECK_VERSION=2.13.0
 RUN curl -sL "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" | tar -xvzf - --directory /tmp/
 RUN cd /tmp/cppcheck-${CPPCHECK_VERSION} && mkdir build && cd build && cmake .. && cmake --build . -j 8
-ENV PATH "/tmp/cppcheck-${CPPCHECK_VERSION}/build/bin:${PATH}"
+ENV PATH="/tmp/cppcheck-${CPPCHECK_VERSION}/build/bin:${PATH}"
 RUN mkdir /usr/local/share/Cppcheck && ln -s /tmp/cppcheck-${CPPCHECK_VERSION}/cfg/ /usr/local/share/Cppcheck/cfg
 
 ARG SHELLCHECK_VERSION=v0.7.1
 RUN curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
-ENV PATH "/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"
+ENV PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"
 
 # This is a hack. It is needed because gcc-multilib and g++-multilib are conflicting with g++-arm-linux-gnueabihf. This is
 # due to gcc-multilib installing the following symbolic link, which is needed for -m32 support. However, this causes

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -92,8 +92,8 @@ ARG USER_ID=1000
 ARG GROUP_ID=1000
 
 # add user with specified (or default) user/group ids
-ENV USER_ID=${USER_ID}
-ENV GROUP_ID=${GROUP_ID}
+ENV USER_ID="${USER_ID}"
+ENV GROUP_ID="${GROUP_ID}"
 RUN groupadd -g ${GROUP_ID} dash
 RUN useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash
 

--- a/contrib/containers/deploy/Dockerfile
+++ b/contrib/containers/deploy/Dockerfile
@@ -5,11 +5,11 @@ LABEL description="Dockerised DashCore, built from CI"
 ARG USER_ID
 ARG GROUP_ID
 
-ENV HOME=/home/dash
+ENV HOME="/home/dash"
 
 # add user with specified (or default) user/group ids
-ENV USER_ID=${USER_ID:-1000}
-ENV GROUP_ID=${GROUP_ID:-1000}
+ENV USER_ID="${USER_ID:-1000}"
+ENV GROUP_ID="${GROUP_ID:-1000}"
 RUN groupadd -g ${GROUP_ID} dash && \
     useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash && \
     mkdir /home/dash/.dashcore && \

--- a/contrib/containers/deploy/Dockerfile
+++ b/contrib/containers/deploy/Dockerfile
@@ -5,11 +5,11 @@ LABEL description="Dockerised DashCore, built from CI"
 ARG USER_ID
 ARG GROUP_ID
 
-ENV HOME /home/dash
+ENV HOME=/home/dash
 
 # add user with specified (or default) user/group ids
-ENV USER_ID ${USER_ID:-1000}
-ENV GROUP_ID ${GROUP_ID:-1000}
+ENV USER_ID=${USER_ID:-1000}
+ENV GROUP_ID=${GROUP_ID:-1000}
 RUN groupadd -g ${GROUP_ID} dash && \
     useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash && \
     mkdir /home/dash/.dashcore && \

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
@@ -50,11 +50,11 @@ ARG USER_ID
 ARG GROUP_ID
 ARG TAG
 
-ENV HOME /home/dash
+ENV HOME=/home/dash
 
 # add user with specified (or default) user/group ids
-ENV USER_ID ${USER_ID:-1000}
-ENV GROUP_ID ${GROUP_ID:-1000}
+ENV USER_ID=${USER_ID:-1000}
+ENV GROUP_ID=${GROUP_ID:-1000}
 RUN groupadd -g ${GROUP_ID} dash && \
     useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash  && \
     mkdir /home/dash/.dashcore && \

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
@@ -50,11 +50,11 @@ ARG USER_ID
 ARG GROUP_ID
 ARG TAG
 
-ENV HOME=/home/dash
+ENV HOME="/home/dash"
 
 # add user with specified (or default) user/group ids
-ENV USER_ID=${USER_ID:-1000}
-ENV GROUP_ID=${GROUP_ID:-1000}
+ENV USER_ID="${USER_ID:-1000}"
+ENV GROUP_ID="${GROUP_ID:-1000}"
 RUN groupadd -g ${GROUP_ID} dash && \
     useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash  && \
     mkdir /home/dash/.dashcore && \

--- a/contrib/containers/guix/Dockerfile
+++ b/contrib/containers/guix/Dockerfile
@@ -26,7 +26,7 @@ ARG guix_checksum_aarch64=72d807392889919940b7ec9632c45a259555e6b0942ea7bfd13110
 ARG guix_checksum_x86_64=236ca7c9c5958b1f396c2924fcc5bc9d6fdebcb1b4cf3c7c6d46d4bf660ed9c9
 ARG builder_count=32
 
-ENV PATH=/usr/local/bin:/usr/local/guix/current/bin:$PATH
+ENV PATH="/usr/local/bin:/usr/local/guix/current/bin:$PATH"
 
 # Application Setup
 # https://guix.gnu.org/manual/en/html_node/Application-Setup.html

--- a/contrib/containers/guix/Dockerfile
+++ b/contrib/containers/guix/Dockerfile
@@ -26,7 +26,7 @@ ARG guix_checksum_aarch64=72d807392889919940b7ec9632c45a259555e6b0942ea7bfd13110
 ARG guix_checksum_x86_64=236ca7c9c5958b1f396c2924fcc5bc9d6fdebcb1b4cf3c7c6d46d4bf660ed9c9
 ARG builder_count=32
 
-ENV PATH /usr/local/bin:/usr/local/guix/current/bin:$PATH
+ENV PATH=/usr/local/bin:/usr/local/guix/current/bin:$PATH
 
 # Application Setup
 # https://guix.gnu.org/manual/en/html_node/Application-Setup.html

--- a/contrib/guix/Dockerfile
+++ b/contrib/guix/Dockerfile
@@ -15,12 +15,12 @@ ARG guix_checksum_aarch64=72d807392889919940b7ec9632c45a259555e6b0942ea7bfd13110
 ARG guix_checksum_x86_64=236ca7c9c5958b1f396c2924fcc5bc9d6fdebcb1b4cf3c7c6d46d4bf660ed9c9
 ARG builder_count=32
 
-ENV PATH=/root/.config/guix/current/bin:$PATH
+ENV PATH="/root/.config/guix/current/bin:$PATH"
 
 # Application Setup
 # https://guix.gnu.org/manual/en/html_node/Application-Setup.html
-ENV GUIX_LOCPATH=/root/.guix-profile/lib/locale
-ENV LC_ALL=en_US.UTF-8
+ENV GUIX_LOCPATH="/root/.guix-profile/lib/locale"
+ENV LC_ALL="en_US.UTF-8"
 
 RUN guix_file_name=guix-binary-${guix_version}.$(uname -m)-linux.tar.xz    && \
     eval "guix_checksum=\${guix_checksum_$(uname -m)}"                     && \

--- a/contrib/guix/Dockerfile
+++ b/contrib/guix/Dockerfile
@@ -15,12 +15,12 @@ ARG guix_checksum_aarch64=72d807392889919940b7ec9632c45a259555e6b0942ea7bfd13110
 ARG guix_checksum_x86_64=236ca7c9c5958b1f396c2924fcc5bc9d6fdebcb1b4cf3c7c6d46d4bf660ed9c9
 ARG builder_count=32
 
-ENV PATH /root/.config/guix/current/bin:$PATH
+ENV PATH=/root/.config/guix/current/bin:$PATH
 
 # Application Setup
 # https://guix.gnu.org/manual/en/html_node/Application-Setup.html
-ENV GUIX_LOCPATH /root/.guix-profile/lib/locale
-ENV LC_ALL en_US.UTF-8
+ENV GUIX_LOCPATH=/root/.guix-profile/lib/locale
+ENV LC_ALL=en_US.UTF-8
 
 RUN guix_file_name=guix-binary-${guix_version}.$(uname -m)-linux.tar.xz    && \
     eval "guix_checksum=\${guix_checksum_$(uname -m)}"                     && \


### PR DESCRIPTION
## Issue being fixed or feature implemented
see: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

Basically avoid old format of ENV in docker files

## What was done?
see commit

## How Has This Been Tested?
Building the containers locally, seems all fine

## Breaking Changes
  _Please describe any breaking changes your code introduces_


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

