### PR TITLE
feat: dynamically register MN in functional tests without IS

### DIFF
--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -76,15 +76,6 @@ class LLMQEvoNodesTest(DashTestFramework):
         self.nodes[0].sporkupdate("SPORK_2_INSTANTSEND_ENABLED", 0)
         self.wait_for_sporks_same()
 
-        self.move_to_next_cycle()
-        self.log.info("Cycle H height:" + str(self.nodes[0].getblockcount()))
-        self.move_to_next_cycle()
-        self.log.info("Cycle H+C height:" + str(self.nodes[0].getblockcount()))
-        self.move_to_next_cycle()
-        self.log.info("Cycle H+2C height:" + str(self.nodes[0].getblockcount()))
-
-        self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
-
         evo_protxhash_list = list()
         for i in range(self.evo_count):
             evo_info = self.dynamically_add_masternode(evo=True)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -640,6 +640,8 @@ class CBlock(CBlockHeader):
     # Calculate the merkle root given a vector of transaction hashes
     @staticmethod
     def get_merkle_root(hashes):
+        if len(hashes) == 0:
+            return 0
         while len(hashes) > 1:
             newhashes = []
             for i in range(0, len(hashes), 2):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1313,7 +1313,7 @@ class DashTestFramework(BitcoinTestFramework):
         collateral_amount = EVONODE_COLLATERAL if evo else MASTERNODE_COLLATERAL
         outputs = {collateral_address: collateral_amount, funds_address: 1}
         collateral_txid = self.nodes[0].sendmany("", outputs)
-        self.wait_for_instantlock(collateral_txid, self.nodes[0])
+        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         tip = self.generate(self.nodes[0], 1)[0]
 
         rawtx = self.nodes[0].getrawtransaction(collateral_txid, 1, tip)
@@ -1334,7 +1334,7 @@ class DashTestFramework(BitcoinTestFramework):
         else:
             protx_result = self.nodes[0].protx("register", collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, funds_address, True)
 
-        self.wait_for_instantlock(protx_result, self.nodes[0])
+        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         tip = self.generate(self.nodes[0], 1)[0]
 
         assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
@@ -1356,14 +1356,14 @@ class DashTestFramework(BitcoinTestFramework):
         platform_http_port = '%d' % (r + 2)
 
         fund_txid = self.nodes[0].sendtoaddress(funds_address, 1)
-        self.wait_for_instantlock(fund_txid, self.nodes[0])
+        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         tip = self.generate(self.nodes[0], 1)[0]
         assert_equal(self.nodes[0].getrawtransaction(fund_txid, 1, tip)['confirmations'], 1)
 
         protx_success = False
         try:
             protx_result = self.nodes[0].protx('update_service_evo', evo_info.proTxHash, evo_info.addr, evo_info.keyOperator, platform_node_id, platform_p2p_port, platform_http_port, operator_reward_address, funds_address)
-            self.wait_for_instantlock(protx_result, self.nodes[0])
+            self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
             tip = self.generate(self.nodes[0], 1)[0]
             assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
             self.log.info("Updated EvoNode %s: platformNodeID=%s, platformP2PPort=%s, platformHTTPPort=%s" % (evo_info.proTxHash, platform_node_id, platform_p2p_port, platform_http_port))


### PR DESCRIPTION
This PR has important fixes to implement "single-node quorum" feature.

## Issue being fixed or feature implemented
Without IS-quorum you can not dynamically add a new MN or Evo node.
For evo nodes adding it dynamically is the only way.

## What was done?
Fixed a function that dynamically adds a masternode without Instant Send quorums; use it in a functional test feature_asset_locks.py

As side effect it improves performance of functional tests which do not wait more IS lock significantly; for feature_asset_locks.py it gave ~20 seconds per run.

## How Has This Been Tested?
See updates in `feature_asset_locks.py`, `feature_llmq_evo.py`, `feature_dip3_v19.py`


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_