### PR TITLE
ci: use `actions/cache` to manage depends cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,24 +86,19 @@ jobs:
           restore-keys: |
             depends-sources-
 
-      - name: Cache dependencies
+      - name: Cache depends
         uses: actions/cache@v4
         with:
           path: |
             depends/built
+            depends/${{ matrix.host }}
           key: ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
           restore-keys: |
             ${{ runner.os }}-depends-${{ matrix.build_target }}-${{ hashFiles('depends/packages/*') }}
             ${{ runner.os }}-depends-${{ matrix.build_target }}
 
-      - name: Build dependencies
+      - name: Build depends
         run: make -j$(nproc) -C depends HOST=${{ matrix.host }}
-
-      - name: Upload built depends
-        uses: actions/upload-artifact@v4
-        with:
-          name: depends-${{ matrix.build_target }}
-          path: depends/${{ matrix.host }}
 
   build:
     name: Build
@@ -146,11 +141,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Download built depends
-        uses: actions/download-artifact@v4
+      - name: Restore depends cache
+        uses: actions/cache/restore@v4
         with:
-          name: depends-${{ matrix.depends_on }}
-          path: depends/${{ matrix.host }}
+          path: |
+            depends/built
+            depends/${{ matrix.host }}
+          key: ${{ runner.os }}-depends-${{ matrix.depends_on }}-${{ hashFiles('depends/packages/*') }}
 
       - name: Determine PR Base SHA
         id: vars


### PR DESCRIPTION
## Additional Information

* Builds after [dash#6401](https://github.com/dashpay/dash/pull/6401) have silently stopped building Dash Qt, see pre-[dash#6401](https://github.com/dashpay/dash/pull/6401) `develop` (6a51ab27)'s [build](https://github.com/dashpay/dash/actions/runs/11881892222/job/33106960691#step:7:725) compared against [build \#1](https://github.com/PastaPastaPasta/dash/actions/runs/11897504945/job/33152711720#step:7:1432) and [build \#2](https://github.com/kwvg/dash/actions/runs/11898510091/job/33156186503#step:7:1432) from [dash#6401](https://github.com/dashpay/dash/pull/6401)'s review process.
  
  This pull request aims to correct that regression.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
