### PR TITLE
fix(qt): allow refreshing wallet data without crashing

### DIFF
--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -114,7 +114,7 @@ private:
 
 public Q_SLOTS:
     /* Refresh the whole wallet, helpful for huge notification queues */
-    void refreshWallet();
+    void refreshWallet(bool foce = false);
     /* New transaction, or transaction changed status */
     void updateTransaction(const QString &hash, int status, bool showTransaction);
     void updateAddressBook(const QString &address, const QString &label,


### PR DESCRIPTION
## Issue being fixed or feature implemented
We re-use `refreshWallet` method to optimise loading for huge wallets https://github.com/dashpay/dash/pull/5453.
However gui121 backport (via 25f87b9434b98a524d38a97d9fe580acc0fa47ce) added a condition that prevents this logic. Fix it by allowing explicit wallet refresh (force=true).

## What was done?


## How Has This Been Tested?
Open a wallet with 10k+ txes, do `rescanblockchain` via rpc console


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

