### PR TITLE
fix: remove mn_rr fork usage from functional test of EHF

### DIFF
--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -231,10 +231,7 @@ std::optional<CMNHFManager::Signals> CMNHFManager::ProcessBlock(const CBlock& bl
             return signals;
         }
         for (const auto& versionBit : new_signals) {
-            if (Params().IsValidMNActivation(versionBit, pindex->GetMedianTimePast())) {
-                signals.insert({versionBit, mined_height});
-            }
-
+            signals.insert({versionBit, mined_height});
         }
 
         AddToCache(signals, pindex);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Using mn_rr in feature_mnehf.py is a blocker for burying mn_rr fork.

## What was done?
Removed useless conditions, uses testdummy fork instead mn_rr in ehf functional test.

## How Has This Been Tested?
Run it `test/functional/feature_mnehf.py`

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone