### PR TITLE
fix: use coinstatsindex instead blockfilterindex in feature_prunning

### DIFF
--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -142,13 +142,9 @@ class PruneTest(BitcoinTestFramework):
             expected_msg='Error: Prune mode is incompatible with -txindex.',
             extra_args=['-prune=550', '-txindex'],
         )
-        # self.nodes[0].assert_start_raises_init_error(
-        #     expected_msg='Error: Prune mode is incompatible with -coinstatsindex.',
-        #     extra_args=['-prune=550', '-coinstatsindex'],
-        # )
         self.nodes[0].assert_start_raises_init_error(
-            expected_msg='Error: Prune mode is incompatible with -blockfilterindex.',
-            extra_args=['-prune=550', '-blockfilterindex'],
+            expected_msg='Error: Prune mode is incompatible with -coinstatsindex.',
+            extra_args=['-prune=550', '-coinstatsindex'],
         )
         self.nodes[0].assert_start_raises_init_error(
             expected_msg='Error: Prune mode is incompatible with -disablegovernance=false.',


### PR DESCRIPTION
## Issue being fixed or feature implemented

This is follow-up changes for backports bitcoin#15946 and bitcoin#19521

It fixes failure:

    TestFramework (INFO): Test invalid pruning command line options
    TestFramework (ERROR): Assertion failed
    Traceback (most recent call last):
      File "dashtest/functional/test_framework/test_node.py", line 511, in assert_start_raises_init_error
        ret = self.process.wait(timeout=self.rpc_timeout)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/subprocess.py", line 1264, in wait
        return self._wait(timeout=timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/subprocess.py", line 2038, in _wait
        raise TimeoutExpired(self.args, timeout)
    subprocess.TimeoutExpired: Command '['dashsrc/dashd', '-datadir=/tmp/dash_func_test_m8w6q7a2/node0', '-logtimemicros', '-debug', '-debugexclude=libevent', '-debugexclude=leveldb', '-mocktime=1417713337', '-uacomment=testnode0', '-logthreadnames', '-logsourcelocations', '-createwalletbackups=0', '-prune=550', '-blockfilterindex', '-mocktime=1417713337']' timed out after 120 seconds

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "dashtest/functional/test_framework/test_framework.py", line 159, in main
        self.run_test()
      File "dashtest/functional/feature_pruning.py", line 495, in run_test
        self.test_invalid_command_line_options()
      File "dashtest/functional/feature_pruning.py", line 149, in test_invalid_command_line_options
        self.nodes[0].assert_start_raises_init_error(
      File "dashtest/functional/test_framework/test_node.py", line 541, in assert_start_raises_init_error
        self._raise_assertion_error(assert_msg)
      File "dashtest/functional/test_framework/test_node.py", line 180, in _raise_assertion_error
        raise AssertionError(self._node_msg(msg))
    AssertionError: [node 0] dashd should have exited within 120s with expected error Error: Prune mode is incompatible with -blockfilterindex.
    TestFramework (INFO): Stopping nodes


## What was done?
Removed `blockfilterindex` test, enabled `coinstatsindex` test.

## How Has This Been Tested?
Run manually: `test/functional/feature_pruning.py`
This test is not run by our CI

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

