### PR TITLE
fix: adjust conditions in `Check Merge Fast-Forward Only` action

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git fetch origin master:master
           git checkout master
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [[ "${{ github.event_name }}" == "pull_request"* ]]; then
             git merge --ff-only ${{ github.event.pull_request.head.sha }}
           else
             git merge --ff-only ${{ github.sha }}


### PR DESCRIPTION
## Issue being fixed or feature implemented
I _think_ we were using the wrong event name since #6190... which is why #6341 is failing atm.

```
V Run git fetch origin master:master
  git fetch origin master:master
  git checkout master
  if [ "pull_request_target" == "pull_request" ]; then
    git merge --ff-only 0172b887c027751e4b371b6012d2a59d1e872e1a
  else
    git merge --ff-only d494339b9f0587902fbf6358966c65bcfcb9febf
  fi

```
https://github.com/dashpay/dash/actions/runs/11474383519/job/31930192140?pr=6341

## What was done?

## How Has This Been Tested?

Pushed these changes to my `develop` https://github.com/UdjinM6/dash/commits/develop/

Created 2 PRs to verify it worked as expected:
- https://github.com/UdjinM6/dash/pull/18
- https://github.com/UdjinM6/dash/pull/19

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

