### PR TITLE
ci: better caching gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,10 +107,10 @@ jobs:
           path: |
             depends/${{ matrix.host }}
           # We don't care about no specific key as depends system will handle that for us
-          key: ${{ runner.os }}-depends-${{ matrix.host }}-${{ hashFiles('depends/packages/*') }}
+          key: ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
-            ${{ runner.os }}-depends-${{ matrix.host }}-${{ hashFiles('depends/packages/*') }}
-            ${{ runner.os }}-depends-${{ matrix.host }}
+            ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
+            ${{ runner.os }}-depends-${{ matrix.build_target }}
 
       - name: Build dependencies
         run: make -j$(nproc) -C depends HOST=${{ matrix.host }}
@@ -154,10 +154,10 @@ jobs:
         with:
           path: |
             depends/${{ matrix.host }}
-          key: ${{ runner.os }}-depends-${{ matrix.host }}-${{ hashFiles('depends/packages/*') }}
+          key: ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
-            ${{ runner.os }}-depends-${{ matrix.host }}-${{ hashFiles('depends/packages/*') }}
-            ${{ runner.os }}-depends-${{ matrix.host }}
+            ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
+            ${{ runner.os }}-depends-${{ matrix.build_target }}
 
       - name: Determine PR Base SHA
         id: vars
@@ -169,11 +169,11 @@ jobs:
         with:
           path: |
             /cache
-          key: ${{ runner.os }}-${{ matrix.host }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.build_target }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.host }}-${{ github.sha }}
-            ${{ runner.os }}-${{ matrix.host }}-${{ steps.vars.outputs.PR_BASE_SHA }}
-            ${{ runner.os }}-${{ matrix.host }}
+            ${{ runner.os }}-${{ matrix.build_target }}-${{ github.sha }}
+            ${{ runner.os }}-${{ matrix.build_target }}-${{ steps.vars.outputs.PR_BASE_SHA }}
+            ${{ runner.os }}-${{ matrix.build_target }}
 
       - name: Build source and run tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,6 @@ jobs:
         with:
           path: |
             depends/sources
-          # We don't care about no specific key as depends system will handle that for us
           key: depends-sources-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
             depends-sources-
@@ -106,7 +105,6 @@ jobs:
         with:
           path: |
             depends/${{ matrix.host }}
-          # We don't care about no specific key as depends system will handle that for us
           key: ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
             ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,15 +105,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            depends/built
             depends/${{ matrix.host }}
-            depends/sdk-sources
           # We don't care about no specific key as depends system will handle that for us
-          key: ${{ runner.os }}-depends-${{ matrix.host }}-${{ github.sha }}
+          key: ${{ runner.os }}-depends-${{ matrix.host }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
-            ${{ runner.os }}-depends-${{ matrix.host }}-${{ github.sha }}
+            ${{ runner.os }}-depends-${{ matrix.host }}-${{ hashFiles('depends/packages/*') }}
             ${{ runner.os }}-depends-${{ matrix.host }}
-            ${{ runner.os }}-depends
 
       - name: Build dependencies
         run: make -j$(nproc) -C depends HOST=${{ matrix.host }}
@@ -156,15 +153,16 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            depends/built
             depends/${{ matrix.host }}
-            depends/sdk-sources
-          # We don't care about no specific key as depends system will handle that for us
-          key: ${{ runner.os }}-depends-${{ matrix.host }}-${{ github.sha }}
+          key: ${{ runner.os }}-depends-${{ matrix.host }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
-            ${{ runner.os }}-depends-${{ matrix.host }}-${{ github.sha }}
+            ${{ runner.os }}-depends-${{ matrix.host }}-${{ hashFiles('depends/packages/*') }}
             ${{ runner.os }}-depends-${{ matrix.host }}
-            ${{ runner.os }}-depends
+
+      - name: Determine PR Base SHA
+        id: vars
+        run: |
+          echo "PR_BASE_SHA=${{ github.event.pull_request.base.sha || '' }}" >> $GITHUB_OUTPUT
 
       - name: CCache
         uses: actions/cache@v4
@@ -174,8 +172,8 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.host }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.host }}-${{ github.sha }}
+            ${{ runner.os }}-${{ matrix.host }}-${{ steps.vars.outputs.PR_BASE_SHA }}
             ${{ runner.os }}-${{ matrix.host }}
-            ${{ runner.os }}
 
       - name: Build source and run tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
 
+      - name: Cache depends sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            depends/sources
+          # We don't care about no specific key as depends system will handle that for us
+          key: depends-sources-${{ hashFiles('depends/packages/*') }}
+          restore-keys: |
+            depends-sources-
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -79,6 +79,14 @@ jobs:
           path: dash
           fetch-depth: 0
 
+      - name: Cache depends sources
+        uses: actions/cache@v4
+        with:
+          path: dash/depends/sources
+          key: depends-sources-${{ hashFiles('dash/depends/packages/*') }}
+          restore-keys: |
+            depends-sources-
+
       - name: Cache Guix and depends
         id: guix-cache-restore
         uses: actions/cache@v3
@@ -86,7 +94,6 @@ jobs:
           path: |
             ${{ github.workspace }}/.cache
             ${{ github.workspace }}/dash/depends/built
-            ${{ github.workspace }}/dash/depends/sources
             ${{ github.workspace }}/dash/depends/work
             /gnu/store
           key: ${{ runner.os }}-guix-${{ matrix.build_target }}-${{ github.sha }}


### PR DESCRIPTION
## Issue being fixed or feature implemented
Improve GitHub Actions caching to not have such large caches that get evicted frequently

## What was done?
Use hash files on depends for depends related caching
bring all depends sources under shared cache

## How Has This Been Tested?
CI in my branches

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

