### PR TITLE
build: update gmp to 6.3.0

### DIFF
--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -6,8 +6,9 @@ $(package)_sha256_hash=ac28211a7cfb609bae2e2c8d6058d66c8fe96434f740cf6fe2e47b000
 
 define $(package)_set_vars
 $(package)_config_opts += --disable-shared --enable-cxx --enable-fat
-$(package)_cflags_armv7l_linux+=-march=armv7-a
-$(package)_cflags_aarch64_darwin+=-march=armv8-a
+$(package)_cflags_aarch64 += -march=armv8-a
+$(package)_cflags_armv7l += -march=armv7-a
+$(package)_cflags_x86_64 += -march=x86-64
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -1,11 +1,11 @@
 package=gmp
-$(package)_version=6.2.1
-$(package)_download_path=https://gmplib.org/download/gmp
+$(package)_version=6.3.0
+$(package)_download_path=https://ftp.gnu.org/gnu/gmp
 $(package)_file_name=gmp-$($(package)_version).tar.bz2
-$(package)_sha256_hash=eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c
+$(package)_sha256_hash=ac28211a7cfb609bae2e2c8d6058d66c8fe96434f740cf6fe2e47b000d1c20cb
 
 define $(package)_set_vars
-$(package)_config_opts+=--enable-cxx --enable-fat --disable-shared
+$(package)_config_opts += --disable-shared --enable-cxx --enable-fat
 $(package)_cflags_armv7l_linux+=-march=armv7-a
 $(package)_cflags_aarch64_darwin+=-march=armv8-a
 endef


### PR DESCRIPTION
## Additional Information

After [bls-signatures#92](https://github.com/dashpay/bls-signatures/pull/92), GMP is re-enabled for Apple Silicon macOS targets so long as GMP 6.3.0 or higher is used. GMP significantly contributes to performance improvements in bls-signatures, generally to the tune of ~50% ([source](https://github.com/dashpay/bls-signatures/pull/93#issuecomment-2395111949)).

The URL has been changed based on guidance from the Homebrew recipe for `gmp` ([source](https://github.com/Homebrew/homebrew-core/blob/51c899140c84d38dfa4c4fe623c859e6241504a0/Formula/g/gmp.rb#L44-L45)).

## Breaking Changes

None expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
