### PR TITLE
fix: fetch PR head before merging it in `Check Merge Fast-Forward Only` action

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -28,6 +28,7 @@ jobs:
           git fetch origin master:master
           git checkout master
           if [[ "${{ github.event_name }}" == "pull_request"* ]]; then
+            git fetch origin pull/${{ github.event.pull_request.number }}/head
             git merge --ff-only ${{ github.event.pull_request.head.sha }}
           else
             git merge --ff-only ${{ github.sha }}


### PR DESCRIPTION
## Issue being fixed or feature implemented
```
v Run git fetch origin master:master
  git fetch origin master:master
  git checkout master
  if [[ "pull_request_target" == "pull_request"* ]]; then
    git merge --ff-only b216a402cc58cb153bebe137064fd0c804752d21
  else
    git merge --ff-only 3a18f087bf16fc7530b2b139a59a056320632b1f
  fi
  shell: /usr/bin/bash -e {0}
From https://github.com/dashpay/dash
 * [new branch]          master     -> master
Switched to branch 'master'
merge: b216a402cc58cb153bebe137064fd0c804752d21 - not something we can merge
Error: Process completed with exit code 1.
```
https://github.com/dashpay/dash/actions/runs/11492009432/job/31999602262?pr=6346

So it's picking the right commit sha now but it has no commit itself.

#6344 follow-up

## What was done?

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

