### PR TITLE
perf: NodesSnapshot, do not hold m_nodes_mutex while shuffling

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -5118,16 +5118,16 @@ bool CConnman::IsMasternodeOrDisconnectRequested(const CService& addr) {
 CConnman::NodesSnapshot::NodesSnapshot(const CConnman& connman, std::function<bool(const CNode* pnode)> filter,
                                        bool shuffle)
 {
-    LOCK(connman.m_nodes_mutex);
-    m_nodes_copy.reserve(connman.m_nodes.size());
+    {
+        LOCK(connman.m_nodes_mutex);
+        m_nodes_copy.reserve(connman.m_nodes.size());
 
-    for (auto& node : connman.m_nodes) {
-        if (!filter(node))
-            continue;
-        node->AddRef();
-        m_nodes_copy.push_back(node);
+        for (auto& node : connman.m_nodes) {
+            if (!filter(node)) continue;
+            node->AddRef();
+            m_nodes_copy.push_back(node);
+        }
     }
-
     if (shuffle) {
         Shuffle(m_nodes_copy.begin(), m_nodes_copy.end(), FastRandomContext{});
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Upstream, as expected, only holds m_nodes_mutex while needed. We hold it a bit too long https://github.com/bitcoin/bitcoin/blob/36f5effa1783a72d57c393588059a688068336e2/src/net.h#L1628-L1640

Not sure how this got introduced. I also don't expect this to be a major contention savior, as there is only one instance in ThreadMessageHandler where we actually do shuffle, but still, might as well fix.

## What was done?


## How Has This Been Tested?
builds

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

