### PR TITLE
refactor: move expensive CInv initialization out of hot loop

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2328,13 +2328,13 @@ void PeerManagerImpl::RelayInvFiltered(CInv &inv, const uint256& relatedTxHash, 
 
 void PeerManagerImpl::RelayTransaction(const uint256& txid)
 {
+    const CInv inv{m_cj_ctx->dstxman->GetDSTX(txid) ? MSG_DSTX : MSG_TX, txid};
     LOCK(m_peer_mutex);
     for(auto& it : m_peer_map) {
         Peer& peer = *it.second;
         auto tx_relay = peer.GetTxRelay();
         if (!tx_relay) continue;
 
-        const CInv inv{m_cj_ctx->dstxman->GetDSTX(txid) ? MSG_DSTX : MSG_TX, txid};
         PushInv(peer, inv);
     };
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Not sure how we introduced this one, but it appears we are calling a CInv construction (pretty cheap) and a GetDSTX ((relatively) EXPENSIVE) for each peer we are connected to in RelayTransaction... I can hope and pray that the compiler somehow was magically optimizing this for us, but I really doubt it

## What was done?
Move the initialization out of the loop

## How Has This Been Tested?


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

