### PR TITLE
ci: refactor GitHub Actions CI to use reusable workflows, respect `DEP_OPTS`, build multiprocess depends with Clang

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,54 @@
+name: Build container
+
+on:
+  workflow_call:
+    outputs:
+      path:
+        description: "Path to built container"
+        value: ghcr.io/${{ jobs.build.outputs.repo }}/dashcore-ci-runner:${{ jobs.build.outputs.tag }}
+
+env:
+  DOCKER_DRIVER: overlay2
+
+jobs:
+  build:
+    name: Build container
+    runs-on: ubuntu-22.04
+    outputs:
+      tag: ${{ steps.prepare.outputs.tag }}
+      repo: ${{ steps.prepare.outputs.repo }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Prepare variables
+        id: prepare
+        run: |
+          BRANCH_NAME=$(echo "${GITHUB_REF##*/}" | tr '[:upper:]' '[:lower:]')
+          REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "tag=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "repo=${REPO_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./contrib/containers/ci
+          file: ./contrib/containers/ci/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:${{ steps.prepare.outputs.tag }}
+            ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:latest
+          cache-from: type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:latest
+          cache-to: type=inline

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -11,19 +11,17 @@ on:
         description: "Path to built container at registry"
         required: true
         type: string
-      host:
-        description: "Target triplet"
-        required: true
-        type: string
     outputs:
       key:
         description: "Key needed for restoring depends cache"
-        value: ${{ jobs.build-depends.restore.outputs.cache-primary-key }}
+        value: ${{ jobs.build-depends.outputs.key }}
 
 jobs:
   build-depends:
     name: Build depends
     runs-on: ubuntu-22.04
+    outputs:
+      key:  ${{ steps.restore.outputs.cache-primary-key }}
     container:
       image: ${{ inputs.container-path }}
       options: --user root
@@ -32,6 +30,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Initial setup
+        id: setup
+        run: |
+          BUILD_TARGET="${{ inputs.build-target }}"
+          source ./ci/dash/matrix.sh
+          echo "HOST=${HOST}" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Cache depends sources
         uses: actions/cache@v4
@@ -49,14 +55,14 @@ jobs:
         with:
           path: |
             depends/built
-            depends/${{ inputs.host }}
+            depends/${{ steps.setup.outputs.HOST }}
           key: ${{ runner.os }}-depends-${{ inputs.build-target }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
             ${{ runner.os }}-depends-${{ inputs.build-target }}-${{ hashFiles('depends/packages/*') }}
             ${{ runner.os }}-depends-${{ inputs.build-target }}
 
       - name: Build depends
-        run: env HOST=${{ inputs.host }} make -j$(nproc) -C depends
+        run: env HOST=${{ steps.setup.outputs.HOST }} make -j$(nproc) -C depends
 
       - name: Save depends cache
         uses: actions/cache/save@v4
@@ -64,5 +70,5 @@ jobs:
         with:
           path: |
             depends/built
-            depends/${{ inputs.host }}
+            depends/${{ steps.setup.outputs.HOST }}
           key: ${{ steps.restore.outputs.cache-primary-key }}

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -15,6 +15,10 @@ on:
         description: "Target triplet"
         required: true
         type: string
+    outputs:
+      key:
+        description: "Key needed for restoring depends cache"
+        value: ${{ jobs.build-depends.restore.outputs.cache-primary-key }}
 
 jobs:
   build-depends:
@@ -39,8 +43,9 @@ jobs:
             depends-sources-${{ hashFiles('depends/packages/*') }}
             depends-sources-
 
-      - name: Cache depends
-        uses: actions/cache@v4
+      - name: Restore cached depends
+        uses: actions/cache/restore@v4
+        id: restore
         with:
           path: |
             depends/built
@@ -52,3 +57,12 @@ jobs:
 
       - name: Build depends
         run: env HOST=${{ inputs.host }} make -j$(nproc) -C depends
+
+      - name: Save depends cache
+        uses: actions/cache/save@v4
+        if: steps.restore.outputs.cache-hit != 'true'
+        with:
+          path: |
+            depends/built
+            depends/${{ inputs.host }}
+          key: ${{ steps.restore.outputs.cache-primary-key }}

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -36,7 +36,12 @@ jobs:
         run: |
           BUILD_TARGET="${{ inputs.build-target }}"
           source ./ci/dash/matrix.sh
-          echo "HOST=${HOST}" >> $GITHUB_OUTPUT
+          echo "DEP_OPTS=${DEP_OPTS}" >> "${GITHUB_OUTPUT}"
+          echo "HOST=${HOST}" >> "${GITHUB_OUTPUT}"
+          DEP_HASH="$(echo -n "${BUILD_TARGET}" "${DEP_OPTS}" "${HOST}" | sha256sum | head -c 64)"
+          echo "\"${BUILD_TARGET}\" has HOST=\"${HOST}\" and DEP_OPTS=\"${DEP_OPTS}\" with hash \"${DEP_HASH}\""
+          echo "DEP_HASH=${DEP_HASH}" >> "${GITHUB_OUTPUT}"
+
         shell: bash
 
       - name: Cache depends sources
@@ -56,13 +61,13 @@ jobs:
           path: |
             depends/built
             depends/${{ steps.setup.outputs.HOST }}
-          key: ${{ runner.os }}-depends-${{ inputs.build-target }}-${{ hashFiles('depends/packages/*') }}
+          key: ${{ runner.os }}-depends-${{ inputs.build-target }}-${{ steps.setup.outputs.DEP_HASH }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
             ${{ runner.os }}-depends-${{ inputs.build-target }}-${{ hashFiles('depends/packages/*') }}
             ${{ runner.os }}-depends-${{ inputs.build-target }}
 
       - name: Build depends
-        run: env HOST=${{ steps.setup.outputs.HOST }} make -j$(nproc) -C depends
+        run: env ${{ steps.setup.outputs.DEP_OPTS }} HOST=${{ steps.setup.outputs.HOST }} make -j$(nproc) -C depends
 
       - name: Save depends cache
         uses: actions/cache/save@v4

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -1,0 +1,54 @@
+name: Build depends
+
+on:
+  workflow_call:
+    inputs:
+      build-target:
+        description: "Target name as defined by matrix.sh"
+        required: true
+        type: string
+      container-path:
+        description: "Path to built container at registry"
+        required: true
+        type: string
+      host:
+        description: "Target triplet"
+        required: true
+        type: string
+
+jobs:
+  build-depends:
+    name: Build depends
+    runs-on: ubuntu-22.04
+    container:
+      image: ${{ inputs.container-path }}
+      options: --user root
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Cache depends sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            depends/sources
+          key: depends-sources-${{ hashFiles('depends/packages/*') }}
+          restore-keys: |
+            depends-sources-${{ hashFiles('depends/packages/*') }}
+            depends-sources-
+
+      - name: Cache depends
+        uses: actions/cache@v4
+        with:
+          path: |
+            depends/built
+            depends/${{ inputs.host }}
+          key: ${{ runner.os }}-depends-${{ inputs.build-target }}-${{ hashFiles('depends/packages/*') }}
+          restore-keys: |
+            ${{ runner.os }}-depends-${{ inputs.build-target }}-${{ hashFiles('depends/packages/*') }}
+            ${{ runner.os }}-depends-${{ inputs.build-target }}
+
+      - name: Build depends
+        run: env HOST=${{ inputs.host }} make -j$(nproc) -C depends

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -1,0 +1,83 @@
+name: Build source
+
+on:
+  workflow_call:
+    inputs:
+      build-target:
+        description: "Target name as defined by inputs.sh"
+        required: true
+        type: string
+      container-path:
+        description: "Path to built container at registry"
+        required: true
+        type: string
+      depends-target:
+        description: "Target name of depends as defined by inputs.sh"
+        required: true
+        type: string
+      host:
+        description: "Target triplet"
+        required: true
+        type: string
+
+jobs:
+  build-src:
+    name: Build source
+    runs-on: ubuntu-22.04
+    container:
+      image: ${{ inputs.container-path }}
+      options: --user root
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Restore depends cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            depends/built
+            depends/${{ inputs.host }}
+          key: ${{ runner.os }}-depends-${{ inputs.depends-target }}-${{ hashFiles('depends/packages/*') }}
+
+      - name: Determine PR Base SHA
+        id: vars
+        run: |
+          echo "PR_BASE_SHA=${{ github.event.pull_request.base.sha || '' }}" >> $GITHUB_OUTPUT
+
+      - name: Manage ccache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /cache
+          key: ${{ runner.os }}-${{ inputs.build-target }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ inputs.build-target }}-${{ github.sha }}
+            ${{ runner.os }}-${{ inputs.build-target }}-${{ steps.vars.outputs.PR_BASE_SHA }}
+            ${{ runner.os }}-${{ inputs.build-target }}
+
+      - name: Build source and run unit tests
+        run: |
+          git config --global --add advice.detachedHead false
+          git config --global --add safe.directory "$PWD"
+          GIT_HEAD="$(git rev-parse HEAD)"
+          git checkout develop
+          git checkout ${GIT_HEAD}
+          CCACHE_SIZE="400M"
+          CACHE_DIR="/cache"
+          mkdir /output
+          BASE_OUTDIR="/output"
+          BUILD_TARGET="${{ inputs.build-target }}"
+          source ./ci/dash/matrix.sh
+          ./ci/dash/build_src.sh
+          ./ci/dash/test_unittests.sh
+        shell: bash
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.build-target }}
+          path: |
+            /output

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -15,10 +15,6 @@ on:
         description: "Key needed to access cached depends"
         required: true
         type: string
-      host:
-        description: "Target triplet"
-        required: true
-        type: string
 
 jobs:
   build-src:
@@ -34,19 +30,28 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Initial setup
+        id: setup
+        run: |
+          git config --global --add advice.detachedHead false
+          git config --global --add safe.directory "$PWD"
+          GIT_HEAD="$(git rev-parse HEAD)"
+          git checkout develop
+          git checkout "${GIT_HEAD}"
+          BUILD_TARGET="${{ inputs.build-target }}"
+          source ./ci/dash/matrix.sh
+          echo "HOST=${HOST}" >> $GITHUB_OUTPUT
+          echo "PR_BASE_SHA=${{ github.event.pull_request.base.sha || '' }}" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Restore depends cache
         uses: actions/cache/restore@v4
         with:
           path: |
             depends/built
-            depends/${{ inputs.host }}
+            depends/${{ steps.setup.outputs.HOST }}
           key: ${{ inputs.depends-key }}
           fail-on-cache-miss: true
-
-      - name: Determine PR Base SHA
-        id: vars
-        run: |
-          echo "PR_BASE_SHA=${{ github.event.pull_request.base.sha || '' }}" >> $GITHUB_OUTPUT
 
       - name: Manage ccache
         uses: actions/cache@v4
@@ -56,16 +61,11 @@ jobs:
           key: ${{ runner.os }}-${{ inputs.build-target }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ inputs.build-target }}-${{ github.sha }}
-            ${{ runner.os }}-${{ inputs.build-target }}-${{ steps.vars.outputs.PR_BASE_SHA }}
+            ${{ runner.os }}-${{ inputs.build-target }}-${{ steps.setup.outputs.HOST }}
             ${{ runner.os }}-${{ inputs.build-target }}
 
       - name: Build source and run unit tests
         run: |
-          git config --global --add advice.detachedHead false
-          git config --global --add safe.directory "$PWD"
-          GIT_HEAD="$(git rev-parse HEAD)"
-          git checkout develop
-          git checkout ${GIT_HEAD}
           CCACHE_SIZE="400M"
           CACHE_DIR="/cache"
           mkdir /output

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -11,8 +11,8 @@ on:
         description: "Path to built container at registry"
         required: true
         type: string
-      depends-target:
-        description: "Target name of depends as defined by inputs.sh"
+      depends-key:
+        description: "Key needed to access cached depends"
         required: true
         type: string
       host:
@@ -40,7 +40,8 @@ jobs:
           path: |
             depends/built
             depends/${{ inputs.host }}
-          key: ${{ runner.os }}-depends-${{ inputs.depends-target }}-${{ hashFiles('depends/packages/*') }}
+          key: ${{ inputs.depends-key }}
+          fail-on-cache-miss: true
 
       - name: Determine PR Base SHA
         id: vars

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       container-path: ${{ needs.container.outputs.path }}
 
   depends-linux64:
-    name: x86_64-pc-linux-gnu
+    name: x86_64-pc-linux-gnu_debug
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
     with:
       build-target: arm-linux
       container-path: ${{ needs.container.outputs.path }}
-      host: arm-linux-gnueabihf
 
   depends-linux64:
     name: x86_64-pc-linux-gnu
@@ -33,7 +32,6 @@ jobs:
     with:
       build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
-      host: x86_64-pc-linux-gnu
 
   depends-win64:
     name: x86_64-w64-mingw32
@@ -42,7 +40,6 @@ jobs:
     with:
       build-target: win64
       container-path: ${{ needs.container.outputs.path }}
-      host: x86_64-w64-mingw32
 
   src-arm-linux:
     name: arm-linux-build
@@ -52,7 +49,6 @@ jobs:
       build-target: arm-linux
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-arm-linux.outputs.key }}
-      host: arm-linux-gnueabihf
 
   src-linux64:
     name: linux64-build
@@ -62,7 +58,6 @@ jobs:
       build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-linux64.outputs.key }}
-      host: x86_64-pc-linux-gnu
 
   src-linux64_cxx20:
     name: linux64_cxx20-build
@@ -72,7 +67,6 @@ jobs:
       build-target: linux64_cxx20
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-linux64.outputs.key }}
-      host: x86_64-pc-linux-gnu
 
   src-linux64_fuzz:
     name: linux64_fuzz-build
@@ -82,7 +76,6 @@ jobs:
       build-target: linux64_fuzz
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-linux64.outputs.key }}
-      host: x86_64-pc-linux-gnu
 
   src-linux64_nowallet:
     name: linux64_nowallet-build
@@ -92,7 +85,6 @@ jobs:
       build-target: linux64_nowallet
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-linux64.outputs.key }}
-      host: x86_64-pc-linux-gnu
 
   src-linux64_sqlite:
     name: linux64_sqlite-build
@@ -102,7 +94,6 @@ jobs:
       build-target: linux64_sqlite
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-linux64.outputs.key }}
-      host: x86_64-pc-linux-gnu
 
   src-linux64_tsan:
     name: linux64_tsan-build
@@ -112,7 +103,6 @@ jobs:
       build-target: linux64_tsan
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-linux64.outputs.key }}
-      host: x86_64-pc-linux-gnu
 
   src-linux64_ubsan:
     name: linux64_ubsan-build
@@ -122,7 +112,6 @@ jobs:
       build-target: linux64_ubsan
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-linux64.outputs.key }}
-      host: x86_64-pc-linux-gnu
 
   src-win64:
     name: win64-build
@@ -132,4 +121,3 @@ jobs:
       build-target: win64
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-win64.outputs.key }}
-      host: x86_64-w64-mingw32

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,22 @@ jobs:
       build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
 
+  depends-linux64_multiprocess:
+    name: x86_64-pc-linux-gnu_multiprocess
+    uses: ./.github/workflows/build-depends.yml
+    needs: [container]
+    with:
+      build-target: linux64_multiprocess
+      container-path: ${{ needs.container.outputs.path }}
+
+  depends-linux64_nowallet:
+    name: x86_64-pc-linux-gnu_nowallet
+    uses: ./.github/workflows/build-depends.yml
+    needs: [container]
+    with:
+      build-target: linux64_nowallet
+      container-path: ${{ needs.container.outputs.path }}
+
   depends-win64:
     name: x86_64-w64-mingw32
     uses: ./.github/workflows/build-depends.yml
@@ -77,14 +93,23 @@ jobs:
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-linux64.outputs.key }}
 
+  src-linux64_multiprocess:
+    name: linux64_multiprocess-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-linux64_multiprocess]
+    with:
+      build-target: linux64_multiprocess
+      container-path: ${{ needs.container.outputs.path }}
+      depends-key: ${{ needs.depends-linux64_multiprocess.outputs.key }}
+
   src-linux64_nowallet:
     name: linux64_nowallet-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64]
+    needs: [container, depends-linux64_nowallet]
     with:
       build-target: linux64_nowallet
       container-path: ${{ needs.container.outputs.path }}
-      depends-key: ${{ needs.depends-linux64.outputs.key }}
+      depends-key: ${{ needs.depends-linux64_nowallet.outputs.key }}
 
   src-linux64_sqlite:
     name: linux64_sqlite-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,11 +123,11 @@ jobs:
   src-linux64_tsan:
     name: linux64_tsan-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64]
+    needs: [container, depends-linux64_multiprocess]
     with:
       build-target: linux64_tsan
       container-path: ${{ needs.container.outputs.path }}
-      depends-key: ${{ needs.depends-linux64.outputs.key }}
+      depends-key: ${{ needs.depends-linux64_multiprocess.outputs.key }}
 
   src-linux64_ubsan:
     name: linux64_ubsan-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,51 +18,23 @@ jobs:
     uses: ./.github/workflows/build-container.yml
 
   build-depends:
-    name: Build Dependencies
-    needs: container
-    runs-on: ubuntu-22.04
+    name: Build depends
+    uses: ./.github/workflows/build-depends.yml
+    needs: [container]
     strategy:
       fail-fast: false
       matrix:
         include:
-        - build_target: arm-linux
+        - build-target: arm-linux
           host: arm-linux-gnueabihf
-        - build_target: linux64
+        - build-target: linux64
           host: x86_64-pc-linux-gnu
-        - build_target: win64
+        - build-target: win64
           host: x86_64-w64-mingw32
-
-    container:
-      image: ${{ needs.container.outputs.path }}
-      options: --user root
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Cache depends sources
-        uses: actions/cache@v4
-        with:
-          path: |
-            depends/sources
-          key: depends-sources-${{ hashFiles('depends/packages/*') }}
-          restore-keys: |
-            depends-sources-
-
-      - name: Cache depends
-        uses: actions/cache@v4
-        with:
-          path: |
-            depends/built
-            depends/${{ matrix.host }}
-          key: ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
-          restore-keys: |
-            ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
-            ${{ runner.os }}-depends-${{ matrix.build_target }}
-
-      - name: Build depends
-        run: make -j$(nproc) -C depends HOST=${{ matrix.host }}
+    with:
+      build-target:  ${{ matrix.build-target }}
+      container-path: ${{ needs.container.outputs.path }}
+      host: ${{ matrix.host }}
 
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,51 +13,13 @@ env:
   FAST_MODE: false
 
 jobs:
-  build-image:
-    name: Build Image
-    runs-on: ubuntu-22.04
-    outputs:
-      image-tag: ${{ steps.prepare.outputs.image-tag }}
-      repo-name: ${{ steps.prepare.outputs.repo-name }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Prepare
-        id: prepare
-        run: |
-          BRANCH_NAME=$(echo "${GITHUB_REF##*/}" | tr '[:upper:]' '[:lower:]')
-          REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "image-tag=${BRANCH_NAME}" >> $GITHUB_OUTPUT
-          echo "repo-name=${REPO_NAME}" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./contrib/containers/ci
-          file: ./contrib/containers/ci/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ steps.prepare.outputs.repo-name }}/dashcore-ci-runner:${{ steps.prepare.outputs.image-tag }}
-            ghcr.io/${{ steps.prepare.outputs.repo-name }}/dashcore-ci-runner:latest
-          cache-from: type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo-name }}/dashcore-ci-runner:latest
-          cache-to: type=inline
+  container:
+    name: Build container
+    uses: ./.github/workflows/build-container.yml
 
   build-depends:
     name: Build Dependencies
-    needs: build-image
+    needs: container
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -71,7 +33,7 @@ jobs:
           host: x86_64-w64-mingw32
 
     container:
-      image: ghcr.io/${{ needs.build-image.outputs.repo-name }}/dashcore-ci-runner:${{ needs.build-image.outputs.image-tag }}
+      image: ${{ needs.container.outputs.path }}
       options: --user root
     steps:
       - name: Checkout code
@@ -104,7 +66,7 @@ jobs:
 
   build:
     name: Build
-    needs: [build-image, build-depends]
+    needs: [container, build-depends]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -138,7 +100,7 @@ jobs:
             host: x86_64-w64-mingw32
             depends_on: win64
     container:
-      image: ghcr.io/${{ needs.build-image.outputs.repo-name }}/dashcore-ci-runner:${{ needs.build-image.outputs.image-tag }}
+      image: ${{ needs.container.outputs.path }}
       options: --user root
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,62 +17,119 @@ jobs:
     name: Build container
     uses: ./.github/workflows/build-container.yml
 
-  build-depends:
-    name: Build depends
+  depends-arm-linux:
+    name: arm-linux-gnueabihf
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - build-target: arm-linux
-          host: arm-linux-gnueabihf
-        - build-target: linux64
-          host: x86_64-pc-linux-gnu
-        - build-target: win64
-          host: x86_64-w64-mingw32
     with:
-      build-target:  ${{ matrix.build-target }}
+      build-target: arm-linux
       container-path: ${{ needs.container.outputs.path }}
-      host: ${{ matrix.host }}
+      host: arm-linux-gnueabihf
 
-  build-src:
-    name: Build source
-    uses: ./.github/workflows/build-src.yml
-    needs: [container, build-depends]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - build-target: arm-linux
-            depends-target: arm-linux
-            host: arm-linux-gnueabihf
-          - build-target: linux64
-            depends-target: linux64
-            host: x86_64-pc-linux-gnu
-          - build-target: linux64_cxx20
-            depends-target: linux64
-            host: x86_64-pc-linux-gnu
-          - build-target: linux64_fuzz
-            depends-target: linux64
-            host: x86_64-pc-linux-gnu
-          - build-target: linux64_nowallet
-            depends-target: linux64
-            host: x86_64-pc-linux-gnu
-          - build-target: linux64_sqlite
-            depends-target: linux64
-            host: x86_64-pc-linux-gnu
-          - build-target: linux64_tsan
-            depends-target: linux64
-            host: x86_64-pc-linux-gnu
-          - build-target: linux64_ubsan
-            depends-target: linux64
-            host: x86_64-pc-linux-gnu
-          - build-target: win64
-            depends-target: win64
-            host: x86_64-w64-mingw32
+  depends-linux64:
+    name: x86_64-pc-linux-gnu
+    uses: ./.github/workflows/build-depends.yml
+    needs: [container]
     with:
-      build-target:  ${{ matrix.build-target }}
+      build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
-      depends-target:  ${{ matrix.build-target }}
-      host: ${{ matrix.host }}
+      host: x86_64-pc-linux-gnu
+
+  depends-win64:
+    name: x86_64-w64-mingw32
+    uses: ./.github/workflows/build-depends.yml
+    needs: [container]
+    with:
+      build-target: win64
+      container-path: ${{ needs.container.outputs.path }}
+      host: x86_64-w64-mingw32
+
+  src-arm-linux:
+    name: arm-linux-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-arm-linux]
+    with:
+      build-target: arm-linux
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: arm-linux
+      host: arm-linux-gnueabihf
+
+  src-linux64:
+    name: linux64-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-linux64]
+    with:
+      build-target: linux64
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: linux64
+      host: x86_64-pc-linux-gnu
+
+  src-linux64_cxx20:
+    name: linux64_cxx20-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-linux64]
+    with:
+      build-target: linux64_cxx20
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: linux64
+      host: x86_64-pc-linux-gnu
+
+  src-linux64_fuzz:
+    name: linux64_fuzz-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-linux64]
+    with:
+      build-target: linux64_fuzz
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: linux64
+      host: x86_64-pc-linux-gnu
+
+  src-linux64_nowallet:
+    name: linux64_nowallet-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-linux64]
+    with:
+      build-target: linux64_nowallet
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: linux64
+      host: x86_64-pc-linux-gnu
+
+  src-linux64_sqlite:
+    name: linux64_sqlite-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-linux64]
+    with:
+      build-target: linux64_sqlite
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: linux64
+      host: x86_64-pc-linux-gnu
+
+  src-linux64_tsan:
+    name: linux64_tsan-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-linux64]
+    with:
+      build-target: linux64_tsan
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: linux64
+      host: x86_64-pc-linux-gnu
+
+  src-linux64_ubsan:
+    name: linux64_ubsan-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-linux64]
+    with:
+      build-target: linux64_ubsan
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: linux64
+      host: x86_64-pc-linux-gnu
+
+  src-win64:
+    name: win64-build
+    uses: ./.github/workflows/build-src.yml
+    needs: [container, depends-win64]
+    with:
+      build-target: win64
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target: win64
+      host: x86_64-w64-mingw32

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,95 +36,43 @@ jobs:
       container-path: ${{ needs.container.outputs.path }}
       host: ${{ matrix.host }}
 
-  build:
-    name: Build
+  build-src:
+    name: Build source
+    uses: ./.github/workflows/build-src.yml
     needs: [container, build-depends]
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - build_target: arm-linux
+          - build-target: arm-linux
+            depends-target: arm-linux
             host: arm-linux-gnueabihf
-            depends_on: arm-linux
-          - build_target: linux64
+          - build-target: linux64
+            depends-target: linux64
             host: x86_64-pc-linux-gnu
-            depends_on: linux64
-          - build_target: linux64_cxx20
+          - build-target: linux64_cxx20
+            depends-target: linux64
             host: x86_64-pc-linux-gnu
-            depends_on: linux64
-          - build_target: linux64_fuzz
+          - build-target: linux64_fuzz
+            depends-target: linux64
             host: x86_64-pc-linux-gnu
-            depends_on: linux64
-          - build_target: linux64_nowallet
+          - build-target: linux64_nowallet
+            depends-target: linux64
             host: x86_64-pc-linux-gnu
-            depends_on: linux64
-          - build_target: linux64_sqlite
+          - build-target: linux64_sqlite
+            depends-target: linux64
             host: x86_64-pc-linux-gnu
-            depends_on: linux64
-          - build_target: linux64_tsan
+          - build-target: linux64_tsan
+            depends-target: linux64
             host: x86_64-pc-linux-gnu
-            depends_on: linux64
-          - build_target: linux64_ubsan
+          - build-target: linux64_ubsan
+            depends-target: linux64
             host: x86_64-pc-linux-gnu
-            depends_on: linux64
-          - build_target: win64
+          - build-target: win64
+            depends-target: win64
             host: x86_64-w64-mingw32
-            depends_on: win64
-    container:
-      image: ${{ needs.container.outputs.path }}
-      options: --user root
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Restore depends cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            depends/built
-            depends/${{ matrix.host }}
-          key: ${{ runner.os }}-depends-${{ matrix.depends_on }}-${{ hashFiles('depends/packages/*') }}
-
-      - name: Determine PR Base SHA
-        id: vars
-        run: |
-          echo "PR_BASE_SHA=${{ github.event.pull_request.base.sha || '' }}" >> $GITHUB_OUTPUT
-
-      - name: CCache
-        uses: actions/cache@v4
-        with:
-          path: |
-            /cache
-          key: ${{ runner.os }}-${{ matrix.build_target }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.build_target }}-${{ github.sha }}
-            ${{ runner.os }}-${{ matrix.build_target }}-${{ steps.vars.outputs.PR_BASE_SHA }}
-            ${{ runner.os }}-${{ matrix.build_target }}
-
-      - name: Build source and run tests
-        run: |
-          git config --global --add advice.detachedHead false
-          git config --global --add safe.directory "$PWD"
-          GIT_HEAD="$(git rev-parse HEAD)"
-          git checkout develop
-          git checkout ${GIT_HEAD}
-          CCACHE_SIZE="400M"
-          CACHE_DIR="/cache"
-          mkdir /output
-          BASE_OUTDIR="/output"
-          BUILD_TARGET="${{ matrix.build_target }}"
-          source ./ci/dash/matrix.sh
-          ./ci/dash/build_src.sh
-          ./ci/dash/test_unittests.sh
-        shell: bash
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts-${{ matrix.build_target }}
-          path: |
-            /output
+    with:
+      build-target:  ${{ matrix.build-target }}
+      container-path: ${{ needs.container.outputs.path }}
+      depends-target:  ${{ matrix.build-target }}
+      host: ${{ matrix.host }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       build-target: arm-linux
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: arm-linux
+      depends-key: ${{ needs.depends-arm-linux.outputs.key }}
       host: arm-linux-gnueabihf
 
   src-linux64:
@@ -61,7 +61,7 @@ jobs:
     with:
       build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: linux64
+      depends-key: ${{ needs.depends-linux64.outputs.key }}
       host: x86_64-pc-linux-gnu
 
   src-linux64_cxx20:
@@ -71,7 +71,7 @@ jobs:
     with:
       build-target: linux64_cxx20
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: linux64
+      depends-key: ${{ needs.depends-linux64.outputs.key }}
       host: x86_64-pc-linux-gnu
 
   src-linux64_fuzz:
@@ -81,7 +81,7 @@ jobs:
     with:
       build-target: linux64_fuzz
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: linux64
+      depends-key: ${{ needs.depends-linux64.outputs.key }}
       host: x86_64-pc-linux-gnu
 
   src-linux64_nowallet:
@@ -91,7 +91,7 @@ jobs:
     with:
       build-target: linux64_nowallet
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: linux64
+      depends-key: ${{ needs.depends-linux64.outputs.key }}
       host: x86_64-pc-linux-gnu
 
   src-linux64_sqlite:
@@ -101,7 +101,7 @@ jobs:
     with:
       build-target: linux64_sqlite
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: linux64
+      depends-key: ${{ needs.depends-linux64.outputs.key }}
       host: x86_64-pc-linux-gnu
 
   src-linux64_tsan:
@@ -111,7 +111,7 @@ jobs:
     with:
       build-target: linux64_tsan
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: linux64
+      depends-key: ${{ needs.depends-linux64.outputs.key }}
       host: x86_64-pc-linux-gnu
 
   src-linux64_ubsan:
@@ -121,7 +121,7 @@ jobs:
     with:
       build-target: linux64_ubsan
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: linux64
+      depends-key: ${{ needs.depends-linux64.outputs.key }}
       host: x86_64-pc-linux-gnu
 
   src-win64:
@@ -131,5 +131,5 @@ jobs:
     with:
       build-target: win64
       container-path: ${{ needs.container.outputs.path }}
-      depends-target: win64
+      depends-key: ${{ needs.depends-win64.outputs.key }}
       host: x86_64-w64-mingw32

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       container-path: ${{ needs.container.outputs.path }}
 
   depends-linux64:
-    name: x86_64-pc-linux-gnu_debug
+    name: x86_64-pc-linux-gnu
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
     with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,7 +184,7 @@ x86_64-w64-mingw32:
   variables:
     BUILD_TARGET: win64
 
-x86_64-pc-linux-gnu_debug:
+x86_64-pc-linux-gnu:
   extends: .build-depends-template
   variables:
     BUILD_TARGET: linux64
@@ -231,7 +231,7 @@ win64-build:
 linux64-build:
   extends: .build-template
   needs:
-    - x86_64-pc-linux-gnu_debug
+    - x86_64-pc-linux-gnu
   variables:
     BUILD_TARGET: linux64
 
@@ -240,7 +240,7 @@ linux64_cxx20-build:
     - .build-template
     - .skip-in-fast-mode-template
   needs:
-    - x86_64-pc-linux-gnu_debug
+    - x86_64-pc-linux-gnu
   variables:
     BUILD_TARGET: linux64_cxx20
 
@@ -249,7 +249,7 @@ linux64_sqlite-build:
     - .build-template
     - .skip-in-fast-mode-template
   needs:
-    - x86_64-pc-linux-gnu_debug
+    - x86_64-pc-linux-gnu
   variables:
     BUILD_TARGET: linux64_sqlite
 
@@ -258,7 +258,7 @@ linux64_fuzz-build:
     - .build-template
     - .skip-in-fast-mode-template
   needs:
-    - x86_64-pc-linux-gnu_debug
+    - x86_64-pc-linux-gnu
   variables:
     BUILD_TARGET: linux64_fuzz
 
@@ -267,7 +267,7 @@ linux64_fuzz-build:
 #    - .build-template
 #    - .skip-in-fast-mode-template
 #  needs:
-#    - x86_64-pc-linux-gnu_debug
+#    - x86_64-pc-linux-gnu
 #  variables:
 #    BUILD_TARGET: linux64_asan
 
@@ -285,7 +285,7 @@ linux64_ubsan-build:
     - .build-template
     - .skip-in-fast-mode-template
   needs:
-    - x86_64-pc-linux-gnu_debug
+    - x86_64-pc-linux-gnu
   variables:
     BUILD_TARGET: linux64_ubsan
 
@@ -312,7 +312,7 @@ linux64_multiprocess-build:
 #    - .build-template
 #    - .skip-in-fast-mode-template
 #  needs:
-#    - x86_64-pc-linux-gnu_debug
+#    - x86_64-pc-linux-gnu
 #  variables:
 #    BUILD_TARGET: linux64_valgrind
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,10 @@ builder-image:
   image: $CI_REGISTRY_IMAGE:builder-$CI_COMMIT_REF_SLUG
   before_script:
     - |
-      echo HOST=${HOST}
+      echo BUILD_TARGET="${BUILD_TARGET}"
+      source ./ci/dash/matrix.sh
+      echo HOST="${HOST}"
+      echo DEP_OPTS="${DEP_OPTS}"
       if [[ "${HOST}" == "x86_64-apple-darwin" ]]; then
         ./contrib/containers/guix/scripts/setup-sdk
       fi
@@ -73,6 +76,8 @@ builder-image:
     - export CACHE_DIR=$CI_PROJECT_DIR/cache
     - echo BUILD_TARGET=$BUILD_TARGET
     - source ./ci/dash/matrix.sh
+    - echo HOST=${HOST}
+    - echo DEP_OPTS=${DEP_OPTS}
 
     # Setup some environment variables
     - |
@@ -170,43 +175,40 @@ builder-image:
 arm-linux-gnueabihf:
   extends: .build-depends-template
   variables:
-    HOST: arm-linux-gnueabihf
+    BUILD_TARGET: arm-linux
 
 x86_64-w64-mingw32:
   extends:
     - .build-depends-template
     - .skip-in-fast-mode-template
   variables:
-    HOST: x86_64-w64-mingw32
+    BUILD_TARGET: win64
 
 x86_64-pc-linux-gnu_debug:
   extends: .build-depends-template
   variables:
-    HOST: x86_64-pc-linux-gnu
-    DEP_OPTS: "DEBUG=1"
+    BUILD_TARGET: linux64
 
 x86_64-pc-linux-gnu_nowallet:
   extends:
     - .build-depends-template
     - .skip-in-fast-mode-template
   variables:
-    HOST: x86_64-pc-linux-gnu
-    DEP_OPTS: "NO_WALLET=1"
+    BUILD_TARGET: linux64_nowallet
 
 x86_64-pc-linux-gnu_multiprocess:
   extends:
     - .build-depends-template
     - .skip-in-fast-mode-template
   variables:
-    HOST: x86_64-pc-linux-gnu
-    DEP_OPTS: "DEBUG=1 MULTIPROCESS=1"
+    BUILD_TARGET: linux64_multiprocess
 
 x86_64-apple-darwin:
   extends:
     - .build-depends-template
     - .skip-in-fast-mode-template
   variables:
-    HOST: x86_64-apple-darwin
+    BUILD_TARGET: mac
 
 ###
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -276,7 +276,7 @@ linux64_tsan-build:
     - .build-template
     - .skip-in-fast-mode-template
   needs:
-    - x86_64-pc-linux-gnu_debug
+    - x86_64-pc-linux-gnu_multiprocess
   variables:
     BUILD_TARGET: linux64_tsan
 

--- a/ci/test/00_setup_env_native_multiprocess.sh
+++ b/ci/test/00_setup_env_native_multiprocess.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_native_multiprocess
 export HOST=x86_64-pc-linux-gnu
 export PACKAGES="cmake python3 llvm clang"
-export DEP_OPTS="DEBUG=1 MULTIPROCESS=1"
+export DEP_OPTS="MULTIPROCESS=1"
 export GOAL="install"
 export TEST_RUNNER_EXTRA="--v2transport"
 export BITCOIN_CONFIG="--with-boost-process --enable-debug CC=clang-18 CXX=clang++-18" # Use clang to avoid OOM

--- a/ci/test/00_setup_env_native_multiprocess.sh
+++ b/ci/test/00_setup_env_native_multiprocess.sh
@@ -7,6 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_multiprocess
+export HOST=x86_64-pc-linux-gnu
 export PACKAGES="cmake python3 llvm clang"
 export DEP_OPTS="DEBUG=1 MULTIPROCESS=1"
 export GOAL="install"

--- a/ci/test/00_setup_env_native_multiprocess.sh
+++ b/ci/test/00_setup_env_native_multiprocess.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_native_multiprocess
 export HOST=x86_64-pc-linux-gnu
 export PACKAGES="cmake python3 llvm clang"
-export DEP_OPTS="MULTIPROCESS=1"
+export DEP_OPTS="MULTIPROCESS=1 CC=clang-18 CXX=clang++-18"
 export GOAL="install"
 export TEST_RUNNER_EXTRA="--v2transport"
 export BITCOIN_CONFIG="--with-boost-process --enable-debug CC=clang-18 CXX=clang++-18" # Use clang to avoid OOM

--- a/ci/test/00_setup_env_native_nowallet.sh
+++ b/ci/test/00_setup_env_native_nowallet.sh
@@ -7,6 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_nowallet
+export HOST=x86_64-pc-linux-gnu
 export PACKAGES="python3-zmq"
 export DEP_OPTS="NO_WALLET=1"
 export GOAL="install"

--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_native_qt5
 export HOST=x86_64-pc-linux-gnu
 export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
-export DEP_OPTS="DEBUG=1"
+export DEP_OPTS=""
 export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_pruning,feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"

--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -7,6 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_qt5
+export HOST=x86_64-pc-linux-gnu
 export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
 export DEP_OPTS="NO_UPNP=1 DEBUG=1"
 export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_pruning,feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash

--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_native_qt5
 export HOST=x86_64-pc-linux-gnu
 export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
-export DEP_OPTS="NO_UPNP=1 DEBUG=1"
+export DEP_OPTS="DEBUG=1"
 export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_pruning,feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"


### PR DESCRIPTION
## Additional Information

* Depends on https://github.com/dashpay/dash/pull/6406

* We have to move away from matrices as matrix-based job variants cannot be _individually_ accepted as dependencies for the next job, only the whole job can. This means that the next job cannot start until the last matrix variant of the dependency succeeds. This also means that if any variant fails in the dependency job fails, every job forward also ceases.

  The approach taken in this PR is a mirror of the current implementation on GitLab CI, defining a reusable unit ("templates" in GitLab parlance, "reusable workflows" in GitHub) and defining each variant, now coming with a unique job name that can be specified as dependencies for the job. This should reduce stalling from slower variants.

* `DEBUG=1` had to be dropped as it resulted in the runners running out of free space ([build](https://github.com/kwvg/dash/actions/runs/13240781702/job/36956549082#step:7:3137)). Despite this only being a problem with GitHub Actions, this change also affects GitLab CI as we now read `DEP_OPTS` from matrix scripts instead of the CI configuration file.
  * We are reading from the matrix script to ensure that both CI instances build with the same configuration and to reduce code complexity arising from passing around details between different workflows.

  * Potential `DEP_OPTS` conflicts (as discussed [here](https://github.com/dashpay/dash/pull/6400#issuecomment-2495995363)) have been circumvented by passing the expected cache key wholesale instead of reconstructing it ([commit](https://github.com/dashpay/dash/commit/1a67a026de39017a544cfb7852390de88864deec)). We do still expect that `HOST` will be defined correctly in the matrix script (the `HOST` of both depends and build should match) but as differing `HOST`s are incompatible regardless, this shouldn't be a problem. 

    * To make sure we can `output` `cache-primary-key`, the depends cache step was split in two so that the output from the `restore` action is can be exported from the workflow  ([source](https://github.com/dashpay/dash/blob/1a67a026de39017a544cfb7852390de88864deec/.github/workflows/build-depends.yml#L21)).

* As `DEP_OPTS` is a new parameter that _could_ require rebuilding depends, it needs to be incorporated into the cache key. The most straightforward way to do it is to append the hash of the file that defines `DEP_OPTS` to the cache key. Unfortunately, this requires us to hardcode the name of the individual file (e.g., `00_setup_env_native_qt5.sh` for `linux64`) as `matrix.sh` is just a dispatcher and comes with the drawback that _any_ change to the script could result in a cache miss due to a changed hash.

  This has been mitigated by hashing the build variant name and the environment variables that influence the build ([source](https://github.com/dashpay/dash/blob/cfdd2c678819de04cd867740a0f9a9f729c891bb/.github/workflows/build-depends.yml#L41-L43)).
  * `head` trims the output of `sha256sum` to 64 characters, the hash itself isn't being trimmed but everything after it is (trailing hyphen and newline). This is also why `echo -n` is used in some places, to avoid newline addition resulting in a different hash value.

* Currently there doesn't seem to be a way to have full control on a reusable workflow's name, it remains a fixed "[caller name] / [reusable workflow name]" and attempting to remove the name altogether will still result in a trailing slash ([source](https://stackoverflow.com/questions/79241079/how-to-control-the-name-of-a-reusable-workflow)).

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
