### PR TITLE
fix: possible bug due to using unspecified behavior of std::move

### DIFF
--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -520,10 +520,8 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
 void CSigningManager::ProcessPendingReconstructedRecoveredSigs()
 {
     decltype(pendingReconstructedRecoveredSigs) m;
-    {
-        LOCK(cs_pending);
-        m = std::move(pendingReconstructedRecoveredSigs);
-    }
+    WITH_LOCK(cs_pending, swap(m, pendingReconstructedRecoveredSigs));
+
     for (const auto& p : m) {
         ProcessRecoveredSig(p.second);
     }

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -1490,10 +1490,7 @@ void CSigSharesManager::AsyncSign(const CQuorumCPtr& quorum, const uint256& id, 
 void CSigSharesManager::SignPendingSigShares()
 {
     std::vector<PendingSignatureData> v;
-    {
-        LOCK(cs_pendingSigns);
-        v = std::move(pendingSigns);
-    }
+    WITH_LOCK(cs_pendingSigns, v.swap(pendingSigns));
 
     for (const auto& [pQuorum, id, msgHash] : v) {
         auto opt_sigShare = CreateSigShare(pQuorum, id, msgHash);

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -122,9 +122,8 @@ void CMasternodeMetaMan::RemoveGovernanceObject(const uint256& nGovernanceObject
 
 std::vector<uint256> CMasternodeMetaMan::GetAndClearDirtyGovernanceObjectHashes()
 {
-    LOCK(cs);
-    std::vector<uint256> vecTmp = std::move(vecDirtyGovernanceObjectHashes);
-    vecDirtyGovernanceObjectHashes.clear();
+    std::vector<uint256> vecTmp;
+    WITH_LOCK(cs, vecTmp.swap(vecDirtyGovernanceObjectHashes));
     return vecTmp;
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
All standard library objects that have been moved from are placed in a "valid but unspecified state", meaning the object's class invariants hold (so functions without preconditions, such as the assignment operator, can be safely used on the object after it was moved from). See example:

```
std::vector<int> v = {2, 3, 3};
std::vector<int> u = std::move(v); // the value of v is unspecified
v.clear(); // we are good now
```

Instead, let's have swap better!
```
WITH_LOCK(cs_pendingSigns, v.swap(pendingSigns));
```

## What was done?
Fixed `CSigSharesManager::SignPendingSigShares`, `CSigningManager::ProcessPendingReconstructedRecoveredSigs` and refactored `CMasternodeMetaMan::GetAndClearDirtyGovernanceObjectHashes` for unification.


## How Has This Been Tested?
Run unit and functional tests.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
