### PR TITLE
feat: improvements for v19, v20 and dip3 - fire up test chains by first block 5/n

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -789,7 +789,7 @@ public:
         consensus.DIP0024Height = 900;
         consensus.DIP0024QuorumsHeight = 900;
         consensus.V19Height = 900;
-        consensus.V20Height = 1200;
+        consensus.V20Height = 900;
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -53,9 +53,6 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, const Chainstat
             }
             return CheckMNHFTx(chainman, qman, tx, pindexPrev, state);
         case TRANSACTION_ASSET_LOCK:
-            if (!DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_V20)) {
-                return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetlocks-before-v20");
-            }
             return CheckAssetLockUnlockTx(chainman.m_blockman, qman, tx, pindexPrev, indexes, state);
         case TRANSACTION_ASSET_UNLOCK:
             if (Params().NetworkIDString() == CBaseChainParams::REGTEST && !DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_V20)) {

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -55,12 +55,8 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, const Chainstat
         case TRANSACTION_ASSET_LOCK:
             return CheckAssetLockUnlockTx(chainman.m_blockman, qman, tx, pindexPrev, indexes, state);
         case TRANSACTION_ASSET_UNLOCK:
-            if (Params().NetworkIDString() == CBaseChainParams::REGTEST && !DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_V20)) {
-                // TODO:  adjust functional tests to make it activated by MN_RR on regtest too
+            if (!DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_V20)) {
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetunlocks-before-v20");
-            }
-            if (Params().NetworkIDString() != CBaseChainParams::REGTEST && !DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_MN_RR)) {
-                return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetunlocks-before-mn_rr");
             }
             return CheckAssetLockUnlockTx(chainman.m_blockman, qman, tx, pindexPrev, indexes, state);
         }

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -48,9 +48,6 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, const Chainstat
         case TRANSACTION_QUORUM_COMMITMENT:
             return llmq::CheckLLMQCommitment(dmnman, chainman, tx, pindexPrev, state);
         case TRANSACTION_MNHF_SIGNAL:
-            if (!DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_V20)) {
-                return state.Invalid(TxValidationResult::TX_CONSENSUS, "mnhf-before-v20");
-            }
             return CheckMNHFTx(chainman, qman, tx, pindexPrev, state);
         case TRANSACTION_ASSET_LOCK:
             return CheckAssetLockUnlockTx(chainman.m_blockman, qman, tx, pindexPrev, indexes, state);

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -52,9 +52,6 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, const Chainstat
         case TRANSACTION_ASSET_LOCK:
             return CheckAssetLockUnlockTx(chainman.m_blockman, qman, tx, pindexPrev, indexes, state);
         case TRANSACTION_ASSET_UNLOCK:
-            if (!DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_V20)) {
-                return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetunlocks-before-v20");
-            }
             return CheckAssetLockUnlockTx(chainman.m_blockman, qman, tx, pindexPrev, indexes, state);
         }
     } catch (const std::exception& e) {

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -36,9 +36,7 @@ struct TestChainBRRBeforeActivationSetup : public TestChainSetup
 {
     // Force fast DIP3 activation
     TestChainBRRBeforeActivationSetup() :
-        TestChainSetup(497, {"-dip3params=30:50",
-                             "-testactivationheight=brr@1000",
-                             "-testactivationheight=v20@1200",
+        TestChainSetup(497, {"-dip3params=30:50", "-testactivationheight=brr@1000", "-testactivationheight=v20@1200",
                              "-vbparams=mn_rr:0:999999999999:0:20:16:12:5:1"})
     {
     }

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -36,7 +36,9 @@ struct TestChainBRRBeforeActivationSetup : public TestChainSetup
 {
     // Force fast DIP3 activation
     TestChainBRRBeforeActivationSetup() :
-        TestChainSetup(497, {"-dip3params=30:50", "-testactivationheight=brr@1000",
+        TestChainSetup(497, {"-dip3params=30:50",
+                             "-testactivationheight=brr@1000",
+                             "-testactivationheight=v20@1200",
                              "-vbparams=mn_rr:0:999999999999:0:20:16:12:5:1"})
     {
     }

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -814,6 +814,38 @@ void FuncVerifyDB(TestChainSetup& setup)
 
 BOOST_AUTO_TEST_SUITE(evo_dip3_activation_tests)
 
+struct TestChainDIP3Setup : public TestChainSetup
+{
+    TestChainDIP3Setup() : TestChainSetup(431) {}
+};
+
+struct TestChainDIP3BeforeActivationSetup : public TestChainSetup
+{
+    TestChainDIP3BeforeActivationSetup() : TestChainSetup(430) {}
+};
+
+struct TestChainV19BeforeActivationSetup : public TestChainSetup
+{
+    TestChainV19BeforeActivationSetup();
+};
+
+struct TestChainV19Setup : public TestChainSetup
+{
+    TestChainV19Setup() : TestChainSetup(899)
+    {
+        bool v19_just_activated{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19) &&
+                                !DeploymentActiveAt(*m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
+        assert(v19_just_activated);
+    }
+};
+
+// 5 blocks earlier
+TestChainV19BeforeActivationSetup::TestChainV19BeforeActivationSetup() : TestChainSetup(894)
+{
+    bool v19_active{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
+    assert(!v19_active);
+}
+
 // DIP3 can only be activated with legacy scheme (v19 is activated later)
 BOOST_AUTO_TEST_CASE(dip3_activation_legacy)
 {

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -814,14 +814,18 @@ void FuncVerifyDB(TestChainSetup& setup)
 
 BOOST_AUTO_TEST_SUITE(evo_dip3_activation_tests)
 
-struct TestChainDIP3Setup : public TestChainSetup
-{
-    TestChainDIP3Setup() : TestChainSetup(431) {}
-};
-
 struct TestChainDIP3BeforeActivationSetup : public TestChainSetup
 {
     TestChainDIP3BeforeActivationSetup() : TestChainSetup(430) {}
+};
+
+struct TestChainDIP3Setup : public TestChainDIP3BeforeActivationSetup
+{
+    TestChainDIP3Setup()
+    {
+        // Activate DIP3 here
+        CreateAndProcessBlock({}, coinbaseKey);
+    }
 };
 
 struct TestChainV19BeforeActivationSetup : public TestChainSetup
@@ -829,10 +833,14 @@ struct TestChainV19BeforeActivationSetup : public TestChainSetup
     TestChainV19BeforeActivationSetup();
 };
 
-struct TestChainV19Setup : public TestChainSetup
+struct TestChainV19Setup : public TestChainV19BeforeActivationSetup
 {
-    TestChainV19Setup() : TestChainSetup(899)
+    TestChainV19Setup()
     {
+        // Activate V19
+        for (int i = 0; i < 5; ++i) {
+            CreateAndProcessBlock({}, coinbaseKey);
+        }
         bool v19_just_activated{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19) &&
                                 !DeploymentActiveAt(*m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
         assert(v19_just_activated);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -814,13 +814,14 @@ void FuncVerifyDB(TestChainSetup& setup)
 
 BOOST_AUTO_TEST_SUITE(evo_dip3_activation_tests)
 
-struct TestChainDIP3BeforeActivationSetup : public TestChainSetup
-{
-    TestChainDIP3BeforeActivationSetup() : TestChainSetup(430) {}
+struct TestChainDIP3BeforeActivationSetup : public TestChainSetup {
+    TestChainDIP3BeforeActivationSetup() :
+        TestChainSetup(430)
+    {
+    }
 };
 
-struct TestChainDIP3Setup : public TestChainDIP3BeforeActivationSetup
-{
+struct TestChainDIP3Setup : public TestChainDIP3BeforeActivationSetup {
     TestChainDIP3Setup()
     {
         // Activate DIP3 here
@@ -828,29 +829,31 @@ struct TestChainDIP3Setup : public TestChainDIP3BeforeActivationSetup
     }
 };
 
-struct TestChainV19BeforeActivationSetup : public TestChainSetup
-{
+struct TestChainV19BeforeActivationSetup : public TestChainSetup {
     TestChainV19BeforeActivationSetup();
 };
 
-struct TestChainV19Setup : public TestChainV19BeforeActivationSetup
-{
+struct TestChainV19Setup : public TestChainV19BeforeActivationSetup {
     TestChainV19Setup()
     {
         // Activate V19
         for (int i = 0; i < 5; ++i) {
             CreateAndProcessBlock({}, coinbaseKey);
         }
-        bool v19_just_activated{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19) &&
-                                !DeploymentActiveAt(*m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
+        bool v19_just_activated{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(),
+                                                      Consensus::DEPLOYMENT_V19) &&
+                                !DeploymentActiveAt(*m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(),
+                                                    Consensus::DEPLOYMENT_V19)};
         assert(v19_just_activated);
     }
 };
 
 // 5 blocks earlier
-TestChainV19BeforeActivationSetup::TestChainV19BeforeActivationSetup() : TestChainSetup(894)
+TestChainV19BeforeActivationSetup::TestChainV19BeforeActivationSetup() :
+    TestChainSetup(894)
 {
-    bool v19_active{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
+    bool v19_active{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(),
+                                          Consensus::DEPLOYMENT_V19)};
     assert(!v19_active);
 }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -358,14 +358,10 @@ TestChainSetup::TestChainSetup(int num_blocks, const std::vector<const char*>& e
             {  100, uint256S("0x6ffb83129c19ebdf1ae3771be6a67fe34b35f4c956326b9ba152fac1649f65ae") },
             /* TestChainDIP3BeforeActivationSetup */
             {  430, uint256S("0x0bcefaa33fec56cd84d05d0e76cd6a78badcc20f627d91903646de6a07930a14") },
-            /* TestChainDIP3Setup */
-            {  431, uint256S("0x5fd3aa5ef29464839499d7f847edd9362e3e73392b79d3bd88b1591f5fb17d4e") },
             /* TestChainBRRBeforeActivationSetup */
             {  497, uint256S("0x23c31820ec5160b7181bfdf328e2b76cd12c9fa4544d892b7f01e74dd6220849") },
             /* TestChainV19BeforeActivationSetup */
             {  894, uint256S("0x2885cf0fe8fdf29803b6c65002ba2570ff011531d8ea92be312a85d655e00c51") },
-            /* TestChainV19Setup */
-            {  899, uint256S("0x7df3c857ce647b3ecd0d4b389b6b0f16e2bdc60b20a8d01c4ad946fe5f15dbc2") },
         }
     };
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -571,16 +571,3 @@ CBlock getBlock13b8a()
     return block;
 }
 
-TestChainV19Setup::TestChainV19Setup() : TestChainSetup(899)
-{
-    bool v19_just_activated{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19) &&
-                            !DeploymentActiveAt(*m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
-    assert(v19_just_activated);
-}
-
-// 5 blocks earlier
-TestChainV19BeforeActivationSetup::TestChainV19BeforeActivationSetup() : TestChainSetup(894)
-{
-    bool v19_active{DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
-    assert(!v19_active);
-}

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -183,26 +183,6 @@ struct TestChain100Setup : public TestChainSetup {
     TestChain100Setup(const std::vector<const char*>& extra_args = {});
 };
 
-struct TestChainDIP3Setup : public TestChainSetup
-{
-    TestChainDIP3Setup() : TestChainSetup(431) {}
-};
-
-struct TestChainV19Setup : public TestChainSetup
-{
-    TestChainV19Setup();
-};
-
-struct TestChainDIP3BeforeActivationSetup : public TestChainSetup
-{
-    TestChainDIP3BeforeActivationSetup() : TestChainSetup(430) {}
-};
-
-struct TestChainV19BeforeActivationSetup : public TestChainSetup
-{
-    TestChainV19BeforeActivationSetup();
-};
-
 /**
  * Make a test setup that has disk access to the debug.log file disabled. Can
  * be used in "hot loops", for example fuzzing or benchmarking.

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -242,8 +242,8 @@ class AssetLocksTest(DashTestFramework):
 
         self.set_sporks()
 
-        self.activate_v19(expected_activation_height=900)
-        self.log.info("Activated v19 at height:" + str(node.getblockcount()))
+        self.activate_v20(expected_activation_height=900)
+        self.log.info("Activated v20 at height:" + str(node.getblockcount()))
 
         self.nodes[0].sporkupdate("SPORK_2_INSTANTSEND_ENABLED", 0)
         self.wait_for_sporks_same()
@@ -256,7 +256,6 @@ class AssetLocksTest(DashTestFramework):
             self.sync_blocks()
 
         self.set_sporks()
-        self.activate_v20()
         node.generate(1)
         self.sync_all()
         self.mempool_size = 0
@@ -640,7 +639,7 @@ class AssetLocksTest(DashTestFramework):
         all_mn_rewards = platform_reward + owner_reward + operator_reward
         assert_equal(all_mn_rewards, bt['coinbasevalue'] * 3 // 4)  # 75/25 mn/miner reward split
         assert_equal(platform_reward, all_mn_rewards * 375 // 1000)  # 0.375 platform share
-        assert_equal(platform_reward, 31916328)
+        assert_equal(platform_reward, 37015386)
         assert_equal(locked, self.get_credit_pool_balance())
         node.generate(1)
         self.sync_all()

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -85,12 +85,12 @@ class FullBlockTest(BitcoinTestFramework):
         # Very large reorgs cause cs_main to be held for a very long time in ActivateBestChainStep,
         # which causes RPC to hang, so we need to increase RPC timeouts
         self.rpc_timeout = 180
-        # Must set '-dip3params=2000:2000' to create pre-dip3 blocks only
         self.extra_args = [[
-            '-dip3params=2000:2000',
+            '-dip3params=2000:2000', # Must set '-dip3params=2000:2000' to create pre-dip3 blocks only
             '-acceptnonstdtxn=1',  # This is a consensus block test, we don't care about tx policy
             '-testactivationheight=bip34@2',
             '-testactivationheight=dip0001@2000',
+            '-testactivationheight=v20@2000',
         ]]
 
     def setup_nodes(self):

--- a/test/functional/feature_blockfilterindex_prune.py
+++ b/test/functional/feature_blockfilterindex_prune.py
@@ -43,7 +43,7 @@ class FeatureBlockfilterindexPruneTest(BitcoinTestFramework):
         assert_greater_than(len(self.nodes[0].getblockfilter(self.nodes[0].getblockhash(2))['filter']), 0)
 
         self.log.info("start node without blockfilterindex")
-        self.restart_node(0, extra_args=["-fastprune", "-prune=1"], expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
+        self.restart_node(0, extra_args=["-fastprune", "-prune=1", '-testactivationheight=v20@2000'], expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
 
         self.log.info("make sure accessing the blockfilters throws an error")
         assert_raises_rpc_error(-1, "Index is not enabled for filtertype basic", self.nodes[0].getblockfilter, self.nodes[0].getblockhash(2))

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -46,7 +46,7 @@ class DIP3V19Test(DashTestFramework):
         self.extra_args = [[
             '-testactivationheight=v20@1200', # required otherwise mine_quorum("llmq_test [100]") fails
         ]] * 6
-        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True, evo_count=2, extra_args=self.extra_args)
+        self.set_dash_test_params(6, 5, evo_count=2, extra_args=self.extra_args)
 
     def run_test(self):
         # Connect all nodes to node1 so that we always have the whole network connected

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -43,7 +43,10 @@ class TestP2PConn(P2PInterface):
 
 class DIP3V19Test(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True, evo_count=2)
+        self.extra_args = [[
+            '-testactivationheight=v20@1200', # required otherwise mine_quorum("llmq_test [100]") fails
+        ]] * 6
+        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True, evo_count=2, extra_args=self.extra_args)
 
     def run_test(self):
         # Connect all nodes to node1 so that we always have the whole network connected

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -44,7 +44,7 @@ class TestP2PConn(P2PInterface):
 class LLMQCoinbaseCommitmentsTest(DashTestFramework):
     def set_test_params(self):
         self.extra_args = [[ f'-testactivationheight=dip0008@{DIP0008_HEIGHT}', "-vbparams=testdummy:999999999999:999999999999" ]] * 4
-        self.set_dash_test_params(4, 3, extra_args = self.extra_args, fast_dip3_enforcement=True)
+        self.set_dash_test_params(4, 3, extra_args = self.extra_args)
     def run_test(self):
         # No IS or Chainlocks in this test
         self.bump_mocktime(1)

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -18,7 +18,7 @@ class DashGovernanceTest (DashTestFramework):
         self.set_dash_test_params(6, 5, [[
             "-budgetparams=10:10:10",
             '-testactivationheight=v20@160',
-        ]] * 6, fast_dip3_enforcement=True)
+        ]] * 6)
 
     def check_superblockbudget(self, v20_active):
         v20_state = self.nodes[0].getblockchaininfo()["softforks"]["v20"]

--- a/test/functional/feature_governance_cl.py
+++ b/test/functional/feature_governance_cl.py
@@ -14,7 +14,7 @@ from test_framework.util import assert_equal, satoshi_round
 
 class DashGovernanceTest (DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 5, [["-budgetparams=10:10:10"]] * 6, fast_dip3_enforcement=True)
+        self.set_dash_test_params(6, 5, [["-budgetparams=10:10:10"]] * 6)
 
     def prepare_object(self, object_type, parent_hash, creation_time, revision, name, amount, payment_address):
         proposal_rev = revision

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -33,7 +33,7 @@ class LLMQChainLocksTest(DashTestFramework):
 
         self.test_coinbase_best_cl(self.nodes[0], expected_cl_in_cb=False)
 
-        self.activate_v20(expected_activation_height=1200)
+        self.activate_v20(expected_activation_height=900)
         self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
 
         # v20 is active for the next block, not for the tip

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -20,7 +20,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error, force_fin
 
 class LLMQChainLocksTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(5, 4, fast_dip3_enforcement=True)
+        self.set_dash_test_params(5, 4)
 
     def run_test(self):
 

--- a/test/functional/feature_llmq_connections.py
+++ b/test/functional/feature_llmq_connections.py
@@ -17,7 +17,7 @@ from test_framework.util import assert_greater_than_or_equal
 
 class LLMQConnections(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(15, 14, fast_dip3_enforcement=True)
+        self.set_dash_test_params(15, 14)
         self.set_dash_llmq_test_params(5, 3)
         # Probes should age after this many seconds.
         # NOTE: mine_quorum() can bump mocktime quite often internally so make sure this number is high enough.

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -25,7 +25,7 @@ llmq_type_strings = {llmq_test: 'llmq_test', llmq_test_v17: 'llmq_test_v17'}
 class QuorumDataRecoveryTest(DashTestFramework):
     def set_test_params(self):
         extra_args = [["-vbparams=testdummy:0:999999999999:0:10:8:6:5:-1"] for _ in range(9)]
-        self.set_dash_test_params(9, 7, fast_dip3_enforcement=True, extra_args=extra_args)
+        self.set_dash_test_params(9, 7, extra_args=extra_args)
         self.set_dash_llmq_test_params(4, 3)
 
     def restart_mn(self, mn, reindex=False, qvvec_sync=None, qdata_recovery_enabled=True):

--- a/test/functional/feature_llmq_dkgerrors.py
+++ b/test/functional/feature_llmq_dkgerrors.py
@@ -14,7 +14,7 @@ Simulate and check DKG errors
 
 class LLMQDKGErrors(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(4, 3, [["-whitelist=127.0.0.1"]] * 4, fast_dip3_enforcement=True)
+        self.set_dash_test_params(4, 3, [["-whitelist=127.0.0.1"]] * 4)
 
     def run_test(self):
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -46,7 +46,7 @@ class TestP2PConn(P2PInterface):
 
 class LLMQEvoNodesTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(5, 4, fast_dip3_enforcement=True, evo_count=5)
+        self.set_dash_test_params(5, 4, evo_count=5)
         self.set_dash_llmq_test_params(4, 4)
 
     def run_test(self):

--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -49,7 +49,7 @@ class TestP2PConn(P2PInterface):
 
 class LLMQ_IS_CL_Conflicts(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(5, 4, fast_dip3_enforcement=True)
+        self.set_dash_test_params(5, 4)
         self.set_dash_llmq_test_params(4, 4)
         self.supports_cli = False
 

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -22,7 +22,7 @@ from test_framework.util import set_node_times
 class LLMQ_IS_RetroactiveSigning(DashTestFramework):
     def set_test_params(self):
         # -whitelist is needed to avoid the trickling logic on node0
-        self.set_dash_test_params(5, 4, [["-whitelist=127.0.0.1"], [], [], [], ["-minrelaytxfee=0.001"]], fast_dip3_enforcement=True)
+        self.set_dash_test_params(5, 4, [["-whitelist=127.0.0.1"], [], [], [], ["-minrelaytxfee=0.001"]])
 
     def run_test(self):
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -51,7 +51,7 @@ class TestP2PConn(P2PInterface):
 
 class LLMQQuorumRotationTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(9, 8, fast_dip3_enforcement=True)
+        self.set_dash_test_params(9, 8)
         self.set_dash_llmq_test_params(4, 4)
 
     def run_test(self):

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -113,9 +113,9 @@ class LLMQQuorumRotationTest(DashTestFramework):
         expectedNew = [h_100_0, h_106_0, h_104_0, h_100_1, h_106_1, h_104_1]
         quorumList = self.test_getmnlistdiff_quorums(b_h_0, b_h_1, {}, expectedDeleted, expectedNew, testQuorumsCLSigs=False)
 
-        projected_activation_height = 1200
+        projected_activation_height = 900
 
-        self.activate_v20(expected_activation_height=1200)
+        self.activate_v20(expected_activation_height=900)
         self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
 
         softfork_info = self.nodes[0].getblockchaininfo()['softforks']['v20']

--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -18,7 +18,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error, force_fin
 
 class LLMQSigningTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True)
+        self.set_dash_test_params(6, 5)
         self.set_dash_llmq_test_params(5, 3)
 
     def add_options(self, parser):

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -18,7 +18,7 @@ from test_framework.util import assert_equal, force_finish_mnsync, p2p_port
 
 class LLMQSimplePoSeTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True)
+        self.set_dash_test_params(6, 5)
         self.set_dash_llmq_test_params(5, 3)
 
     def run_test(self):

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -25,7 +25,7 @@ from test_framework.util import (
 class MnehfTest(DashTestFramework):
     def set_test_params(self):
         extra_args = [["-vbparams=testdummy:0:999999999999:0:12:12:12:5:1", "-persistmempool=0"] for _ in range(4)]
-        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True, extra_args=extra_args)
+        self.set_dash_test_params(4, 3, extra_args=extra_args)
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -27,7 +27,7 @@ def notify_outputname(walletname, txid):
 
 class NotificationsTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 4, fast_dip3_enforcement=True)
+        self.set_dash_test_params(6, 4)
 
     def setup_network(self):
         self.wallet = ''.join(chr(i) for i in range(FILE_CHAR_START, FILE_CHAR_END) if chr(i) not in FILE_CHARS_DISALLOWED)

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -108,7 +108,7 @@ class DashZMQTest (DashTestFramework):
 
         extra_args = [[]] * 5
         extra_args[0] = node0_extra_args
-        self.set_dash_test_params(5, 4, fast_dip3_enforcement=True, extra_args=extra_args)
+        self.set_dash_test_params(5, 4, extra_args=extra_args)
         self.set_dash_llmq_test_params(4, 4)
 
     def skip_test_if_missing_module(self):

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -48,7 +48,7 @@ class P2PStaller(P2PDataStore):
 class P2PIBDStallingTest(BitcoinTestFramework):
     def set_test_params(self):
         self.disable_mocktime = True
-        self.extra_args = [["-dip3params=2000:2000"]]
+        self.extra_args = [["-dip3params=2000:2000", "-testactivationheight=v20@2000"]]
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/p2p_instantsend.py
+++ b/test/functional/p2p_instantsend.py
@@ -14,7 +14,7 @@ Tests InstantSend functionality (prevent doublespend for unconfirmed transaction
 
 class InstantSendTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(8, 4, fast_dip3_enforcement=True)
+        self.set_dash_test_params(8, 4)
         # set sender,  receiver,  isolated nodes
         self.isolated_idx = 1
         self.receiver_idx = 2

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -118,7 +118,7 @@ class QuorumDataInterface(P2PInterface):
 class QuorumDataMessagesTest(DashTestFramework):
     def set_test_params(self):
         extra_args = [["-llmq-data-recovery=0", "-deprecatedrpc=banscore"]] * 4
-        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True, extra_args=extra_args)
+        self.set_dash_test_params(4, 3, extra_args=extra_args)
 
     def restart_mn(self, mn, reindex=False):
         args = self.extra_args[mn.node.index] + ['-masternodeblsprivkey=%s' % mn.keyOperator]

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -155,7 +155,7 @@ class BlockchainTest(BitcoinTestFramework):
             'dip0024': { 'type': 'buried', 'active': False, 'height': 900},
             'realloc': { 'type': 'buried', 'active': True, 'height': 1},
             'v19': { 'type': 'buried', 'active': False, 'height': 900},
-            'v20': { 'type': 'buried', 'active': False, 'height': 1200},
+            'v20': { 'type': 'buried', 'active': False, 'height': 900},
             'mn_rr': {
                 'type': 'bip9',
                 'bip9': {

--- a/test/functional/rpc_masternode.py
+++ b/test/functional/rpc_masternode.py
@@ -13,7 +13,7 @@ Test "masternode" rpc subcommands
 
 class RPCMasternodeTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
+        self.set_dash_test_params(4, 3)
 
     def run_test(self):
         self.log.info("test that results from `winners` and `payments` RPCs match")

--- a/test/functional/rpc_mnauth.py
+++ b/test/functional/rpc_mnauth.py
@@ -17,7 +17,7 @@ Tests mnauth RPC command
 
 class FakeMNAUTHTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(2, 1, fast_dip3_enforcement=True)
+        self.set_dash_test_params(2, 1)
 
     def run_test(self):
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -41,7 +41,7 @@ def assert_net_servicesnames(servicesflag, servicenames):
 
 class NetTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(3, 1, fast_dip3_enforcement=True)
+        self.set_dash_test_params(3, 1)
         self.supports_cli = False
 
     def run_test(self):

--- a/test/functional/rpc_quorum.py
+++ b/test/functional/rpc_quorum.py
@@ -13,7 +13,7 @@ Test "quorum" rpc subcommands
 
 class RPCMasternodeTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
+        self.set_dash_test_params(4, 3)
 
     def run_test(self):
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -19,7 +19,7 @@ Test the following RPC:
 class RPCVerifyChainLockTest(DashTestFramework):
     def set_test_params(self):
         # -whitelist is needed to avoid the trickling logic on node0
-        self.set_dash_test_params(5, 3, [["-whitelist=127.0.0.1"], [], [], [], []], fast_dip3_enforcement=True)
+        self.set_dash_test_params(5, 3, [["-whitelist=127.0.0.1"], [], [], [], []])
         self.set_dash_llmq_test_params(3, 2)
 
     def cl_helper(self, height, chainlock, mempool):

--- a/test/functional/rpc_verifyislock.py
+++ b/test/functional/rpc_verifyislock.py
@@ -17,7 +17,7 @@ Test verifyislock rpc
 class RPCVerifyISLockTest(DashTestFramework):
     def set_test_params(self):
         # -whitelist is needed to avoid the trickling logic on node0
-        self.set_dash_test_params(6, 5, [["-whitelist=127.0.0.1"], [], [], [], [], []], fast_dip3_enforcement=True)
+        self.set_dash_test_params(6, 5, [["-whitelist=127.0.0.1"], [], [], [], [], []])
 
     def get_request_id(self, tx_hex):
         tx = from_hex(CTransaction(), tx_hex)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1108,7 +1108,7 @@ class DashTestFramework(BitcoinTestFramework):
             if mn2.node is not None:
                 mn2.node.setmnthreadactive(True)
 
-    def set_dash_test_params(self, num_nodes, masterodes_count, extra_args=None, fast_dip3_enforcement=False, evo_count=0):
+    def set_dash_test_params(self, num_nodes, masterodes_count, extra_args=None, evo_count=0):
         self.mn_count = masterodes_count
         self.evo_count = evo_count
         self.num_nodes = num_nodes
@@ -1120,10 +1120,8 @@ class DashTestFramework(BitcoinTestFramework):
         assert_equal(len(extra_args), num_nodes)
         self.extra_args = [copy.deepcopy(a) for a in extra_args]
         self.extra_args[0] += ["-sporkkey=cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"]
-        self.fast_dip3_enforcement = fast_dip3_enforcement
-        if fast_dip3_enforcement:
-            for i in range(0, num_nodes):
-                self.extra_args[i].append("-dip3params=30:50")
+        for i in range(0, num_nodes):
+            self.extra_args[i].append("-dip3params=2:2")
 
         # LLMQ default test params (no need to pass -llmqtestparams)
         self.llmq_size = 3
@@ -1481,12 +1479,6 @@ class DashTestFramework(BitcoinTestFramework):
         while self.nodes[0].getbalance() < required_balance:
             self.bump_mocktime(1)
             self.nodes[0].generate(10)
-
-        self.log.info("Activating DIP3")
-        if not self.fast_dip3_enforcement:
-            while self.nodes[0].getblockcount() < 500:
-                self.nodes[0].generate(10)
-        self.sync_all()
 
         # create masternodes
         self.prepare_masternodes()


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR is 5th in the achieving ultimate goal to activate old forks from block 1.
It helps to run unit and functional tests faster; it helps for platform's dev-environment to start faster. 

## What was done?
 - v20 on RegTest is activated from same block as v19 (height 1200 changed to 900)
 - relaxed condition for special transactions Asset Lock (can be mined any block so far as v20 is activated long time ago).
 - unify code for regtest, mainnet, testnet for Asset Unlock validation
 - removed 2 checkpoints: TestChainDIP3Setup and TestChainV19Setup from unit tests which make further changes for forks easier
 - enforced flag `fast_dip3_enforcement=True` from functional tests which is always true

## How Has This Been Tested?
Run unit and functional tests

`tsan` job runs  500 seconds faster of real time and 2000seconds faster for "accumulated time"
https://gitlab.com/dashpay/dash/-/jobs/7817453421 - this PR
https://gitlab.com/dashpay/dash/-/jobs/7805625816 - some old PR for reference

No breakdown per tests here, because they affect each other and runs in parallel.

## Breaking Changes
Regtest has v20 activated on same block as v19 if otherwise is not specified with `-testactivationheight=v20@1200`

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone