### PR TITLE
feat: implement new RPCs getrawislock and getrawbestchainlock

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -275,6 +275,37 @@ static RPCHelpMan getbestchainlock()
     };
 }
 
+static RPCHelpMan getrawbestchainlock()
+{
+    return RPCHelpMan{"getrawbestchainlock",
+        "\nReturns the raw best ChainLock. Throws an error if there is no known ChainLock yet.",
+        {},
+        RPCResult{
+             RPCResult::Type::STR, "data", "The serialized, hex-encoded data for best ChainLock"
+        },
+        RPCExamples{
+            HelpExampleCli("getrawbestchainlock", "")
+            + HelpExampleRpc("getrawbestchainlock", "")
+        },
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    UniValue result(UniValue::VOBJ);
+
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+
+    LLMQContext& llmq_ctx = EnsureLLMQContext(node);
+    llmq::CChainLockSig clsig = llmq_ctx.clhandler->GetBestChainLock();
+    if (clsig.IsNull()) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to find any ChainLock");
+    }
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << clsig;
+    return HexStr(ssTx);
+
+},
+    };
+}
+
 void RPCNotifyBlockChange(const CBlockIndex* pindex)
 {
     if(pindex) {
@@ -3106,6 +3137,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         &getblockstats,                      },
     { "blockchain",         &getbestblockhash,                   },
     { "blockchain",         &getbestchainlock,                   },
+    { "blockchain",         &getrawbestchainlock,                },
     { "blockchain",         &getblockcount,                      },
     { "blockchain",         &getblock,                           },
     { "blockchain",         &getblockfrompeer,                   },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -115,6 +115,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "gettransaction", 1, "include_watchonly" },
     { "gettransaction", 2, "verbose" },
     { "getrawtransaction", 1, "verbose" },
+    { "getrawislocks", 0, "txids" },
     { "getrawtransactionmulti", 0, "transactions" },
     { "getrawtransactionmulti", 1, "verbose" },
     { "gettxchainlocks", 0, "txids" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -295,6 +295,7 @@ static RPCHelpMan getrawtransactionmulti() {
                     {"verbose", RPCArg::Type::BOOL, RPCArg::Default{false},
                      "If false, return a string, otherwise return a json object"},
             },
+            // TODO: replace RPCResults to proper annotation
             RPCResults{},
             RPCExamples{
                     HelpExampleCli("getrawtransactionmulti",
@@ -357,6 +358,60 @@ static RPCHelpMan getrawtransactionmulti() {
         }
     }
     return result;
+},
+    };
+}
+
+static RPCHelpMan getrawislocks()
+{
+    return RPCHelpMan{"getrawislocks",
+        "\nReturns the raw InstantSend lock data for each txids. Returns Null if there is no known IS yet.",
+        {
+            {"txids", RPCArg::Type::ARR, RPCArg::Optional::NO, "The transaction ids (no more than 100)",
+                {
+                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "A transaction hash"},
+                },
+            },
+        },
+        RPCResult{
+            RPCResult::Type::ARR, "", "Response is an array with the same size as the input txids",
+            {
+                RPCResult{"if InstantSend Lock is known for specified txid",
+                     RPCResult::Type::STR, "data", "The serialized, hex-encoded data for 'txid'"
+                },
+                RPCResult{"if no InstantSend Lock is known for specified txid",
+                     RPCResult::Type::STR, "data", "Just 'None' string"
+                },
+            }},
+        RPCExamples{
+            HelpExampleCli("getrawislocks", "'[\"txid\",...]'")
+            + HelpExampleRpc("getrawislocks", "'[\"txid\",...]'")
+        },
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+
+    UniValue result_arr(UniValue::VARR);
+    UniValue txids = request.params[0].get_array();
+    if (txids.size() > 100) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Up to 100 txids only");
+    }
+
+    for (const auto idx : irange::range(txids.size())) {
+        const uint256 txid(ParseHashV(txids[idx], "txid"));
+
+        LLMQContext& llmq_ctx = EnsureLLMQContext(node);
+        llmq::CInstantSendLockPtr islock = llmq_ctx.isman->GetInstantSendLockByTxid(txid);
+        if (islock == nullptr) {
+            result_arr.push_back("None");
+        } else {
+            CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+            ssTx << *islock;
+            result_arr.push_back(HexStr(ssTx));
+        }
+    }
+    return result_arr;
+
 },
     };
 }
@@ -2077,6 +2132,7 @@ static const CRPCCommand commands[] =
     { "rawtransactions",     &getassetunlockstatuses,     },
     { "rawtransactions",     &getrawtransaction,          },
     { "rawtransactions",     &getrawtransactionmulti,     },
+    { "rawtransactions",     &getrawislocks,              },
     { "rawtransactions",     &gettxchainlocks,            },
     { "rawtransactions",     &createrawtransaction,       },
     { "rawtransactions",     &decoderawtransaction,       },

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -263,6 +263,7 @@ class DashZMQTest (DashTestFramework):
         assert_equal(uint256_to_string(zmq_chain_lock.blockHash), rpc_chain_lock_hash)
         assert_equal(zmq_chain_locked_block.hash, rpc_chain_lock_hash)
         assert_equal(zmq_chain_lock.sig.hex(), rpc_best_chain_lock_sig)
+        assert_equal(zmq_chain_lock.serialize().hex(), self.nodes[0].getrawbestchainlock())
         # Unsubscribe from ChainLock messages
         self.unsubscribe(chain_lock_publishers)
 

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -285,6 +285,7 @@ class DashZMQTest (DashTestFramework):
         # Create two raw TXs, they will conflict with each other
         rpc_raw_tx_1 = self.create_raw_tx(self.nodes[0], self.nodes[0], 1, 1, 100)
         rpc_raw_tx_2 = self.create_raw_tx(self.nodes[0], self.nodes[0], 1, 1, 100)
+        assert_equal([None], self.nodes[0].getrawislocks([rpc_raw_tx_1['txid']]))
         # Send the first transaction and wait for the InstantLock
         rpc_raw_tx_1_hash = self.nodes[0].sendrawtransaction(rpc_raw_tx_1['hex'])
         self.wait_for_instantlock(rpc_raw_tx_1_hash, self.nodes[0])
@@ -304,6 +305,7 @@ class DashZMQTest (DashTestFramework):
         assert_equal(zmq_tx_lock_tx.hash, rpc_raw_tx_1['txid'])
         zmq_tx_lock = msg_isdlock()
         zmq_tx_lock.deserialize(zmq_tx_lock_sig_stream)
+        assert_equal([zmq_tx_lock.serialize().hex()], self.nodes[0].getrawislocks([rpc_raw_tx_1['txid']]))
         assert_equal(uint256_to_string(zmq_tx_lock.txid), rpc_raw_tx_1['txid'])
         # Try to send the second transaction. This must throw an RPC error because it conflicts with rpc_raw_tx_1
         # which already got the InstantSend lock.


### PR DESCRIPTION
## it's a draft because I need a confirmation from pshenmic that it works as he expects.

## Issue being fixed or feature implemented
https://github.com/dashpay/dash/issues/6391

> To register an identity in the DashPlatform network, there is a required field of InstantLock or ChainLock buffer in IdentityCreateTransition. You first create and broadcast Core transaction, then wait for InstantLock or ChainLock, and then create and broadcast transaction in the Platform chain with that data.

## What was done?
Implemented 2 new RPC `getrawislock` and `getrawbestchainlock` which output is similar to ZMQ output.

## How Has This Been Tested?
See new asserts in functional test interface_zmq_dash.py

## Breaking Changes
N/A

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
