### PR TITLE
fix: devnet stuck on block 2 with crash

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -454,6 +454,11 @@ std::optional<CCbTx> GetCoinbaseTx(const CBlockIndex* pindex)
         return std::nullopt;
     }
 
+    // There's no CbTx before DIP0003 activation
+    if (!DeploymentActiveAt(*pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0003)) {
+        return std::nullopt;
+    }
+
     CBlock block;
     if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
         return std::nullopt;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Failure on devnet:

![image](https://github.com/user-attachments/assets/66163c3d-e818-478c-8915-48889317ecd1)

+extra logs haven't got to screenshot:
```
2024-10-31T13:19:21Z CreateNewBlock(): total size 1000 txs: 0 fees: 0 sigops 100
2024-10-31T13:19:21Z Posix Signal: Aborted
```

Locally similar error is caught with stacktrace:

        Assertion failure:
          assertion: (tx.nType == T::SPECIALTX_TYPE)
          file: ./evo/specialtx.h, line: 33
          function: std::optional<_Tp> GetTxPayload(const TxType&, bool) [with T = CCbTx; TxType = CTransaction]
           0#: (0x5CE686FB3AB0) stacktraces.cpp:655 - __wrap___assert_fail
           1#: (0x5CE686BB9120) specialtx.h:33      - std::optional<CCbTx> GetTxPayload<CCbTx, CTransaction>(CTransaction const&, bool)
           2#: (0x5CE686BB9120) cbtx.cpp:463        - GetCoinbaseTx(CBlockIndex const*)
           3#: (0x5CE686BB916D) cbtx.cpp:470        - GetNonNullCoinbaseChainlock(CBlockIndex const*)
           4#: (0x5CE686BB92AA) optional:469        - std::_Optional_base_impl<std::pair<CBLSSignature, unsigned int>, std::_Optional_base<std::pair<CBLSSignature, unsigned int>, false, false> >::_M_is_engaged() const
           5#: (0x5CE686BB92AA) optional:986        - std::optional<std::pair<CBLSSignature, unsigned int> >::has_value() const
           6#: (0x5CE686BB92AA) cbtx.cpp:401        - CalcCbTxBestChainlock(llmq::CChainLocksHandler const&, CBlockIndex const*, unsigned int&, CBLSSignature&)
           7#: (0x5CE686D36318) miner.cpp:233       - BlockAssembler::CreateNewBlock(CScript const&)


## What was done?
Added check if DIP0003 is indeed activated before retrieving Chainlock of previous block.

## How Has This Been Tested?
No crash observed locally


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone