### PR TITLE
feat: update IS database instantly, no more dependency on DIP0020

### DIFF
--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -112,11 +112,11 @@ private:
     uint256 GetInstantSendLockHashByTxidInternal(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_db);
 
 
+    void Upgrade(bool unitTests) EXCLUSIVE_LOCKS_REQUIRED(!cs_db);
+
 public:
     explicit CInstantSendDb(bool unitTests, bool fWipe);
     ~CInstantSendDb();
-
-    void Upgrade() EXCLUSIVE_LOCKS_REQUIRED(!cs_db);
 
     /**
      * This method is called when an InstantSend Lock is processed and adds the lock to the database
@@ -263,7 +263,6 @@ public:
         shareman(_shareman), spork_manager(sporkman), mempool(_mempool), m_mn_sync(mn_sync), m_peerman(peerman),
         m_is_masternode{is_masternode}
     {
-        db.Upgrade(); // Upgrade DB if need to do it
         workInterrupt.reset();
     }
     ~CInstantSendManager() = default;

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -116,7 +116,7 @@ public:
     explicit CInstantSendDb(bool unitTests, bool fWipe);
     ~CInstantSendDb();
 
-    void Upgrade(const CTxMemPool& mempool) EXCLUSIVE_LOCKS_REQUIRED(!cs_db);
+    void Upgrade() EXCLUSIVE_LOCKS_REQUIRED(!cs_db);
 
     /**
      * This method is called when an InstantSend Lock is processed and adds the lock to the database
@@ -209,7 +209,6 @@ private:
     const std::unique_ptr<PeerManager>& m_peerman;
 
     const bool m_is_masternode;
-    std::atomic<bool> fUpgradedDB{false};
 
     std::thread workThread;
     CThreadInterrupt workInterrupt;
@@ -264,6 +263,7 @@ public:
         shareman(_shareman), spork_manager(sporkman), mempool(_mempool), m_mn_sync(mn_sync), m_peerman(peerman),
         m_is_masternode{is_masternode}
     {
+        db.Upgrade(); // Upgrade DB if need to do it
         workInterrupt.reset();
     }
     ~CInstantSendManager() = default;


### PR DESCRIPTION
## Issue being fixed or feature implemented

Upgrade of IS database depends on activation of DIP0020. It's no more need because it is activated long time ago.


## What was done?
Removed dependency of IS database upgrade on DIP0020. Also removed LOCK for `::mempool.cs` which is not actually has been used inside GetTransaction during upgrade: no mempool -- no lock.

## How Has This Been Tested?
Run unit and functional tests.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone