### PR TITLE
fix: only run some GH actions on PR approval, not on every comment

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -6,7 +6,8 @@ permissions:
 on:
   - push
   - pull_request_target
-  - pull_request_review
+  - pull_request_review:
+      types: [submitted]
 
 jobs:
   check_merge:

--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -1,7 +1,8 @@
 name: "Check Potential Conflicts"
 on:
   - pull_request_target
-  - pull_request_review
+  - pull_request_review:
+      types: [submitted]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-a-workflow-when-a-pull-request-is-approved

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

