### PR TITLE
backport: merge bitcoin#23289, #23365, #23777, #23782, #23737, #24039, #24192, #24117, #24789, #25192, #25294, #27280 (auxiliary backports: part 19)

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -94,11 +94,12 @@ bool BaseIndex::Init()
             const CBlockIndex* block = active_chain.Tip();
             prune_violation = true;
             // check backwards from the tip if we have all block data until we reach the indexes bestblock
-            while (block_to_test && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA)) {
+            while (block_to_test && block && (block->nStatus & BLOCK_HAVE_DATA)) {
                 if (block_to_test == block) {
                     prune_violation = false;
                     break;
                 }
+                assert(block->pprev);
                 block = block->pprev;
             }
         }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -99,6 +99,8 @@ bool BaseIndex::Init()
                     prune_violation = false;
                     break;
                 }
+                // block->pprev must exist at this point, since block_to_test is part of the chain
+                // and thus must be encountered when going backwards from the tip
                 assert(block->pprev);
                 block = block->pprev;
             }

--- a/test/functional/feature_blockfilterindex_prune.py
+++ b/test/functional/feature_blockfilterindex_prune.py
@@ -30,6 +30,8 @@ class FeatureBlockfilterindexPruneTest(BitcoinTestFramework):
 
         self.log.info("prune some blocks")
         pruneheight = self.nodes[0].pruneblockchain(400)
+        # the prune heights used here and below are magic numbers that are determined by the
+        # thresholds at which block files wrap, so they depend on disk serialization and default block file size.
         assert_equal(pruneheight, 366)
 
         self.log.info("check if we can access the tips blockfilter when we have pruned some blocks")

--- a/test/functional/feature_blockfilterindex_prune.py
+++ b/test/functional/feature_blockfilterindex_prune.py
@@ -15,7 +15,7 @@ from test_framework.governance import EXPECTED_STDERR_NO_GOV_PRUNE
 class FeatureBlockfilterindexPruneTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [["-fastprune", "-prune=1", "-blockfilterindex=1"]]
+        self.extra_args = [["-fastprune", "-prune=1", "-blockfilterindex=1", "-testactivationheight=v20@2000"]]
 
     def sync_index(self, height):
         expected = {'basic block filter index': {'synced': True, 'best_block_height': height}}
@@ -25,9 +25,7 @@ class FeatureBlockfilterindexPruneTest(BitcoinTestFramework):
         self.log.info("check if we can access a blockfilter when pruning is enabled but no blocks are actually pruned")
         self.sync_index(height=200)
         assert_greater_than(len(self.nodes[0].getblockfilter(self.nodes[0].getbestblockhash())['filter']), 0)
-        # Mine two batches of blocks to avoid hitting NODE_NETWORK_LIMITED_MIN_BLOCKS disconnection
-        self.generate(self.nodes[0], 250)
-        self.generate(self.nodes[0], 250)
+        self.generate(self.nodes[0], 500)
         self.sync_index(height=700)
 
         self.log.info("prune some blocks")
@@ -40,16 +38,29 @@ class FeatureBlockfilterindexPruneTest(BitcoinTestFramework):
         self.log.info("check if we can access the blockfilter of a pruned block")
         assert_greater_than(len(self.nodes[0].getblockfilter(self.nodes[0].getblockhash(2))['filter']), 0)
 
+        # mine and sync index up to a height that will later be the pruneheight
+        self.generate(self.nodes[0], 298)
+        self.sync_index(height=998)
+
         self.log.info("start node without blockfilterindex")
-        self.restart_node(0, extra_args=["-fastprune", "-prune=1", '-testactivationheight=v20@2000'], expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
+        self.restart_node(0, extra_args=["-fastprune", "-prune=1", "-testactivationheight=v20@2000"], expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
 
         self.log.info("make sure accessing the blockfilters throws an error")
         assert_raises_rpc_error(-1, "Index is not enabled for filtertype basic", self.nodes[0].getblockfilter, self.nodes[0].getblockhash(2))
-        self.generate(self.nodes[0], 1000)
+        self.generate(self.nodes[0], 502)
+
+        self.log.info("prune exactly up to the blockfilterindexes best block while blockfilters are disabled")
+        pruneheight_2 = self.nodes[0].pruneblockchain(1000)
+        assert_equal(pruneheight_2, 932)
+        self.restart_node(0, extra_args=["-fastprune", "-prune=1", "-blockfilterindex=1", "-testactivationheight=v20@2000"], expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
+        self.log.info("make sure that we can continue with the partially synced index after having pruned up to the index height")
+        self.sync_index(height=1500)
 
         self.log.info("prune below the blockfilterindexes best block while blockfilters are disabled")
-        pruneheight_new = self.nodes[0].pruneblockchain(1000)
-        assert_greater_than(pruneheight_new, pruneheight)
+        self.restart_node(0, extra_args=["-fastprune", "-prune=1", "-testactivationheight=v20@2000"], expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
+        self.generate(self.nodes[0], 1000)
+        pruneheight_3 = self.nodes[0].pruneblockchain(2000)
+        assert_greater_than(pruneheight_3, pruneheight_2)
         self.stop_node(0, expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
 
         self.log.info("make sure we get an init error when starting the node again with block filters")

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -245,6 +245,20 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         res10 = index_node.gettxoutsetinfo('muhash')
         assert(res8['txouts'] < res10['txouts'])
 
+        self.log.info("Test that the index works with -reindex")
+
+        self.restart_node(1, extra_args=["-coinstatsindex", "-reindex"])
+        res11 = index_node.gettxoutsetinfo('muhash')
+        assert_equal(res11, res10)
+
+        self.log.info("Test that -reindex-chainstate is disallowed with coinstatsindex")
+
+        self.nodes[1].assert_start_raises_init_error(
+            expected_msg='Error: -reindex-chainstate option is not compatible with -coinstatsindex. '
+            'Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.',
+            extra_args=['-coinstatsindex', '-reindex-chainstate'],
+        )
+
     def _test_use_index_option(self):
         self.log.info("Test use_index option for nodes running the index")
 

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -64,6 +64,8 @@ class InitStressTest(BitcoinTestFramework):
             'addcon thread start',
             'loadblk thread start',
             'txindex thread start',
+            'block filter index thread start',
+            'coinstatsindex thread start',
             'msghand thread start',
             'net thread start',
             'addcon thread start',
@@ -74,7 +76,7 @@ class InitStressTest(BitcoinTestFramework):
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will exit after line '{terminate_line}'")
             with node.wait_for_debug_log([terminate_line], ignore_case=True):
-                node.start(extra_args=['-txindex=1'])
+                node.start(extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'])
             self.log.debug("Terminating node after terminate line was found")
             sigterm_node()
 
@@ -109,7 +111,7 @@ class InitStressTest(BitcoinTestFramework):
             # investigate doing this later.
 
             node.assert_start_raises_init_error(
-                extra_args=['-txindex=1'],
+                extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'],
                 expected_msg=err_fragment,
                 match=ErrorMatch.PARTIAL_REGEX,
             )

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -49,33 +49,33 @@ class InitStressTest(BitcoinTestFramework):
             assert_equal(200, node.getblockcount())
 
         lines_to_terminate_after = [
-            'Validating signatures for all blocks',
-            'scheduler thread start',
-            'Starting HTTP server',
-            'Loading P2P addresses',
-            'Loading banlist',
-            'Loading block index',
-            'Switching active chainstate',
-            'Checking all blk files are present',
-            'Loaded best chain:',
-            'init message: Verifying blocks',
-            'init message: Starting network threads',
-            'net thread start',
-            'addcon thread start',
-            'loadblk thread start',
-            'txindex thread start',
-            'block filter index thread start',
-            'coinstatsindex thread start',
-            'msghand thread start',
-            'net thread start',
-            'addcon thread start',
+            b'Validating signatures for all blocks',
+            b'scheduler thread start',
+            b'Starting HTTP server',
+            b'Loading P2P addresses',
+            b'Loading banlist',
+            b'Loading block index',
+            b'Switching active chainstate',
+            b'Checking all blk files are present',
+            b'Loaded best chain:',
+            b'init message: Verifying blocks',
+            b'init message: Starting network threads',
+            b'net thread start',
+            b'addcon thread start',
+            b'loadblk thread start',
+            b'txindex thread start',
+            b'block filter index thread start',
+            b'coinstatsindex thread start',
+            b'msghand thread start',
+            b'net thread start',
+            b'addcon thread start',
         ]
         if self.is_wallet_compiled():
-            lines_to_terminate_after.append('Verifying wallet')
+            lines_to_terminate_after.append(b'Verifying wallet')
 
         for terminate_line in lines_to_terminate_after:
-            self.log.info(f"Starting node and will exit after line '{terminate_line}'")
-            with node.wait_for_debug_log([terminate_line], ignore_case=True):
+            self.log.info(f"Starting node and will exit after line {terminate_line}")
+            with node.wait_for_debug_log([terminate_line]):
                 node.start(extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'])
             self.log.debug("Terminating node after terminate line was found")
             sigterm_node()

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Stress tests related to node initialization."""
+import random
+import time
+import os
+from pathlib import Path
+
+from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.test_node import ErrorMatch
+from test_framework.util import assert_equal
+
+
+class InitStressTest(BitcoinTestFramework):
+    """
+    Ensure that initialization can be interrupted at a number of points and not impair
+    subsequent starts.
+    """
+
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 1
+
+    def run_test(self):
+        """
+        - test terminating initialization after seeing a certain log line.
+        - test terminating init after seeing a random number of log lines.
+        - test removing certain essential files to test startup error paths.
+        """
+        # TODO: skip Windows for now since it isn't clear how to SIGTERM.
+        #
+        # Windows doesn't support `process.terminate()`.
+        # and other approaches (like below) don't work:
+        #
+        #   os.kill(node.process.pid, signal.CTRL_C_EVENT)
+        if os.name == 'nt':
+            raise SkipTest("can't SIGTERM on Windows")
+
+        self.stop_node(0)
+        node = self.nodes[0]
+
+        def sigterm_node():
+            node.process.terminate()
+            node.process.wait()
+            node.debug_log_path.unlink()
+            node.debug_log_path.touch()
+
+        def check_clean_start():
+            """Ensure that node restarts successfully after various interrupts."""
+            # TODO: add -txindex=1 to fully test index initiatlization.
+            # See https://github.com/bitcoin/bitcoin/pull/23289#discussion_r735159180 for
+            # a discussion of the related bug.
+            node.start()
+            node.wait_for_rpc_connection()
+            assert_equal(200, node.getblockcount())
+
+        lines_to_terminate_after = [
+            'scheduler thread start',
+            'Loading P2P addresses',
+            'Loading banlist',
+            'Loading block index',
+            'Switching active chainstate',
+            'Loaded best chain:',
+            'init message: Verifying blocks',
+            'loadblk thread start',
+            # TODO: reenable - see above TODO
+            # 'txindex thread start',
+            'net thread start',
+            'addcon thread start',
+            'msghand thread start',
+        ]
+        if self.is_wallet_compiled():
+            lines_to_terminate_after.append('Verifying wallet')
+
+        for terminate_line in lines_to_terminate_after:
+            self.log.info(f"Starting node and will exit after line '{terminate_line}'")
+            node.start(
+                # TODO: add -txindex=1 to fully test index initiatlization.
+                # extra_args=['-txindex=1'],
+            )
+            logfile = open(node.debug_log_path, 'r', encoding='utf8')
+
+            MAX_SECS_TO_WAIT = 30
+            start = time.time()
+            num_lines = 0
+
+            while True:
+                line = logfile.readline()
+                if line:
+                    num_lines += 1
+
+                if line and terminate_line.lower() in line.lower():
+                    self.log.debug(f"Terminating node after {num_lines} log lines seen")
+                    sigterm_node()
+                    break
+
+                if (time.time() - start) > MAX_SECS_TO_WAIT:
+                    raise AssertionError(
+                        f"missed line {terminate_line}; terminating now after {num_lines} lines")
+
+                if node.process.poll() is not None:
+                    raise AssertionError(f"node failed to start (line: '{terminate_line}')")
+
+        check_clean_start()
+        num_total_logs = len(node.debug_log_path.read_text().splitlines())
+        self.stop_node(0)
+
+        self.log.info(
+            f"Terminate at some random point in the init process (max logs: {num_total_logs})")
+
+        for _ in range(40):
+            terminate_after = random.randint(1, num_total_logs)
+            self.log.debug(f"Starting node and will exit after {terminate_after} lines")
+            node.start(
+                # TODO: add -txindex=1 to fully test index initiatlization.
+                # extra_args=['-txindex=1'],
+            )
+            logfile = open(node.debug_log_path, 'r', encoding='utf8')
+
+            MAX_SECS_TO_WAIT = 10
+            start = time.time()
+            num_lines = 0
+
+            while True:
+                line = logfile.readline()
+                if line:
+                    num_lines += 1
+
+                if num_lines >= terminate_after or (time.time() - start) > MAX_SECS_TO_WAIT:
+                    self.log.debug(f"Terminating node after {num_lines} log lines seen")
+                    sigterm_node()
+                    break
+
+                if node.process.poll() is not None:
+                    raise AssertionError("node failed to start")
+
+        check_clean_start()
+        self.stop_node(0)
+
+        self.log.info("Test startup errors after removing certain essential files")
+
+        files_to_disturb = {
+            'blocks/index/*.ldb': 'Error opening block database.',
+            'chainstate/*.ldb': 'Error opening block database.',
+            'blocks/blk*.dat': 'Error loading block database.',
+        }
+
+        for file_patt, err_fragment in files_to_disturb.items():
+            target_file = list(node.chain_path.glob(file_patt))[0]
+
+            self.log.info(f"Tweaking file to ensure failure {target_file}")
+            bak_path = str(target_file) + ".bak"
+            target_file.rename(bak_path)
+
+            # TODO: at some point, we should test perturbing the files instead of removing
+            # them, e.g.
+            #
+            # contents = target_file.read_bytes()
+            # tweaked_contents = bytearray(contents)
+            # tweaked_contents[50:250] = b'1' * 200
+            # target_file.write_bytes(bytes(tweaked_contents))
+            #
+            # At the moment I can't get this to work (bitcoind loads successfully?) so
+            # investigate doing this later.
+
+            node.assert_start_raises_init_error(
+                # TODO: add -txindex=1 to fully test index initiatlization.
+                # extra_args=['-txindex=1'],
+                expected_msg=err_fragment,
+                match=ErrorMatch.PARTIAL_REGEX,
+            )
+
+            self.log.info(f"Restoring file from {bak_path} and restarting")
+            Path(bak_path).rename(target_file)
+            check_clean_start()
+            self.stop_node(0)
+
+
+if __name__ == '__main__':
+    InitStressTest().main()

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -93,7 +93,7 @@ class InitStressTest(BitcoinTestFramework):
             additional_lines = random.randint(1, num_total_logs)
             self.log.debug(f"Starting node and will exit after {additional_lines} lines")
             node.start(extra_args=['-txindex=1'])
-            logfile = open(node.debug_log_path, 'r', encoding='utf8')
+            logfile = open(node.debug_log_path, 'rb')
 
             MAX_SECS_TO_WAIT = 10
             start = time.time()

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -44,14 +44,9 @@ class InitStressTest(BitcoinTestFramework):
         def sigterm_node():
             node.process.terminate()
             node.process.wait()
-            node.debug_log_path.unlink()
-            node.debug_log_path.touch()
 
         def check_clean_start():
             """Ensure that node restarts successfully after various interrupts."""
-            # TODO: add -txindex=1 to fully test index initiatlization.
-            # See https://github.com/bitcoin/bitcoin/pull/23289#discussion_r735159180 for
-            # a discussion of the related bug.
             node.start()
             node.wait_for_rpc_connection()
             assert_equal(200, node.getblockcount())
@@ -71,56 +66,33 @@ class InitStressTest(BitcoinTestFramework):
             'net thread start',
             'addcon thread start',
             'loadblk thread start',
-            # TODO: reenable - see above TODO
-            # 'txindex thread start',
-            'msghand thread start'
+            'txindex thread start',
+            'msghand thread start',
+            'net thread start',
+            'addcon thread start',
         ]
         if self.is_wallet_compiled():
             lines_to_terminate_after.append('Verifying wallet')
 
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will exit after line '{terminate_line}'")
-            node.start(
-                # TODO: add -txindex=1 to fully test index initiatlization.
-                # extra_args=['-txindex=1'],
-            )
-            logfile = open(node.debug_log_path, 'r', encoding='utf8')
+            node.start(extra_args=['-txindex=1'])
 
-            MAX_SECS_TO_WAIT = 30
-            start = time.time()
-            num_lines = 0
-
-            while True:
-                line = logfile.readline()
-                if line:
-                    num_lines += 1
-
-                if line and terminate_line.lower() in line.lower():
-                    self.log.debug(f"Terminating node after {num_lines} log lines seen")
-                    sigterm_node()
-                    break
-
-                if (time.time() - start) > MAX_SECS_TO_WAIT:
-                    raise AssertionError(
-                        f"missed line {terminate_line}; terminating now after {num_lines} lines")
-
-                if node.process.poll() is not None:
-                    raise AssertionError(f"node failed to start (line: '{terminate_line}')")
+            num_total_logs = node.wait_for_debug_log([terminate_line], ignore_case=True)
+            self.log.debug(f"Terminating node after {num_total_logs} log lines seen")
+            sigterm_node()
 
         check_clean_start()
-        num_total_logs = len(node.debug_log_path.read_text().splitlines())
         self.stop_node(0)
 
         self.log.info(
             f"Terminate at some random point in the init process (max logs: {num_total_logs})")
 
         for _ in range(40):
-            terminate_after = random.randint(1, num_total_logs)
-            self.log.debug(f"Starting node and will exit after {terminate_after} lines")
-            node.start(
-                # TODO: add -txindex=1 to fully test index initiatlization.
-                # extra_args=['-txindex=1'],
-            )
+            num_logs = len(Path(node.debug_log_path).read_text().splitlines())
+            additional_lines = random.randint(1, num_total_logs)
+            self.log.debug(f"Starting node and will exit after {additional_lines} lines")
+            node.start(extra_args=['-txindex=1'])
             logfile = open(node.debug_log_path, 'r', encoding='utf8')
 
             MAX_SECS_TO_WAIT = 10
@@ -132,7 +104,8 @@ class InitStressTest(BitcoinTestFramework):
                 if line:
                     num_lines += 1
 
-                if num_lines >= terminate_after or (time.time() - start) > MAX_SECS_TO_WAIT:
+                if num_lines >= (num_logs + additional_lines) or \
+                        (time.time() - start) > MAX_SECS_TO_WAIT:
                     self.log.debug(f"Terminating node after {num_lines} log lines seen")
                     sigterm_node()
                     break
@@ -152,11 +125,12 @@ class InitStressTest(BitcoinTestFramework):
         }
 
         for file_patt, err_fragment in files_to_disturb.items():
-            target_file = list(node.chain_path.glob(file_patt))[0]
+            target_files = list(node.chain_path.glob(file_patt))
 
-            self.log.info(f"Tweaking file to ensure failure {target_file}")
-            bak_path = str(target_file) + ".bak"
-            target_file.rename(bak_path)
+            for target_file in target_files:
+                self.log.info(f"Tweaking file to ensure failure {target_file}")
+                bak_path = str(target_file) + ".bak"
+                target_file.rename(bak_path)
 
             # TODO: at some point, we should test perturbing the files instead of removing
             # them, e.g.
@@ -170,14 +144,16 @@ class InitStressTest(BitcoinTestFramework):
             # investigate doing this later.
 
             node.assert_start_raises_init_error(
-                # TODO: add -txindex=1 to fully test index initiatlization.
-                # extra_args=['-txindex=1'],
+                extra_args=['-txindex=1'],
                 expected_msg=err_fragment,
                 match=ErrorMatch.PARTIAL_REGEX,
             )
 
-            self.log.info(f"Restoring file from {bak_path} and restarting")
-            Path(bak_path).rename(target_file)
+            for target_file in target_files:
+                bak_path = str(target_file) + ".bak"
+                self.log.debug(f"Restoring file from {bak_path} and restarting")
+                Path(bak_path).rename(target_file)
+
             check_clean_start()
             self.stop_node(0)
 

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -57,19 +57,23 @@ class InitStressTest(BitcoinTestFramework):
             assert_equal(200, node.getblockcount())
 
         lines_to_terminate_after = [
+            'Validating signatures for all blocks',
             'scheduler thread start',
+            'Starting HTTP server',
             'Loading P2P addresses',
             'Loading banlist',
             'Loading block index',
             'Switching active chainstate',
+            'Checking all blk files are present',
             'Loaded best chain:',
             'init message: Verifying blocks',
+            'init message: Starting network threads',
+            'net thread start',
+            'addcon thread start',
             'loadblk thread start',
             # TODO: reenable - see above TODO
             # 'txindex thread start',
-            'net thread start',
-            'addcon thread start',
-            'msghand thread start',
+            'msghand thread start'
         ]
         if self.is_wallet_compiled():
             lines_to_terminate_after.append('Verifying wallet')

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -22,7 +22,7 @@ class ReindexTest(BitcoinTestFramework):
         self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
-        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]
+        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex", "-txindex=0"]]
         self.start_nodes(extra_args)
         assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
         self.log.info("Success")

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -251,6 +251,12 @@ class CompactFiltersTest(BitcoinTestFramework):
         msg = "Error: Cannot set -peerblockfilters without -blockfilterindex."
         self.nodes[0].assert_start_raises_init_error(expected_msg=msg)
 
+        self.log.info("Test -blockfilterindex with -reindex-chainstate raises an error")
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: -reindex-chainstate option is not compatible with -blockfilterindex. '
+            'Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.',
+            extra_args=['-blockfilterindex', '-reindex-chainstate'],
+        )
 
 def compute_last_header(prev_header, hashes):
     """Compute the last filter header from a starting header and a sequence of filter hashes."""

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -251,6 +251,11 @@ class CompactFiltersTest(BitcoinTestFramework):
         msg = "Error: Cannot set -peerblockfilters without -blockfilterindex."
         self.nodes[0].assert_start_raises_init_error(expected_msg=msg)
 
+        self.log.info("Test unknown value to -blockfilterindex raises an error")
+        self.nodes[0].extra_args = ["-blockfilterindex=abc"]
+        msg = "Error: Unknown -blockfilterindex value abc."
+        self.nodes[0].assert_start_raises_init_error(expected_msg=msg)
+
         self.log.info("Test -blockfilterindex with -reindex-chainstate raises an error")
         self.nodes[0].assert_start_raises_init_error(
             expected_msg='Error: -reindex-chainstate option is not compatible with -blockfilterindex. '

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -442,7 +442,8 @@ class TestNode():
             time.sleep(0.05)
         self._raise_assertion_error('Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(str(expected_msgs), print_log))
 
-    def wait_for_debug_log(self, expected_msgs, timeout=10, ignore_case=False) -> int:
+    @contextlib.contextmanager
+    def wait_for_debug_log(self, expected_msgs, timeout=60, ignore_case=False):
         """
         Block until we see a particular debug log message fragment or until we exceed the timeout.
         Return:
@@ -451,6 +452,8 @@ class TestNode():
         time_end = time.time() + timeout * self.timeout_factor
         prev_size = self.debug_log_bytes()
         re_flags = re.MULTILINE | (re.IGNORECASE if ignore_case else 0)
+
+        yield
 
         while True:
             found = True
@@ -463,8 +466,7 @@ class TestNode():
                     found = False
 
             if found:
-                num_logs = len(log.splitlines())
-                return num_logs
+                return
 
             if time.time() >= time_end:
                 print_log = " - " + "\n - ".join(log.splitlines())
@@ -476,7 +478,6 @@ class TestNode():
         self._raise_assertion_error(
             'Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(
                 str(expected_msgs), print_log))
-        return -1  # useless return to satisfy linter
 
     @contextlib.contextmanager
     def profile_with_perf(self, profile_name: str):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -409,14 +409,17 @@ class TestNode():
     def debug_log_path(self) -> Path:
         return self.chain_path / 'debug.log'
 
+    def debug_log_bytes(self) -> int:
+        with open(self.debug_log_path, encoding='utf-8') as dl:
+            dl.seek(0, 2)
+            return dl.tell()
+
     @contextlib.contextmanager
     def assert_debug_log(self, expected_msgs, unexpected_msgs=None, timeout=2):
         if unexpected_msgs is None:
             unexpected_msgs = []
         time_end = time.time() + timeout * self.timeout_factor
-        with open(self.debug_log_path, encoding='utf-8') as dl:
-            dl.seek(0, 2)
-            prev_size = dl.tell()
+        prev_size = self.debug_log_bytes()
 
         yield
 
@@ -438,6 +441,42 @@ class TestNode():
                 break
             time.sleep(0.05)
         self._raise_assertion_error('Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(str(expected_msgs), print_log))
+
+    def wait_for_debug_log(self, expected_msgs, timeout=10, ignore_case=False) -> int:
+        """
+        Block until we see a particular debug log message fragment or until we exceed the timeout.
+        Return:
+            the number of log lines we encountered when matching
+        """
+        time_end = time.time() + timeout * self.timeout_factor
+        prev_size = self.debug_log_bytes()
+        re_flags = re.MULTILINE | (re.IGNORECASE if ignore_case else 0)
+
+        while True:
+            found = True
+            with open(self.debug_log_path, encoding='utf-8') as dl:
+                dl.seek(prev_size)
+                log = dl.read()
+
+            for expected_msg in expected_msgs:
+                if re.search(re.escape(expected_msg), log, flags=re_flags) is None:
+                    found = False
+
+            if found:
+                num_logs = len(log.splitlines())
+                return num_logs
+
+            if time.time() >= time_end:
+                print_log = " - " + "\n - ".join(log.splitlines())
+                break
+
+            # No sleep here because we want to detect the message fragment as fast as
+            # possible.
+
+        self._raise_assertion_error(
+            'Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(
+                str(expected_msgs), print_log))
+        return -1  # useless return to satisfy linter
 
     @contextlib.contextmanager
     def profile_with_perf(self, profile_name: str):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -443,7 +443,7 @@ class TestNode():
         self._raise_assertion_error('Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(str(expected_msgs), print_log))
 
     @contextlib.contextmanager
-    def wait_for_debug_log(self, expected_msgs, timeout=60, ignore_case=False):
+    def wait_for_debug_log(self, expected_msgs, timeout=60):
         """
         Block until we see a particular debug log message fragment or until we exceed the timeout.
         Return:
@@ -451,18 +451,17 @@ class TestNode():
         """
         time_end = time.time() + timeout * self.timeout_factor
         prev_size = self.debug_log_bytes()
-        re_flags = re.MULTILINE | (re.IGNORECASE if ignore_case else 0)
 
         yield
 
         while True:
             found = True
-            with open(self.debug_log_path, encoding='utf-8') as dl:
+            with open(self.debug_log_path, "rb") as dl:
                 dl.seek(prev_size)
                 log = dl.read()
 
             for expected_msg in expected_msgs:
-                if re.search(re.escape(expected_msg), log, flags=re_flags) is None:
+                if expected_msg not in log:
                     found = False
 
             if found:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -468,7 +468,7 @@ class TestNode():
                 return
 
             if time.time() >= time_end:
-                print_log = " - " + "\n - ".join(log.splitlines())
+                print_log = " - " + "\n - ".join(log.decode("utf8", errors="replace").splitlines())
                 break
 
             # No sleep here because we want to detect the message fragment as fast as

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -20,6 +20,7 @@ import urllib.parse
 import shlex
 import sys
 import collections
+from pathlib import Path
 
 from .authproxy import JSONRPCException
 from .descriptors import descsum_create
@@ -400,14 +401,20 @@ class TestNode():
     def wait_until_stopped(self, timeout=BITCOIND_PROC_WAIT_TIMEOUT):
         wait_until_helper(self.is_node_stopped, timeout=timeout, timeout_factor=self.timeout_factor)
 
+    @property
+    def chain_path(self) -> Path:
+        return Path(self.datadir) / get_chain_folder(self.datadir, self.chain)
+
+    @property
+    def debug_log_path(self) -> Path:
+        return self.chain_path / 'debug.log'
+
     @contextlib.contextmanager
     def assert_debug_log(self, expected_msgs, unexpected_msgs=None, timeout=2):
         if unexpected_msgs is None:
             unexpected_msgs = []
         time_end = time.time() + timeout * self.timeout_factor
-        chain = get_chain_folder(self.datadir, self.chain)
-        debug_log = os.path.join(self.datadir, chain, 'debug.log')
-        with open(debug_log, encoding='utf-8') as dl:
+        with open(self.debug_log_path, encoding='utf-8') as dl:
             dl.seek(0, 2)
             prev_size = dl.tell()
 
@@ -415,7 +422,7 @@ class TestNode():
 
         while True:
             found = True
-            with open(debug_log, encoding='utf-8') as dl:
+            with open(self.debug_log_path, encoding='utf-8') as dl:
                 dl.seek(prev_size)
                 log = dl.read()
             print_log = " - " + "\n - ".join(log.splitlines())

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -327,6 +327,7 @@ BASE_SCRIPTS = [
     'rpc_wipewallettxes.py',
     'feature_dip0020_activation.py',
     'feature_uacomment.py',
+    'feature_init.py',
     'wallet_coinbase_category.py --legacy-wallet',
     'wallet_coinbase_category.py --descriptors',
     'feature_filelock.py',


### PR DESCRIPTION
## Additional Information

* When backporting [bitcoin#24789](https://github.com/bitcoin/bitcoin/pull/24789), `-txindex=0` had to be appended to the arguments passed in `feature_reindex.py` as unlike Bitcoin ([source](https://github.com/bitcoin/bitcoin/blob/dac44fc06ff9938d070aa5221d106a7f31da9d81/src/validation.h#L83)), Dash enables the transaction index by default ([source](https://github.com/dashpay/dash/blob/74e54b8a12e2b557109c29af38445bb9484e7a33/src/validation.h#L94)).

  As having the index enabled when using `-reindex-chainstate` is now prohibited, without this change, the test will crash.

## Breaking Changes

None expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

