### PR TITLE
ci: do not build derivations in parallel on GH

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -110,7 +110,6 @@ jobs:
         run: |
           docker run --privileged -d --rm -t \
             --name guix-daemon \
-            -e ADDITIONAL_GUIX_COMMON_FLAGS="--max-jobs=$(nproc --all)" \
             -v ${{ github.workspace }}/dash:/src/dash \
             -v ${{ github.workspace }}/.cache:/home/ubuntu/.cache \
             -w /src/dash \


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should fix GH Guix builds

develop: https://github.com/UdjinM6/dash/actions/runs/11563155278
develop + this patch merged into it: https://github.com/UdjinM6/dash/actions/runs/11562899245

more info https://github.com/dashpay/dash/blob/develop/contrib/guix/README.md#controlling-the-number-of-threads-used-by-guix-build-commands

## What was done?

## How Has This Been Tested?

## Breaking Changes

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

