### PR TITLE
fix: resolve GitHub workflow warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           BRANCH_NAME=$(echo "${GITHUB_REF##*/}" | tr '[:upper:]' '[:lower:]')
           REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=image-tag::${BRANCH_NAME}"
-          echo "::set-output name=repo-name::${REPO_NAME}"
+          echo "image-tag=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "repo-name=${REPO_NAME}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -32,8 +32,8 @@ jobs:
           echo "host_group_id=$(id -g)" >> $GITHUB_OUTPUT
           BRANCH_NAME=$(echo "${GITHUB_REF##*/}" | tr '[:upper:]' '[:lower:]')
           REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=image-tag::${BRANCH_NAME}"
-          echo "::set-output name=repo-name::${REPO_NAME}"
+          echo "image-tag=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "repo-name=${REPO_NAME}" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## What was done?


## How Has This Been Tested?
Check results for CI and Guix actions (in future PRs? 🤷‍♂️ )

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

