### PR TITLE
chore: bump MIN_MASTERNODE_PROTO_VERSION to latest proto

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -20,7 +20,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION = 70216;
 
 //! minimum proto version of masternode to accept in DKGs
-static const int MIN_MASTERNODE_PROTO_VERSION = 70233;
+static const int MIN_MASTERNODE_PROTO_VERSION = 70235;
 
 //! protocol version is included in MNAUTH starting with this version
 static const int MNAUTH_NODE_VER_VERSION = 70218;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Bump minimum master node protocol version to latest protocol.

## What was done?

## How Has This Been Tested?

## Breaking Changes
Masternodes that don't upgrade will end up getting a PoSe ban

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

