### PR TITLE
fix: rpc getblock and getblockstats for blocks with withdrawal transactions (asset unlock)

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -335,7 +335,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, bool include_add
 
     if (calculate_fee) {
         CAmount fee = amt_total_in - amt_total_out;
-        if (tx.nType == TRANSACTION_ASSET_UNLOCK) {
+        if (tx.IsPlatformTransfer()) {
             fee = CHECK_NONFATAL(GetTxPayload<CAssetUnlockPayload>(tx))->getFee();
         }
         CHECK_NONFATAL(MoneyRange(fee));

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -334,7 +334,10 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, bool include_add
     }
 
     if (calculate_fee) {
-        const CAmount fee = amt_total_in - amt_total_out;
+        CAmount fee = amt_total_in - amt_total_out;
+        if (tx.nType == TRANSACTION_ASSET_UNLOCK) {
+            fee = CHECK_NONFATAL(GetTxPayload<CAssetUnlockPayload>(tx))->getFee();
+        }
         CHECK_NONFATAL(MoneyRange(fee));
         entry.pushKV("fee", ValueFromAmount(fee));
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2452,7 +2452,7 @@ static RPCHelpMan getblockstats()
 
             CAmount txfee = tx_total_in - tx_total_out;
 
-            if (tx->nType == TRANSACTION_ASSET_UNLOCK) {
+            if (tx->IsPlatformTransfer()) {
                 txfee = CHECK_NONFATAL(GetTxPayload<CAssetUnlockPayload>(*tx))->getFee();
             }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -49,6 +49,7 @@
 #include <versionbits.h>
 #include <warnings.h>
 
+#include <evo/assetlocktx.h>
 #include <evo/cbtx.h>
 #include <evo/evodb.h>
 #include <evo/mnhftx.h>
@@ -2450,6 +2451,11 @@ static RPCHelpMan getblockstats()
             }
 
             CAmount txfee = tx_total_in - tx_total_out;
+
+            if (tx->nType == TRANSACTION_ASSET_UNLOCK) {
+                txfee = CHECK_NONFATAL(GetTxPayload<CAssetUnlockPayload>(*tx))->getFee();
+            }
+
             CHECK_NONFATAL(MoneyRange(txfee));
             if (do_medianfee) {
                 fee_array.push_back(txfee);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <evo/assetlocktx.h>
 #include <evo/chainhelper.h>
 #include <evo/deterministicmns.h>
 #include <governance/classes.h>
@@ -406,6 +407,11 @@ static RPCHelpMan masternode_payments()
             if (tx->IsCoinBase()) {
                 continue;
             }
+            if (tx->IsPlatformTransfer()) {
+                nBlockFees += CHECK_NONFATAL(GetTxPayload<CAssetUnlockPayload>(*tx))->getFee();
+                continue;
+            }
+
             CAmount nValueIn{0};
             for (const auto& txin : tx->vin) {
                 uint256 blockHashTmp;

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -407,6 +407,9 @@ class AssetLocksTest(DashTestFramework):
         self.mempool_size -= 2
         self.check_mempool_size()
         block_asset_unlock = node.getrawtransaction(asset_unlock_tx.rehash(), 1)['blockhash']
+        self.log.info("Checking rpc `getblock` and `getblockstats` succeeds as they use own fee calculation mechanism")
+        assert_equal(node.getblockstats(node.getblockcount())['maxfee'], tiny_amount)
+        node.getblock(block_asset_unlock, 2)
 
         self.send_tx(asset_unlock_tx,
             expected_error = "Transaction already in block chain",

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -370,6 +370,7 @@ class AssetLocksTest(DashTestFramework):
         self.wait_for_sporks_same()
 
         txid = self.send_tx(asset_unlock_tx)
+        assert_equal(node.getmempoolentry(txid)['fee'], Decimal("0.0007"))
         is_id = node_wallet.sendtoaddress(node_wallet.getnewaddress(), 1)
         for node in self.nodes:
             self.wait_for_instantlock(is_id, node)


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash/issues/6335


## What was done?
Applied fixes for `getblock` rpc and `getblockstats` rpc to make them work with withdrawal transactions (asset unlock).

## How Has This Been Tested?
Run updated functional test `feature_asset_locks.py` without the fix causes a failure:
```
2024-10-22T12:01:35.902000Z TestFramework (ERROR): JSONRPC error
Traceback (most recent call last):
  File "/home/knst/projects/dash-reviews/test/functional/test_framework/test_framework.py", line 160, in main
    self.run_test()
  File "/home/knst/projects/dash-reviews/test/functional/feature_asset_locks.py", line 273, in run_test
    self.test_asset_unlocks(node_wallet, node, pubkey)
  File "/home/knst/projects/dash-reviews/test/functional/feature_asset_locks.py", line 410, in test_asset_unlocks
    self.log.info(f"block info: {node.getblock(block_asset_unlock, 2)}")
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/knst/projects/dash-reviews/test/functional/test_framework/coverage.py", line 49, in __call__
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/knst/projects/dash-reviews/test/functional/test_framework/authproxy.py", line 148, in __call__
    raise JSONRPCException(response['error'], status)
test_framework.authproxy.JSONRPCException: Internal bug detected: "MoneyRange(fee)"
core_write.cpp:338 (TxToUniv)
Please report this issue here: https://github.com/dashpay/dash/issues
 (-1)
```

With patch functional test `feature_asset_locks.py` succeed.




## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

