### PR TITLE
fix: dataraces

### DIFF
--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -56,11 +56,10 @@ class LLMQChainLocksTest(DashTestFramework):
         self.move_to_next_cycle()
         self.log.info("Cycle H+2C height:" + str(self.nodes[0].getblockcount()))
         self.mine_cycle_quorum(llmq_type_name="llmq_test_dip0024", llmq_type=103)
-
-
-        self.log.info("Mine single block, wait for chainlock")
-        self.generate(self.nodes[0], 1, sync_fun=self.no_op)
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
+
+        self.log.info("Mine single block, ensure it includes latest chainlock")
+        self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks)
         self.test_coinbase_best_cl(self.nodes[0])
 
         # ChainLock locks all the blocks below it so nocl_block_hash should be locked too


### PR DESCRIPTION
## Issue being fixed or feature implemented
See each commit; fixes two bugs, both discovered while running feature_llmq_chainlocks.py with tsan / debug.

one a datarace in net_processing.cpp and the other in the test I was using to ensure this fix was correct, feature_llmq_chainlocks

## What was done?
### net_processing.cpp
You can see the datarace here: https://gist.github.com/PastaPastaPasta/c966a9f805758b34524085e3d52ea7f8

We simply guard it with an existing mutex that is always locked in close proximity.

### feature_llmq_chainlocks.py
Most of the time, while generating the cycle quorum, there is sufficient time to generate a chainlock; however, this is racey, and I've observed locally where the block gets generated before a chainlock is present and as such `test_coinbase_best_cl` fails. We should instead wait for the chainlock first, and then mine the block. This was we can ensure the mined block will include that chainlock.

This was observed locally maybe 1/10 times or so

## How Has This Been Tested?
ran feature_llmq_chainlocks.py ~40 times locally with tsan / debug

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

