### PR TITLE
fix: adjust the number of spork defaults

### DIFF
--- a/src/spork.h
+++ b/src/spork.h
@@ -68,7 +68,7 @@ struct CSporkDef
 };
 
 #define MAKE_SPORK_DEF(name, defaultValue) CSporkDef{name, defaultValue, #name}
-[[maybe_unused]] static constexpr std::array<CSporkDef, 8> sporkDefs = {
+[[maybe_unused]] static constexpr std::array<CSporkDef, 7> sporkDefs = {
     MAKE_SPORK_DEF(SPORK_2_INSTANTSEND_ENABLED,            4070908800ULL), // OFF
     MAKE_SPORK_DEF(SPORK_3_INSTANTSEND_BLOCK_FILTERING,    4070908800ULL), // OFF
     MAKE_SPORK_DEF(SPORK_9_SUPERBLOCKS_ENABLED,            4070908800ULL), // OFF

--- a/test/functional/feature_sporks.py
+++ b/test/functional/feature_sporks.py
@@ -59,5 +59,8 @@ class SporkTest(BitcoinTestFramework):
         self.connect_nodes(1, 2)
         self.wait_until(lambda: self.get_test_spork_state(self.nodes[2]), timeout=10)
 
+        assert "" not in self.nodes[0].spork('show').keys()
+
+
 if __name__ == '__main__':
     SporkTest().main()


### PR DESCRIPTION
## Issue being fixed or feature implemented
```
{
  "SPORK_2_INSTANTSEND_ENABLED": 4070908800,
  "SPORK_3_INSTANTSEND_BLOCK_FILTERING": 4070908800,
  "SPORK_9_SUPERBLOCKS_ENABLED": 4070908800,
  "SPORK_17_QUORUM_DKG_ENABLED": 4070908800,
  "SPORK_19_CHAINLOCKS_ENABLED": 4070908800,
  "SPORK_21_QUORUM_ALL_CONNECTED": 4070908800,
  "SPORK_23_QUORUM_POSE": 4070908800,
  "": 0 <----- this line shouldn't exist
}
```

6275 follow-up

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

