### PR TITLE
fix: avoid potential divide-by-zero in network hashrate stats calculation

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -848,20 +848,23 @@ static void PeriodicStats(NodeContext& node)
         LogPrintf("%s: GetUTXOStats failed\n", __func__);
     }
 
-    // short version of GetNetworkHashPS(120, -1);
     CBlockIndex *tip = chainman.ActiveChain().Tip();
-    CBlockIndex *pindex = tip;
-    int64_t minTime = pindex->GetBlockTime();
-    int64_t maxTime = minTime;
-    for (int i = 0; i < 120 && pindex->pprev != nullptr; i++) {
-        pindex = pindex->pprev;
-        int64_t time = pindex->GetBlockTime();
-        minTime = std::min(time, minTime);
-        maxTime = std::max(time, maxTime);
-    }
-    arith_uint256 workDiff = tip->nChainWork - pindex->nChainWork;
-    int64_t timeDiff = maxTime - minTime;
-    double nNetworkHashPS = workDiff.getdouble() / timeDiff;
+    double nNetworkHashPS = [&]() {
+        // Short version of GetNetworkHashPS(120, -1);
+        CBlockIndex *pindex = tip;
+        int64_t minTime = pindex->GetBlockTime();
+        int64_t maxTime = minTime;
+        for (int i = 0; i < 120 && pindex->pprev != nullptr; i++) {
+            pindex = pindex->pprev;
+            int64_t time = pindex->GetBlockTime();
+            minTime = std::min(time, minTime);
+            maxTime = std::max(time, maxTime);
+        }
+        if (minTime == maxTime) return 0.0;
+        arith_uint256 workDiff = tip->nChainWork - pindex->nChainWork;
+        int64_t timeDiff = maxTime - minTime;
+        return workDiff.getdouble() / timeDiff;
+    }();
 
     ::g_stats_client->gaugeDouble("network.hashesPerSecond", nNetworkHashPS);
     ::g_stats_client->gaugeDouble("network.terahashesPerSecond", nNetworkHashPS / 1e12);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -866,10 +866,12 @@ static void PeriodicStats(NodeContext& node)
         return workDiff.getdouble() / timeDiff;
     }();
 
-    ::g_stats_client->gaugeDouble("network.hashesPerSecond", nNetworkHashPS);
-    ::g_stats_client->gaugeDouble("network.terahashesPerSecond", nNetworkHashPS / 1e12);
-    ::g_stats_client->gaugeDouble("network.petahashesPerSecond", nNetworkHashPS / 1e15);
-    ::g_stats_client->gaugeDouble("network.exahashesPerSecond", nNetworkHashPS / 1e18);
+    if (nNetworkHashPS > 0.0) {
+        ::g_stats_client->gaugeDouble("network.hashesPerSecond", nNetworkHashPS);
+        ::g_stats_client->gaugeDouble("network.terahashesPerSecond", nNetworkHashPS / 1e12);
+        ::g_stats_client->gaugeDouble("network.petahashesPerSecond", nNetworkHashPS / 1e15);
+        ::g_stats_client->gaugeDouble("network.exahashesPerSecond", nNetworkHashPS / 1e18);
+    }
     // No need for cs_main, we never use null tip here
     ::g_stats_client->gaugeDouble("network.difficulty", (double)GetDifficulty(tip));
 


### PR DESCRIPTION
## Additional Information

It was reported that on occasion, `network.*hashesPerSecond` would report NaN gauge values, which would be dismissed as malformed reporting by Grafana (see below). Those gauges use a simplified version ([source](https://github.com/dashpay/dash/blob/1ecfb891bcdcfd62db7827c55370be9bc3587f2e/src/init.cpp#L851-L864)) of `GetNetworkHashPS` ([source](https://github.com/dashpay/dash/blob/1ecfb891bcdcfd62db7827c55370be9bc3587f2e/src/rpc/mining.cpp#L61)), crucially, without a check meant to avoid divide-by-zeros ([source](https://github.com/dashpay/dash/blob/1ecfb891bcdcfd62db7827c55370be9bc3587f2e/src/rpc/mining.cpp#L89-L91)).

<details>

<summary>Error log (courtesy of PastaPastaPasta):</summary>

```
[...]
graphite-1             | 7 Dec 21:18:05 - DEBUG: Bad line: -nan,g in msg "network.terahashesPerSecond:-nan|g"
graphite-1             | 7 Dec 21:18:05 - DEBUG: Bad line: -nan,g in msg "network.petahashesPerSecond:-nan|g"
graphite-1             | 7 Dec 21:18:05 - DEBUG: Bad line: -nan,g in msg "network.exahashesPerSecond:-nan|g"
graphite-1             | 7 Dec 21:18:10 - DEBUG: Bad line: -nan,g in msg "network.hashesPerSecond:-nan|g"
graphite-1             | 7 Dec 21:18:10 - DEBUG: Bad line: -nan,g in msg "network.terahashesPerSecond:-nan|g"
graphite-1             | 7 Dec 21:18:10 - DEBUG: Bad line: -nan,g in msg "network.petahashesPerSecond:-nan|g"
graphite-1             | 7 Dec 21:18:10 - DEBUG: Bad line: -nan,g in msg "network.exahashesPerSecond:-nan|g"
graphite-1             | 7 Dec 21:18:15 - DEBUG: Bad line: -nan,g in msg "network.hashesPerSecond:-nan|g"
[...]
```

</details>

This has been resolved by adding that check, alongside encapsulating the logic in a lambda and not reporting the gauge values if the estimated hashes per second reported is zero, due to the unlikelihood of it being correct.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
