### PR TITLE
fix: Exclude SCRIPT_ENABLE_DIP0020_OPCODES from flags in mempool checks while DIP0020 is not activated yet

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -769,7 +769,12 @@ bool MemPoolAccept::PolicyScriptChecks(const ATMPArgs& args, Workspace& ws, Prec
     const CTransaction& tx = *ws.m_ptx;
     TxValidationState& state = ws.m_state;
 
-    constexpr unsigned int scriptVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
+    unsigned int scriptVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS;
+
+    // Exclude SCRIPT_ENABLE_DIP0020_OPCODES while DIP0020 is not activated yet
+    if (!DeploymentActiveAt(*m_active_chainstate.m_chain.Tip(), args.m_chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0020)) {
+        scriptVerifyFlags = STANDARD_SCRIPT_VERIFY_FLAGS & ~SCRIPT_ENABLE_DIP0020_OPCODES;
+    }
 
     // Check input scripts and signatures.
     // This is done last to help prevent CPU exhaustion denial-of-service attacks.


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should fix the crash reported in #6256

## What was done?

## How Has This Been Tested?

## Breaking Changes
n/a, only affects txes prior to DIP0020 activation

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

