### PR TITLE
fix: release unused memory in `CNetMsgMaker::Make()`

### DIFF
--- a/src/netmessagemaker.h
+++ b/src/netmessagemaker.h
@@ -21,6 +21,7 @@ public:
         msg.m_type = std::move(msg_type);
         msg.data.reserve(4 * 1024);
         CVectorWriter{ SER_NETWORK, nFlags | nVersion, msg.data, 0, std::forward<Args>(args)... };
+        msg.data.shrink_to_fit();
         return msg;
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
We reserve capacity for large messages in `CNetMsgMaker::Make()` but most messages are small yet we never release unused memory here. Discovered while debugging 28165 backport issues.

## What was done?


## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

