### PR TITLE
ci: improve conflicts checker to skip PRs which are a draft

### DIFF
--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -27,9 +27,6 @@ import hjson
 def get_label(pr_num):
     return requests.get(f'https://api.github.com/repos/dashpay/dash/pulls/{pr_num}').json()['head']['label']
 
-def is_draft(pr_num):
-    return requests.get(f'https://api.github.com/repos/dashpay/dash/pulls/{pr_num}').json()['draft']
-
 def main():
     if len(sys.argv) != 2:
         print(f'Usage: {sys.argv[0]} <conflicts>', file=sys.stderr)
@@ -60,11 +57,11 @@ def main():
             print(f'{this_pr_num} needs rebase. Skipping conflict check')
             continue
 
-        if is_draft(this_pr_num):
+        if r.json()["draft"]:
             print(f'{this_pr_num} is a draft. Skipping conflict check')
             continue
 
-        r = requests.get(f'https://github.com/dashpay/dash/branches/pre_mergeable/{our_pr_label}...{get_label(this_pr_num)}')
+        r = requests.get(f'https://github.com/dashpay/dash/branches/pre_mergeable/{our_pr_label}...{r.json()['head']['label']}')
         if "These branches can be automatically merged." in r.text:
             good.append(this_pr_num)
         elif "Can’t automatically merge" in r.text:

--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -27,6 +27,9 @@ import hjson
 def get_label(pr_num):
     return requests.get(f'https://api.github.com/repos/dashpay/dash/pulls/{pr_num}').json()['head']['label']
 
+def is_draft(pr_num):
+    return requests.get(f'https://api.github.com/repos/dashpay/dash/pulls/{pr_num}').json()['draft']
+
 def main():
     if len(sys.argv) != 2:
         print(f'Usage: {sys.argv[0]} <conflicts>', file=sys.stderr)
@@ -55,6 +58,10 @@ def main():
         mergable_state = r.json()['mergeable_state']
         if mergable_state == "dirty":
             print(f'{this_pr_num} needs rebase. Skipping conflict check')
+            continue
+
+        if is_draft(this_pr_num):
+            print(f'{this_pr_num} is a draft. Skipping conflict check')
             continue
 
         r = requests.get(f'https://github.com/dashpay/dash/branches/pre_mergeable/{our_pr_label}...{get_label(this_pr_num)}')

--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -19,7 +19,7 @@ permissions:
   statuses: none
 
 jobs:
-  main:
+  predict_conflicts:
     runs-on: ubuntu-latest
     steps:
       - name: check for potential conflicts


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently, CI will report a lot of conflicts on most normal PRs. This is because a lot of times a WIP PR will be opened which depends on another. This will result in both being unhappy. 

## What was done?
Instead, skip any PR which is considered a draft. 

## How Has This Been Tested?
Hasn't, wish us luck!

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

