### PR TITLE
fix: add platform transfer to "most common" filter

### DIFF
--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -23,7 +23,7 @@ public:
     /** Type filter bit field (all types) */
     static const quint32 ALL_TYPES = 0xFFFFFFFF;
     /** Type filter bit field (all types but Darksend-SPAM) */
-    static const quint32 COMMON_TYPES = 0x107f;
+    static const quint32 COMMON_TYPES = 0x307f;
 
     static quint32 TYPE(int type) { return 1<<type; }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -23,7 +23,7 @@ public:
     /** Type filter bit field (all types) */
     static const quint32 ALL_TYPES = 0xFFFFFFFF;
     /** Type filter bit field (all types but Darksend-SPAM) */
-    static const quint32 COMMON_TYPES = 4223;
+    static const quint32 COMMON_TYPES = 0x107f;
 
     static quint32 TYPE(int type) { return 1<<type; }
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -82,6 +82,7 @@ public:
 class TransactionRecord
 {
 public:
+    // Update COMMON_TYPES in TransactionFilterProxyWhen when adding a new type
     enum Type
     {
         Other,


### PR DESCRIPTION
## Issue being fixed or feature implemented
Follow-up https://github.com/dashpay/dash/pull/6131 - missing 'Platform Transfer' in the list of most common. Reported by splawik.

## What was done?
Updated filter, added comment to prevent similar mistakes in future, present filter in hex for better readability.


## How Has This Been Tested?
Transaction with platform transfer appeared in filter "Most Common"
![image](https://github.com/user-attachments/assets/ccc17553-d71a-45f8-be2f-8ce5fb699c1a)
Also they are added to Overview page (compare screenshots by 'address' field)
![image](https://github.com/user-attachments/assets/ea657672-46c8-4a66-a972-15768feb4d57)


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone