### PR TITLE
ci: attest results of guix builds

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -2,6 +2,8 @@ name: Guix Build
 
 permissions:
   packages: write
+  id-token: write
+  attestations: write
 
 on:
   pull_request_target:
@@ -127,3 +129,7 @@ jobs:
           path: |
             ${{ github.workspace }}/dash/guix-build*/output/${{ matrix.build_target }}/
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ github.workspace }}/dash/guix-build*/output/${{ matrix.build_target }}/*


### PR DESCRIPTION
## Issue being fixed or feature implemented
This simply adds attestations to guix results by GitHub. This way, not only can someone verify that all us developers agree, but also that GitHub hosted runners agree :)

## What was done?
Add actions/attest-build-provenance to guix-build CI

## How Has This Been Tested?
see: https://github.com/PastaPastaPasta/dash/actions/runs/11239755631

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

