### PR TITLE
WIP - DO NOT MERGE - benchmark descriptor wallets

### DIFF
--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -11,10 +11,12 @@ $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
-$(package)_config_opts_debug=--enable-debug
-$(package)_cflags+=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
-$(package)_cflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
-$(package)_cflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
+# We avoid using `--enable-debug` because it overrides CFLAGS, a behavior we want to prevent.
+$(package)_cflags_debug += -g
+$(package)_cppflags_debug += -DSQLITE_DEBUG
+$(package)_cppflags+=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
+$(package)_cppflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
+$(package)_cppflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -6,10 +6,15 @@ $(package)_sha256_hash=5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
+$(package)_config_opts+= --disable-rtree --disable-fts4 --disable-fts5
 $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
+$(package)_config_opts_debug=--enable-debug
+$(package)_cflags=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
+$(package)_cflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
+$(package)_cflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -12,7 +12,7 @@ $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
 $(package)_config_opts_debug=--enable-debug
-$(package)_cflags=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
+$(package)_cflags+=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
 $(package)_cflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
 $(package)_cflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
 endef

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -10,6 +10,7 @@
 #include <fs.h>
 #include <streams.h>
 #include <support/allocators/secure.h>
+#include <logging.h>
 
 #include <atomic>
 #include <memory>
@@ -59,14 +60,17 @@ public:
     template <typename K, typename T>
     bool Write(const K& key, const T& value, bool fOverwrite = true)
     {
+        LogPrintf("benchmark write batch cp-1\n");
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(1000);
         ssKey << key;
 
+        LogPrintf("benchmark write batch cp-2\n");
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         ssValue.reserve(10000);
         ssValue << value;
 
+        LogPrintf("benchmark write batch cp-3\n");
         return WriteKey(std::move(ssKey), std::move(ssValue), fOverwrite);
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -254,25 +254,31 @@ RPCHelpMan getnewaddress()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    LogPrintf("benchmark getnewaddresss: cp-1\n");
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;
 
+    LogPrintf("benchmark getnewaddresss: cp-2\n");
     LOCK(pwallet->cs_wallet);
 
+    LogPrintf("benchmark getnewaddresss: cp-3\n");
     if (!pwallet->CanGetAddresses()) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: This wallet has no available keys");
     }
 
+    LogPrintf("benchmark getnewaddresss: cp-4\n");
     // Parse the label first so we don't generate a key if there's an error
     std::string label;
     if (!request.params[0].isNull())
         label = LabelFromValue(request.params[0]);
 
+    LogPrintf("benchmark getnewaddresss: cp-5\n");
     CTxDestination dest;
     std::string error;
     if (!pwallet->GetNewDestination(label, dest, error)) {
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, error);
     }
+    LogPrintf("benchmark getnewaddresss: cp-6\n");
     return EncodeDestination(dest);
 },
     };

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1946,6 +1946,7 @@ bool DescriptorScriptPubKeyMan::TopUp(unsigned int size)
 
     LogPrintf("benchmark getnewaddresss: DescriptorScriptPubKeyMan::TopUp: cp-4\n");
     WalletBatch batch(m_storage.GetDatabase());
+    LogPrintf("benchmark getnewaddresss: DescriptorScriptPubKeyMan::TopUp: cp-4.1\n");
     uint256 id = GetID();
     LogPrintf("benchmark getnewaddresss: DescriptorScriptPubKeyMan::TopUp: cp-5\n");
     for (int32_t i = m_max_cached_index + 1; i < new_range_end; ++i) {
@@ -2329,10 +2330,14 @@ std::unique_ptr<CKeyMetadata> DescriptorScriptPubKeyMan::GetMetadata(const CTxDe
 
 uint256 DescriptorScriptPubKeyMan::GetID() const
 {
+    LogPrintf("benchmark DescriptorScriptPubKeyMan::GetID cp-1\n");
     LOCK(cs_desc_man);
+    LogPrintf("benchmark DescriptorScriptPubKeyMan::GetID cp-2\n");
     std::string desc_str = m_wallet_descriptor.descriptor->ToString();
+    LogPrintf("benchmark DescriptorScriptPubKeyMan::GetID cp-3\n");
     uint256 id;
     CSHA256().Write((unsigned char*)desc_str.data(), desc_str.size()).Finalize(id.begin());
+    LogPrintf("benchmark DescriptorScriptPubKeyMan::GetID cp-4\n");
     return id;
 }
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -327,6 +327,7 @@ void SQLiteDatabase::Close()
 
 std::unique_ptr<DatabaseBatch> SQLiteDatabase::MakeBatch(bool flush_on_close)
 {
+    LogPrintf("benchmark: make-on-batch\n");
     // We ignore flush_on_close because we don't do manual flushing for SQLite
     return std::make_unique<SQLiteBatch>(*this);
 }

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -406,9 +406,12 @@ bool SQLiteBatch::ReadKey(CDataStream&& key, CDataStream& value)
 
 bool SQLiteBatch::WriteKey(CDataStream&& key, CDataStream&& value, bool overwrite)
 {
+    LogPrintf("benchmark sqlitebatch WriteKey cp-1 overwrite=%d\n", overwrite);
     if (!m_database.m_db) return false;
+    LogPrintf("benchmark sqlitebatch WriteKey cp-2\n");
     assert(m_insert_stmt && m_overwrite_stmt);
 
+    LogPrintf("benchmark sqlitebatch WriteKey cp-3\n");
     sqlite3_stmt* stmt;
     if (overwrite) {
         stmt = m_overwrite_stmt;
@@ -416,16 +419,21 @@ bool SQLiteBatch::WriteKey(CDataStream&& key, CDataStream&& value, bool overwrit
         stmt = m_insert_stmt;
     }
 
+    LogPrintf("benchmark sqlitebatch WriteKey cp-4\n");
     // Bind: leftmost parameter in statement is index 1
     // Insert index 1 is key, 2 is value
     int res = sqlite3_bind_blob(stmt, 1, key.data(), key.size(), SQLITE_STATIC);
+    LogPrintf("benchmark sqlitebatch WriteKey cp-5\n");
     if (res != SQLITE_OK) {
         LogPrintf("%s: Unable to bind key to statement: %s\n", __func__, sqlite3_errstr(res));
         sqlite3_clear_bindings(stmt);
         sqlite3_reset(stmt);
+        LogPrintf("benchmark sqlitebatch WriteKey cp-6\n");
         return false;
     }
+    LogPrintf("benchmark sqlitebatch WriteKey cp-7\n");
     res = sqlite3_bind_blob(stmt, 2, value.data(), value.size(), SQLITE_STATIC);
+    LogPrintf("benchmark sqlitebatch WriteKey cp-8\n");
     if (res != SQLITE_OK) {
         LogPrintf("%s: Unable to bind value to statement: %s\n", __func__, sqlite3_errstr(res));
         sqlite3_clear_bindings(stmt);
@@ -434,9 +442,13 @@ bool SQLiteBatch::WriteKey(CDataStream&& key, CDataStream&& value, bool overwrit
     }
 
     // Execute
+    LogPrintf("benchmark sqlitebatch WriteKey cp-9\n");
     res = sqlite3_step(stmt);
+    LogPrintf("benchmark sqlitebatch WriteKey cp-10\n");
     sqlite3_clear_bindings(stmt);
+    LogPrintf("benchmark sqlitebatch WriteKey cp-11\n");
     sqlite3_reset(stmt);
+    LogPrintf("benchmark sqlitebatch WriteKey cp-12\n");
     if (res != SQLITE_DONE) {
         LogPrintf("%s: Unable to execute statement: %s\n", __func__, sqlite3_errstr(res));
     }

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -7,6 +7,8 @@
 
 #include <wallet/db.h>
 
+#include <logging.h>
+
 #include <sqlite3.h>
 
 struct bilingual_str;
@@ -35,7 +37,11 @@ private:
 
 public:
     explicit SQLiteBatch(SQLiteDatabase& database);
-    ~SQLiteBatch() override { Close(); }
+    ~SQLiteBatch() override {
+        LogPrintf("benchmark sqlitebatch cp-1\n");
+        Close();
+        LogPrintf("benchmark sqlitebatch cp-2\n");
+    }
 
     /* No-op. See comment on SQLiteDatabase::Flush */
     void Flush() override {}

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4171,20 +4171,29 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
 
 bool CWallet::GetNewDestination(const std::string label, CTxDestination& dest, std::string& error)
 {
+    LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-1\n");
     error.clear();
     bool result = false;
 
+    LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-2\n");
     LOCK(cs_wallet);
+    LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-3\n");
     auto spk_man = GetScriptPubKeyMan(false /* internal */);
+    LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-4\n");
     if (spk_man) {
+        LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-5\n");
         spk_man->TopUp();
+        LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-6\n");
         result = spk_man->GetNewDestination(dest, error);
+        LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-7\n");
     } else {
         error = strprintf("Error: No addresses available.");
     }
+    LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-8\n");
     if (result) {
         SetAddressBook(dest, label, "receive");
     }
+    LogPrintf("benchmark getnewaddresss: CWallet::GetNewDestination: cp-9\n");
 
     return result;
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -144,13 +144,19 @@ private:
     template <typename K, typename T>
     bool WriteIC(const K& key, const T& value, bool fOverwrite = true)
     {
+        LogPrintf("benchmark: write-ic cp-1\n");
         if (!m_batch->Write(key, value, fOverwrite)) {
+            LogPrintf("benchmark: write-ic cp-2\n");
             return false;
         }
+        LogPrintf("benchmark: write-ic cp-3\n");
         m_database.IncrementUpdateCounter();
+        LogPrintf("benchmark: write-ic cp-4\n");
         if (m_database.nUpdateCounter % 1000 == 0) {
+            LogPrintf("benchmark: write-ic cp-5\n");
             m_batch->Flush();
         }
+        LogPrintf("benchmark: write-ic cp-6\n");
         return true;
     }
 
@@ -172,6 +178,7 @@ public:
         m_batch(database.MakeBatch(_fFlushOnClose)),
         m_database(database)
     {
+        LogPrintf("benchmark WalletBatch\n");
     }
     WalletBatch(const WalletBatch&) = delete;
     WalletBatch& operator=(const WalletBatch&) = delete;


### PR DESCRIPTION
This PR exists to trigger CI with extra logs, it's not meant to be merged.

## Issue being fixed or feature implemented

Somehow, on CI  descriptor wallets are significantly slower (sometimes 5 times slower)
At my machine descriptor wallets are faster as expected.


Localhost:
```
wallet_send.py --descriptors   | ✓ Passed  | 10 s
wallet_send.py --legacy-wallet | ✓ Passed  | 11 s
wallet_create_tx.py --descriptors   | ✓ Passed  | 5 s
wallet_create_tx.py --legacy-wallet | ✓ Passed  | 7 s
```

CI linux64:
```
wallet_send.py --descriptors                       | ✓ Passed  | 10 s
wallet_send.py --legacy-wallet                     | ✓ Passed  | 9 s
wallet_create_tx.py --descriptors                  | ✓ Passed  | 14 s <------------ 2x
wallet_create_tx.py --legacy-wallet                | ✓ Passed  | 7 s
```

CI tsan:
```
wallet_send.py --descriptors                       | ✓ Passed  | 100 s <-------------- 4x
wallet_send.py --legacy-wallet                     | ✓ Passed  | 25 s
wallet_create_tx.py --descriptors                  | ✓ Passed  | 471 s <---------------- 5x
wallet_create_tx.py --legacy-wallet                | ✓ Passed  | 99 s
```



## What was done?



## How Has This Been Tested?
N/A

## Breaking Changes
N/A


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

