### PR TITLE
feat: increased withdrawal limits to flat 2000 from v22

### DIFF
--- a/doc/release-notes-6279.md
+++ b/doc/release-notes-6279.md
@@ -1,0 +1,8 @@
+# Notable changes
+
+## Asset Unlock transactions (platform transfer)
+
+This version introduces a new fork `withdrawals` that changes consensus rules.
+New logic of validation of Asset Unlock transactions's signature. It let to use all 24 active quorums and the most recent inactive, while previous version of Dash Core may refuse withdrawal with error `bad-assetunlock-not-active-quorum` even if quorum is active.
+
+Limits for withdrawals has been increased to flat 2000 Dash per 576 latest blocks.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -812,9 +812,9 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].bit = 11;
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nWindowSize = 300;
-        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nThresholdStart = 300 / 5 * 4;     // 80% of 12
-        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nThresholdMin = 300 / 5 * 3;       // 60% of 7
+        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nWindowSize = 900;
+        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nThresholdStart = 900 / 5 * 4;     // 80% of window size
+        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nThresholdMin = 900 / 5 * 3;       // 60% of window size
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nFalloffCoeff = 5;          // this corresponds to 10 periods
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].useEHF = true;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -812,9 +812,9 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].bit = 11;
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nWindowSize = 900;
-        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nThresholdStart = 900 / 5 * 4;     // 80% of window size
-        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nThresholdMin = 900 / 5 * 3;       // 60% of window size
+        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nWindowSize = 600;
+        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nThresholdStart = 600 / 5 * 4;     // 80% of window size
+        consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nThresholdMin = 600 / 5 * 3;       // 60% of window size
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].nFalloffCoeff = 5;          // this corresponds to 10 periods
         consensus.vDeployments[Consensus::DEPLOYMENT_WITHDRAWALS].useEHF = true;
 

--- a/src/evo/assetlocktx.cpp
+++ b/src/evo/assetlocktx.cpp
@@ -138,7 +138,10 @@ bool CAssetUnlockPayload::VerifySig(const llmq::CQuorumManager& qman, const uint
     }
 
     const auto quorum = qman.GetQuorum(llmqType, quorumHash);
-    assert(quorum);
+    // quorum must be valid at this point. Let's check and throw error just in case
+    if (!quorum) {
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "internal-error");
+    }
 
     const uint256 requestId = ::SerializeHash(std::make_pair(ASSETUNLOCK_REQUESTID_PREFIX, index));
 

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -187,10 +187,11 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const CBlockIndex* const blo
     assert(currentLimit >= 0);
 
     if (currentLimit > 0 || latelyUnlocked > 0 || locked > 0) {
-        LogPrint(BCLog::CREDITPOOL, "CCreditPoolManager: asset unlock limits on height: %d locked: %d.%08d limit: %d.%08d unlocked-in-window: %d.%08d\n",
-               block_index->nHeight, locked / COIN, locked % COIN,
-               currentLimit / COIN, currentLimit % COIN,
-               latelyUnlocked / COIN, latelyUnlocked % COIN);
+        LogPrint(BCLog::CREDITPOOL, /* Continued */
+                 "CCreditPoolManager: asset unlock limits on height: %d locked: %d.%08d limit: %d.%08d "
+                 "unlocked-in-window: %d.%08d\n",
+                 block_index->nHeight, locked / COIN, locked % COIN, currentLimit / COIN, currentLimit % COIN,
+                 latelyUnlocked / COIN, latelyUnlocked % COIN);
     }
 
     CCreditPool pool{locked, currentLimit, latelyUnlocked, indexes};

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -187,7 +187,7 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const CBlockIndex* const blo
     assert(currentLimit >= 0);
 
     if (currentLimit > 0 || latelyUnlocked > 0 || locked > 0) {
-        LogPrint(BCLog::CREDITPOOL, "CCreditPoolManager: asset unlock limits on height: %d locked: %d.%08d limit: %d.%08d previous: %d.%08d\n",
+        LogPrint(BCLog::CREDITPOOL, "CCreditPoolManager: asset unlock limits on height: %d locked: %d.%08d limit: %d.%08d unlocked-in-window: %d.%08d\n",
                block_index->nHeight, locked / COIN, locked % COIN,
                currentLimit / COIN, currentLimit % COIN,
                latelyUnlocked / COIN, latelyUnlocked % COIN);

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -117,6 +117,7 @@ public:
     static constexpr int LimitBlocksToTrace = 576;
     static constexpr CAmount LimitAmountLow = 100 * COIN;
     static constexpr CAmount LimitAmountHigh = 1000 * COIN;
+    static constexpr CAmount LimitAmountV22 = 2000 * COIN;
 
     explicit CCreditPoolManager(CEvoDB& _evoDb);
 

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -613,7 +613,7 @@ class AssetLocksTest(DashTestFramework):
 
 
         self.log.info("generate many blocks to be sure that mempool is empty after expiring txes...")
-        self.generate_batch(60)
+        self.generate_batch(HEIGHT_DIFF_EXPIRING)
         self.log.info("Checking that credit pool is not changed...")
         assert_equal(new_total, self.get_credit_pool_balance())
         self.check_mempool_size()
@@ -624,7 +624,7 @@ class AssetLocksTest(DashTestFramework):
         self.log.info("Activate mn_rr...")
         locked = self.get_credit_pool_balance()
         self.activate_mn_rr(expected_activation_height=2500)
-        self.log.info(f'height: {node.getblockcount()} credit: {self.get_credit_pool_balance()}')
+        self.log.info(f'mn-rr height: {node.getblockcount()} credit: {self.get_credit_pool_balance()}')
         assert_equal(locked, self.get_credit_pool_balance())
 
         bt = node.getblocktemplate()
@@ -650,8 +650,8 @@ class AssetLocksTest(DashTestFramework):
 
     def test_withdrawal_fork(self, node_wallet, node, pubkey):
         self.log.info("Testing asset unlock after 'withdrawal' activation...")
-        self.activate_by_name('withdrawals')
         assert softfork_active(node_wallet, 'withdrawals')
+        self.log.info(f'post-withdrawals height: {node.getblockcount()} credit: {self.get_credit_pool_balance()}')
 
         index = 501
         while index < 511:


### PR DESCRIPTION
## Issue being fixed or feature implemented
Limit 1000 seems a bit small at the moment, while limit 2000 is still safe enough.

## What was done?
Withdrawals limits in pre-v22 are:
 - if credit pool is more than 10k -> limit withdrawals to 1k
 - if credit pool is between 100 dash and 10000 dash -> let to withdraw 10%.
 - if 10% of credit pool is less than 100 dash -> no limits, let to withdraw everything.

The fork `withdrawals` introduces higher limit:
 - 2000 dash per last 576 blocks. That's all. 

## How Has This Been Tested?
Updated functional test `feature_asset_locks.py`


## Breaking Changes
Limits of withdrawals are increased to 2000 dash. It changes consensus rules.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone