### PR TITLE
perf: make m_peer_mutex a SharedMutex

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -784,7 +784,7 @@ private:
 
     /** Protects m_peer_map. This mutex must not be locked while holding a lock
      *  on any of the mutexes inside a Peer object. */
-    mutable Mutex m_peer_mutex;
+    mutable SharedMutex m_peer_mutex;
     /**
      * Map of all Peer objects, keyed by peer id. This map is protected
      * by the m_peer_mutex. Once a shared pointer reference is
@@ -1692,7 +1692,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node) {
 
 PeerRef PeerManagerImpl::GetPeerRef(NodeId id) const
 {
-    LOCK(m_peer_mutex);
+    READ_LOCK(m_peer_mutex);
     auto it = m_peer_map.find(id);
     return it != m_peer_map.end() ? it->second : nullptr;
 }
@@ -2262,7 +2262,7 @@ bool PeerManagerImpl::AlreadyHaveBlock(const uint256& block_hash)
 
 void PeerManagerImpl::SendPings()
 {
-    LOCK(m_peer_mutex);
+    READ_LOCK(m_peer_mutex);
     for(auto& it : m_peer_map) it.second->m_ping_queued = true;
 }
 
@@ -2272,7 +2272,7 @@ void PeerManagerImpl::AskPeersForTransaction(const uint256& txid, bool is_master
     peersToAsk.reserve(4);
 
     {
-        LOCK(m_peer_mutex);
+        READ_LOCK(m_peer_mutex);
         // TODO consider prioritizing MNs again, once that flag is moved into Peer
         for (const auto& [_, peer] : m_peer_map) {
             if (peersToAsk.size() >= 4) {
@@ -2337,7 +2337,7 @@ void PeerManagerImpl::RelayInv(CInv &inv, const int minProtoVersion)
 
 void PeerManagerImpl::RelayInv(CInv &inv)
 {
-    LOCK(m_peer_mutex);
+    READ_LOCK(m_peer_mutex);
     for (const auto& [_, peer] : m_peer_map) {
         if (!peer->GetInvRelay()) continue;
         PushInv(*peer, inv);
@@ -2349,7 +2349,7 @@ void PeerManagerImpl::RelayDSQ(const CCoinJoinQueue& queue)
     CInv inv{MSG_DSQ, queue.GetHash()};
     std::vector<NodeId> nodes_send_all;
     {
-        LOCK(m_peer_mutex);
+        READ_LOCK(m_peer_mutex);
         for (const auto& [nodeid, peer] : m_peer_map) {
             switch (peer->m_wants_dsq) {
             case Peer::WantsDSQ::NONE:
@@ -2425,7 +2425,7 @@ void PeerManagerImpl::RelayInvFiltered(CInv &inv, const uint256& relatedTxHash, 
 void PeerManagerImpl::RelayTransaction(const uint256& txid)
 {
     const CInv inv{m_cj_ctx->dstxman->GetDSTX(txid) ? MSG_DSTX : MSG_TX, txid};
-    LOCK(m_peer_mutex);
+    READ_LOCK(m_peer_mutex);
     for(auto& it : m_peer_map) {
         Peer& peer = *it.second;
         auto tx_relay = peer.GetTxRelay();
@@ -2438,7 +2438,7 @@ void PeerManagerImpl::RelayTransaction(const uint256& txid)
 void PeerManagerImpl::RelayRecoveredSig(const uint256& sigHash)
 {
     const CInv inv{MSG_QUORUM_RECOVERED_SIG, sigHash};
-    LOCK(m_peer_mutex);
+    READ_LOCK(m_peer_mutex);
     for (const auto& [_, peer] : m_peer_map) {
         if (peer->m_wants_recsigs) {
             PushInv(*peer, inv);
@@ -2471,7 +2471,7 @@ void PeerManagerImpl::RelayAddress(NodeId originator,
     std::array<std::pair<uint64_t, Peer*>, 2> best{{{0, nullptr}, {0, nullptr}}};
     assert(nRelayNodes <= best.size());
 
-    LOCK(m_peer_mutex);
+    READ_LOCK(m_peer_mutex);
 
     for (auto& [id, peer] : m_peer_map) {
         if (peer->m_addr_relay_enabled && id != originator && IsAddrCompatible(*peer, addr)) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
m_peer_mutex is a great use case for a shared mutex; it's private, well contained scope, and 99% of usages are for the read case. The only time we hold an exclusive lock is when adding or removing a peer, which happens rarely compared to all other usages.

On latest nightly, this mutex only represents about 2% of contention (all in PeerRef PeerManagerImpl::GetPeerRef), however, I intend to move over mnauth / verified protx related stuff over into PeerManager, and I expect that will result in significantly more contention over m_peer_mutex, making this change more valuable.

I expect this will reduce contention over this mutex to ~0

## What was done?


## How Has This Been Tested?
Hasn't yet, I will want to deploy a dev version of this and view what happens to contention over this mutex.

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

