### PR TITLE
chore: add `stats` as a pull request header type and scope

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -47,3 +47,4 @@ jobs:
             utils
             wallet
             zmq
+            stats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,7 @@ include:
   - *wallet* for changes to the wallet code
   - *zmq* for changes to the ZMQ APIs
   - *guix* for changes to the GUIX reproducible builds
+  - *stats* for changes to reporting of statistics
 
 Examples:
 


### PR DESCRIPTION
## Additional Information

Would allow tagging https://github.com/dashpay/dash/pull/5167, https://github.com/dashpay/dash/pull/6267 and https://github.com/dashpay/dash/pull/6237 as `feat(stats)`.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code **(note: N/A)**
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_ **(note: N/A)**

