### PR TITLE
refactor: implement minimal RelayInv which doesn't rely on m_connman

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3439,7 +3439,7 @@ void PeerManagerImpl::PostProcessMessage(MessageProcessingResult&& result, NodeI
         WITH_LOCK(cs_main, RelayTransaction(tx));
     }
     if (result.m_inventory) {
-        RelayInv(result.m_inventory.value(), MIN_PEER_PROTO_VERSION);
+        RelayInv(result.m_inventory.value());
     }
 }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -614,6 +614,7 @@ public:
     bool IgnoresIncomingTxs() override { return m_ignore_incoming_txs; }
     void SendPings() override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);;
     void PushInventory(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+    void RelayInv(CInv &inv) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void RelayInv(CInv &inv, const int minProtoVersion) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void RelayInvFiltered(CInv &inv, const uint256 &relatedTxHash, const int minProtoVersion) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
@@ -2287,6 +2288,15 @@ void PeerManagerImpl::RelayInv(CInv &inv, const int minProtoVersion)
         if (peer == nullptr) return;
         PushInv(*peer, inv);
     });
+}
+
+void PeerManagerImpl::RelayInv(CInv &inv)
+{
+    LOCK(m_peer_mutex);
+    for (const auto& [_, peer] : m_peer_map) {
+        if (!peer->GetInvRelay()) continue;
+        PushInv(*peer, inv);
+    }
 }
 
 void PeerManagerImpl::RelayDSQ(const CCoinJoinQueue& queue)

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -98,7 +98,8 @@ public:
     virtual void RelayDSQ(const CCoinJoinQueue& queue) = 0;
 
     /** Relay inventories to all peers */
-    virtual void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION) = 0;
+    virtual void RelayInv(CInv &inv) = 0;
+    virtual void RelayInv(CInv &inv, const int minProtoVersion) = 0;
     virtual void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx,
                                   const int minProtoVersion = MIN_PEER_PROTO_VERSION) = 0;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Vast majority of usages of RelayInv don't use the minProtoVersion, we may as well have these not contribute to contention of m_nodes_mutex / use m_connman

## What was done?
new implementation of RelayInv which doesn't rely on m_connman

## How Has This Been Tested?
See CI

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

