### PR TITLE
fix(qt): improve GUI responsiveness for huge wallets

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -313,10 +313,7 @@ void TransactionTableModel::updateAddressBook(const QString& address, const QStr
 void TransactionTableModel::updateConfirmations()
 {
     // Blocks came in since last poll.
-    // Invalidate status (number of confirmations) and (possibly) description
-    //  for all rows. Qt is smart enough to only actually request the data for the
-    //  visible rows.
-    Q_EMIT dataChanged(index(0, Status), index(priv->size()-1, Status));
+    Q_EMIT dataChanged(QModelIndex(), QModelIndex());
 }
 
 
@@ -798,7 +795,7 @@ void TransactionTableModel::updateDisplayUnit()
 {
     // emit dataChanged to update Amount column with the current unit
     updateAmountColumnTitle();
-    Q_EMIT dataChanged(index(0, Amount), index(priv->size()-1, Amount));
+    Q_EMIT dataChanged(QModelIndex(), QModelIndex());
 }
 
 void TransactionTablePriv::NotifyTransactionChanged(const uint256 &hash, ChangeType status)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Somehow a 500k+ txes wallet is MUCH more responsive with this patch. I'm not sure if it's macos only or not though, pls test.

## What was done?


## How Has This Been Tested?
Run a wallet with 100k+ txes in it and send a tx or try changing units.

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

