### PR TITLE
ci: cache built

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            depends/${{ matrix.host }}
+            depends/built
           key: ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
             ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}


### PR DESCRIPTION
## Issue being fixed or feature implemented
Depends build didn't seem to be caching properly

## What was done?
changed depends/${{ matrix.host }} to depends/built as gitlab does


## How Has This Been Tested?
Depends "build" now takes only ~1 minute instead of ~15 minutes in CI: https://github.com/PastaPastaPasta/dash/actions/runs/11899038167

## Breaking Changes
None

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

