### PR TITLE
test: call `self.generate()` in `p2p_net_deadlock.py` (follow-up dash#6276)

### DIFF
--- a/test/functional/p2p_net_deadlock.py
+++ b/test/functional/p2p_net_deadlock.py
@@ -29,8 +29,7 @@ class NetDeadlockTest(BitcoinTestFramework):
         thread1.join()
 
         self.log.info("Check whether a deadlock happened")
-        self.nodes[0].generate(1)
-        self.sync_blocks()
+        self.generate(self.nodes[0], 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Additional Information

`develop` is currently borked ([build](https://gitlab.com/dashpay/dash/-/jobs/7999893074#L266)) because [dash#6288](https://github.com/dashpay/dash/pull/6288) changed the expected syntax for `generate*` calls and [dash#6276](https://github.com/dashpay/dash/pull/6276) introduced a new test (`p2p_net_deadlock.py`) that was based on a version of `develop` that used the older syntax.

No conflicts were reported because it was a new file introduced in the latter PR that the former PR did not have knowledge of.

## Breaking changes

None expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
