### PR TITLE
fix: do not use extra_args for enforced DashTestFramework arguments

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -311,7 +311,7 @@ class NetTest(DashTestFramework):
         by first testing adding a tried table entry before testing adding a new table one.
         """
         self.log.info("Test addpeeraddress")
-        self.restart_node(1, self.extra_args[1] + ["-checkaddrman=1"])
+        self.restart_node(1, ["-checkaddrman=1"])
         node = self.nodes[1]
 
         self.log.debug("Test that addpeerinfo is a hidden RPC")

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -13,7 +13,6 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [['-usehd=1']]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -23,18 +22,18 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
 
         self.log.info("Invalid -mnemonicbits should rise an error")
         self.stop_node(0)
-        self.nodes[0].assert_start_raises_init_error(self.extra_args[0] + ['-mnemonicbits=123'], "Error: Invalid '-mnemonicbits'. Allowed values: 128, 160, 192, 224, 256.")
+        self.nodes[0].assert_start_raises_init_error(['-mnemonicbits=123'], "Error: Invalid '-mnemonicbits'. Allowed values: 128, 160, 192, 224, 256.")
         self.start_node(0)
         assert_equal(len(self.nodes[0].dumphdinfo()["mnemonic"].split()), 12)  # 12 words by default
 
         self.log.info("Can have multiple wallets with different mnemonic length loaded at the same time")
-        self.restart_node(0, extra_args=self.extra_args[0] + ["-mnemonicbits=160"])
+        self.restart_node(0, extra_args=["-mnemonicbits=160"])
         self.nodes[0].createwallet("wallet_160")
-        self.restart_node(0, extra_args=self.extra_args[0] + ["-mnemonicbits=192"])
+        self.restart_node(0, extra_args=["-mnemonicbits=192"])
         self.nodes[0].createwallet("wallet_192")
-        self.restart_node(0, extra_args=self.extra_args[0] + ["-mnemonicbits=224"])
+        self.restart_node(0, extra_args=["-mnemonicbits=224"])
         self.nodes[0].createwallet("wallet_224")
-        self.restart_node(0, extra_args=self.extra_args[0] + ["-mnemonicbits=256"])
+        self.restart_node(0, extra_args=["-mnemonicbits=256"])
         self.nodes[0].loadwallet("wallet_160")
         self.nodes[0].loadwallet("wallet_192")
         self.nodes[0].loadwallet("wallet_224")


### PR DESCRIPTION
## Issue being fixed or feature implemented
DashTestFramework requires 2 arguments for dashd which are lost every dashd restart: `sporkkey` and `dip3params`.
Without this PR you need to pass this arguments manually every time when you restart dashd in functional tests.




## What was done?
Make dash specific args `sporkkey` and `dip3params` resilient for dashd restart

It makes workarounds such as [these](https://github.com/dashpay/dash/commit/c28b05c5ca1d2b85687fa5e481e32208e7d48adc) no more needed: 
```
self.restart_node(1, self.extra_args[1] + ["-checkaddrman=1"])
```

Also there's some cleanup for `wallet_mnemonicbits.py` to remove `usehd=1` which is not required, and it has been discovered during revising all node's restarts related code.

## How Has This Been Tested?
Removed workaround from `rpc_net.py` and run functional tests


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone