### PR TITLE
ci: use GCC 14 for building `nowallet` source and depends, GCC 11 for building `sqlite` source

### DIFF
--- a/ci/test/00_setup_env_native_nowallet.sh
+++ b/ci/test/00_setup_env_native_nowallet.sh
@@ -9,6 +9,6 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_native_nowallet
 export HOST=x86_64-pc-linux-gnu
 export PACKAGES="python3-zmq"
-export DEP_OPTS="NO_WALLET=1"
+export DEP_OPTS="NO_WALLET=1 CC=gcc-14 CXX=g++-14"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-reduce-exports --with-boost-process"
+export BITCOIN_CONFIG="--enable-reduce-exports --with-boost-process CC=gcc-14 CXX=g++-14"

--- a/ci/test/00_setup_env_native_sqlite.sh
+++ b/ci/test/00_setup_env_native_sqlite.sh
@@ -10,4 +10,4 @@ export CONTAINER_NAME=ci_native_sqlite
 export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
 export DEP_OPTS="NO_BDB=1 NO_UPNP=1 DEBUG=1"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --with-sqlite --without-bdb"
+export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --with-sqlite --without-bdb CC=gcc-11 CXX=g++-11"

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -171,6 +171,7 @@ RUN set -ex; \
 RUN apt-get update && apt-get install $APT_ARGS \
     bc \
     gawk \
+    g++-11 \
     g++-14 \
     g++-arm-linux-gnueabihf \
     g++-mingw-w64-x86-64 \

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -171,6 +171,7 @@ RUN set -ex; \
 RUN apt-get update && apt-get install $APT_ARGS \
     bc \
     gawk \
+    g++-14 \
     g++-arm-linux-gnueabihf \
     g++-mingw-w64-x86-64 \
     jq \


### PR DESCRIPTION
## Motivation

This PR is a spiritual continuation of [dash#5375](https://github.com/dashpay/dash/pull/5375) to help catch issues like the ones resolved in [dash#5064](https://github.com/dashpay/dash/pull/5064) during CI. 

## Additional Information

* Earlier iterations of this PR built GCC 14 as the toolchain PPA wouldn't go higher than GCC 12 for `jammy` ([source](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/ppa?field.series_filter=jammy)) (GCC 13 if we were willing to use the `test` branch, [source](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test?field.series_filter=jammy)) and we ruled out upgrading our base image to `noble` (which does offer GCC 14 even without a PPA, [source](https://packages.ubuntu.com/noble/g++-14)) so we could test against the lowest supported LTS.

  * Unfortunately, staying on `jammy` was no longer tenable as we require at least GCC 11.1 (since [dash#6389](https://github.com/dashpay/dash/pull/6389)) but `jammy` shipped GCC 10.3 for the Windows cross-compiler ([source](https://packages.ubuntu.com/jammy/gcc-mingw-w64-x86-64-posix)) and this proved to be a blocker for backports. See [dash#6564](https://github.com/dashpay/dash/pull/6564) for more information.

* Since we've upgraded to `noble` now, we not only can use GCC 14 (the latest major version of GCC as of this writing), we can also use older versions and GCC 11.4 is readily available on `noble` ([source](https://packages.ubuntu.com/noble/g++-11)), which can help us test for unexpected regressions on the lowest supported version and versions likely to be used by rolling release distros.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
