### PR TITLE
refactor: drop some unneeded `this` and `const`

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -239,22 +239,22 @@ public:
 
     [[nodiscard]] size_t GetValidMNsCount() const
     {
-        return ranges::count_if(mnMap, [this](const auto& p){ return IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [](const auto& p){ return IsMNValid(*p.second); });
     }
 
     [[nodiscard]] size_t GetAllEvoCount() const
     {
-        return ranges::count_if(mnMap, [this](const auto& p) { return p.second->nType == MnType::Evo; });
+        return ranges::count_if(mnMap, [](const auto& p) { return p.second->nType == MnType::Evo; });
     }
 
     [[nodiscard]] size_t GetValidEvoCount() const
     {
-        return ranges::count_if(mnMap, [this](const auto& p) { return p.second->nType == MnType::Evo && IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [](const auto& p) { return p.second->nType == MnType::Evo && IsMNValid(*p.second); });
     }
 
     [[nodiscard]] size_t GetValidWeightedMNsCount() const
     {
-        return std::accumulate(mnMap.begin(), mnMap.end(), 0, [this](auto res, const auto& p) {
+        return std::accumulate(mnMap.begin(), mnMap.end(), 0, [](auto res, const auto& p) {
                                                                 if (!IsMNValid(*p.second)) return res;
                                                                 return res + GetMnType(p.second->nType).voting_weight;
                                                             });

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -239,7 +239,7 @@ public:
 
     [[nodiscard]] size_t GetValidMNsCount() const
     {
-        return ranges::count_if(mnMap, [](const auto& p){ return IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [](const auto& p) { return IsMNValid(*p.second); });
     }
 
     [[nodiscard]] size_t GetAllEvoCount() const
@@ -249,15 +249,16 @@ public:
 
     [[nodiscard]] size_t GetValidEvoCount() const
     {
-        return ranges::count_if(mnMap, [](const auto& p) { return p.second->nType == MnType::Evo && IsMNValid(*p.second); });
+        return ranges::count_if(mnMap,
+                                [](const auto& p) { return p.second->nType == MnType::Evo && IsMNValid(*p.second); });
     }
 
     [[nodiscard]] size_t GetValidWeightedMNsCount() const
     {
         return std::accumulate(mnMap.begin(), mnMap.end(), 0, [](auto res, const auto& p) {
-                                                                if (!IsMNValid(*p.second)) return res;
-                                                                return res + GetMnType(p.second->nType).voting_weight;
-                                                            });
+            if (!IsMNValid(*p.second)) return res;
+            return res + GetMnType(p.second->nType).voting_weight;
+        });
     }
 
     /**

--- a/src/evo/dmn_types.h
+++ b/src/evo/dmn_types.h
@@ -62,7 +62,7 @@ constexpr auto Invalid = mntype_struct{
     }
 }
 
-[[nodiscard]] constexpr const bool IsValidMnType(MnType type)
+[[nodiscard]] constexpr bool IsValidMnType(MnType type)
 {
     return type < MnType::COUNT;
 }

--- a/src/evo/dmn_types.h
+++ b/src/evo/dmn_types.h
@@ -62,9 +62,6 @@ constexpr auto Invalid = mntype_struct{
     }
 }
 
-[[nodiscard]] constexpr bool IsValidMnType(MnType type)
-{
-    return type < MnType::COUNT;
-}
+[[nodiscard]] constexpr bool IsValidMnType(MnType type) { return type < MnType::COUNT; }
 
 #endif // BITCOIN_EVO_DMN_TYPES_H


### PR DESCRIPTION
## Issue being fixed or feature implemented
Neither identifies are used for anything, the const is always gonna be discarded as it's on a value return value, and the `this` is not used, so should be dropped. 

This fixes some spammy warnings for me locally

## What was done?


## How Has This Been Tested?
Compiled in CI

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

