### PR TITLE
fix: don't shrink window when setting minimum width

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1419,7 +1419,9 @@ void BitcoinGUI::updateWidth()
     // Use nButtonsVisible + 1 <- for the dash logo
     int nWidth = std::max<int>(980, (nWidthWidestButton + 30) * (nButtonsVisible + 1));
     setMinimumWidth(nWidth);
-    resize(nWidth, height());
+
+    // Resize to new minimum width but don't shrink window
+    resize(std::max(width(), nWidth), height());
 }
 
 void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QString& blockHash, double nVerificationProgress, bool header, SynchronizationState sync_state)

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -544,7 +544,9 @@ void OptionsDialog::updateWidth()
     // Add 10 per button as padding and use minimum 585 which is what we used in css before
     int nWidth = std::max<int>(585, (nWidthWidestButton + 10) * nButtonsVisible);
     setMinimumWidth(nWidth);
-    resize(nWidth, height());
+
+    // Resize to new minimum width but don't shrink window
+    resize(std::max(width(), nWidth), height());
 }
 
 void OptionsDialog::showEvent(QShowEvent* event)


### PR DESCRIPTION
## Additional Information

* Closes https://github.com/dashpay/dash/issues/5886
* We've been setting restrictions on the width of the window since [dash#3734](https://github.com/dashpay/dash/pull/3734) (see d351fca6a6b099f02e36a478a3a2cbad0407560b and c0447b0bc69ca08c13b024f582ded50fb50ca645), meaning, the behavior as described in [dash#5886](https://github.com/dashpay/dash/issues/5886) has been present since v0.16 (v0.15 and earlier used the old UI design). 
  * We do not set any restrictions on height and in that respect, Dash Qt will behave similar to Bitcoin Qt in that it can be resized to be arbitrarily small.

## How Has This Been Tested?

Crossed compiled for `x86_64-w64-mingw32` and tested resulting `dash-qt.exe` on Windows 11 22H2 (Build 22621.431). Followed reproduction steps as mentioned in [dash#5886](https://github.com/dashpay/dash/issues/5886), found width to persist even after closing Options modal using buttons and the close button on the top right.

## Breaking Changes

None expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
