### PR TITLE
ci: treat all non-protected branches as pull requests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,14 +95,16 @@ builder-image:
       else
         # CI_EXTERNAL_PULL_REQUEST_IID is false every time until https://gitlab.com/gitlab-org/gitlab/issues/5667 is done
         # Until then, we're using https://github.com/brndnmtthws/labhub atm to mirror Github pull requests as branches into Gitlab,
-        # which allows us to use Gitlab CI for Github. The following check detects such mirrored branches.
-        if [[ $CI_COMMIT_REF_NAME =~ ^pr-[^/]*/[^/]*/[^/]*/[^/]*$ ]]; then
+        # which allows us to use Gitlab CI for Github.
+        if [[ $CI_COMMIT_REF_NAME = "master" ]] || [[ $CI_COMMIT_REF_NAME = "develop" ]] || [[ $CI_COMMIT_REF_NAME =~ ^v([0-9]{1,2}\.)*x$ ]]; then
+          # These names are reserved for protected branches
+          export PULL_REQUEST="false"
+        else
+          # Everything else including experemental "feat/smth" branches must be merged via PRs, treat them as such
           export PULL_REQUEST="true"
           # CI_COMMIT_BEFORE_SHA is also invalid until #5667 is implemented, so we need to figure it out by ourself
           git fetch origin develop
           export CI_COMMIT_BEFORE_SHA="$(git merge-base origin/develop HEAD)"
-        else
-          export PULL_REQUEST="false"
         fi
       fi
     - export COMMIT_RANGE="$CI_COMMIT_BEFORE_SHA..$CI_COMMIT_SHA"


### PR DESCRIPTION
## Issue being fixed or feature implemented
This branch https://github.com/dashpay/dash/tree/feat/flatpak is 3 commits ahead so CI checks should use d494339b9f0587902fbf6358966c65bcfcb9febf as `$CI_COMMIT_BEFORE_SHA`. But that's not the case according to CI logs https://gitlab.com/dashpay/dash/-/jobs/8179463810#L38

```
PULL_REQUEST=false COMMIT_RANGE=4d1b648bad417ef9b1c5a96edfa04b0e382f096f..860f6ee48f61f0b670b21ef142d13ae02d3cc50a HOST_SRC_DIR=/builds/dashpay/dash CACHE_DIR=/builds/dashpay/dash/cache
```

The commit range is just 1 commit instead of 3 and this results in incomplete CI checks. This happens because only branches with special refs like `pr-xxxx/author/dash/branch` are considered as pull requests.

## What was done?
Reverse the check - protected branches are the only non-PRs now, everything else is treated as PRs

## How Has This Been Tested?

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

