### PR TITLE
feat(qt): Governance Tab should respect selected units and settings

### DIFF
--- a/src/qt/governancelist.h
+++ b/src/qt/governancelist.h
@@ -7,6 +7,7 @@
 
 #include <governance/object.h>
 #include <primitives/transaction.h>
+#include <qt/bitcoinunits.h>
 #include <sync.h>
 #include <util/system.h>
 
@@ -48,6 +49,7 @@ private:
     QTimer* timer;
 
 private Q_SLOTS:
+    void updateDisplayUnit();
     void updateProposalList();
     void updateProposalCount() const;
     void showProposalContextMenu(const QPoint& pos);
@@ -92,6 +94,7 @@ class ProposalModel : public QAbstractTableModel
 private:
     QList<const Proposal*> m_data;
     int nAbsVoteReq = 0;
+    int m_display_unit{BitcoinUnits::DASH};
 
 public:
     explicit ProposalModel(QObject* parent = nullptr) :
@@ -119,6 +122,8 @@ public:
     void setVotingParams(int nAbsVoteReq);
 
     const Proposal* getProposalAt(const QModelIndex& index) const;
+
+    void setDisplayUnit(int display_unit);
 };
 
 #endif // BITCOIN_QT_GOVERNANCELIST_H


### PR DESCRIPTION
## Issue being fixed or feature implemented
Governance Tab ignores selected units and settings atm. Let's fix this.

Display settings:
<img width="607" alt="Screenshot 2024-11-19 at 00 49 35" src="https://github.com/user-attachments/assets/4ee777b4-8104-4e82-801a-c412573aa505">

develop:
<img width="965" alt="Screenshot 2024-11-19 at 00 47 35" src="https://github.com/user-attachments/assets/8aa69db0-c8a7-4e31-b733-e765e7f7f510">
<img width="956" alt="Screenshot 2024-11-19 at 00 48 02" src="https://github.com/user-attachments/assets/1213fd66-24a2-40b8-bb32-87f3310f0086">

this PR:

<img width="956" alt="Screenshot 2024-11-19 at 00 49 04" src="https://github.com/user-attachments/assets/a09f8134-eddd-4e9c-ab86-1b5c4afeb994">
<img width="958" alt="Screenshot 2024-11-19 at 00 49 17" src="https://github.com/user-attachments/assets/f9c34938-c56f-4198-8613-26f6e8c08c71">

## What was done?



## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

