### PR TITLE
feat: add transactions.mempool.lockedTransactions and chainlocks.blockHeight stats

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -650,14 +650,16 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, gsl::not_null<co
         updatesRet = {newList, oldList, diff};
     }
 
-    ::g_stats_client->gauge("masternodes.count", newList.GetAllMNsCount());
-    ::g_stats_client->gauge("masternodes.weighted_count", newList.GetValidWeightedMNsCount());
-    ::g_stats_client->gauge("masternodes.enabled", newList.GetValidMNsCount());
-    ::g_stats_client->gauge("masternodes.weighted_enabled", newList.GetValidWeightedMNsCount());
-    ::g_stats_client->gauge("masternodes.evo.count", newList.GetAllEvoCount());
-    ::g_stats_client->gauge("masternodes.evo.enabled", newList.GetValidEvoCount());
-    ::g_stats_client->gauge("masternodes.mn.count", newList.GetAllMNsCount() - newList.GetAllEvoCount());
-    ::g_stats_client->gauge("masternodes.mn.enabled", newList.GetValidMNsCount() - newList.GetValidEvoCount());
+    if (::g_stats_client->active()) {
+        ::g_stats_client->gauge("masternodes.count", newList.GetAllMNsCount());
+        ::g_stats_client->gauge("masternodes.weighted_count", newList.GetValidWeightedMNsCount());
+        ::g_stats_client->gauge("masternodes.enabled", newList.GetValidMNsCount());
+        ::g_stats_client->gauge("masternodes.weighted_enabled", newList.GetValidWeightedMNsCount());
+        ::g_stats_client->gauge("masternodes.evo.count", newList.GetAllEvoCount());
+        ::g_stats_client->gauge("masternodes.evo.enabled", newList.GetValidEvoCount());
+        ::g_stats_client->gauge("masternodes.mn.count", newList.GetAllMNsCount() - newList.GetAllEvoCount());
+        ::g_stats_client->gauge("masternodes.mn.enabled", newList.GetValidMNsCount() - newList.GetValidEvoCount());
+    }
 
     if (nHeight == consensusParams.DIP0003EnforcementHeight) {
         if (!consensusParams.DIP0003EnforcementHash.IsNull() && consensusParams.DIP0003EnforcementHash != pindex->GetBlockHash()) {

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -21,6 +21,7 @@
 #include <univalue.h>
 #include <messagesigner.h>
 #include <uint256.h>
+#include <statsd_client.h>
 
 #include <optional>
 #include <memory>
@@ -648,6 +649,15 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, gsl::not_null<co
     if (diff.HasChanges()) {
         updatesRet = {newList, oldList, diff};
     }
+
+    statsClient.gauge("masternodes.count", newList.GetAllMNsCount());
+    statsClient.gauge("masternodes.weighted_count", newList.GetValidWeightedMNsCount());
+    statsClient.gauge("masternodes.enabled", newList.GetValidMNsCount());
+    statsClient.gauge("masternodes.weighted_enabled", newList.GetValidWeightedMNsCount());
+    statsClient.gauge("masternodes.evo.count", newList.GetAllEvoCount());
+    statsClient.gauge("masternodes.evo.enabled", newList.GetValidEvoCount());
+    statsClient.gauge("masternodes.mn.count", newList.GetAllMNsCount() - newList.GetAllEvoCount());
+    statsClient.gauge("masternodes.mn.enabled", newList.GetValidMNsCount() - newList.GetValidEvoCount());
 
     if (nHeight == consensusParams.DIP0003EnforcementHeight) {
         if (!consensusParams.DIP0003EnforcementHash.IsNull() && consensusParams.DIP0003EnforcementHash != pindex->GetBlockHash()) {

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -21,7 +21,7 @@
 #include <univalue.h>
 #include <messagesigner.h>
 #include <uint256.h>
-#include <statsd_client.h>
+#include <stats/client.h>
 
 #include <optional>
 #include <memory>
@@ -650,14 +650,14 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, gsl::not_null<co
         updatesRet = {newList, oldList, diff};
     }
 
-    statsClient.gauge("masternodes.count", newList.GetAllMNsCount());
-    statsClient.gauge("masternodes.weighted_count", newList.GetValidWeightedMNsCount());
-    statsClient.gauge("masternodes.enabled", newList.GetValidMNsCount());
-    statsClient.gauge("masternodes.weighted_enabled", newList.GetValidWeightedMNsCount());
-    statsClient.gauge("masternodes.evo.count", newList.GetAllEvoCount());
-    statsClient.gauge("masternodes.evo.enabled", newList.GetValidEvoCount());
-    statsClient.gauge("masternodes.mn.count", newList.GetAllMNsCount() - newList.GetAllEvoCount());
-    statsClient.gauge("masternodes.mn.enabled", newList.GetValidMNsCount() - newList.GetValidEvoCount());
+    ::g_stats_client->gauge("masternodes.count", newList.GetAllMNsCount());
+    ::g_stats_client->gauge("masternodes.weighted_count", newList.GetValidWeightedMNsCount());
+    ::g_stats_client->gauge("masternodes.enabled", newList.GetValidMNsCount());
+    ::g_stats_client->gauge("masternodes.weighted_enabled", newList.GetValidWeightedMNsCount());
+    ::g_stats_client->gauge("masternodes.evo.count", newList.GetAllEvoCount());
+    ::g_stats_client->gauge("masternodes.evo.enabled", newList.GetValidEvoCount());
+    ::g_stats_client->gauge("masternodes.mn.count", newList.GetAllMNsCount() - newList.GetAllEvoCount());
+    ::g_stats_client->gauge("masternodes.mn.enabled", newList.GetValidMNsCount() - newList.GetValidEvoCount());
 
     if (nHeight == consensusParams.DIP0003EnforcementHeight) {
         if (!consensusParams.DIP0003EnforcementHash.IsNull() && consensusParams.DIP0003EnforcementHash != pindex->GetBlockHash()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -826,6 +826,7 @@ static void PeriodicStats(NodeContext& node)
     const ArgsManager& args = *Assert(node.args);
     ChainstateManager& chainman = *Assert(node.chainman);
     const CTxMemPool& mempool = *Assert(node.mempool);
+    const llmq::CInstantSendManager& isman = *Assert(node.llmq_ctx->isman);
     CCoinsStats stats{CoinStatsHashType::NONE};
     chainman.ActiveChainstate().ForceFlushStateToDisk();
     if (WITH_LOCK(cs_main, return GetUTXOStats(&chainman.ActiveChainstate().CoinsDB(), chainman.m_blockman, stats, node.rpc_interruption_point, chainman.ActiveChain().Tip()))) {
@@ -878,6 +879,7 @@ static void PeriodicStats(NodeContext& node)
         ::g_stats_client->gauge("transactions.mempool.memoryUsageBytes", (int64_t) mempool.DynamicMemoryUsage(), 1.0f);
         ::g_stats_client->gauge("transactions.mempool.minFeePerKb", mempool.GetMinFee(args.GetIntArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK(), 1.0f);
     }
+    ::g_stats_client.gauge("transactions.mempool.lockedTransactions", isman.GetInstantSendLockCount(), 1.0f);
 }
 
 static bool AppInitServers(NodeContext& node)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -879,7 +879,7 @@ static void PeriodicStats(NodeContext& node)
         ::g_stats_client->gauge("transactions.mempool.memoryUsageBytes", (int64_t) mempool.DynamicMemoryUsage(), 1.0f);
         ::g_stats_client->gauge("transactions.mempool.minFeePerKb", mempool.GetMinFee(args.GetIntArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK(), 1.0f);
     }
-    ::g_stats_client.gauge("transactions.mempool.lockedTransactions", isman.GetInstantSendLockCount(), 1.0f);
+    ::g_stats_client->gauge("transactions.mempool.lockedTransactions", isman.GetInstantSendLockCount(), 1.0f);
 }
 
 static bool AppInitServers(NodeContext& node)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -91,6 +91,7 @@
 #include <llmq/dkgsessionmgr.h>
 #include <llmq/options.h>
 #include <llmq/signing.h>
+#include <llmq/instantsend.h>
 #include <masternode/meta.h>
 #include <masternode/node.h>
 #include <masternode/sync.h>

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -15,6 +15,7 @@
 #include <node/interface_ui.h>
 #include <scheduler.h>
 #include <spork.h>
+#include <statsd_client.h>
 #include <txmempool.h>
 #include <util/thread.h>
 #include <util/time.h>
@@ -497,6 +498,7 @@ void CChainLocksHandler::EnforceBestChainLock()
 
     GetMainSignals().NotifyChainLock(currentBestChainLockBlockIndex, clsig);
     uiInterface.NotifyChainLock(clsig->getBlockHash().ToString(), clsig->getHeight());
+    statsClient.gauge("chainlocks.blockHeight", clsig->getHeight(), 1.0f);
 }
 
 MessageProcessingResult CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -15,7 +15,7 @@
 #include <node/interface_ui.h>
 #include <scheduler.h>
 #include <spork.h>
-#include <statsd_client.h>
+#include <stats/client.h>
 #include <txmempool.h>
 #include <util/thread.h>
 #include <util/time.h>
@@ -498,7 +498,7 @@ void CChainLocksHandler::EnforceBestChainLock()
 
     GetMainSignals().NotifyChainLock(currentBestChainLockBlockIndex, clsig);
     uiInterface.NotifyChainLock(clsig->getBlockHash().ToString(), clsig->getHeight());
-    statsClient.gauge("chainlocks.blockHeight", clsig->getHeight(), 1.0f);
+    ::g_stats_client->gauge("chainlocks.blockHeight", clsig->getHeight(), 1.0f);
 }
 
 MessageProcessingResult CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -23,7 +23,7 @@
 #include <util/ranges.h>
 #include <util/thread.h>
 #include <validation.h>
-#include <statsd_client.h>
+#include <stats/client.h>
 
 #include <cxxtimer.hpp>
 
@@ -784,7 +784,7 @@ PeerMsgRet CInstantSendManager::ProcessMessageInstantSendLock(const CNode& pfrom
         // But if we received the islock and don't know when we got the tx, then say 0, to indicate we received the islock first.
         return 0;
     }();
-    statsClient.timing("islock_ms", time_diff);
+    ::g_stats_client->timing("islock_ms", time_diff);
 
     LOCK(cs_pendingLocks);
     pendingInstantSendLocks.emplace(hash, std::make_pair(pfrom.GetId(), islock));

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -1193,9 +1193,7 @@ void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlock
     if (ShouldReportISLockTiming()) {
         LOCK(cs_timingsTxSeen);
         // Only insert the time the first time we see the tx, as we sometimes try to resign
-        if (auto it = timingsTxSeen.find(tx->GetHash()); it == timingsTxSeen.end()) {
-            timingsTxSeen[tx->GetHash()] = GetTimeMillis();
-        }
+        timingsTxSeen.try_emplace(tx->GetHash(), GetTimeMillis());
     }
 
     LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, pindexMined=%s\n", __func__,

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -742,6 +742,10 @@ PeerMsgRet CInstantSendManager::ProcessMessage(const CNode& pfrom, PeerManager& 
     return {};
 }
 
+bool ShouldReportISLockTiming() {
+    return g_stats_client->active() || LogAcceptDebug(BCLog::INSTANTSEND);
+}
+
 PeerMsgRet CInstantSendManager::ProcessMessageInstantSendLock(const CNode& pfrom, PeerManager& peerman,
                                                               const llmq::CInstantSendLockPtr& islock)
 {
@@ -775,16 +779,22 @@ PeerMsgRet CInstantSendManager::ProcessMessageInstantSendLock(const CNode& pfrom
     LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s: received islock, peer=%d\n", __func__,
             islock->txid.ToString(), hash.ToString(), pfrom.GetId());
 
-    auto time_diff =  [&] () -> int64_t {
-        LOCK(cs_timingsTxSeen);
-        if (auto it = timingsTxSeen.find(islock->txid); it != timingsTxSeen.end()) {
-            // This is the normal case where we received the TX before the islock
-            return GetTimeMillis() - it->second;
-        }
-        // But if we received the islock and don't know when we got the tx, then say 0, to indicate we received the islock first.
-        return 0;
-    }();
-    ::g_stats_client->timing("islock_ms", time_diff);
+    if (ShouldReportISLockTiming()) {
+        auto time_diff =  [&] () -> int64_t {
+            LOCK(cs_timingsTxSeen);
+            if (auto it = timingsTxSeen.find(islock->txid); it != timingsTxSeen.end()) {
+                // This is the normal case where we received the TX before the islock
+                auto diff = GetTimeMillis() - it->second;
+                timingsTxSeen.erase(it);
+                return diff;
+            }
+            // But if we received the islock and don't know when we got the tx, then say 0, to indicate we received the islock first.
+            return 0;
+        }();
+        ::g_stats_client->timing("islock_ms", time_diff);
+        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock took %dms\n", __func__,
+            islock->txid.ToString(), time_diff);
+    }
 
     LOCK(cs_pendingLocks);
     pendingInstantSendLocks.emplace(hash, std::make_pair(pfrom.GetId(), islock));
@@ -1180,7 +1190,7 @@ void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlock
         }
     }
 
-    {
+    if (ShouldReportISLockTiming()) {
         LOCK(cs_timingsTxSeen);
         // Only insert the time the first time we see the tx, as we sometimes try to resign
         if (auto it = timingsTxSeen.find(tx->GetHash()); it == timingsTxSeen.end()) {

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -252,6 +252,9 @@ private:
     mutable Mutex cs_pendingRetry;
     std::unordered_set<uint256, StaticSaltedHasher> pendingRetryTxs GUARDED_BY(cs_pendingRetry);
 
+    mutable Mutex cs_timingsTxSeen;
+    std::unordered_map<uint256, int64_t, StaticSaltedHasher> timingsTxSeen GUARDED_BY(cs_timingsTxSeen);
+
 public:
     explicit CInstantSendManager(CChainLocksHandler& _clhandler, CChainState& chainstate, CQuorumManager& _qman,
                                  CSigningManager& _sigman, CSigSharesManager& _shareman, CSporkManager& sporkman,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2579,7 +2579,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
 
     ::g_stats_client->timing("ConnectBlock_ms", (nTime8 - nTimeStart) / 1000, 1.0f);
     ::g_stats_client->gauge("blocks.tip.SizeBytes", ::GetSerializeSize(block, PROTOCOL_VERSION), 1.0f);
-    ::g_stats_client->gauge("blocks.tip.Height", m_chain.Height(), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.Height", m_chain.Height() + 1, 1.0f); // without the +1, the "tip.Height" doesn't match rpc calls like `getblockcount`
     ::g_stats_client->gauge("blocks.tip.Version", block.nVersion, 1.0f);
     ::g_stats_client->gauge("blocks.tip.NumTransactions", block.vtx.size(), 1.0f);
     ::g_stats_client->gauge("blocks.tip.SigOps", nSigOps, 1.0f);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2968,12 +2968,12 @@ bool CChainState::DisconnectTip(BlockValidationState& state, DisconnectedBlockTr
     for (const auto& tx : block.vtx) {
         nSigOps += GetLegacySigOpCount(*tx);
     }
-    statsClient.timing("DisconnectTip_ms", (nTime2 - nTime1) / 1000, 1.0f);
-    statsClient.gauge("blocks.tip.SizeBytes", ::GetSerializeSize(block, PROTOCOL_VERSION), 1.0f);
-    statsClient.gauge("blocks.tip.Height", m_chain.Height(), 1.0f);
-    statsClient.gauge("blocks.tip.Version", block.nVersion, 1.0f);
-    statsClient.gauge("blocks.tip.NumTransactions", block.vtx.size(), 1.0f);
-    statsClient.gauge("blocks.tip.SigOps", nSigOps, 1.0f);
+    ::g_stats_client->timing("DisconnectTip_ms", (nTime2 - nTime1) / 1000, 1.0f);
+    ::g_stats_client->gauge("blocks.tip.SizeBytes", ::GetSerializeSize(block, PROTOCOL_VERSION), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.Height", m_chain.Height(), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.Version", block.nVersion, 1.0f);
+    ::g_stats_client->gauge("blocks.tip.NumTransactions", block.vtx.size(), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.SigOps", nSigOps, 1.0f);
     return true;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2901,6 +2901,8 @@ bool CChainState::DisconnectTip(BlockValidationState& state, DisconnectedBlockTr
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
+    int64_t nTime1 = GetTimeMicros();
+
     CBlockIndex *pindexDelete = m_chain.Tip();
     assert(pindexDelete);
     // Read block from disk.
@@ -2959,6 +2961,19 @@ bool CChainState::DisconnectTip(BlockValidationState& state, DisconnectedBlockTr
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     GetMainSignals().BlockDisconnected(pblock, pindexDelete);
+
+    int64_t nTime2 = GetTimeMicros();
+
+    unsigned int nSigOps = 0;
+    for (const auto& tx : block.vtx) {
+        nSigOps += GetLegacySigOpCount(*tx);
+    }
+    statsClient.timing("DisconnectTip_ms", (nTime2 - nTime1) / 1000, 1.0f);
+    statsClient.gauge("blocks.tip.SizeBytes", ::GetSerializeSize(block, PROTOCOL_VERSION), 1.0f);
+    statsClient.gauge("blocks.tip.Height", m_chain.Height(), 1.0f);
+    statsClient.gauge("blocks.tip.Version", block.nVersion, 1.0f);
+    statsClient.gauge("blocks.tip.NumTransactions", block.vtx.size(), 1.0f);
+    statsClient.gauge("blocks.tip.SigOps", nSigOps, 1.0f);
     return true;
 }
 
@@ -3077,7 +3092,16 @@ bool CChainState::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew
     LogPrint(BCLog::BENCHMARK, "  - Connect postprocess: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime6 - nTime5) * MILLI, nTimePostConnect * MICRO, nTimePostConnect * MILLI / nBlocksTotal);
     LogPrint(BCLog::BENCHMARK, "- Connect block: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime6 - nTime1) * MILLI, nTimeTotal * MICRO, nTimeTotal * MILLI / nBlocksTotal);
 
+    unsigned int nSigOps = 0;
+    for (const auto& tx : blockConnecting.vtx) {
+        nSigOps += GetLegacySigOpCount(*tx);
+    }
     ::g_stats_client->timing("ConnectTip_ms", (nTime6 - nTime1) / 1000, 1.0f);
+    ::g_stats_client->gauge("blocks.tip.SizeBytes", ::GetSerializeSize(blockConnecting, PROTOCOL_VERSION), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.Height", m_chain.Height(), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.Version", blockConnecting.nVersion, 1.0f);
+    ::g_stats_client->gauge("blocks.tip.NumTransactions", blockConnecting.vtx.size(), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.SigOps", nSigOps, 1.0f);
 
     connectTrace.BlockConnected(pindexNew, std::move(pthisBlock));
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2578,11 +2578,6 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     LogPrint(BCLog::BENCHMARK, "    - Callbacks: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime8 - nTime5), nTimeCallbacks * MICRO, nTimeCallbacks * MILLI / nBlocksTotal);
 
     ::g_stats_client->timing("ConnectBlock_ms", (nTime8 - nTimeStart) / 1000, 1.0f);
-    ::g_stats_client->gauge("blocks.tip.SizeBytes", ::GetSerializeSize(block, PROTOCOL_VERSION), 1.0f);
-    ::g_stats_client->gauge("blocks.tip.Height", m_chain.Height() + 1, 1.0f); // without the +1, the "tip.Height" doesn't match rpc calls like `getblockcount`
-    ::g_stats_client->gauge("blocks.tip.Version", block.nVersion, 1.0f);
-    ::g_stats_client->gauge("blocks.tip.NumTransactions", block.vtx.size(), 1.0f);
-    ::g_stats_client->gauge("blocks.tip.SigOps", nSigOps, 1.0f);
 
     TRACE6(validation, block_connected,
         block_hash.data(),


### PR DESCRIPTION
## Issue being fixed or feature implemented
Add basic lockedTransactions count and chain locked block height to stats

## What was done?


## How Has This Been Tested?
Will be tested once this has a docker image

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

