### PR TITLE
feat: show human friendly error if missing spentindex, txindex or addressindex

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -870,10 +870,6 @@ static RPCHelpMan getblockhashes()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!IsTimestampIndexAvailable()) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "Timestamp index is disabled. You should run Dash Core with -timestampindex (requires reindex)");
-    }
-
     unsigned int high = request.params[0].get_int();
     unsigned int low = request.params[1].get_int();
     std::vector<uint256> blockHashes;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -870,6 +870,10 @@ static RPCHelpMan getblockhashes()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (!IsTimestampIndexAvailable()) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Timestamp index is disabled. You should run Dash Core with -timestampindex (requires reindex)");
+    }
+
     unsigned int high = request.params[0].get_int();
     unsigned int low = request.params[1].get_int();
     std::vector<uint256> blockHashes;

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -10,6 +10,11 @@
 #include <txmempool.h>
 #include <uint256.h>
 
+bool IsAddressIndexAvailable()
+{
+    return fAddressIndex;
+}
+
 bool GetAddressIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
                      std::vector<CAddressIndexEntry>& addressIndex,
                      const int32_t start, const int32_t end)
@@ -67,6 +72,11 @@ bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
     return true;
 }
 
+bool IsSpentIndexAvailable()
+{
+    return fSpentIndex;
+}
+
 bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const CSpentIndexKey& key,
                    CSpentIndexValue& value)
 {
@@ -82,6 +92,11 @@ bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const
         return error("Unable to get spend information");
 
     return true;
+}
+
+bool IsTimestampIndexAvailable()
+{
+    return fTimestampIndex;
 }
 
 bool GetTimestampIndex(CBlockTreeDB& block_tree_db, const uint32_t high, const uint32_t low,

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -24,25 +24,27 @@ enum class AddressType : uint8_t;
 
 extern RecursiveMutex cs_main;
 
-bool IsAddressIndexAvailable();
+//! throws JSONRPCError if address index is unavailable
 bool GetAddressIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
                      std::vector<CAddressIndexEntry>& addressIndex,
                      const int32_t start = 0, const int32_t end = 0)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+//! throws JSONRPCError if address index is unavailable
 bool GetAddressUnspentIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
                             std::vector<CAddressUnspentIndexEntry>& unspentOutputs, const bool height_sort = false)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+//! throws JSONRPCError if address index is unavailable
 bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
                                  const std::vector<CMempoolAddressDeltaKey>& addressDeltaIndex,
                                  std::vector<CMempoolAddressDeltaEntry>& addressDeltaEntries,
                                  const bool timestamp_sort = false);
 
-bool IsSpentIndexAvailable();
+//! throws JSONRPCError if spent index is unavailable
 bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const CSpentIndexKey& key,
                    CSpentIndexValue& value)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-bool IsTimestampIndexAvailable();
+//! throws JSONRPCError if timestamp index is unavailable
 bool GetTimestampIndex(CBlockTreeDB& block_tree_db, const uint32_t high, const uint32_t low,
                        std::vector<uint256>& hashes)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -24,6 +24,7 @@ enum class AddressType : uint8_t;
 
 extern RecursiveMutex cs_main;
 
+bool IsAddressIndexAvailable();
 bool GetAddressIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
                      std::vector<CAddressIndexEntry>& addressIndex,
                      const int32_t start = 0, const int32_t end = 0)
@@ -35,9 +36,13 @@ bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
                                  const std::vector<CMempoolAddressDeltaKey>& addressDeltaIndex,
                                  std::vector<CMempoolAddressDeltaEntry>& addressDeltaEntries,
                                  const bool timestamp_sort = false);
+
+bool IsSpentIndexAvailable();
 bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const CSpentIndexKey& key,
                    CSpentIndexValue& value)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+bool IsTimestampIndexAvailable();
 bool GetTimestampIndex(CBlockTreeDB& block_tree_db, const uint32_t high, const uint32_t low,
                        std::vector<uint256>& hashes)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -742,6 +742,10 @@ static RPCHelpMan getaddressmempool()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (!IsAddressIndexAvailable()) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
+    }
+
     CTxMemPool& mempool = EnsureAnyMemPool(request.context);
 
     std::vector<std::pair<uint160, AddressType>> addresses;
@@ -814,6 +818,9 @@ static RPCHelpMan getaddressutxos()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (!IsAddressIndexAvailable()) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
+    }
 
     std::vector<std::pair<uint160, AddressType> > addresses;
 
@@ -887,7 +894,9 @@ static RPCHelpMan getaddressdeltas()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-
+    if (!IsAddressIndexAvailable()) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
+    }
 
     UniValue startValue = find_value(request.params[0].get_obj(), "start");
     UniValue endValue = find_value(request.params[0].get_obj(), "end");
@@ -979,6 +988,9 @@ static RPCHelpMan getaddressbalance()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (!IsAddressIndexAvailable()) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
+    }
 
     std::vector<std::pair<uint160, AddressType> > addresses;
 
@@ -1052,6 +1064,9 @@ static RPCHelpMan getaddresstxids()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (!IsAddressIndexAvailable()) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
+    }
 
     std::vector<std::pair<uint160, AddressType> > addresses;
 
@@ -1142,6 +1157,9 @@ static RPCHelpMan getspentinfo()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (!IsSpentIndexAvailable()) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Spent index is disabled. You should run Dash Core with -spentindex (requires reindex)");
+    }
 
     UniValue txidValue = find_value(request.params[0].get_obj(), "txid");
     UniValue indexValue = find_value(request.params[0].get_obj(), "index");

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -742,10 +742,6 @@ static RPCHelpMan getaddressmempool()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!IsAddressIndexAvailable()) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
-    }
-
     CTxMemPool& mempool = EnsureAnyMemPool(request.context);
 
     std::vector<std::pair<uint160, AddressType>> addresses;
@@ -818,12 +814,7 @@ static RPCHelpMan getaddressutxos()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!IsAddressIndexAvailable()) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
-    }
-
     std::vector<std::pair<uint160, AddressType> > addresses;
-
     if (!getAddressesFromParams(request.params, addresses)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
@@ -894,10 +885,6 @@ static RPCHelpMan getaddressdeltas()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!IsAddressIndexAvailable()) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
-    }
-
     UniValue startValue = find_value(request.params[0].get_obj(), "start");
     UniValue endValue = find_value(request.params[0].get_obj(), "end");
 
@@ -988,10 +975,6 @@ static RPCHelpMan getaddressbalance()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!IsAddressIndexAvailable()) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
-    }
-
     std::vector<std::pair<uint160, AddressType> > addresses;
 
     if (!getAddressesFromParams(request.params, addresses)) {
@@ -1064,10 +1047,6 @@ static RPCHelpMan getaddresstxids()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!IsAddressIndexAvailable()) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
-    }
-
     std::vector<std::pair<uint160, AddressType> > addresses;
 
     if (!getAddressesFromParams(request.params, addresses)) {
@@ -1157,10 +1136,6 @@ static RPCHelpMan getspentinfo()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!IsSpentIndexAvailable()) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "Spent index is disabled. You should run Dash Core with -spentindex (requires reindex)");
-    }
-
     UniValue txidValue = find_value(request.params[0].get_obj(), "txid");
     UniValue indexValue = find_value(request.params[0].get_obj(), "index");
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -75,7 +75,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, CTxMemPool& mempo
 
     // Add spent information if spentindex is enabled
     CSpentIndexTxInfo txSpentInfo;
-    if (IsSpentIndexAvailable()) {
+    if (fSpentIndex) {
         txSpentInfo = CSpentIndexTxInfo{};
         for (const auto& txin : tx.vin) {
             if (!tx.IsCoinBase()) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Currently user receive error `Unable to get spent info` or even worse `No information available for address` which doesn't say anything about required extra indexes.


Also, every call of RPC `getrawtransaction` causes this error logs on high level if spent index is disabled, but actually it just means that no couple extra fields are hidden in output which is expected if no index.

    node0 2024-12-03T18:54:33.349605Z [      http] [httpserver.cpp:248] [http_request_cb] [http] Received a POST request for / from 127.0.0.1:40052
    node0 2024-12-03T18:54:33.349634Z [httpworker.3] [rpc/request.cpp:180] [parse] [rpc] ThreadRPCServer method=getrawtransaction user=__cookie__
    node0 2024-12-03T18:54:33.349729Z [httpworker.3] [util/system.h:57] [error] ERROR: Spent index not enabled
    node0 2024-12-03T18:54:33.349735Z [httpworker.3] [util/system.h:57] [error] ERROR: Spent index not enabled
    node0 2024-12-03T18:54:33.349738Z [httpworker.3] [util/system.h:57] [error] ERROR: Spent index not enabled
    node0 2024-12-03T18:54:33.349808Z [httpworker.3] [httprpc.cpp:93] [~RpcHttpRequest] [bench] HTTP RPC request handled: user=__cookie__ command=getrawtransaction external=false status=200 elapsed_time_ms=0
    node0 2024-12-03T18:54:33.349998Z [      http] [httpserver.cpp:248] [http_request_cb] [http] Received a POST request for / from 127.0.0.1:40052
    node0 2024-12-03T18:54:33.350027Z [httpworker.0] [rpc/request.cpp:180] [parse] [rpc] ThreadRPCServer method=getrawtransaction user=__cookie__
    node0 2024-12-03T18:54:33.350128Z [httpworker.0] [util/system.h:57] [error] ERROR: Spent index not enabled
    node0 2024-12-03T18:54:33.350133Z [httpworker.0] [util/system.h:57] [error] ERROR: Spent index not enabled
    node0 2024-12-03T18:54:33.350137Z [httpworker.0] [util/system.h:57] [error] ERROR: Spent index not enabled



## What was done?
Improved all usages of extra indexes `spentindex`, `txindex` and `addressindex` in RPC implementation.

Affected RPCc:
 - getaddressmempool
 - getaddressutxos
 - getaddressdeltas
 - getaddressbalance
 - getaddresstxids
 - getspentinfo
 - getblockhashes

## How Has This Been Tested?
Run unit&functional tests.
```
$ dash-cli getaddressutxos '["yW4kiSd2pytXC2erbjm6crt1PGBvbwS4YX"]'
Address index is disabled. You should run Dash Core with -addressindex (requires reindex) (code -32600) 
```

Check logs after calling getrawtransaction:
```
    node0 2024-12-03T19:10:00.378770Z [httpworker.3] [rpc/request.cpp:180] [parse] [rpc] ThreadRPCServer method=getrawtransaction user=__cookie__
    node0 2024-12-03T19:10:00.378861Z [httpworker.3] [httprpc.cpp:93] [~RpcHttpRequest] [bench] HTTP RPC request handled: user=__cookie__ command=getrawtransaction external=false status=500 elapsed_time_ms=0
    node0 2024-12-03T19:10:00.379017Z [      http] [httpserver.cpp:248] [http_request_cb] [http] Received a POST request for / from 127.0.0.1:44984
    node0 2024-12-03T19:10:00.379036Z [httpworker.0] [rpc/request.cpp:180] [parse] [rpc] ThreadRPCServer method=getrawtransaction user=__cookie__
    node0 2024-12-03T19:10:00.379090Z [httpworker.0] [httprpc.cpp:93] [~RpcHttpRequest] [bench] HTTP RPC request handled: user=__cookie__ command=getrawtransaction external=false status=500 elapsed_time_ms=0
    node0 2024-12-03T19:10:00.379240Z [      http] [httpserver.cpp:248] [http_request_cb] [http] Received a POST request for / from 127.0.0.1:44984
```

## Breaking Changes
Error type and message changed. It's no more `RPC_INVALID_ADDRESS_OR_KEY` but `RPC_INVALID_REQUEST`.


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

