### PR TITLE
refactor: drop some of circular dependencies over dkgsession

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -8,6 +8,7 @@
 #include <llmq/chainlocks.h>
 #include <llmq/commitment.h>
 #include <llmq/options.h>
+#include <llmq/quorums.h>
 #include <node/blockstorage.h>
 #include <evo/simplifiedmns.h>
 #include <evo/specialtx.h>

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -2,17 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/validation.h>
 #include <evo/cbtx.h>
 #include <evo/deterministicmns.h>
+#include <evo/simplifiedmns.h>
+#include <evo/specialtx.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/chainlocks.h>
 #include <llmq/commitment.h>
 #include <llmq/options.h>
 #include <llmq/quorums.h>
 #include <node/blockstorage.h>
-#include <evo/simplifiedmns.h>
-#include <evo/specialtx.h>
-#include <consensus/validation.h>
 
 #include <chain.h>
 #include <chainparams.h>

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -6,6 +6,7 @@
 
 #include <evo/assetlocktx.h>
 #include <evo/cbtx.h>
+#include <evo/evodb.h>
 #include <evo/specialtx.h>
 
 #include <chain.h>

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -8,7 +8,6 @@
 #include <coins.h>
 
 #include <evo/assetlocktx.h>
-#include <evo/evodb.h>
 
 #include <saltedhasher.h>
 #include <serialize.h>
@@ -23,6 +22,7 @@
 class BlockManager;
 class CBlockIndex;
 class BlockValidationState;
+class CEvoDB;
 class TxValidationState;
 namespace Consensus {
 struct Params;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <evo/evodb.h>
 #include <evo/deterministicmns.h>
 #include <evo/dmn_types.h>
 #include <evo/dmnstate.h>
+#include <evo/evodb.h>
 #include <evo/providertx.h>
 #include <evo/specialtx.h>
 #include <llmq/commitment.h>

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <evo/evodb.h>
 #include <evo/deterministicmns.h>
 #include <evo/dmn_types.h>
 #include <evo/dmnstate.h>

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -8,10 +8,10 @@
 #include <evo/dmnstate.h>
 
 #include <arith_uint256.h>
+#include <clientversion.h>
 #include <consensus/params.h>
 #include <crypto/common.h>
 #include <evo/dmn_types.h>
-#include <evo/evodb.h>
 #include <evo/providertx.h>
 #include <saltedhasher.h>
 #include <scheduler.h>
@@ -30,6 +30,7 @@ class CBlock;
 class CBlockIndex;
 class CChainState;
 class CConnman;
+class CEvoDB;
 class TxValidationState;
 
 extern RecursiveMutex cs_main;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -13,10 +13,10 @@
 #include <crypto/common.h>
 #include <evo/dmn_types.h>
 #include <evo/providertx.h>
+#include <gsl/pointers.h>
 #include <saltedhasher.h>
 #include <scheduler.h>
 #include <sync.h>
-#include <gsl/pointers.h>
 
 #include <immer/map.hpp>
 

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -4,6 +4,7 @@
 
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
+#include <evo/evodb.h>
 #include <evo/mnhftx.h>
 #include <evo/specialtx.h>
 #include <llmq/commitment.h>

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -8,8 +8,8 @@
 #include <evo/mnhftx.h>
 #include <evo/specialtx.h>
 #include <llmq/commitment.h>
-#include <llmq/signing.h>
 #include <llmq/quorums.h>
+#include <llmq/signing.h>
 #include <node/blockstorage.h>
 
 #include <chain.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -90,6 +90,7 @@
 #include <spork.h>
 #include <walletinitinterface.h>
 
+#include <evo/evodb.h>
 #include <evo/chainhelper.h>
 #include <evo/creditpool.h>
 #include <evo/deterministicmns.h>

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -9,7 +9,6 @@
 
 #include <crypto/common.h>
 #include <llmq/signing.h>
-#include <llmq/quorums.h>
 #include <net.h>
 #include <net_types.h>
 #include <primitives/block.h>
@@ -36,6 +35,7 @@ namespace llmq
 {
 class CSigningManager;
 class CSigSharesManager;
+enum class VerifyRecSigStatus;
 
 class CChainLocksHandler : public CRecoveredSigsListener
 {

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -33,7 +33,10 @@ namespace llmq
 {
 
 CDKGLogger::CDKGLogger(const CDKGSession& _quorumDkg, std::string_view _func, int source_line) :
-    CBatchedLogger(BCLog::LLMQ_DKG, strprintf("QuorumDKG(type=%s, qIndex=%d, h=%d, member=%d)", _quorumDkg.params.name, _quorumDkg.quorumIndex, _quorumDkg.m_quorum_base_block_index->nHeight, _quorumDkg.AreWeMember()), __FILE__, source_line)
+    CBatchedLogger(BCLog::LLMQ_DKG,
+                   strprintf("QuorumDKG(type=%s, qIndex=%d, h=%d, member=%d)", _quorumDkg.params.name, _quorumDkg.quorumIndex,
+                             _quorumDkg.m_quorum_base_block_index->nHeight, _quorumDkg.AreWeMember()),
+                   __FILE__, source_line)
 {
 }
 
@@ -68,12 +71,21 @@ CDKGMember::CDKGMember(const CDeterministicMNCPtr& _dmn, size_t _idx) :
 
 }
 
-CDKGSession::CDKGSession(const CBlockIndex* pQuorumBaseBlockIndex, const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CConnman& _connman,
-                         CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager,
+CDKGSession::CDKGSession(const CBlockIndex* pQuorumBaseBlockIndex, const Consensus::LLMQParams& _params,
+                         CBLSWorker& _blsWorker, CConnman& _connman, CDeterministicMNManager& dmnman,
+                         CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager,
                          CMasternodeMetaMan& mn_metaman, const CActiveMasternodeManager* const mn_activeman,
                          const CSporkManager& sporkman) :
-    params(_params), blsWorker(_blsWorker), cache(_blsWorker), connman(_connman), m_dmnman(dmnman), dkgManager(_dkgManager),
-    dkgDebugManager(_dkgDebugManager), m_mn_metaman(mn_metaman), m_mn_activeman(mn_activeman), m_sporkman(sporkman),
+    params(_params),
+    blsWorker(_blsWorker),
+    cache(_blsWorker),
+    connman(_connman),
+    m_dmnman(dmnman),
+    dkgManager(_dkgManager),
+    dkgDebugManager(_dkgDebugManager),
+    m_mn_metaman(mn_metaman),
+    m_mn_activeman(mn_activeman),
+    m_sporkman(sporkman),
     m_quorum_base_block_index{pQuorumBaseBlockIndex}
 {
 }

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -33,12 +33,7 @@ namespace llmq
 {
 
 CDKGLogger::CDKGLogger(const CDKGSession& _quorumDkg, std::string_view _func, int source_line) :
-    CDKGLogger(_quorumDkg.params.name, _quorumDkg.quorumIndex, _quorumDkg.m_quorum_base_block_index->GetBlockHash(), _quorumDkg.m_quorum_base_block_index->nHeight, _quorumDkg.AreWeMember(), _func, source_line)
-{
-}
-
-CDKGLogger::CDKGLogger(std::string_view _llmqTypeName, int _quorumIndex, const uint256& _quorumHash, int _height, bool _areWeMember, std::string_view _func, int source_line) :
-    CBatchedLogger(BCLog::LLMQ_DKG, strprintf("QuorumDKG(type=%s, qIndex=%d, h=%d, member=%d)", _llmqTypeName, _quorumIndex, _height, _areWeMember), __FILE__, source_line)
+    CBatchedLogger(BCLog::LLMQ_DKG, strprintf("QuorumDKG(type=%s, qIndex=%d, h=%d, member=%d)", _quorumDkg.params.name, _quorumDkg.quorumIndex, _quorumDkg.m_quorum_base_block_index->nHeight, _quorumDkg.AreWeMember()), __FILE__, source_line)
 {
 }
 

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -259,11 +259,9 @@ bool CDKGSession::PreVerifyMessage(const CDKGContribution& qc, bool& retBan) con
     return true;
 }
 
-void CDKGSession::ReceiveMessage(const CDKGContribution& qc, bool& retBan)
+void CDKGSession::ReceiveMessage(const CDKGContribution& qc)
 {
     CDKGLogger logger(*this, __func__, __LINE__);
-
-    retBan = false;
 
     auto* member = GetMember(qc.proTxHash);
 
@@ -569,11 +567,9 @@ bool CDKGSession::PreVerifyMessage(const CDKGComplaint& qc, bool& retBan) const
     return true;
 }
 
-void CDKGSession::ReceiveMessage(const CDKGComplaint& qc, bool& retBan)
+void CDKGSession::ReceiveMessage(const CDKGComplaint& qc)
 {
     CDKGLogger logger(*this, __func__, __LINE__);
-
-    retBan = false;
 
     logger.Batch("received complaint from %s", qc.proTxHash.ToString());
 
@@ -780,11 +776,9 @@ bool CDKGSession::PreVerifyMessage(const CDKGJustification& qj, bool& retBan) co
     return true;
 }
 
-void CDKGSession::ReceiveMessage(const CDKGJustification& qj, bool& retBan)
+void CDKGSession::ReceiveMessage(const CDKGJustification& qj)
 {
     CDKGLogger logger(*this, __func__, __LINE__);
-
-    retBan = false;
 
     logger.Batch("received justification from %s", qj.proTxHash.ToString());
 
@@ -1095,11 +1089,9 @@ bool CDKGSession::PreVerifyMessage(const CDKGPrematureCommitment& qc, bool& retB
     return true;
 }
 
-void CDKGSession::ReceiveMessage(const CDKGPrematureCommitment& qc, bool& retBan)
+void CDKGSession::ReceiveMessage(const CDKGPrematureCommitment& qc)
 {
     CDKGLogger logger(*this, __func__, __LINE__);
-
-    retBan = false;
 
     cxxtimer::Timer t1(true);
 

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -68,8 +68,19 @@ CDKGMember::CDKGMember(const CDeterministicMNCPtr& _dmn, size_t _idx) :
 
 }
 
-bool CDKGSession::Init(Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex)
+CDKGSession::CDKGSession(const CBlockIndex* pQuorumBaseBlockIndex, const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CConnman& _connman,
+                         CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager,
+                         CMasternodeMetaMan& mn_metaman, const CActiveMasternodeManager* const mn_activeman,
+                         const CSporkManager& sporkman) :
+    params(_params), blsWorker(_blsWorker), cache(_blsWorker), connman(_connman), m_dmnman(dmnman), dkgManager(_dkgManager),
+    dkgDebugManager(_dkgDebugManager), m_mn_metaman(mn_metaman), m_mn_activeman(mn_activeman), m_sporkman(sporkman),
+    m_quorum_base_block_index{pQuorumBaseBlockIndex}
 {
+}
+
+bool CDKGSession::Init(const uint256& _myProTxHash, int _quorumIndex)
+{
+    const auto mns = utils::GetAllQuorumMembers(params.type, m_dmnman, m_quorum_base_block_index);
     quorumIndex = _quorumIndex;
     members.resize(mns.size());
     memberIds.resize(members.size());

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -68,9 +68,8 @@ CDKGMember::CDKGMember(const CDeterministicMNCPtr& _dmn, size_t _idx) :
 
 }
 
-bool CDKGSession::Init(gsl::not_null<const CBlockIndex*> _pQuorumBaseBlockIndex, Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex)
+bool CDKGSession::Init(Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex)
 {
-    m_quorum_base_block_index = _pQuorumBaseBlockIndex;
     quorumIndex = _quorumIndex;
     members.resize(mns.size());
     memberIds.resize(members.size());

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -326,10 +326,10 @@ private:
     std::set<uint256> validCommitments GUARDED_BY(invCs);
 
 public:
-    CDKGSession(const CBlockIndex* pQuorumBaseBlockIndex, const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CConnman& _connman,
-                CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager,
-                CMasternodeMetaMan& mn_metaman, const CActiveMasternodeManager* const mn_activeman,
-                const CSporkManager& sporkman);
+    CDKGSession(const CBlockIndex* pQuorumBaseBlockIndex, const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker,
+                CConnman& _connman, CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager,
+                CDKGDebugManager& _dkgDebugManager, CMasternodeMetaMan& mn_metaman,
+                const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman);
 
     // TODO: remove Init completely
     bool Init(const uint256& _myProTxHash, int _quorumIndex);

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -288,7 +288,7 @@ private:
     const CActiveMasternodeManager* const m_mn_activeman;
     const CSporkManager& m_sporkman;
 
-    const CBlockIndex* m_quorum_base_block_index{nullptr};
+    const CBlockIndex* const m_quorum_base_block_index;
     int quorumIndex{0};
 
 private:
@@ -326,16 +326,17 @@ private:
     std::set<uint256> validCommitments GUARDED_BY(invCs);
 
 public:
-    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CConnman& _connman,
+    CDKGSession(const CBlockIndex* pQuorumBaseBlockIndex, const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CConnman& _connman,
                 CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager,
                 CMasternodeMetaMan& mn_metaman, const CActiveMasternodeManager* const mn_activeman,
                 const CSporkManager& sporkman) :
         params(_params), blsWorker(_blsWorker), cache(_blsWorker), connman(_connman), m_dmnman(dmnman), dkgManager(_dkgManager),
-        dkgDebugManager(_dkgDebugManager), m_mn_metaman(mn_metaman), m_mn_activeman(mn_activeman), m_sporkman(sporkman)
+        dkgDebugManager(_dkgDebugManager), m_mn_metaman(mn_metaman), m_mn_activeman(mn_activeman), m_sporkman(sporkman),
+        m_quorum_base_block_index{pQuorumBaseBlockIndex}
         {}
 
     // TODO: remove Init completely
-    bool Init(gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex);
+    bool Init(Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex);
 
     [[nodiscard]] std::optional<size_t> GetMyMemberIndex() const { return myIdx; }
 

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -350,7 +350,7 @@ public:
     void Contribute(CDKGPendingMessages& pendingMessages);
     void SendContributions(CDKGPendingMessages& pendingMessages);
     bool PreVerifyMessage(const CDKGContribution& qc, bool& retBan) const;
-    void ReceiveMessage(const CDKGContribution& qc, bool& retBan);
+    void ReceiveMessage(const CDKGContribution& qc);
     void VerifyPendingContributions() EXCLUSIVE_LOCKS_REQUIRED(cs_pending);
 
     // Phase 2: complaint
@@ -358,19 +358,19 @@ public:
     void VerifyConnectionAndMinProtoVersions() const;
     void SendComplaint(CDKGPendingMessages& pendingMessages);
     bool PreVerifyMessage(const CDKGComplaint& qc, bool& retBan) const;
-    void ReceiveMessage(const CDKGComplaint& qc, bool& retBan);
+    void ReceiveMessage(const CDKGComplaint& qc);
 
     // Phase 3: justification
     void VerifyAndJustify(CDKGPendingMessages& pendingMessages);
     void SendJustification(CDKGPendingMessages& pendingMessages, const std::set<uint256>& forMembers);
     bool PreVerifyMessage(const CDKGJustification& qj, bool& retBan) const;
-    void ReceiveMessage(const CDKGJustification& qj, bool& retBan);
+    void ReceiveMessage(const CDKGJustification& qj);
 
     // Phase 4: commit
     void VerifyAndCommit(CDKGPendingMessages& pendingMessages);
     void SendCommitment(CDKGPendingMessages& pendingMessages);
     bool PreVerifyMessage(const CDKGPrematureCommitment& qc, bool& retBan) const;
-    void ReceiveMessage(const CDKGPrematureCommitment& qc, bool& retBan);
+    void ReceiveMessage(const CDKGPrematureCommitment& qc);
 
     // Phase 5: aggregate/finalize
     std::vector<CFinalCommitment> FinalizeCommitments();

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -253,7 +253,6 @@ class CDKGLogger : public CBatchedLogger
 {
 public:
     CDKGLogger(const CDKGSession& _quorumDkg, std::string_view _func, int source_line);
-    CDKGLogger(std::string_view _llmqTypeName, int _quorumIndex, const uint256& _quorumHash, int _height, bool _areWeMember, std::string_view _func, int source_line);
 };
 
 /**

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -329,14 +329,10 @@ public:
     CDKGSession(const CBlockIndex* pQuorumBaseBlockIndex, const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CConnman& _connman,
                 CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager,
                 CMasternodeMetaMan& mn_metaman, const CActiveMasternodeManager* const mn_activeman,
-                const CSporkManager& sporkman) :
-        params(_params), blsWorker(_blsWorker), cache(_blsWorker), connman(_connman), m_dmnman(dmnman), dkgManager(_dkgManager),
-        dkgDebugManager(_dkgDebugManager), m_mn_metaman(mn_metaman), m_mn_activeman(mn_activeman), m_sporkman(sporkman),
-        m_quorum_base_block_index{pQuorumBaseBlockIndex}
-        {}
+                const CSporkManager& sporkman);
 
     // TODO: remove Init completely
-    bool Init(Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex);
+    bool Init(const uint256& _myProTxHash, int _quorumIndex);
 
     [[nodiscard]] std::optional<size_t> GetMyMemberIndex() const { return myIdx; }
 

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -41,7 +41,7 @@ CDKGSessionHandler::CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chai
         m_peerman(peerman),
         params(_params),
         quorumIndex(_quorumIndex),
-        curSession(std::make_unique<CDKGSession>(_params, _blsWorker, _connman, dmnman, _dkgManager, _dkgDebugManager, m_mn_metaman, m_mn_activeman, sporkman)),
+        curSession(std::make_unique<CDKGSession>(nullptr, _params, _blsWorker, _connman, dmnman, _dkgManager, _dkgDebugManager, m_mn_metaman, m_mn_activeman, sporkman)),
         pendingContributions((size_t)_params.size * 2, MSG_QUORUM_CONTRIB), // we allow size*2 messages as we need to make sure we see bad behavior (double messages)
         pendingComplaints((size_t)_params.size * 2, MSG_QUORUM_COMPLAINT),
         pendingJustifications((size_t)_params.size * 2, MSG_QUORUM_JUSTIFICATION),
@@ -194,10 +194,10 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
         return false;
     }
 
-    curSession = std::make_unique<CDKGSession>(params, blsWorker, connman, m_dmnman, dkgManager, dkgDebugManager, m_mn_metaman, m_mn_activeman, m_sporkman);
-
     auto mns = utils::GetAllQuorumMembers(params.type, m_dmnman, pQuorumBaseBlockIndex);
-    if (!curSession->Init(pQuorumBaseBlockIndex, mns, m_mn_activeman->GetProTxHash(), quorumIndex)) {
+    curSession = std::make_unique<CDKGSession>(pQuorumBaseBlockIndex, params, blsWorker, connman, m_dmnman, dkgManager, dkgDebugManager, m_mn_metaman, m_mn_activeman, m_sporkman);
+
+    if (!curSession->Init(mns, m_mn_activeman->GetProTxHash(), quorumIndex)) {
         LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d] mns[%d]\n", __func__, pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex, mns.size());
         return false;
     }

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -190,11 +190,11 @@ void CDKGSessionHandler::StopThread()
 
 bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
 {
-    curSession = std::make_unique<CDKGSession>(params, blsWorker, connman, m_dmnman, dkgManager, dkgDebugManager, m_mn_metaman, m_mn_activeman, m_sporkman);
-
     if (!DeploymentDIP0003Enforced(pQuorumBaseBlockIndex->nHeight, Params().GetConsensus())) {
         return false;
     }
+
+    curSession = std::make_unique<CDKGSession>(params, blsWorker, connman, m_dmnman, dkgManager, dkgDebugManager, m_mn_metaman, m_mn_activeman, m_sporkman);
 
     auto mns = utils::GetAllQuorumMembers(params.type, m_dmnman, pQuorumBaseBlockIndex);
     if (!curSession->Init(pQuorumBaseBlockIndex, mns, m_mn_activeman->GetProTxHash(), quorumIndex)) {

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -194,11 +194,10 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
         return false;
     }
 
-    auto mns = utils::GetAllQuorumMembers(params.type, m_dmnman, pQuorumBaseBlockIndex);
     curSession = std::make_unique<CDKGSession>(pQuorumBaseBlockIndex, params, blsWorker, connman, m_dmnman, dkgManager, dkgDebugManager, m_mn_metaman, m_mn_activeman, m_sporkman);
 
-    if (!curSession->Init(mns, m_mn_activeman->GetProTxHash(), quorumIndex)) {
-        LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d] mns[%d]\n", __func__, pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex, mns.size());
+    if (!curSession->Init(m_mn_activeman->GetProTxHash(), quorumIndex)) {
+        LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d]\n", __func__, pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex);
         return false;
     }
 

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -489,13 +489,7 @@ bool ProcessPendingMessageBatch(CDKGSession& session, CDKGPendingMessages& pendi
         if (badNodes.count(nodeId)) {
             continue;
         }
-        bool ban = false;
-        session.ReceiveMessage(*p.second, ban);
-        if (ban) {
-            LogPrint(BCLog::LLMQ_DKG, "%s -- banning node after ReceiveMessage failed, peer=%d\n", __func__, nodeId);
-            pendingMessages.Misbehaving(nodeId, 100);
-            badNodes.emplace(nodeId);
-        }
+        session.ReceiveMessage(*p.second);
     }
 
     return true;

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -52,6 +52,8 @@ CDKGSessionHandler::CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chai
     }
 }
 
+CDKGSessionHandler::~CDKGSessionHandler() = default;
+
 void CDKGPendingMessages::PushPendingMessage(NodeId from, PeerManager* peerman, CDataStream& vRecv)
 {
     // if peer is not -1 we should always pass valid peerman
@@ -587,6 +589,50 @@ void CDKGSessionHandler::PhaseHandlerThread()
             LogPrint(BCLog::LLMQ_DKG, "CDKGSessionHandler::%s -- %s qi[%d] - aborted current DKG session\n", __func__, params.name, quorumIndex);
         }
     }
+}
+
+bool CDKGSessionHandler::GetContribution(const uint256& hash, CDKGContribution& ret) const
+{
+    LOCK(curSession->invCs);
+    auto it = curSession->contributions.find(hash);
+    if (it != curSession->contributions.end()) {
+        ret = it->second;
+        return true;
+    }
+    return false;
+}
+
+bool CDKGSessionHandler::GetComplaint(const uint256& hash, CDKGComplaint& ret) const
+{
+    LOCK(curSession->invCs);
+    auto it = curSession->complaints.find(hash);
+    if (it != curSession->complaints.end()) {
+        ret = it->second;
+        return true;
+    }
+    return false;
+}
+
+bool CDKGSessionHandler::GetJustification(const uint256& hash, CDKGJustification& ret) const
+{
+    LOCK(curSession->invCs);
+    auto it = curSession->justifications.find(hash);
+    if (it != curSession->justifications.end()) {
+        ret = it->second;
+        return true;
+    }
+    return false;
+}
+
+bool CDKGSessionHandler::GetPrematureCommitment(const uint256& hash, CDKGPrematureCommitment& ret) const
+{
+    LOCK(curSession->invCs);
+    auto it = curSession->prematureCommitments.find(hash);
+    if (it != curSession->prematureCommitments.end() && curSession->validCommitments.count(hash)) {
+        ret = it->second;
+        return true;
+    }
+    return false;
 }
 
 } // namespace llmq

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -24,28 +24,34 @@
 namespace llmq
 {
 
-CDKGSessionHandler::CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
-                                       CDKGDebugManager& _dkgDebugManager, CDKGSessionManager& _dkgManager, CMasternodeMetaMan& mn_metaman,
-                                       CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* const mn_activeman,
-                                       const CSporkManager& sporkman, const std::unique_ptr<PeerManager>& peerman, const Consensus::LLMQParams& _params, int _quorumIndex) :
-        blsWorker(_blsWorker),
-        m_chainstate(chainstate),
-        connman(_connman),
-        m_dmnman(dmnman),
-        dkgDebugManager(_dkgDebugManager),
-        dkgManager(_dkgManager),
-        m_mn_metaman(mn_metaman),
-        quorumBlockProcessor(_quorumBlockProcessor),
-        m_mn_activeman(mn_activeman),
-        m_sporkman(sporkman),
-        m_peerman(peerman),
-        params(_params),
-        quorumIndex(_quorumIndex),
-        curSession(std::make_unique<CDKGSession>(nullptr, _params, _blsWorker, _connman, dmnman, _dkgManager, _dkgDebugManager, m_mn_metaman, m_mn_activeman, sporkman)),
-        pendingContributions((size_t)_params.size * 2, MSG_QUORUM_CONTRIB), // we allow size*2 messages as we need to make sure we see bad behavior (double messages)
-        pendingComplaints((size_t)_params.size * 2, MSG_QUORUM_COMPLAINT),
-        pendingJustifications((size_t)_params.size * 2, MSG_QUORUM_JUSTIFICATION),
-        pendingPrematureCommitments((size_t)_params.size * 2, MSG_QUORUM_PREMATURE_COMMITMENT)
+CDKGSessionHandler::CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman,
+                                       CDeterministicMNManager& dmnman, CDKGDebugManager& _dkgDebugManager,
+                                       CDKGSessionManager& _dkgManager, CMasternodeMetaMan& mn_metaman,
+                                       CQuorumBlockProcessor& _quorumBlockProcessor,
+                                       const CActiveMasternodeManager* const mn_activeman,
+                                       const CSporkManager& sporkman, const std::unique_ptr<PeerManager>& peerman,
+                                       const Consensus::LLMQParams& _params, int _quorumIndex) :
+    blsWorker(_blsWorker),
+    m_chainstate(chainstate),
+    connman(_connman),
+    m_dmnman(dmnman),
+    dkgDebugManager(_dkgDebugManager),
+    dkgManager(_dkgManager),
+    m_mn_metaman(mn_metaman),
+    quorumBlockProcessor(_quorumBlockProcessor),
+    m_mn_activeman(mn_activeman),
+    m_sporkman(sporkman),
+    m_peerman(peerman),
+    params(_params),
+    quorumIndex(_quorumIndex),
+    curSession(std::make_unique<CDKGSession>(nullptr, _params, _blsWorker, _connman, dmnman, _dkgManager,
+                                             _dkgDebugManager, m_mn_metaman, m_mn_activeman, sporkman)),
+    pendingContributions(
+        (size_t)_params.size * 2,
+        MSG_QUORUM_CONTRIB), // we allow size*2 messages as we need to make sure we see bad behavior (double messages)
+    pendingComplaints((size_t)_params.size * 2, MSG_QUORUM_COMPLAINT),
+    pendingJustifications((size_t)_params.size * 2, MSG_QUORUM_JUSTIFICATION),
+    pendingPrematureCommitments((size_t)_params.size * 2, MSG_QUORUM_PREMATURE_COMMITMENT)
 {
     if (params.type == Consensus::LLMQType::LLMQ_NONE) {
         throw std::runtime_error("Can't initialize CDKGSessionHandler with LLMQ_NONE type.");
@@ -194,10 +200,12 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
         return false;
     }
 
-    curSession = std::make_unique<CDKGSession>(pQuorumBaseBlockIndex, params, blsWorker, connman, m_dmnman, dkgManager, dkgDebugManager, m_mn_metaman, m_mn_activeman, m_sporkman);
+    curSession = std::make_unique<CDKGSession>(pQuorumBaseBlockIndex, params, blsWorker, connman, m_dmnman, dkgManager,
+                                               dkgDebugManager, m_mn_metaman, m_mn_activeman, m_sporkman);
 
     if (!curSession->Init(m_mn_activeman->GetProTxHash(), quorumIndex)) {
-        LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d]\n", __func__, pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex);
+        LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d]\n", __func__,
+                  pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex);
         return false;
     }
 
@@ -445,37 +453,32 @@ static void RelayInvToParticipants(const CDKGSession& session, CConnman& connman
     for (const auto& r : relayMembers) {
         ss << r.ToString().substr(0, 4) << " | ";
     }
-    logger.Batch("RelayInvToParticipants inv[%s] relayMembers[%d] GetNodeCount[%d] GetNetworkActive[%d] HasMasternodeQuorumNodes[%d] for quorumHash[%s] forMember[%s] relayMembers[%s]",
-                 inv.ToString(),
-                 relayMembers.size(),
-                 connman.GetNodeCount(ConnectionDirection::Both),
+    logger.Batch("RelayInvToParticipants inv[%s] relayMembers[%d] GetNodeCount[%d] GetNetworkActive[%d] "
+                 "HasMasternodeQuorumNodes[%d] for quorumHash[%s] forMember[%s] relayMembers[%s]",
+                 inv.ToString(), relayMembers.size(), connman.GetNodeCount(ConnectionDirection::Both),
                  connman.GetNetworkActive(),
                  connman.HasMasternodeQuorumNodes(session.GetParams().type, session.BlockIndex()->GetBlockHash()),
-                 session.BlockIndex()->GetBlockHash().ToString(),
-                 session.ProTx().ToString().substr(0, 4), ss.str());
+                 session.BlockIndex()->GetBlockHash().ToString(), session.ProTx().ToString().substr(0, 4), ss.str());
 
     std::stringstream ss2;
     connman.ForEachNode([&](const CNode* pnode) {
         if (pnode->qwatch ||
-                (!pnode->GetVerifiedProRegTxHash().IsNull() && (relayMembers.count(pnode->GetVerifiedProRegTxHash()) != 0))) {
+            (!pnode->GetVerifiedProRegTxHash().IsNull() && (relayMembers.count(pnode->GetVerifiedProRegTxHash()) != 0))) {
             peerman.PushInventory(pnode->GetId(), inv);
         }
 
         if (pnode->GetVerifiedProRegTxHash().IsNull()) {
-            logger.Batch("node[%d:%s] not mn",
-                         pnode->GetId(),
-                         pnode->m_addr_name);
+            logger.Batch("node[%d:%s] not mn", pnode->GetId(), pnode->m_addr_name);
         } else if (relayMembers.count(pnode->GetVerifiedProRegTxHash()) == 0) {
             ss2 << pnode->GetVerifiedProRegTxHash().ToString().substr(0, 4) << " | ";
         }
     });
-    logger.Batch("forMember[%s] NOTrelayMembers[%s]",
-                 session.ProTx().ToString().substr(0, 4),
-                 ss2.str());
+    logger.Batch("forMember[%s] NOTrelayMembers[%s]", session.ProTx().ToString().substr(0, 4), ss2.str());
     logger.Flush();
 }
-template<typename Message, int MessageType>
-bool ProcessPendingMessageBatch(CConnman& connman, PeerManager* peerman, CDKGSession& session, CDKGPendingMessages& pendingMessages, size_t maxCount)
+template <typename Message, int MessageType>
+bool ProcessPendingMessageBatch(CConnman& connman, PeerManager* peerman, CDKGSession& session,
+                                CDKGPendingMessages& pendingMessages, size_t maxCount)
 {
     auto msgs = pendingMessages.PopAndDeserializeMessages<Message>(maxCount);
     if (msgs.empty()) {
@@ -571,7 +574,8 @@ void CDKGSessionHandler::HandleDKGRound()
         curSession->Contribute(pendingContributions);
     };
     auto fContributeWait = [this] {
-        return ProcessPendingMessageBatch<CDKGContribution, MSG_QUORUM_CONTRIB>(connman, m_peerman.get(), *curSession, pendingContributions, 8);
+        return ProcessPendingMessageBatch<CDKGContribution, MSG_QUORUM_CONTRIB>(connman, m_peerman.get(), *curSession,
+                                                                                pendingContributions, 8);
     };
     HandlePhase(QuorumPhase::Contribute, QuorumPhase::Complain, curQuorumHash, 0.05, fContributeStart, fContributeWait);
 
@@ -580,7 +584,8 @@ void CDKGSessionHandler::HandleDKGRound()
         curSession->VerifyAndComplain(pendingComplaints);
     };
     auto fComplainWait = [this] {
-        return ProcessPendingMessageBatch<CDKGComplaint, MSG_QUORUM_COMPLAINT>(connman, m_peerman.get(), *curSession, pendingComplaints, 8);
+        return ProcessPendingMessageBatch<CDKGComplaint, MSG_QUORUM_COMPLAINT>(connman, m_peerman.get(), *curSession,
+                                                                               pendingComplaints, 8);
     };
     HandlePhase(QuorumPhase::Complain, QuorumPhase::Justify, curQuorumHash, 0.05, fComplainStart, fComplainWait);
 
@@ -589,7 +594,9 @@ void CDKGSessionHandler::HandleDKGRound()
         curSession->VerifyAndJustify(pendingJustifications);
     };
     auto fJustifyWait = [this] {
-        return ProcessPendingMessageBatch<CDKGJustification, MSG_QUORUM_JUSTIFICATION>(connman, m_peerman.get(), *curSession, pendingJustifications, 8);
+        return ProcessPendingMessageBatch<CDKGJustification, MSG_QUORUM_JUSTIFICATION>(connman, m_peerman.get(),
+                                                                                       *curSession,
+                                                                                       pendingJustifications, 8);
     };
     HandlePhase(QuorumPhase::Justify, QuorumPhase::Commit, curQuorumHash, 0.05, fJustifyStart, fJustifyWait);
 
@@ -598,7 +605,8 @@ void CDKGSessionHandler::HandleDKGRound()
         curSession->VerifyAndCommit(pendingPrematureCommitments);
     };
     auto fCommitWait = [this] {
-        return ProcessPendingMessageBatch<CDKGPrematureCommitment, MSG_QUORUM_PREMATURE_COMMITMENT>(connman, m_peerman.get(), *curSession, pendingPrematureCommitments, 8);
+        return ProcessPendingMessageBatch<CDKGPrematureCommitment, MSG_QUORUM_PREMATURE_COMMITMENT>(
+            connman, m_peerman.get(), *curSession, pendingPrematureCommitments, 8);
     };
     HandlePhase(QuorumPhase::Commit, QuorumPhase::Finalize, curQuorumHash, 0.1, fCommitStart, fCommitWait);
 

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -25,6 +25,10 @@ class PeerManager;
 
 namespace llmq
 {
+class CDKGContribution;
+class CDKGComplaint;
+class CDKGJustification;
+class CDKGPrematureCommitment;
 class CDKGDebugManager;
 class CDKGSession;
 class CDKGSessionManager;
@@ -153,13 +157,18 @@ public:
                        CDKGDebugManager& _dkgDebugManager, CDKGSessionManager& _dkgManager, CMasternodeMetaMan& mn_metaman,
                        CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* const mn_activeman,
                        const CSporkManager& sporkman, const std::unique_ptr<PeerManager>& peerman, const Consensus::LLMQParams& _params, int _quorumIndex);
-    ~CDKGSessionHandler() = default;
+    ~CDKGSessionHandler();
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew);
     void ProcessMessage(const CNode& pfrom, gsl::not_null<PeerManager*> peerman, const std::string& msg_type, CDataStream& vRecv);
 
     void StartThread();
     void StopThread();
+
+    bool GetContribution(const uint256& hash, CDKGContribution& ret) const;
+    bool GetComplaint(const uint256& hash, CDKGComplaint& ret) const;
+    bool GetJustification(const uint256& hash, CDKGJustification& ret) const;
+    bool GetPrematureCommitment(const uint256& hash, CDKGPrematureCommitment& ret) const;
 
 private:
     bool InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex);

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <llmq/debug.h>
+#include <llmq/dkgsession.h>
 #include <llmq/dkgsessionmgr.h>
 #include <llmq/options.h>
 #include <llmq/params.h>
@@ -55,6 +56,8 @@ CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chai
         }
     }
 }
+
+CDKGSessionManager::~CDKGSessionManager() = default;
 
 void CDKGSessionManager::MigrateDKG()
 {

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <llmq/debug.h>
-#include <llmq/dkgsession.h>
 #include <llmq/dkgsessionmgr.h>
 #include <llmq/options.h>
 #include <llmq/params.h>
@@ -300,10 +299,7 @@ bool CDKGSessionManager::GetContribution(const uint256& hash, CDKGContribution& 
         if (dkgType.phase < QuorumPhase::Initialized || dkgType.phase > QuorumPhase::Contribute) {
             continue;
         }
-        LOCK(dkgType.curSession->invCs);
-        auto it = dkgType.curSession->contributions.find(hash);
-        if (it != dkgType.curSession->contributions.end()) {
-            ret = it->second;
+        if (dkgType.GetContribution(hash, ret)) {
             return true;
         }
     }
@@ -321,10 +317,7 @@ bool CDKGSessionManager::GetComplaint(const uint256& hash, CDKGComplaint& ret) c
         if (dkgType.phase < QuorumPhase::Contribute || dkgType.phase > QuorumPhase::Complain) {
             continue;
         }
-        LOCK(dkgType.curSession->invCs);
-        auto it = dkgType.curSession->complaints.find(hash);
-        if (it != dkgType.curSession->complaints.end()) {
-            ret = it->second;
+        if (dkgType.GetComplaint(hash, ret)) {
             return true;
         }
     }
@@ -342,10 +335,7 @@ bool CDKGSessionManager::GetJustification(const uint256& hash, CDKGJustification
         if (dkgType.phase < QuorumPhase::Complain || dkgType.phase > QuorumPhase::Justify) {
             continue;
         }
-        LOCK(dkgType.curSession->invCs);
-        auto it = dkgType.curSession->justifications.find(hash);
-        if (it != dkgType.curSession->justifications.end()) {
-            ret = it->second;
+        if (dkgType.GetJustification(hash, ret)) {
             return true;
         }
     }
@@ -363,10 +353,7 @@ bool CDKGSessionManager::GetPrematureCommitment(const uint256& hash, CDKGPrematu
         if (dkgType.phase < QuorumPhase::Justify || dkgType.phase > QuorumPhase::Commit) {
             continue;
         }
-        LOCK(dkgType.curSession->invCs);
-        auto it = dkgType.curSession->prematureCommitments.find(hash);
-        if (it != dkgType.curSession->prematureCommitments.end() && dkgType.curSession->validCommitments.count(hash)) {
-            ret = it->second;
+        if (dkgType.GetPrematureCommitment(hash, ret)) {
             return true;
         }
     }

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -5,10 +5,10 @@
 #ifndef BITCOIN_LLMQ_DKGSESSIONMGR_H
 #define BITCOIN_LLMQ_DKGSESSIONMGR_H
 
-#include <llmq/dkgsessionhandler.h>
 #include <bls/bls.h>
 #include <bls/bls_ies.h>
 #include <bls/bls_worker.h>
+#include <llmq/dkgsessionhandler.h>
 #include <net_types.h>
 
 #include <map>

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -6,8 +6,8 @@
 #define BITCOIN_LLMQ_DKGSESSIONMGR_H
 
 #include <llmq/dkgsessionhandler.h>
-#include <llmq/dkgsession.h>
 #include <bls/bls.h>
+#include <bls/bls_ies.h>
 #include <bls/bls_worker.h>
 #include <net_types.h>
 
@@ -23,6 +23,10 @@ class CDKGDebugManager;
 class CMasternodeMetaMan;
 class CSporkManager;
 class PeerManager;
+class CDKGContribution;
+class CDKGComplaint;
+class CDKGJustification;
+class CDKGPrematureCommitment;
 
 class UniValue;
 
@@ -71,7 +75,7 @@ public:
                        CDKGDebugManager& _dkgDebugManager, CMasternodeMetaMan& mn_metaman, CQuorumBlockProcessor& _quorumBlockProcessor,
                        const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman,
                        const std::unique_ptr<PeerManager>& peerman, bool unitTests, bool fWipe);
-    ~CDKGSessionManager() = default;
+    ~CDKGSessionManager();
 
     void StartThreads();
     void StopThreads();

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -11,10 +11,12 @@
 #include <llmq/params.h>
 #include <llmq/utils.h>
 
+#include <evo/evodb.h>
 #include <evo/specialtx.h>
 #include <evo/deterministicmns.h>
 
 #include <chainparams.h>
+#include <dbwrapper.h>
 #include <masternode/node.h>
 #include <masternode/sync.h>
 #include <net.h>
@@ -228,6 +230,11 @@ CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, 
     utils::InitQuorumsCache(mapQuorumsCache, false);
     quorumThreadInterrupt.reset();
     MigrateOldQuorumDB(_evoDb);
+}
+
+CQuorumManager::~CQuorumManager()
+{
+    Stop();
 }
 
 void CQuorumManager::Start()

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -11,9 +11,9 @@
 #include <llmq/params.h>
 #include <llmq/utils.h>
 
+#include <evo/deterministicmns.h>
 #include <evo/evodb.h>
 #include <evo/specialtx.h>
-#include <evo/deterministicmns.h>
 
 #include <chainparams.h>
 #include <dbwrapper.h>
@@ -232,10 +232,7 @@ CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, 
     MigrateOldQuorumDB(_evoDb);
 }
 
-CQuorumManager::~CQuorumManager()
-{
-    Stop();
-}
+CQuorumManager::~CQuorumManager() { Stop(); }
 
 void CQuorumManager::Start()
 {

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -14,7 +14,6 @@
 #include <bls/bls.h>
 #include <bls/bls_worker.h>
 
-#include <evo/evodb.h>
 #include <net_types.h>
 #include <gsl/pointers.h>
 
@@ -26,8 +25,11 @@ class CActiveMasternodeManager;
 class CBlockIndex;
 class CChainState;
 class CConnman;
+class CDataStream;
 class CDeterministicMN;
 class CDeterministicMNManager;
+class CDBWrapper;
+class CEvoDB;
 class CMasternodeSync;
 class CNode;
 class CSporkManager;
@@ -258,7 +260,7 @@ public:
                    CDKGSessionManager& _dkgManager, CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor,
                    const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync,
                    const CSporkManager& sporkman, bool unit_tests, bool wipe);
-    ~CQuorumManager() { Stop(); };
+    ~CQuorumManager();
 
     void Start();
     void Stop();

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -4,6 +4,7 @@
 
 #include <llmq/snapshot.h>
 
+#include <evo/evodb.h>
 #include <evo/simplifiedmns.h>
 #include <evo/specialtx.h>
 

--- a/src/llmq/snapshot.h
+++ b/src/llmq/snapshot.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_LLMQ_SNAPSHOT_H
 #define BITCOIN_LLMQ_SNAPSHOT_H
 
-#include <evo/evodb.h>
 #include <evo/simplifiedmns.h>
 #include <llmq/commitment.h>
 #include <llmq/params.h>
@@ -20,6 +19,7 @@
 class CBlockIndex;
 class CDeterministicMN;
 class CDeterministicMNList;
+class CEvoDb;
 
 namespace llmq {
 class CQuorumBlockProcessor;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -61,6 +61,7 @@
 #include <llmq/chainlocks.h>
 #include <llmq/commitment.h>
 #include <llmq/context.h>
+#include <llmq/dkgsession.h>
 #include <llmq/dkgsessionmgr.h>
 #include <llmq/instantsend.h>
 #include <llmq/options.h>

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -93,7 +93,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "llmq/context -> llmq/ehf_signals -> net_processing -> llmq/context"
     "llmq/blockprocessor -> net_processing -> llmq/blockprocessor"
     "llmq/chainlocks -> net_processing -> llmq/chainlocks"
-    "llmq/dkgsession -> net_processing -> llmq/quorums -> llmq/dkgsession"
     "net_processing -> spork -> net_processing"
     "evo/simplifiedmns -> llmq/blockprocessor -> net_processing -> evo/simplifiedmns"
     "governance/governance -> net_processing -> governance/governance"

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -62,7 +62,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "banman -> bloom -> evo/assetlocktx -> llmq/quorums -> net -> banman"
     "banman -> bloom -> evo/assetlocktx -> llmq/signing -> net_processing -> banman"
 
-    "llmq/dkgsession -> llmq/dkgsessionmgr -> llmq/dkgsession"
     "llmq/chainlocks -> validation -> llmq/chainlocks"
     "coinjoin/coinjoin -> llmq/chainlocks -> net -> coinjoin/coinjoin"
     "evo/deterministicmns -> llmq/utils -> llmq/snapshot -> evo/simplifiedmns -> evo/deterministicmns"


### PR DESCRIPTION
## Issue being fixed or feature implemented
We have 72 circular dependencies of dash specific code. This PR removes 2 of them, over dkgsession.


## What was done?
Refactor dkgsession initialization, message processing, dropped unused arguments, re-distributed code between functions and modules... See each commit.
Also optimized headers: excluded evo/evodb.h and llmq/quorums.h from the headers where they are not needed.


## How Has This Been Tested?
Run `test/lint/lint-circular-dependencies.sh`
Run unit/functional tests

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone