### PR TITLE
feat(rpc): introduce and use `setmnthreadactive` (regtest-only)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3486,8 +3486,7 @@ void CConnman::ThreadOpenMasternodeConnections(CDeterministicMNManager& dmnman, 
 
         didConnect = false;
 
-        if (!fNetworkActive || !mn_sync.IsBlockchainSynced())
-            continue;
+        if (!fNetworkActive || !m_masternode_thread_active || !mn_sync.IsBlockchainSynced()) continue;
 
         std::set<CService> connectedNodes;
         std::map<uint256 /*proTxHash*/, bool /*fInbound*/> connectedProRegTxHashes;

--- a/src/net.h
+++ b/src/net.h
@@ -1223,6 +1223,8 @@ public:
     bool GetNetworkActive() const { return fNetworkActive; };
     bool GetUseAddrmanOutgoing() const { return m_use_addrman_outgoing; };
     void SetNetworkActive(bool active, CMasternodeSync* const mn_sync);
+    bool GetMasternodeThreadActive() const { return m_masternode_thread_active; };
+    void SetMasternodeThreadActive(bool active) { m_masternode_thread_active = active; };
     SocketEventsMode GetSocketEventsMode() const { return socketEventsMode; }
 
     enum class MasternodeConn {
@@ -1721,6 +1723,7 @@ private:
 
     std::vector<ListenSocket> vhListenSocket;
     std::atomic<bool> fNetworkActive{true};
+    std::atomic<bool> m_masternode_thread_active{true};
     bool fAddressesInitialized{false};
     AddrMan& addrman;
     const NetGroupManager& m_netgroupman;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -175,6 +175,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "prioritisetransaction", 1, "fee_delta" },
     { "setban", 2, "bantime" },
     { "setban", 3, "absolute" },
+    { "setmnthreadactive", 0, "state" },
     { "setnetworkactive", 0, "state" },
     { "setcoinjoinrounds", 0, "rounds" },
     { "setcoinjoinamount", 0, "amount" },

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1019,6 +1019,32 @@ static RPCHelpMan addpeeraddress()
     };
 }
 
+static RPCHelpMan setmnthreadactive()
+{
+    return RPCHelpMan{"setmnthreadactive",
+        "\nDisable/enable automatic masternode connections thread activity.\n",
+        {
+            {"state", RPCArg::Type::BOOL, RPCArg::Optional::NO, "true to enable the thread, false to disable"},
+        },
+        RPCResult{RPCResult::Type::BOOL, "", "The value that was passed in"},
+        RPCExamples{""},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+
+    if (Params().NetworkIDString() != CBaseChainParams::REGTEST) {
+        throw std::runtime_error("setmnthreadactive is for regression testing (-regtest mode) only.");
+    }
+
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CConnman& connman = EnsureConnman(node);
+
+    connman.SetMasternodeThreadActive(request.params[0].get_bool());
+
+    return connman.GetMasternodeThreadActive();
+},
+    };
+}
+
 void RegisterNetRPCCommands(CRPCTable &t)
 {
 // clang-format off
@@ -1042,6 +1068,7 @@ static const CRPCCommand commands[] =
 
     { "hidden",              &addconnection,           },
     { "hidden",              &addpeeraddress,          },
+    { "hidden",              &setmnthreadactive        },
 };
 // clang-format on
     for (const auto& c : commands) {

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -150,6 +150,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "reconsiderblock",
     "scantxoutset",
     "sendrawtransaction",
+    "setmnthreadactive",
     "setmocktime",
     "setnetworkactive",
     "signmessagewithprivkey",

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1083,6 +1083,8 @@ class MasternodeInfo:
         self.collateral_vout = collateral_vout
         self.addr = addr
         self.evo = evo
+        self.node = None
+        self.nodeIdx = None
 
 
 class DashTestFramework(BitcoinTestFramework):
@@ -1096,6 +1098,15 @@ class DashTestFramework(BitcoinTestFramework):
     def run_test(self):
         """Tests must override this method to define test logic"""
         raise NotImplementedError
+
+    def connect_nodes(self, a, b):
+        for mn2 in self.mninfo:
+            if mn2.node is not None:
+                mn2.node.setmnthreadactive(False)
+        super().connect_nodes(a, b)
+        for mn2 in self.mninfo:
+            if mn2.node is not None:
+                mn2.node.setmnthreadactive(True)
 
     def set_dash_test_params(self, num_nodes, masterodes_count, extra_args=None, fast_dip3_enforcement=False, evo_count=0):
         self.mn_count = masterodes_count

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1446,16 +1446,11 @@ class DashTestFramework(BitcoinTestFramework):
             job.result()
         jobs.clear()
 
-        # connect nodes in parallel
-        for idx in range(0, self.mn_count):
-            jobs.append(executor.submit(do_connect, idx))
-
-        # wait for all nodes to connect
-        for job in jobs:
-            job.result()
-        jobs.clear()
-
         executor.shutdown()
+
+        # connect nodes
+        for idx in range(0, self.mn_count):
+            do_connect(idx)
 
     def start_masternode(self, mninfo, extra_args=None):
         args = ['-masternodeblsprivkey=%s' % mninfo.keyOperator] + self.extra_args[mninfo.nodeIdx]


### PR DESCRIPTION
## Issue being fixed or feature implemented
This adds a new rpc command to enable/disable automatic masternode connections creation. We need this for #6276. 1e17b7420785a0f92ce512167c2bce59b08538df is extracted from https://github.com/dashpay/dash/pull/6276/commits/ede1833ba442617c5efc77de64df6401102d16e7 to avoid multiple jobs calling `setmnthreadactive` on the same node in parallel.

## What was done?
Add `setmnthreadactive` rpc and use it

## How Has This Been Tested?
run tests

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

