### PR TITLE
feat(stats): split off transmission to `RawSender`, implement batching and queueing support, add streamlined prefix and suffix support

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -26,7 +26,6 @@ EXCLUDE = [
     'src/crypto/*',
     'src/ctpl_stl.h',
     'src/reverse_iterator.h',
-    'src/stats/client.cpp',
     'src/test/fuzz/FuzzedDataProvider.h',
     'src/tinyformat.h',
     'src/bench/nanobench.h',

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -26,7 +26,7 @@ EXCLUDE = [
     'src/crypto/*',
     'src/ctpl_stl.h',
     'src/reverse_iterator.h',
-    'src/statsd_client.cpp',
+    'src/stats/client.cpp',
     'src/test/fuzz/FuzzedDataProvider.h',
     'src/tinyformat.h',
     'src/bench/nanobench.h',

--- a/doc/release-notes-6267.md
+++ b/doc/release-notes-6267.md
@@ -1,0 +1,25 @@
+Statistics
+-----------
+
+### New Features
+
+- The Statsd client now supports queueing and batching messages, reducing the number of packets and the rate at which
+  they are sent to the Statsd daemon.
+
+- The maximum size of each batch of messages (default, 1KiB) can be adjusted using `-statsbatchsize` (in bytes)
+  and the frequency at which queued messages are sent to the daemon (default, 1 second) can be adjusted using
+  `-statsduration` (in milliseconds)
+  - `-statsduration` has no bearing on `-statsperiod`, which dictates how frequently some stats are _collected_.
+
+### Deprecations
+
+- `-statsenabled` has been deprecated and enablement will now be implied by the presence of `-statshost`. `-statsenabled`
+  will be removed in a future release.
+
+- `-statshostname` has been deprecated and replaced with `-statssuffix` as the latter is better representative of the
+  argument's purpose. They behave identically to each other. `-statshostname` will be removed in a future
+  release.
+
+- `-statsns` has been deprecated and replaced with `-statsprefix` as the latter is better representative of the
+  argument's purpose. `-statsprefix`, unlike `-statsns`, will enforce the usage of a delimiter between the prefix
+  and key. `-statsns` will be removed in a future release.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -313,7 +313,7 @@ BITCOIN_CORE_H = \
   spork.h \
   stacktraces.h \
   streams.h \
-  statsd_client.h \
+  stats/client.h \
   support/allocators/mt_pooled_secure.h \
   support/allocators/pool.h \
   support/allocators/pooled_secure.h \
@@ -526,7 +526,7 @@ libbitcoin_server_a_SOURCES = \
   script/sigcache.cpp \
   shutdown.cpp \
   spork.cpp \
-  statsd_client.cpp \
+  stats/client.cpp \
   timedata.cpp \
   torcontrol.cpp \
   txdb.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -314,6 +314,7 @@ BITCOIN_CORE_H = \
   stacktraces.h \
   streams.h \
   stats/client.h \
+  stats/rawsender.h \
   support/allocators/mt_pooled_secure.h \
   support/allocators/pool.h \
   support/allocators/pooled_secure.h \
@@ -527,6 +528,7 @@ libbitcoin_server_a_SOURCES = \
   shutdown.cpp \
   spork.cpp \
   stats/client.cpp \
+  stats/rawsender.cpp \
   timedata.cpp \
   torcontrol.cpp \
   txdb.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -775,10 +775,11 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-statsbatchsize=<bytes>", strprintf("Specify the size of each batch of stats messages (default: %d)", DEFAULT_STATSD_BATCH_SIZE), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsduration=<ms>", strprintf("Specify the number of milliseconds between stats messages (default: %d)", DEFAULT_STATSD_DURATION), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statshost=<ip>", strprintf("Specify statsd host (default: %s)", DEFAULT_STATSD_HOST), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
-    argsman.AddArg("-statshostname=<ip>", strprintf("Specify statsd host name (default: %s)", DEFAULT_STATSD_HOSTNAME), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
+    hidden_args.emplace_back("-statshostname");
     argsman.AddArg("-statsport=<port>", strprintf("Specify statsd port (default: %u)", DEFAULT_STATSD_PORT), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
-    argsman.AddArg("-statsns=<ns>", strprintf("Specify additional namespace prefix (default: %s)", DEFAULT_STATSD_NAMESPACE), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
+    argsman.AddArg("-statsns=<ns>", strprintf("Specify additional namespace prefix (default: %s)", DEFAULT_STATSD_SUFFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsperiod=<seconds>", strprintf("Specify the number of seconds between periodic measurements (default: %d)", DEFAULT_STATSD_PERIOD), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
+    argsman.AddArg("-statssuffix=<string>", strprintf("Specify an optional string appended to every stats key (default: %s)", DEFAULT_STATSD_SUFFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
 #if HAVE_DECL_FORK
     argsman.AddArg("-daemon", strprintf("Run in the background as a daemon and accept commands (default: %d)", DEFAULT_DAEMON), ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
     argsman.AddArg("-daemonwait", strprintf("Wait for initialization to be finished before exiting. This implies -daemon (default: %d)", DEFAULT_DAEMONWAIT), ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -777,8 +777,9 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-statshost=<ip>", strprintf("Specify statsd host (default: %s)", DEFAULT_STATSD_HOST), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     hidden_args.emplace_back("-statshostname");
     argsman.AddArg("-statsport=<port>", strprintf("Specify statsd port (default: %u)", DEFAULT_STATSD_PORT), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
-    argsman.AddArg("-statsns=<ns>", strprintf("Specify additional namespace prefix (default: %s)", DEFAULT_STATSD_SUFFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
+    hidden_args.emplace_back("-statsns");
     argsman.AddArg("-statsperiod=<seconds>", strprintf("Specify the number of seconds between periodic measurements (default: %d)", DEFAULT_STATSD_PERIOD), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
+    argsman.AddArg("-statsprefix=<string>", strprintf("Specify an optional string prepended to every stats key (default: %s)", DEFAULT_STATSD_PREFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statssuffix=<string>", strprintf("Specify an optional string appended to every stats key (default: %s)", DEFAULT_STATSD_SUFFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
 #if HAVE_DECL_FORK
     argsman.AddArg("-daemon", strprintf("Run in the background as a daemon and accept commands (default: %d)", DEFAULT_DAEMON), ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -772,6 +772,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
     argsman.AddArg("-statsenabled", strprintf("Publish internal stats to statsd (default: %u)", DEFAULT_STATSD_ENABLE), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
+    argsman.AddArg("-statsduration=<ms>", strprintf("Specify the number of milliseconds between stats messages (default: %d)", DEFAULT_STATSD_DURATION), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statshost=<ip>", strprintf("Specify statsd host (default: %s)", DEFAULT_STATSD_HOST), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statshostname=<ip>", strprintf("Specify statsd host name (default: %s)", DEFAULT_STATSD_HOSTNAME), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsport=<port>", strprintf("Specify statsd port (default: %u)", DEFAULT_STATSD_PORT), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
@@ -1540,8 +1541,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // regardless of whether transmitting stats are desirable or not and if
     // g_stats_client isn't present when that attempt is made, the client will crash.
     ::g_stats_client = std::make_unique<StatsdClient>(args.GetArg("-statshost", DEFAULT_STATSD_HOST),
-                                                      args.GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
                                                       args.GetArg("-statsport", DEFAULT_STATSD_PORT),
+                                                      args.GetArg("-statsduration", DEFAULT_STATSD_DURATION),
+                                                      args.GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
                                                       args.GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),
                                                       args.GetBoolArg("-statsenabled", DEFAULT_STATSD_ENABLE));
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -772,6 +772,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
     argsman.AddArg("-statsenabled", strprintf("Publish internal stats to statsd (default: %u)", DEFAULT_STATSD_ENABLE), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
+    argsman.AddArg("-statsbatchsize=<bytes>", strprintf("Specify the size of each batch of stats messages (default: %d)", DEFAULT_STATSD_BATCH_SIZE), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsduration=<ms>", strprintf("Specify the number of milliseconds between stats messages (default: %d)", DEFAULT_STATSD_DURATION), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statshost=<ip>", strprintf("Specify statsd host (default: %s)", DEFAULT_STATSD_HOST), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statshostname=<ip>", strprintf("Specify statsd host name (default: %s)", DEFAULT_STATSD_HOSTNAME), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
@@ -1542,6 +1543,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // g_stats_client isn't present when that attempt is made, the client will crash.
     ::g_stats_client = std::make_unique<StatsdClient>(args.GetArg("-statshost", DEFAULT_STATSD_HOST),
                                                       args.GetArg("-statsport", DEFAULT_STATSD_PORT),
+                                                      args.GetArg("-statsbatchsize", DEFAULT_STATSD_BATCH_SIZE),
                                                       args.GetArg("-statsduration", DEFAULT_STATSD_DURATION),
                                                       args.GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
                                                       args.GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -105,7 +105,7 @@
 #include <llmq/snapshot.h>
 #include <llmq/signing_shares.h>
 
-#include <statsd_client.h>
+#include <stats/client.h>
 
 #include <algorithm>
 #include <condition_variable>
@@ -1539,11 +1539,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // We need to initialize g_stats_client early as currently, g_stats_client is called
     // regardless of whether transmitting stats are desirable or not and if
     // g_stats_client isn't present when that attempt is made, the client will crash.
-    ::g_stats_client = std::make_unique<statsd::StatsdClient>(args.GetArg("-statshost", DEFAULT_STATSD_HOST),
-                                                              args.GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
-                                                              args.GetArg("-statsport", DEFAULT_STATSD_PORT),
-                                                              args.GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),
-                                                              args.GetBoolArg("-statsenabled", DEFAULT_STATSD_ENABLE));
+    ::g_stats_client = std::make_unique<StatsdClient>(args.GetArg("-statshost", DEFAULT_STATSD_HOST),
+                                                      args.GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
+                                                      args.GetArg("-statsport", DEFAULT_STATSD_PORT),
+                                                      args.GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),
+                                                      args.GetBoolArg("-statsenabled", DEFAULT_STATSD_ENABLE));
 
     {
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -4145,7 +4145,7 @@ void CConnman::RecordBytesRecv(uint64_t bytes)
 {
     nTotalBytesRecv += bytes;
     ::g_stats_client->count("bandwidth.bytesReceived", bytes, 0.1f);
-    ::g_stats_client->gauge("bandwidth.totalBytesReceived", nTotalBytesRecv, 0.01f);
+    ::g_stats_client->gauge("bandwidth.totalBytesReceived", nTotalBytesRecv.load(), 0.01f);
 }
 
 void CConnman::RecordBytesSent(uint64_t bytes)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1688,7 +1688,7 @@ void CConnman::NotifyNumConnectionsChanged(CMasternodeSync& mn_sync)
 
 void CConnman::CalculateNumConnectionsChangedStats()
 {
-    if (!gArgs.GetBoolArg("-statsenabled", DEFAULT_STATSD_ENABLE)) {
+    if (!::g_stats_client->active()) {
         return;
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -41,7 +41,7 @@
 #include <coinjoin/coinjoin.h>
 #include <evo/deterministicmns.h>
 
-#include <statsd_client.h>
+#include <stats/client.h>
 
 #ifdef WIN32
 #include <string.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -69,7 +69,7 @@
 #include <llmq/signing_shares.h>
 #include <llmq/snapshot.h>
 
-#include <statsd_client.h>
+#include <stats/client.h>
 
 /** Maximum number of in-flight objects from a peer */
 static constexpr int32_t MAX_PEER_OBJECT_IN_FLIGHT = 100;

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -33,7 +33,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 
-#include <statsd_client.h>
+#include <stats/client.h>
 
 #include <compat.h>
 #include <netbase.h>
@@ -43,9 +43,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <random>
 
-std::unique_ptr<statsd::StatsdClient> g_stats_client;
+std::unique_ptr<StatsdClient> g_stats_client;
 
-namespace statsd {
 bool StatsdClient::ShouldSend(float sample_rate)
 {
     sample_rate = std::clamp(sample_rate, 0.f, 1.f);
@@ -193,4 +192,3 @@ bool StatsdClient::send(const std::string& message)
 
     return true;
 }
-} // namespace statsd

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -4,36 +4,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-/**
-Copyright (c) 2014, Rex
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of the {organization} nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-**/
-
 #include <stats/client.h>
 
 #include <stats/rawsender.h>

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2014-2017 Statoshi Developers
+// Copyright (c) 2017-2023 Vincent Thiery
 // Copyright (c) 2020-2024 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -35,8 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stats/client.h>
 
-#include <compat.h>
-#include <netbase.h>
+#include <stats/rawsender.h>
 #include <util/system.h>
 
 #include <cmath>
@@ -60,10 +60,8 @@ bool StatsdClient::ShouldSend(float sample_rate)
     return sample_rate > std::uniform_real_distribution<float>(0.f, 1.f)(insecure_rand);
 }
 
-StatsdClient::StatsdClient(const std::string& host, const std::string& nodename, uint16_t port, const std::string& ns,
-                           bool enabled) :
-    m_port{port},
-    m_host{host},
+StatsdClient::StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
+                           const std::string& ns, bool enabled) :
     m_nodename{nodename},
     m_ns{ns}
 {
@@ -72,30 +70,18 @@ StatsdClient::StatsdClient(const std::string& host, const std::string& nodename,
         return;
     }
 
-    if (auto netaddr = LookupHost(m_host, /*fAllowLookup=*/true); netaddr.has_value()) {
-        if (!netaddr->IsIPv4()) {
-            LogPrintf("ERROR: Host %s on unsupported network, cannot init StatsdClient\n", m_host);
-            return;
-        }
-        if (!CService(*netaddr, port).GetSockAddr(reinterpret_cast<struct sockaddr*>(&m_server.first), &m_server.second)) {
-            LogPrintf("ERROR: Cannot get socket address for %s, cannot init StatsdClient\n", m_host);
-            return;
-        }
-    } else {
-        LogPrintf("Unable to lookup host %s, cannot init StatsdClient\n", m_host);
+    std::optional<std::string> error_opt;
+    m_sender = std::make_unique<RawSender>(host, port, error_opt);
+    if (error_opt.has_value()) {
+        LogPrintf("ERROR: %s, cannot initialize StatsdClient.\n", error_opt.value());
+        m_sender.reset();
         return;
     }
 
-    SOCKET hSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (hSocket == INVALID_SOCKET) {
-        LogPrintf("ERROR: Cannot create socket (socket() returned error %s), cannot init StatsdClient\n",
-                  NetworkErrorString(WSAGetLastError()));
-        return;
-    }
-    m_sock = std::make_unique<Sock>(hSocket);
-
-    LogPrintf("StatsdClient initialized to transmit stats to %s:%d\n", m_host, m_port);
+    LogPrintf("StatsdClient initialized to transmit stats to %s:%d\n", host, port);
 }
+
+StatsdClient::~StatsdClient() {}
 
 /* will change the original string */
 void StatsdClient::cleanup(std::string& key)
@@ -133,7 +119,7 @@ bool StatsdClient::timing(const std::string& key, int64_t ms, float sample_rate)
 
 bool StatsdClient::send(std::string key, int64_t value, const std::string& type, float sample_rate)
 {
-    if (!m_sock) {
+    if (!m_sender) {
         return false;
     }
 
@@ -147,17 +133,22 @@ bool StatsdClient::send(std::string key, int64_t value, const std::string& type,
 
     cleanup(key);
 
-    std::string buf{strprintf("%s%s:%d|%s", m_ns, key, value, type)};
+    RawMessage msg{strprintf("%s%s:%d|%s", m_ns, key, value, type)};
     if (sample_rate < 1.f) {
-        buf += strprintf("|@%.2f", sample_rate);
+        msg += strprintf("|@%.2f", sample_rate);
     }
 
-    return send(buf);
+    if (auto error_opt = m_sender->Send(msg); error_opt.has_value()) {
+        LogPrintf("ERROR: %s.\n", error_opt.value());
+        return false;
+    }
+
+    return true;
 }
 
 bool StatsdClient::sendDouble(std::string key, double value, const std::string& type, float sample_rate)
 {
-    if (!m_sock) {
+    if (!m_sender) {
         return false;
     }
 
@@ -171,22 +162,13 @@ bool StatsdClient::sendDouble(std::string key, double value, const std::string& 
 
     cleanup(key);
 
-    std::string buf{strprintf("%s%s:%f|%s", m_ns, key, value, type)};
+    RawMessage msg{strprintf("%s%s:%f|%s", m_ns, key, value, type)};
     if (sample_rate < 1.f) {
-        buf += strprintf("|@%.2f", sample_rate);
+        msg += strprintf("|@%.2f", sample_rate);
     }
 
-    return send(buf);
-}
-
-bool StatsdClient::send(const std::string& message)
-{
-    assert(m_sock);
-
-    if (::sendto(m_sock->Get(), message.data(), message.size(), /*flags=*/0,
-                 reinterpret_cast<struct sockaddr*>(&m_server.first), m_server.second) == SOCKET_ERROR) {
-        LogPrintf("ERROR: Unable to send message (sendto() returned error %s), host=%s:%d\n",
-                  NetworkErrorString(WSAGetLastError()), m_host, m_port);
+    if (auto error_opt = m_sender->Send(msg); error_opt.has_value()) {
+        LogPrintf("ERROR: %s.\n", error_opt.value());
         return false;
     }
 

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -60,7 +60,7 @@ bool StatsdClient::ShouldSend(float sample_rate)
     return sample_rate > std::uniform_real_distribution<float>(0.f, 1.f)(insecure_rand);
 }
 
-StatsdClient::StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
+StatsdClient::StatsdClient(const std::string& host, uint16_t port, uint64_t interval_ms, const std::string& nodename,
                            const std::string& ns, bool enabled) :
     m_nodename{nodename},
     m_ns{ns}
@@ -71,7 +71,7 @@ StatsdClient::StatsdClient(const std::string& host, const std::string& nodename,
     }
 
     std::optional<std::string> error_opt;
-    m_sender = std::make_unique<RawSender>(host, port, error_opt);
+    m_sender = std::make_unique<RawSender>(host, port, interval_ms, error_opt);
     if (error_opt.has_value()) {
         LogPrintf("ERROR: %s, cannot initialize StatsdClient.\n", error_opt.value());
         m_sender.reset();

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -49,6 +49,12 @@ static constexpr float EPSILON{0.0001f};
 
 /** Delimiter segmenting two fully formed Statsd messages */
 static constexpr char STATSD_MSG_DELIMITER{'\n'};
+/** Character used to denote Statsd message type as count */
+static constexpr char STATSD_METRIC_COUNT[]{"c"};
+/** Character used to denote Statsd message type as gauge */
+static constexpr char STATSD_METRIC_GAUGE[]{"g"};
+/** Characters used to denote Statsd message type as timing */
+static constexpr char STATSD_METRIC_TIMING[]{"ms"};
 } // anonymous namespace
 
 std::unique_ptr<StatsdClient> g_stats_client;
@@ -82,28 +88,28 @@ bool StatsdClient::dec(const std::string& key, float sample_rate) { return count
 
 bool StatsdClient::inc(const std::string& key, float sample_rate) { return count(key, 1, sample_rate); }
 
-bool StatsdClient::count(const std::string& key, int64_t value, float sample_rate)
+bool StatsdClient::count(const std::string& key, int64_t delta, float sample_rate)
 {
-    return send(key, value, "c", sample_rate);
+    return send(key, delta, STATSD_METRIC_COUNT, sample_rate);
 }
 
 bool StatsdClient::gauge(const std::string& key, int64_t value, float sample_rate)
 {
-    return send(key, value, "g", sample_rate);
+    return send(key, value, STATSD_METRIC_GAUGE, sample_rate);
 }
 
 bool StatsdClient::gaugeDouble(const std::string& key, double value, float sample_rate)
 {
-    return sendDouble(key, value, "g", sample_rate);
+    return send(key, value, STATSD_METRIC_GAUGE, sample_rate);
 }
 
-bool StatsdClient::timing(const std::string& key, int64_t ms, float sample_rate)
+bool StatsdClient::timing(const std::string& key, uint64_t ms, float sample_rate)
 {
-    return send(key, ms, "ms", sample_rate);
+    return send(key, ms, STATSD_METRIC_TIMING, sample_rate);
 }
 
 template <typename T1>
-bool StatsdClient::Send(const std::string& key, T1 value, const std::string& type, float sample_rate)
+bool StatsdClient::send(const std::string& key, T1 value, const std::string& type, float sample_rate)
 {
     static_assert(std::is_arithmetic<T1>::value, "Must specialize to an arithmetic type");
 
@@ -137,3 +143,9 @@ bool StatsdClient::Send(const std::string& key, T1 value, const std::string& typ
 
     return true;
 }
+
+template bool StatsdClient::send(const std::string& key, double value, const std::string& type, float sample_rate);
+template bool StatsdClient::send(const std::string& key, int32_t value, const std::string& type, float sample_rate);
+template bool StatsdClient::send(const std::string& key, int64_t value, const std::string& type, float sample_rate);
+template bool StatsdClient::send(const std::string& key, uint32_t value, const std::string& type, float sample_rate);
+template bool StatsdClient::send(const std::string& key, uint64_t value, const std::string& type, float sample_rate);

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -43,6 +43,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <random>
 
+/** Delimiter segmenting two fully formed Statsd messages */
+static constexpr char STATSD_MSG_DELIMITER{'\n'};
+
 std::unique_ptr<StatsdClient> g_stats_client;
 
 bool StatsdClient::ShouldSend(float sample_rate)
@@ -60,8 +63,8 @@ bool StatsdClient::ShouldSend(float sample_rate)
     return sample_rate > std::uniform_real_distribution<float>(0.f, 1.f)(insecure_rand);
 }
 
-StatsdClient::StatsdClient(const std::string& host, uint16_t port, uint64_t interval_ms, const std::string& nodename,
-                           const std::string& ns, bool enabled) :
+StatsdClient::StatsdClient(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
+                           const std::string& nodename, const std::string& ns, bool enabled) :
     m_nodename{nodename},
     m_ns{ns}
 {
@@ -71,7 +74,9 @@ StatsdClient::StatsdClient(const std::string& host, uint16_t port, uint64_t inte
     }
 
     std::optional<std::string> error_opt;
-    m_sender = std::make_unique<RawSender>(host, port, interval_ms, error_opt);
+    m_sender = std::make_unique<RawSender>(host, port,
+                                           std::make_pair(batch_size, static_cast<uint8_t>(STATSD_MSG_DELIMITER)),
+                                           interval_ms, error_opt);
     if (error_opt.has_value()) {
         LogPrintf("ERROR: %s, cannot initialize StatsdClient.\n", error_opt.value());
         m_sender.reset();

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -15,10 +15,15 @@
 
 class RawSender;
 
+/** Default state of Statsd enablement */
 static constexpr bool DEFAULT_STATSD_ENABLE{false};
+/** Default port used to connect to a Statsd server */
 static constexpr uint16_t DEFAULT_STATSD_PORT{8125};
+/** Default host assumed to be running a Statsd server */
 static const std::string DEFAULT_STATSD_HOST{"127.0.0.1"};
+/** Default suffix appended to Statsd message keys */
 static const std::string DEFAULT_STATSD_HOSTNAME{""};
+/** Default prefix prepended to Statsd message keys */
 static const std::string DEFAULT_STATSD_NAMESPACE{""};
 
 /** Default number of milliseconds between flushing a queue of messages */
@@ -40,39 +45,34 @@ public:
     ~StatsdClient();
 
 public:
-    bool inc(const std::string& key, float sample_rate = 1.f);
+    /* Statsd-defined APIs */
     bool dec(const std::string& key, float sample_rate = 1.f);
-    bool count(const std::string& key, int64_t value, float sample_rate = 1.f);
+    bool inc(const std::string& key, float sample_rate = 1.f);
+    bool count(const std::string& key, int64_t delta, float sample_rate = 1.f);
     bool gauge(const std::string& key, int64_t value, float sample_rate = 1.f);
     bool gaugeDouble(const std::string& key, double value, float sample_rate = 1.f);
-    bool timing(const std::string& key, int64_t ms, float sample_rate = 1.f);
+    bool timing(const std::string& key, uint64_t ms, float sample_rate = 1.f);
 
-    /* (Low Level Api) manually send a message
-        * type = "c", "g" or "ms"
-        */
-    bool send(const std::string& key, int64_t value, const std::string& type, float sample_rate = 1.f)
-    {
-        return Send(key, value, type, sample_rate);
-    }
-    bool sendDouble(const std::string& key, double value, const std::string& type, float sample_rate = 1.f)
-    {
-        return Send(key, value, type, sample_rate);
-    }
-
-private:
+    /* Statsd-compatible APIs */
     template <typename T1>
-    bool Send(const std::string& key, T1 value, const std::string& type, float sample_rate);
+    bool send(const std::string& key, T1 value, const std::string& type, float sample_rate = 1.f);
 
 private:
+    /* Mutex to protect PRNG */
     mutable Mutex cs;
+    /* PRNG used to dice-roll messages that are 0 < f < 1 */
     mutable FastRandomContext insecure_rand GUARDED_BY(cs);
 
+    /* Broadcasts messages crafted by StatsdClient */
     std::unique_ptr<RawSender> m_sender{nullptr};
 
+    /* Phrase prepended to keys */
     const std::string m_nodename;
+    /* Phrase appended to keys */
     const std::string m_ns;
 };
 
+/** Global smart pointer containing StatsdClient instance */
 extern std::unique_ptr<StatsdClient> g_stats_client;
 
 #endif // BITCOIN_STATS_CLIENT_H

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -50,12 +50,18 @@ public:
     /* (Low Level Api) manually send a message
         * type = "c", "g" or "ms"
         */
-    bool send(std::string key, int64_t value, const std::string& type, float sample_rate);
-    bool sendDouble(std::string key, double value, const std::string& type, float sample_rate);
+    bool send(const std::string& key, int64_t value, const std::string& type, float sample_rate = 1.f)
+    {
+        return Send(key, value, type, sample_rate);
+    }
+    bool sendDouble(const std::string& key, double value, const std::string& type, float sample_rate = 1.f)
+    {
+        return Send(key, value, type, sample_rate);
+    }
 
 private:
-    void cleanup(std::string& key);
-    bool ShouldSend(float sample_rate);
+    template <typename T1>
+    bool Send(const std::string& key, T1 value, const std::string& type, float sample_rate);
 
 private:
     mutable Mutex cs;

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -13,10 +13,9 @@
 #include <memory>
 #include <string>
 
+class ArgsManager;
 class RawSender;
 
-/** Default state of Statsd enablement */
-static constexpr bool DEFAULT_STATSD_ENABLE{false};
 /** Default port used to connect to a Statsd server */
 static constexpr uint16_t DEFAULT_STATSD_PORT{8125};
 /** Default host assumed to be running a Statsd server */
@@ -57,6 +56,9 @@ public:
     template <typename T1>
     bool send(const std::string& key, T1 value, const std::string& type, float sample_rate = 1.f);
 
+    /* Check if a StatsdClient instance is ready to send messages */
+    bool active() const { return m_sender != nullptr; }
+
 private:
     /* Mutex to protect PRNG */
     mutable Mutex cs;
@@ -71,6 +73,9 @@ private:
     /* Phrase appended to keys */
     const std::string m_ns;
 };
+
+/** Parses arguments and constructs a StatsdClient instance */
+std::unique_ptr<StatsdClient> InitStatsClient(const ArgsManager& args);
 
 /** Global smart pointer containing StatsdClient instance */
 extern std::unique_ptr<StatsdClient> g_stats_client;

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2014-2017 Statoshi Developers
+// Copyright (c) 2017-2023 Vincent Thiery
 // Copyright (c) 2020-2023 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -7,11 +8,12 @@
 #define BITCOIN_STATS_CLIENT_H
 
 #include <random.h>
-#include <threadsafety.h>
-#include <util/sock.h>
+#include <sync.h>
 
 #include <memory>
 #include <string>
+
+class RawSender;
 
 static constexpr bool DEFAULT_STATSD_ENABLE{false};
 static constexpr uint16_t DEFAULT_STATSD_PORT{8125};
@@ -29,6 +31,7 @@ class StatsdClient
 public:
     explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
                             const std::string& ns, bool enabled);
+    ~StatsdClient();
 
 public:
     bool inc(const std::string& key, float sample_rate = 1.f);
@@ -45,12 +48,6 @@ public:
     bool sendDouble(std::string key, double value, const std::string& type, float sample_rate);
 
 private:
-    /**
-        * (Low Level Api) manually send a message
-        * which might be composed of several lines.
-        */
-    bool send(const std::string& message);
-
     void cleanup(std::string& key);
     bool ShouldSend(float sample_rate);
 
@@ -58,11 +55,8 @@ private:
     mutable Mutex cs;
     mutable FastRandomContext insecure_rand GUARDED_BY(cs);
 
-    std::unique_ptr<Sock> m_sock{nullptr};
-    std::pair<struct sockaddr_storage, socklen_t> m_server{{}, sizeof(struct sockaddr_storage)};
+    std::unique_ptr<RawSender> m_sender{nullptr};
 
-    const uint16_t m_port;
-    const std::string m_host;
     const std::string m_nodename;
     const std::string m_ns;
 };

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -20,10 +20,10 @@ class RawSender;
 static constexpr uint16_t DEFAULT_STATSD_PORT{8125};
 /** Default host assumed to be running a Statsd server */
 static const std::string DEFAULT_STATSD_HOST{"127.0.0.1"};
-/** Default suffix appended to Statsd message keys */
-static const std::string DEFAULT_STATSD_HOSTNAME{""};
 /** Default prefix prepended to Statsd message keys */
 static const std::string DEFAULT_STATSD_NAMESPACE{""};
+/** Default suffix appended to Statsd message keys */
+static const std::string DEFAULT_STATSD_SUFFIX{""};
 
 /** Default number of milliseconds between flushing a queue of messages */
 static constexpr int DEFAULT_STATSD_DURATION{1000};
@@ -40,7 +40,7 @@ class StatsdClient
 {
 public:
     explicit StatsdClient(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
-                          const std::string& nodename, const std::string& ns, bool enabled);
+                          const std::string& ns, const std::string& suffix, bool enabled);
     ~StatsdClient();
 
 public:
@@ -69,9 +69,9 @@ private:
     std::unique_ptr<RawSender> m_sender{nullptr};
 
     /* Phrase prepended to keys */
-    const std::string m_nodename;
-    /* Phrase appended to keys */
     const std::string m_ns;
+    /* Phrase appended to keys */
+    const std::string m_suffix{""};
 };
 
 /** Parses arguments and constructs a StatsdClient instance */

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -21,16 +21,20 @@ static const std::string DEFAULT_STATSD_HOST{"127.0.0.1"};
 static const std::string DEFAULT_STATSD_HOSTNAME{""};
 static const std::string DEFAULT_STATSD_NAMESPACE{""};
 
-// schedule periodic measurements, in seconds: default - 1 minute, min - 5 sec, max - 1h.
+/** Default number of milliseconds between flushing a queue of messages */
+static constexpr int DEFAULT_STATSD_DURATION{1000};
+/** Default number of seconds between recording periodic stats */
 static constexpr int DEFAULT_STATSD_PERIOD{60};
+/** Minimum number of seconds between recording periodic stats */
 static constexpr int MIN_STATSD_PERIOD{5};
+/** Maximum number of seconds between recording periodic stats */
 static constexpr int MAX_STATSD_PERIOD{60 * 60};
 
 class StatsdClient
 {
 public:
-    explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
-                            const std::string& ns, bool enabled);
+    explicit StatsdClient(const std::string& host, uint16_t port, uint64_t interval_ms, const std::string& nodename,
+                          const std::string& ns, bool enabled);
     ~StatsdClient();
 
 public:

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -3,15 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_STATSD_CLIENT_H
-#define BITCOIN_STATSD_CLIENT_H
+#ifndef BITCOIN_STATS_CLIENT_H
+#define BITCOIN_STATS_CLIENT_H
 
 #include <random.h>
 #include <threadsafety.h>
 #include <util/sock.h>
 
-#include <string>
 #include <memory>
+#include <string>
 
 static constexpr bool DEFAULT_STATSD_ENABLE{false};
 static constexpr uint16_t DEFAULT_STATSD_PORT{8125};
@@ -24,8 +24,8 @@ static constexpr int DEFAULT_STATSD_PERIOD{60};
 static constexpr int MIN_STATSD_PERIOD{5};
 static constexpr int MAX_STATSD_PERIOD{60 * 60};
 
-namespace statsd {
-class StatsdClient {
+class StatsdClient
+{
 public:
     explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
                             const std::string& ns, bool enabled);
@@ -66,8 +66,7 @@ private:
     const std::string m_nodename;
     const std::string m_ns;
 };
-} // namespace statsd
 
-extern std::unique_ptr<statsd::StatsdClient> g_stats_client;
+extern std::unique_ptr<StatsdClient> g_stats_client;
 
-#endif // BITCOIN_STATSD_CLIENT_H
+#endif // BITCOIN_STATS_CLIENT_H

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -25,6 +25,8 @@ static const std::string DEFAULT_STATSD_NAMESPACE{""};
 static constexpr int DEFAULT_STATSD_DURATION{1000};
 /** Default number of seconds between recording periodic stats */
 static constexpr int DEFAULT_STATSD_PERIOD{60};
+/** Default size in bytes of a batch of messages */
+static constexpr int DEFAULT_STATSD_BATCH_SIZE{1024};
 /** Minimum number of seconds between recording periodic stats */
 static constexpr int MIN_STATSD_PERIOD{5};
 /** Maximum number of seconds between recording periodic stats */
@@ -33,8 +35,8 @@ static constexpr int MAX_STATSD_PERIOD{60 * 60};
 class StatsdClient
 {
 public:
-    explicit StatsdClient(const std::string& host, uint16_t port, uint64_t interval_ms, const std::string& nodename,
-                          const std::string& ns, bool enabled);
+    explicit StatsdClient(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
+                          const std::string& nodename, const std::string& ns, bool enabled);
     ~StatsdClient();
 
 public:

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -21,7 +21,7 @@ static constexpr uint16_t DEFAULT_STATSD_PORT{8125};
 /** Default host assumed to be running a Statsd server */
 static const std::string DEFAULT_STATSD_HOST{"127.0.0.1"};
 /** Default prefix prepended to Statsd message keys */
-static const std::string DEFAULT_STATSD_NAMESPACE{""};
+static const std::string DEFAULT_STATSD_PREFIX{""};
 /** Default suffix appended to Statsd message keys */
 static const std::string DEFAULT_STATSD_SUFFIX{""};
 
@@ -40,7 +40,7 @@ class StatsdClient
 {
 public:
     explicit StatsdClient(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
-                          const std::string& ns, const std::string& suffix, bool enabled);
+                          const std::string& prefix, const std::string& suffix, bool enabled);
     ~StatsdClient();
 
 public:
@@ -69,7 +69,7 @@ private:
     std::unique_ptr<RawSender> m_sender{nullptr};
 
     /* Phrase prepended to keys */
-    const std::string m_ns;
+    const std::string m_prefix{""};
     /* Phrase appended to keys */
     const std::string m_suffix{""};
 };

--- a/src/stats/rawsender.cpp
+++ b/src/stats/rawsender.cpp
@@ -8,10 +8,13 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <util/sock.h>
+#include <util/thread.h>
 
-RawSender::RawSender(const std::string& host, uint16_t port, std::optional<std::string>& error) :
+RawSender::RawSender(const std::string& host, uint16_t port, uint64_t interval_ms,
+                     std::optional<std::string>& error) :
     m_host{host},
-    m_port{port}
+    m_port{port},
+    m_interval_ms{interval_ms}
 {
     if (host.empty()) {
         error = "No host specified";
@@ -39,16 +42,42 @@ RawSender::RawSender(const std::string& host, uint16_t port, std::optional<std::
     }
     m_sock = std::make_unique<Sock>(hSocket);
 
-    LogPrintf("Started RawSender sending messages to %s:%d\n", m_host, m_port);
+    if (m_interval_ms == 0) {
+        LogPrintf("Send interval is zero, not starting RawSender queueing thread.\n");
+    } else {
+        m_interrupt.reset();
+        m_thread = std::thread(&util::TraceThread, "rawsender", [this] { QueueThreadMain(); });
+    }
+
+    LogPrintf("Started %sRawSender sending messages to %s:%d\n", m_thread.joinable() ? "threaded " : "", m_host, m_port);
 }
 
 RawSender::~RawSender()
 {
-    LogPrintf("Stopping RawSender instance sending messages to %s:%d. %d successes, %d failures.\n",
+    // If there is a thread, interrupt and stop it
+    if (m_thread.joinable()) {
+        m_interrupt();
+        m_thread.join();
+    }
+    // Flush queue of uncommitted messages
+    QueueFlush();
+
+    LogPrintf("Stopped RawSender instance sending messages to %s:%d. %d successes, %d failures.\n",
               m_host, m_port, m_successes, m_failures);
 }
 
 std::optional<std::string> RawSender::Send(const RawMessage& msg)
+{
+    // If there is a thread, append to queue
+    if (m_thread.joinable()) {
+        QueueAdd(msg);
+        return std::nullopt;
+    }
+    // There isn't a queue, send directly
+    return SendDirectly(msg);
+}
+
+std::optional<std::string> RawSender::SendDirectly(const RawMessage& msg)
 {
     if (!m_sock) {
         m_failures++;
@@ -72,3 +101,42 @@ std::optional<std::string> RawSender::Send(const RawMessage& msg)
 }
 
 std::string RawSender::ToStringHostPort() const { return strprintf("%s:%d", m_host, m_port); }
+
+void RawSender::QueueAdd(const RawMessage& msg)
+{
+    AssertLockNotHeld(cs);
+    WITH_LOCK(cs, m_queue.push_back(msg));
+}
+
+void RawSender::QueueFlush()
+{
+    AssertLockNotHeld(cs);
+    WITH_LOCK(cs, QueueFlush(m_queue));
+}
+
+void RawSender::QueueFlush(std::deque<RawMessage>& queue)
+{
+    while (!queue.empty()) {
+        SendDirectly(queue.front());
+        queue.pop_front();
+    }
+}
+
+void RawSender::QueueThreadMain()
+{
+    AssertLockNotHeld(cs);
+
+    while (!m_interrupt) {
+        // Swap the queues to commit the existing queue of messages
+        std::deque<RawMessage> queue;
+        WITH_LOCK(cs, m_queue.swap(queue));
+
+        // Flush the committed queue
+        QueueFlush(queue);
+        assert(queue.empty());
+
+        if (!m_interrupt.sleep_for(std::chrono::milliseconds(m_interval_ms))) {
+            return;
+        }
+    }
+}

--- a/src/stats/rawsender.cpp
+++ b/src/stats/rawsender.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2017-2023 Vincent Thiery
+// Copyright (c) 2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stats/rawsender.h>
+
+#include <netaddress.h>
+#include <netbase.h>
+#include <util/sock.h>
+
+RawSender::RawSender(const std::string& host, uint16_t port, std::optional<std::string>& error) :
+    m_host{host},
+    m_port{port}
+{
+    if (host.empty()) {
+        error = "No host specified";
+        return;
+    }
+
+    if (auto netaddr = LookupHost(m_host, /*fAllowLookup=*/true); netaddr.has_value()) {
+        if (!netaddr->IsIPv4()) {
+            error = strprintf("Host %s on unsupported network", m_host);
+            return;
+        }
+        if (!CService(*netaddr, port).GetSockAddr(reinterpret_cast<struct sockaddr*>(&m_server.first), &m_server.second)) {
+            error = strprintf("Cannot get socket address for %s", m_host);
+            return;
+        }
+    } else {
+        error = strprintf("Unable to lookup host %s", m_host);
+        return;
+    }
+
+    SOCKET hSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (hSocket == INVALID_SOCKET) {
+        error = strprintf("Cannot create socket (socket() returned error %s)", NetworkErrorString(WSAGetLastError()));
+        return;
+    }
+    m_sock = std::make_unique<Sock>(hSocket);
+
+    LogPrintf("Started RawSender sending messages to %s:%d\n", m_host, m_port);
+}
+
+RawSender::~RawSender()
+{
+    LogPrintf("Stopping RawSender instance sending messages to %s:%d. %d successes, %d failures.\n",
+              m_host, m_port, m_successes, m_failures);
+}
+
+std::optional<std::string> RawSender::Send(const RawMessage& msg)
+{
+    if (!m_sock) {
+        m_failures++;
+        return "Socket not initialized, cannot send message";
+    }
+
+    if (::sendto(m_sock->Get(), reinterpret_cast<const char*>(msg.data()),
+#ifdef WIN32
+                 static_cast<int>(msg.size()),
+#else
+                 msg.size(),
+#endif // WIN32
+                 /*flags=*/0, reinterpret_cast<struct sockaddr*>(&m_server.first), m_server.second) == SOCKET_ERROR) {
+        m_failures++;
+        return strprintf("Unable to send message to %s (sendto() returned error %s)", this->ToStringHostPort(),
+                         NetworkErrorString(WSAGetLastError()));
+    }
+
+    m_successes++;
+    return std::nullopt;
+}
+
+std::string RawSender::ToStringHostPort() const { return strprintf("%s:%d", m_host, m_port); }

--- a/src/stats/rawsender.h
+++ b/src/stats/rawsender.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2017-2023 Vincent Thiery
+// Copyright (c) 2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STATS_RAWSENDER_H
+#define BITCOIN_STATS_RAWSENDER_H
+
+#include <compat.h>
+#include <sync.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+class Sock;
+
+struct RawMessage : public std::vector<uint8_t>
+{
+    using parent_type = std::vector<value_type>;
+    using parent_type::parent_type;
+
+    explicit RawMessage(const std::string& data) : parent_type{data.begin(), data.end()} {}
+
+    parent_type& operator+=(value_type rhs) { return append(rhs); }
+    parent_type& operator+=(std::string::value_type rhs) { return append(rhs); }
+    parent_type& operator+=(const parent_type& rhs) { return append(rhs); }
+    parent_type& operator+=(const std::string& rhs) { return append(rhs); }
+
+    parent_type& append(value_type rhs)
+    {
+        push_back(rhs);
+        return *this;
+    }
+    parent_type& append(std::string::value_type rhs)
+    {
+        push_back(static_cast<value_type>(rhs));
+        return *this;
+    }
+    parent_type& append(const parent_type& rhs)
+    {
+        insert(end(), rhs.begin(), rhs.end());
+        return *this;
+    }
+    parent_type& append(const std::string& rhs)
+    {
+        insert(end(), rhs.begin(), rhs.end());
+        return *this;
+    }
+};
+
+class RawSender
+{
+public:
+    RawSender(const std::string& host, uint16_t port, std::optional<std::string>& error);
+    ~RawSender();
+
+    RawSender(const RawSender&) = delete;
+    RawSender& operator=(const RawSender&) = delete;
+    RawSender(RawSender&&) = delete;
+
+    std::optional<std::string> Send(const RawMessage& msg);
+
+    std::string ToStringHostPort() const;
+
+private:
+    /* Socket used to communicate with host */
+    std::unique_ptr<Sock> m_sock{nullptr};
+    /* Socket address containing host information */
+    std::pair<struct sockaddr_storage, socklen_t> m_server{{}, sizeof(struct sockaddr_storage)};
+
+    /* Hostname of server receiving messages */
+    const std::string m_host;
+    /* Port of server receiving messages */
+    const uint16_t m_port;
+
+    /* Number of messages sent */
+    uint64_t m_successes{0};
+    /* Number of messages not sent */
+    uint64_t m_failures{0};
+};
+
+#endif // BITCOIN_STATS_RAWSENDER_H

--- a/src/stats/rawsender.h
+++ b/src/stats/rawsender.h
@@ -55,7 +55,8 @@ struct RawMessage : public std::vector<uint8_t>
 class RawSender
 {
 public:
-    RawSender(const std::string& host, uint16_t port, uint64_t interval_ms, std::optional<std::string>& error);
+    RawSender(const std::string& host, uint16_t port, std::pair<uint64_t, uint8_t> batching_opts,
+              uint64_t interval_ms, std::optional<std::string>& error);
     ~RawSender();
 
     RawSender(const RawSender&) = delete;
@@ -78,11 +79,11 @@ private:
     /* Socket address containing host information */
     std::pair<struct sockaddr_storage, socklen_t> m_server{{}, sizeof(struct sockaddr_storage)};
 
-    /* Mutex to protect messages queue */
+    /* Mutex to protect (batches of) messages queue */
     mutable Mutex cs;
     /* Interrupt for queue processing thread */
     CThreadInterrupt m_interrupt;
-    /* Queue of messages to be sent */
+    /* Queue of (batches of) messages to be sent */
     std::deque<RawMessage> m_queue GUARDED_BY(cs);
     /* Thread that processes queue every m_interval_ms */
     std::thread m_thread;
@@ -91,6 +92,8 @@ private:
     const std::string m_host;
     /* Port of server receiving messages */
     const uint16_t m_port;
+    /* Batching parameters */
+    const std::pair</*size=*/uint64_t, /*delimiter=*/uint8_t> m_batching_opts{0, 0};
     /* Time between queue thread runs (expressed in milliseconds) */
     const uint64_t m_interval_ms;
 

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -26,45 +26,45 @@ static constexpr int MAX_STATSD_PERIOD{60 * 60};
 
 namespace statsd {
 class StatsdClient {
-    public:
-        explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
-                              const std::string& ns, bool enabled);
+public:
+    explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
+                            const std::string& ns, bool enabled);
 
-    public:
-        bool inc(const std::string& key, float sample_rate = 1.f);
-        bool dec(const std::string& key, float sample_rate = 1.f);
-        bool count(const std::string& key, int64_t value, float sample_rate = 1.f);
-        bool gauge(const std::string& key, int64_t value, float sample_rate = 1.f);
-        bool gaugeDouble(const std::string& key, double value, float sample_rate = 1.f);
-        bool timing(const std::string& key, int64_t ms, float sample_rate = 1.f);
+public:
+    bool inc(const std::string& key, float sample_rate = 1.f);
+    bool dec(const std::string& key, float sample_rate = 1.f);
+    bool count(const std::string& key, int64_t value, float sample_rate = 1.f);
+    bool gauge(const std::string& key, int64_t value, float sample_rate = 1.f);
+    bool gaugeDouble(const std::string& key, double value, float sample_rate = 1.f);
+    bool timing(const std::string& key, int64_t ms, float sample_rate = 1.f);
 
-        /* (Low Level Api) manually send a message
-         * type = "c", "g" or "ms"
-         */
-        bool send(std::string key, int64_t value, const std::string& type, float sample_rate);
-        bool sendDouble(std::string key, double value, const std::string& type, float sample_rate);
+    /* (Low Level Api) manually send a message
+        * type = "c", "g" or "ms"
+        */
+    bool send(std::string key, int64_t value, const std::string& type, float sample_rate);
+    bool sendDouble(std::string key, double value, const std::string& type, float sample_rate);
 
-    private:
-        /**
-         * (Low Level Api) manually send a message
-         * which might be composed of several lines.
-         */
-        bool send(const std::string& message);
+private:
+    /**
+        * (Low Level Api) manually send a message
+        * which might be composed of several lines.
+        */
+    bool send(const std::string& message);
 
-        void cleanup(std::string& key);
-        bool ShouldSend(float sample_rate);
+    void cleanup(std::string& key);
+    bool ShouldSend(float sample_rate);
 
-    private:
-        mutable Mutex cs;
-        mutable FastRandomContext insecure_rand GUARDED_BY(cs);
+private:
+    mutable Mutex cs;
+    mutable FastRandomContext insecure_rand GUARDED_BY(cs);
 
-        std::unique_ptr<Sock> m_sock{nullptr};
-        std::pair<struct sockaddr_storage, socklen_t> m_server{{}, sizeof(struct sockaddr_storage)};
+    std::unique_ptr<Sock> m_sock{nullptr};
+    std::pair<struct sockaddr_storage, socklen_t> m_server{{}, sizeof(struct sockaddr_storage)};
 
-        const uint16_t m_port;
-        const std::string m_host;
-        const std::string m_nodename;
-        const std::string m_ns;
+    const uint16_t m_port;
+    const std::string m_host;
+    const std::string m_nodename;
+    const std::string m_ns;
 };
 } // namespace statsd
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -186,6 +186,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     ::g_stats_client = std::make_unique<StatsdClient>(
         m_node.args->GetArg("-statshost", DEFAULT_STATSD_HOST),
         m_node.args->GetArg("-statsport", DEFAULT_STATSD_PORT),
+        m_node.args->GetArg("-statsbatchsize", DEFAULT_STATSD_BATCH_SIZE),
         m_node.args->GetArg("-statsduration", DEFAULT_STATSD_DURATION),
         m_node.args->GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
         m_node.args->GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -183,15 +183,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     SetupNetworking();
     InitSignatureCache();
     InitScriptExecutionCache();
-    ::g_stats_client = std::make_unique<StatsdClient>(
-        m_node.args->GetArg("-statshost", DEFAULT_STATSD_HOST),
-        m_node.args->GetArg("-statsport", DEFAULT_STATSD_PORT),
-        m_node.args->GetArg("-statsbatchsize", DEFAULT_STATSD_BATCH_SIZE),
-        m_node.args->GetArg("-statsduration", DEFAULT_STATSD_DURATION),
-        m_node.args->GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
-        m_node.args->GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),
-        m_node.args->GetBoolArg("-statsenabled", DEFAULT_STATSD_ENABLE)
-    );
+    ::g_stats_client = InitStatsClient(*m_node.args);
     m_node.chain = interfaces::MakeChain(m_node);
 
     m_node.netgroupman = std::make_unique<NetGroupManager>(/*asmap=*/std::vector<bool>());

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -39,7 +39,7 @@
 #include <scheduler.h>
 #include <script/sigcache.h>
 #include <spork.h>
-#include <statsd_client.h>
+#include <stats/client.h>
 #include <streams.h>
 #include <test/util/index.h>
 #include <txdb.h>
@@ -183,7 +183,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     SetupNetworking();
     InitSignatureCache();
     InitScriptExecutionCache();
-    ::g_stats_client = std::make_unique<statsd::StatsdClient>(
+    ::g_stats_client = std::make_unique<StatsdClient>(
         m_node.args->GetArg("-statshost", DEFAULT_STATSD_HOST),
         m_node.args->GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
         m_node.args->GetArg("-statsport", DEFAULT_STATSD_PORT),

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -185,8 +185,9 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     InitScriptExecutionCache();
     ::g_stats_client = std::make_unique<StatsdClient>(
         m_node.args->GetArg("-statshost", DEFAULT_STATSD_HOST),
-        m_node.args->GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
         m_node.args->GetArg("-statsport", DEFAULT_STATSD_PORT),
+        m_node.args->GetArg("-statsduration", DEFAULT_STATSD_DURATION),
+        m_node.args->GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
         m_node.args->GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),
         m_node.args->GetBoolArg("-statsenabled", DEFAULT_STATSD_ENABLE)
     );

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -7,7 +7,7 @@
 #include <consensus/validation.h>
 #include <logging.h>
 #include <policy/policy.h>
-#include <statsd_client.h>
+#include <stats/client.h>
 
 #include <cassert>
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -66,7 +66,7 @@
 #include <llmq/instantsend.h>
 #include <llmq/chainlocks.h>
 
-#include <statsd_client.h>
+#include <stats/client.h>
 
 #include <algorithm>
 #include <cassert>

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -45,7 +45,7 @@ KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/rest.cpp:.*strtol"
-    "src/statsd_client.cpp:.*snprintf"
+    "src/stats/client.cpp:.*snprintf"
     "src/test/dbwrapper_tests.cpp:.*snprintf"
     "src/test/fuzz/locale.cpp"
     "src/test/fuzz/string.cpp"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -45,7 +45,6 @@ KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/rest.cpp:.*strtol"
-    "src/stats/client.cpp:.*snprintf"
     "src/test/dbwrapper_tests.cpp:.*snprintf"
     "src/test/fuzz/locale.cpp"
     "src/test/fuzz/string.cpp"

--- a/test/util/data/non-backported.txt
+++ b/test/util/data/non-backported.txt
@@ -29,7 +29,8 @@ src/rpc/quorums.cpp
 src/saltedhasher.*
 src/spork.*
 src/stacktraces.*
-src/statsd_client.*
+src/stats/*.cpp
+src/stats/*.h
 src/test/block_reward_reallocation_tests.cpp
 src/test/bls_tests.cpp
 src/test/dip0020opcodes_tests.cpp


### PR DESCRIPTION
## Motivation

This pull request achieves the goal originally set out in [dash#5167](https://github.com/dashpay/dash/pull/5167), to migrate the base of our Statsd client implementation to one that is actively maintained. Statoshi ([source](https://github.com/jlopp/statoshi/blob/54c3ffdcf0f85af1795d5398ca362744464a7b06/src/statsd_client.cpp)) utilizes [talebook/statsd-client-cpp](https://github.com/talebook/statsd-client-cpp), which in turn is inherited by Dash.

As Statsd is the only cross-platform reporting mechanism available (USDT requires a Linux host with superuser privileges and RPCs don't provide as much flexibility as desired), emphasis is placed on using Statsd as the primary way for the Dash daemon to report metrics related to node and network health.

As part of maintaining our Statsd client, this PR aims to migrate the base of our implementation to [vthiery/cpp-statsd-client](https://github.com/vthiery/cpp-statsd-client), a streamlined implementation that embraces C++11 with a thread-safe implementation of queueing and batching, which reduces the number of packets used to transmit stats.

These capabilities are optional and users can opt not to use them by setting `-statsduration=0` to disable queueing (which will also disable batching) or `-statsbatchsize=0`, which will disable batching (but will not disable queueing unless requested explicitly).

## Additional Information

* Dependent on https://github.com/dashpay/dash/pull/5167
* `RawSender` (and by extension, `RawMessage`) strive to remain as unopinionated as possible, moving the responsibility to construct valid Statsd messages onto `StatsdClient`. This is to ensure that  `RawSender` can be reused down the line or independently extended without impacting the Statsd client.
  * `RawMessage` exists to provide extensions to `std::vector<uint8_t>` that make it easier to abstract away strings while also implementing some of its semantics like `append()` (and its alias, `+=`).
* `InitStatsClient()` was introduced to keep `StatsdClient` indifferent to _how_ arguments are obtained and sanitized before they're supplied to the constructor. This is to keep it indifferent to all the backwards-compatibility code for deprecated arguments still work.
* When constructing the Statsd message, we can use `%f` without having to specify a precision as tinyformat automatically assumes a precision of 6 ([source](https://github.com/dashpay/dash/blob/17110f50b3adb1b8a51348259e752a760ab3ee0a/src/tinyformat.h#L673)) and problems don't seem to be observed when using `%f` with integers ([source](https://github.com/dashpay/dash/pull/6267#issuecomment-2345592051)). 
  * As a guardrail, there is a `static_assert` to ensure that a specialization of `send()` involving a non-arithmetic type will raise alarm when compiling ([source](https://github.com/dashpay/dash/blob/a0ce720207cf010cf8af8be7acd30561ed970b30/src/stats/client.cpp#L145)).

## Breaking changes

* `-statsenabled` (replaced with specifying `-statshost`), `-statshostname` (replaced by `-statssuffix`) and `-statsns` (replaced by `-statsprefix`) have been deprecated and will be removed in a future release.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
