### PR TITLE
fix: early EHF and buried EHF are indistinguish

### DIFF
--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -75,7 +75,8 @@ CMNHFManager::Signals CMNHFManager::GetSignalsStage(const CBlockIndex* const pin
             if (deployment.bit != signal.first) continue;
             if (signal_time < deployment.nStartTime) {
                 // new deployment is using the same bit as the old one
-                LogPrintf("CMNHFManager::GetSignalsStage: mnhf signal bit=%d height:%d is expired at height=%d\n", signal.first, signal.second, height);
+                LogPrintf("CMNHFManager::GetSignalsStage: mnhf signal bit=%d height:%d is expired at height=%d\n",
+                          signal.first, signal.second, height);
                 expired = true;
             }
         }

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 static const std::string MNEHF_REQUESTID_PREFIX = "mnhf";
+static const std::string DB_SIGNALS = "mnhf";
 static const std::string DB_SIGNALS_v2 = "mnhf_s2";
 
 uint256 MNHFTxPayload::GetRequestId() const
@@ -333,6 +334,14 @@ std::optional<CMNHFManager::Signals> CMNHFManager::GetFromCache(const CBlockInde
         LOCK(cs_cache);
         mnhfCache.insert(blockHash, signals);
         return signals;
+    }
+    if (!DeploymentActiveAt(*pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_MN_RR)) {
+        // before mn_rr activation we are safe
+        if (m_evoDb.Read(std::make_pair(DB_SIGNALS, blockHash), signals)) {
+            LOCK(cs_cache);
+            mnhfCache.insert(blockHash, signals);
+            return signals;
+        }
     }
     return std::nullopt;
 }

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 static const std::string MNEHF_REQUESTID_PREFIX = "mnhf";
-static const std::string DB_SIGNALS = "mnhf";
+static const std::string DB_SIGNALS = "mnhf_s";
 static const std::string DB_SIGNALS_v2 = "mnhf_s2";
 
 uint256 MNHFTxPayload::GetRequestId() const

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 static const std::string MNEHF_REQUESTID_PREFIX = "mnhf";
-static const std::string DB_SIGNALS = "mnhf_s";
+static const std::string DB_SIGNALS_v2 = "mnhf_s2";
 
 uint256 MNHFTxPayload::GetRequestId() const
 {
@@ -57,34 +57,32 @@ CMNHFManager::Signals CMNHFManager::GetSignalsStage(const CBlockIndex* const pin
 {
     if (!DeploymentActiveAfter(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_V20)) return {};
 
-    Signals signals = GetForBlock(pindexPrev);
+    Signals signals_tmp = GetForBlock(pindexPrev);
+
     if (pindexPrev == nullptr) return {};
     const int height = pindexPrev->nHeight + 1;
-    for (auto it = signals.begin(); it != signals.end(); ) {
-        bool found{false};
-        const auto signal_pindex = pindexPrev->GetAncestor(it->second);
+
+    Signals signals_ret;
+
+    for (auto signal : signals_tmp) {
+        bool expired{false};
+        const auto signal_pindex = pindexPrev->GetAncestor(signal.second);
         assert(signal_pindex != nullptr);
         const int64_t signal_time = signal_pindex->GetMedianTimePast();
         for (int index = 0; index < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++index) {
             const auto& deployment = Params().GetConsensus().vDeployments[index];
-            if (deployment.bit != it->first) continue;
+            if (deployment.bit != signal.first) continue;
             if (signal_time < deployment.nStartTime) {
                 // new deployment is using the same bit as the old one
-                LogPrintf("CMNHFManager::GetSignalsStage: mnhf signal bit=%d height:%d is expired at height=%d\n", it->first, it->second, height);
-                it = signals.erase(it);
-            } else {
-                ++it;
+                LogPrintf("CMNHFManager::GetSignalsStage: mnhf signal bit=%d height:%d is expired at height=%d\n", signal.first, signal.second, height);
+                expired = true;
             }
-            found = true;
-            break;
         }
-        if (!found) {
-            // no deployment means we buried it and aren't using the same bit (yet)
-            LogPrintf("CMNHFManager::GetSignalsStage: mnhf signal bit=%d height:%d is not known at height=%d\n", it->first, it->second, height);
-            it = signals.erase(it);
+        if (!expired) {
+            signals_ret.insert(signal);
         }
     }
-    return signals;
+    return signals_ret;
 }
 
 bool MNHFTx::Verify(const llmq::CQuorumManager& qman, const uint256& quorumHash, const uint256& requestId, const uint256& msgHash, TxValidationState& state) const
@@ -287,6 +285,9 @@ CMNHFManager::Signals CMNHFManager::GetForBlock(const CBlockIndex* pindex)
     const Consensus::Params& consensusParams{Params().GetConsensus()};
     while (!to_calculate.empty()) {
         const CBlockIndex* pindex_top{to_calculate.top()};
+        if (pindex_top->nHeight % 1000 == 0) {
+            LogPrintf("re-index EHF signals at block %d\n", pindex_top->nHeight);
+        }
         CBlock block;
         if (!ReadBlockFromDisk(block, pindex_top, consensusParams)) {
             throw std::runtime_error("failed-getehfforblock-read");
@@ -328,7 +329,7 @@ std::optional<CMNHFManager::Signals> CMNHFManager::GetFromCache(const CBlockInde
             return signals;
         }
     }
-    if (m_evoDb.Read(std::make_pair(DB_SIGNALS, blockHash), signals)) {
+    if (m_evoDb.Read(std::make_pair(DB_SIGNALS_v2, blockHash), signals)) {
         LOCK(cs_cache);
         mnhfCache.insert(blockHash, signals);
         return signals;
@@ -346,7 +347,7 @@ void CMNHFManager::AddToCache(const Signals& signals, const CBlockIndex* const p
     }
     if (!DeploymentActiveAt(*pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20)) return;
 
-    m_evoDb.Write(std::make_pair(DB_SIGNALS, blockHash), signals);
+    m_evoDb.Write(std::make_pair(DB_SIGNALS_v2, blockHash), signals);
 }
 
 void CMNHFManager::AddSignal(const CBlockIndex* const pindex, int bit)

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -155,6 +155,8 @@ public:
      */
     void DisconnectManagers() { m_chainman = nullptr; m_qman = nullptr; };
 
+    bool ForceSignalDBUpdate();
+
 private:
     void AddToCache(const Signals& signals, const CBlockIndex* const pindex);
 

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -155,7 +155,7 @@ public:
      */
     void DisconnectManagers() { m_chainman = nullptr; m_qman = nullptr; };
 
-    bool ForceSignalDBUpdate();
+    bool ForceSignalDBUpdate() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 private:
     void AddToCache(const Signals& signals, const CBlockIndex* const pindex);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2058,6 +2058,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                     strLoadError = _("Error upgrading evo database");
                     break;
                 }
+                if (!node.mnhf_manager->ForceSignalDBUpdate()) {
+                    strLoadError = _("Error upgrading evo database for EHF");
+                    break;
+                }
 
                 for (CChainState* chainstate : chainman.GetAll()) {
                     if (!is_coinsview_empty(chainstate)) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
It seems as EHF signal will be mined before node is updated, this signal is lost and node can't activate hard-fork anymore.


## What was done?
EHF signals doesn't expire anymore.
To avoid full re-index key in database is changed.
Client with enabled "pruned mode" will be required to do re-index.

Alternate solution - revert this commit 4b046bb60808927349cf5556fdb73f04f818057e and introduce time-out for expiring EHF signals.


## How Has This Been Tested?
Test on my local instance with testnet and mainnet.

Testing on miner-1 on testnet is done.
First start of miner took 50 seconds, 29 of them the node was re-scanning blockchain and looking for EHF transaction


## Breaking Changes
It requires re-index for nodes with enabled pruning of blocks.

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_