### PR TITLE
test: a simpler way to disable mocktime in `p2p_initial_headers_sync.py`

### DIFF
--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -30,19 +30,9 @@ class HeadersSyncTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def setup_chain(self):
-        # This test operates under the assumption that the adjusted time is well ahead of block
-        # time.
-        #
-        # By default when we setup a new chain, we also adjust the mocktime (this is not done in
-        # Bitcoin's test suite), which violates this test's assumption and causes it to fail. We
-        # remedy this by ensuring the test's assumptions are met (i.e. we don't adjust mocktime)
-        #
-        self.log.info("Initializing test directory " + self.options.tmpdir)
-        if self.setup_clean_chain:
-            self._initialize_chain_clean()
-        else:
-            self._initialize_chain()
+    def setup_network(self):
+        self.disable_mocktime()
+        super().setup_network()
 
     def announce_random_block(self, peers):
         new_block_announcement = msg_inv(inv=[CInv(MSG_BLOCK, random.randrange(1<<256))])


### PR DESCRIPTION
## Issue being fixed or feature implemented
simplify mocktime disabling in `p2p_initial_headers_sync.py`

## What was done?

## How Has This Been Tested?
run `p2p_initial_headers_sync.py`

## Breaking Changes
n/a

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

