### PR TITLE
fix: make 6336 compile in v21.1.x branch, using older CHECK_NONFATAL functionality

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -336,7 +336,9 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, bool include_add
     if (calculate_fee) {
         CAmount fee = amt_total_in - amt_total_out;
         if (tx.IsPlatformTransfer()) {
-            fee = CHECK_NONFATAL(GetTxPayload<CAssetUnlockPayload>(tx))->getFee();
+            auto payload = GetTxPayload<CAssetUnlockPayload>(tx);
+            CHECK_NONFATAL(payload);
+            fee = payload->getFee();
         }
         CHECK_NONFATAL(MoneyRange(fee));
         entry.pushKV("fee", ValueFromAmount(fee));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2453,7 +2453,9 @@ static RPCHelpMan getblockstats()
             CAmount txfee = tx_total_in - tx_total_out;
 
             if (tx->IsPlatformTransfer()) {
-                txfee = CHECK_NONFATAL(GetTxPayload<CAssetUnlockPayload>(*tx))->getFee();
+                auto payload = GetTxPayload<CAssetUnlockPayload>(*tx);
+                CHECK_NONFATAL(payload);
+                txfee = payload->getFee();
             }
 
             CHECK_NONFATAL(MoneyRange(txfee));

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -408,7 +408,9 @@ static RPCHelpMan masternode_payments()
                 continue;
             }
             if (tx->IsPlatformTransfer()) {
-                nBlockFees += CHECK_NONFATAL(GetTxPayload<CAssetUnlockPayload>(*tx))->getFee();
+                auto payload = GetTxPayload<CAssetUnlockPayload>(*tx);
+                CHECK_NONFATAL(payload);
+                nBlockFees += payload->getFee();
                 continue;
             }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Resolve build failures when 6336 is back ported

## What was done?
Use older functionality of CHECK_NONFATAL

## How Has This Been Tested?
built on both branches

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

