### PR TITLE
fix(qt): re-run parameter interactions after setting prune settings on first-run

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -722,6 +722,9 @@ int GuiMain(int argc, char* argv[])
     if (did_show_intro) {
         // Store intro dialog settings other than datadir (network specific)
         app.InitPruneSetting(prune_MiB);
+        // Run parameter interactions again to make sure parameters affected by
+        // new prune settings are processed
+        app.parameterSetup();
     }
 
     if (gArgs.GetBoolArg("-splash", DEFAULT_SPLASHSCREEN) && !gArgs.GetBoolArg("-min", false))

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -192,12 +192,10 @@ void OptionsModel::Init(bool resetSettings)
 
     // If GUI is setting prune, then we also must set disablegovernance and txindex
     if (settings.value("bPrune").toBool()) {
-        if (gArgs.SoftSetBoolArg("-disablegovernance", true)) {
-            LogPrintf("%s: parameter interaction: -prune=true -> setting -disablegovernance=true\n", __func__);
+        if (!gArgs.SoftSetBoolArg("-disablegovernance", true)) {
             addOverriddenOption("-disablegovernance");
         }
-        if (gArgs.SoftSetBoolArg("-txindex", false)) {
-            LogPrintf("%s: parameter interaction: -prune=true -> setting -txindex=false\n", __func__);
+        if (!gArgs.SoftSetBoolArg("-txindex", false)) {
             addOverriddenOption("-txindex");
         }
     }


### PR DESCRIPTION
## Additional Information

The bug reported in https://github.com/dashpay/dash/issues/6366 can be reproduced by deleting `~/.config/*/Dash-Qt*.conf` and running `dash-qt` (the decision on whether to display the splash screen is based on Qt settings, which are read before datadir).

This bug has been reproduced on `develop` (f211bb92891ec2b638bc763413264ee5f0f34f44) and as early as v20.0.4 (the ability to enable pruning was introduced in https://github.com/dashpay/dash/pull/5255). 

The bug occurs we're given two opportunities to disable of `-txindex` and enable of `-disablegovernance` if `-prune` is set, `InitParameterInteraction()` ([source](https://github.com/dashpay/dash/blob/f211bb92891ec2b638bc763413264ee5f0f34f44/src/init.cpp#L981-L989)) (via `BitcoinApplication::parameterSetup()`, [source](https://github.com/dashpay/dash/blob/f211bb92891ec2b638bc763413264ee5f0f34f44/src/qt/bitcoin.cpp#L304)) and `OptionsModel::Init()` ([source](https://github.com/dashpay/dash/blob/f211bb92891ec2b638bc763413264ee5f0f34f44/src/qt/optionsmodel.cpp#L194-L203)) **but** both opportunities are exhausted before we set the `-prune` flag in response to enabling the option in the UI ([source](https://github.com/dashpay/dash/blob/f211bb92891ec2b638bc763413264ee5f0f34f44/src/qt/bitcoin.cpp#L722-L725)).

We cannot simply just move `BitcoinApplication::InitPruneSetting()` up as it assumes `OptionsModel` is initialized and `OptionsModel::Init()` is called from the constructor.

This means when arguments are parsed for the last time, we get our "Prune mode is incompatible with -txindex" ([source](https://github.com/dashpay/dash/blob/f211bb92891ec2b638bc763413264ee5f0f34f44/src/init.cpp#L1153-L1154)) because our parameter interactions took place **before** prune settings were set.

This PR resolves that by running `BitcoinApplication::parameterSetup()` _again_ after `BitcoinApplication::InitPruneSetting()`. We do this instead of using `OptionsModel::Init()` as all the `SoftSet{Bool}Arg()` failures will result in an unnaturally populated overridden arguments list.

## Breaking Changes

None expected

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
