### PR TITLE
fix: `creditOutputs` in AssetLock tx json output should be an array of objects, not debug strings

### DIFF
--- a/doc/release-notes-6229.md
+++ b/doc/release-notes-6229.md
@@ -1,0 +1,4 @@
+RPC changes
+-----------
+
+- `creditOutputs` entries in various RPCs that output transaction JSON are shown as objects now instead of being shown as strings.

--- a/src/evo/assetlocktx.h
+++ b/src/evo/assetlocktx.h
@@ -9,6 +9,7 @@
 #include <primitives/transaction.h>
 #include <gsl/pointers.h>
 
+#include <core_io.h>
 #include <serialize.h>
 #include <univalue.h>
 
@@ -51,14 +52,18 @@ public:
 
     [[nodiscard]] UniValue ToJson() const
     {
-        UniValue obj;
-        obj.setObject();
-        obj.pushKV("version", int(nVersion));
-        UniValue outputs;
-        outputs.setArray();
-        for (const CTxOut& out : creditOutputs) {
-            outputs.push_back(out.ToString());
+        UniValue outputs(UniValue::VARR);
+        for (const CTxOut& credit_output : creditOutputs) {
+            UniValue out(UniValue::VOBJ);
+            out.pushKV("value", ValueFromAmount(credit_output.nValue));
+            out.pushKV("valueSat", credit_output.nValue);
+            UniValue spk(UniValue::VOBJ);
+            ScriptPubKeyToUniv(credit_output.scriptPubKey, spk, /* fIncludeHex = */ true, /* include_addresses = */ false);
+            out.pushKV("scriptPubKey", spk);
+            outputs.push_back(out);
         }
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("version", int(nVersion));
         obj.pushKV("creditOutputs", outputs);
         return obj;
     }

--- a/src/evo/assetlocktx.h
+++ b/src/evo/assetlocktx.h
@@ -9,7 +9,6 @@
 #include <primitives/transaction.h>
 #include <gsl/pointers.h>
 
-#include <core_io.h>
 #include <serialize.h>
 #include <univalue.h>
 
@@ -22,6 +21,10 @@ class TxValidationState;
 namespace llmq {
 class CQuorumManager;
 } // namespace llmq
+
+// Forward declaration from core_io to get rid of circular dependency
+UniValue ValueFromAmount(const CAmount amount);
+void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex, bool include_addresses);
 
 class CAssetLockPayload
 {

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -30,11 +30,7 @@ from test_framework.messages import (
 from test_framework.script import (
     CScript,
     OP_CHECKSIG,
-    OP_DUP,
-    OP_EQUALVERIFY,
-    OP_HASH160,
     OP_RETURN,
-    hash160,
 )
 from test_framework.script_util import key_to_p2pkh_script
 from test_framework.test_framework import DashTestFramework
@@ -67,8 +63,8 @@ class AssetLocksTest(DashTestFramework):
         tmp_amount = amount
         if tmp_amount > COIN:
             tmp_amount -= COIN
-            credit_outputs.append(CTxOut(COIN, CScript([OP_DUP, OP_HASH160, hash160(pubkey), OP_EQUALVERIFY, OP_CHECKSIG])))
-        credit_outputs.append(CTxOut(tmp_amount, CScript([OP_DUP, OP_HASH160, hash160(pubkey), OP_EQUALVERIFY, OP_CHECKSIG])))
+            credit_outputs.append(CTxOut(COIN, key_to_p2pkh_script(pubkey)))
+        credit_outputs.append(CTxOut(tmp_amount, key_to_p2pkh_script(pubkey)))
 
         lockTx_payload = CAssetLockTx(1, credit_outputs)
 

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -102,6 +102,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "llmq/chainlocks -> net_processing -> llmq/context -> llmq/chainlocks"
     "coinjoin/client -> coinjoin/coinjoin -> llmq/chainlocks -> net_processing -> coinjoin/client"
     "rpc/blockchain -> rpc/server -> rpc/blockchain"
+    "core_io -> evo/assetlocktx -> core_io"
 )
 
 EXIT_CODE=0

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -102,7 +102,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "llmq/chainlocks -> net_processing -> llmq/context -> llmq/chainlocks"
     "coinjoin/client -> coinjoin/coinjoin -> llmq/chainlocks -> net_processing -> coinjoin/client"
     "rpc/blockchain -> rpc/server -> rpc/blockchain"
-    "core_io -> evo/assetlocktx -> core_io"
 )
 
 EXIT_CODE=0


### PR DESCRIPTION
## Issue being fixed or feature implemented
Txout-s in `creditOutputs` for AssetLock txes should be shown the way txout-s are shown in other places. We should not be using debug strings there.

Example: `getrawtransaction 50757f651f335e22c5a810bd05c1e5aac0d95b132f6454e2a72683f88e3983f3 1`

develop:
```
  "assetLockTx": {
    "version": 1,
    "creditOutputs": [
      "CTxOut(nValue=0.01000000, scriptPubKey=76a914cdfca4ae1cf2333056659a2c)"
    ]
  },
```
This PR:
```
  "assetLockTx": {
    "version": 1,
    "creditOutputs": [
      {
        "value": 0.01000000,
        "valueSat": 1000000,
        "scriptPubKey": {
          "asm": "OP_DUP OP_HASH160 cdfca4ae1cf2333056659a2c8dc656f36d228402 OP_EQUALVERIFY OP_CHECKSIG",
          "hex": "76a914cdfca4ae1cf2333056659a2c8dc656f36d22840288ac",
          "address": "yf6c2VSpWGXUgmjQSHRpfEcTPsbqN4oL4c",
          "type": "pubkeyhash"
        }
      }
    ]
  },
```
kudos to @coolaj86 for finding the issue

## What was done?
Change `CAssetLockPayload::ToJson()` output to be closer to [`TxToUniv()`](https://github.com/dashpay/dash/blob/develop/src/core_write.cpp#L262-L272)

NOTE: `refactor: use key_to_p2pkh_script in more places` commit is a bit unrelated but I decided to add it anyway to make it easier to follow assetlock creation vs getrawtransaction rpc check.

## How Has This Been Tested?
Try example above, run tests

## Breaking Changes
RPC output is different for AssetLock txes

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

