### PR TITLE
backport: merge bitcoin#27015 (resolve flaky addrman unit test)

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -117,7 +117,7 @@ public:
     * @param[in] in_new           Select addresses only from one table (true = new, false = tried, nullopt = both)
     * @return                     Number of unique addresses that match specified options.
     */
-    size_t Size(std::optional<Network> net = {}, std::optional<bool> in_new = {}) const;
+    size_t Size(std::optional<Network> net = std::nullopt, std::optional<bool> in_new = std::nullopt) const;
 
     /**
      * Attempt to add one or more addresses to addrman's new table.

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -1035,8 +1035,6 @@ BOOST_AUTO_TEST_CASE(load_addrman_corrupted)
     } catch (const std::exception&) {
         exceptionThrown = true;
     }
-    // Even though de-serialization failed addrman is not left in a clean state.
-    BOOST_CHECK(addrman1.Size() == 1);
     BOOST_CHECK(exceptionThrown);
 
     // Test that ReadFromStream fails if peers.dat is corrupt


### PR DESCRIPTION
## Additional Information

As part of [dash#6254](https://github.com/dashpay/dash/pull/6254), [bitcoin#26847](https://github.com/bitcoin/bitcoin/pull/26847) was backported and since then, it was observed that unit tests were flakier than expected ([build](https://gitlab.com/dashpay/dash/-/jobs/7811041841), [build](https://gitlab.com/dashpay/dash/-/jobs/7802460298)).

The flakiness was caused by behavior introduced by the aforementioned backport, this was resolved upstream with [bitcoin#27015](https://github.com/bitcoin/bitcoin/pull/27015), which this pull request contains.

## Breaking Changes

None observed.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

