### PR TITLE
fix: debug print the full bytes

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -58,7 +58,7 @@ CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn)
 
 std::string CTxOut::ToString() const
 {
-    return strprintf("CTxOut(nValue=%d.%08d, scriptPubKey=%s)", nValue / COIN, nValue % COIN, HexStr(scriptPubKey).substr(0, 30));
+    return strprintf("CTxOut(nValue=%d.%08d, scriptPubKey=%s)", nValue / COIN, nValue % COIN, HexStr(scriptPubKey));
 }
 
 CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nType(TRANSACTION_NORMAL), nLockTime(0) {}


### PR DESCRIPTION
Either this one, or https://github.com/dashpay/dash/pull/6227 but, please, for the love of all that is right in this world, DO NOT print out THE WRONG NUMBER OF BYTES!!!!

Better yet, why are there different forms of serialization for the same object?

<img width="781" alt="Screenshot 2024-08-23 at 11 35 07 AM" src="https://github.com/user-attachments/assets/341a8c44-9fdc-42a3-b256-95b718bde6e4">

This should just consistently serialize to the same object because it's the same output script.

## Issue being fixed or feature implemented

## What was done?

## How Has This Been Tested?

## Breaking Changes

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
