### PR TITLE
feat: increase threshold from 2000 DASH to 21M DASH for CJ amount with UI

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -532,7 +532,7 @@
             <number>2</number>
            </property>
            <property name="maximum">
-            <number>2000</number>
+            <number>21000000</number>
            </property>
            <property name="singleStep">
             <number>10</number>


### PR DESCRIPTION
## Issue being fixed or feature implemented
With rpc and command line option you can choose any amount of CJ (threshold to stop), but UI let to choose maximum 2000 Dash.
Assuming, that Evo collateral is 4000 it's unwisely to limit UI to just 2k.

## What was done?
Limits are increased to `MAX_COINJOIN_AMOUNT` (21M)


## How Has This Been Tested?
Run UI and set

## Breaking Changes
n/a


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone