### PR TITLE
fix: correct is_snapshot_cs in VerifyDB

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4063,7 +4063,7 @@ bool CVerifyDB::VerifyDB(
     int reportDone = 0;
     LogPrintf("[0%%]..."); /* Continued */
 
-    const bool is_snapshot_cs{!chainstate.m_from_snapshot_blockhash};
+    const bool is_snapshot_cs{chainstate.m_from_snapshot_blockhash};
 
     for (pindex = chainstate.m_chain.Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         const int percentageDone = std::max(1, std::min(99, (int)(((double)(chainstate.m_chain.Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));


### PR DESCRIPTION
## Issue being fixed or feature implemented
Flag `is_snapshot_cs` has been inverted in bitcoin#21584

Discovered during investigation of issue:
```
Verifying last 6 blocks at level 3
2024-08-14T14:51:55Z [0%]...*** Found EvoDB inconsistency, you must reindex to continue
```
So far as code below does:
```
        if ((fPruneMode || is_snapshot_cs) && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
            // If pruning or running under an assumeutxo snapshot, only go
            // back as far as we have data.
            LogPrintf("VerifyDB(): block verification stopping at height %d (pruning, no data)\n", pindex->nHeight);
            break;
        }
```
In case of missing data in evo db we will get instead of "block verification stopping at height" we may get data inconsistency issue.

## What was done?
Inverted condition back (same fix in bitcoin/bitcoin#27596)


## How Has This Been Tested?
Unit/functional tests doesn't cover it, but they do no fail after fix.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone