### PR TITLE
feat: logging time inside lock to help debugging lock contentions

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -177,18 +177,31 @@ template <typename Mutex, typename Base = typename Mutex::UniqueLock>
 class SCOPED_LOCKABLE UniqueLock : public Base
 {
 private:
+#ifdef DEBUG_LOCKCONTENTION
+    std::string m_lock_log_time_prefix;
+    std::chrono::microseconds m_started_time{};
+#endif
     void Enter(const char* pszName, const char* pszFile, int nLine)
     {
         EnterCritical(pszName, pszFile, nLine, Base::mutex());
 #ifdef DEBUG_LOCKCONTENTION
+        m_lock_log_time_prefix = strprintf("lock contention %s, %s:%d", pszName, pszFile, nLine);
+        m_started_time = GetTime<std::chrono::microseconds>();
         if (Base::try_lock()) return;
-        LOG_TIME_MICROS_WITH_CATEGORY(strprintf("lock contention %s, %s:%d", pszName, pszFile, nLine), BCLog::LOCK);
+        LOG_TIME_MICROS_WITH_CATEGORY(m_lock_log_time_prefix, BCLog::LOCK);
 #endif
         Base::lock();
+#ifdef DEBUG_LOCKCONTENTION
+        m_started_time = GetTime<std::chrono::microseconds>();
+#endif
     }
 
     bool TryEnter(const char* pszName, const char* pszFile, int nLine)
     {
+#ifdef DEBUG_LOCKCONTENTION
+        m_lock_log_time_prefix = strprintf("lock contention %s, %s:%d", pszName, pszFile, nLine);
+        m_started_time = GetTime<std::chrono::microseconds>();
+#endif
         EnterCritical(pszName, pszFile, nLine, Base::mutex(), true);
         if (Base::try_lock()) {
             return true;
@@ -219,8 +232,16 @@ public:
 
     ~UniqueLock() UNLOCK_FUNCTION()
     {
+#ifdef DEBUG_LOCKCONTENTION
+        const auto diff_time = (GetTime<std::chrono::microseconds>() - m_started_time);
+#endif
         if (Base::owns_lock())
             LeaveCritical();
+#ifdef DEBUG_LOCKCONTENTION
+        if (diff_time.count() > 100 && m_started_time.count() > 0) {
+            LogPrint(BCLog::LOCK, "%s inside %iμs\n", m_lock_log_time_prefix, diff_time.count());
+        }
+#endif
     }
 
     operator bool()


### PR DESCRIPTION
This PR is not meant to be merged at the moment, let's try to collect real data and find-out at least one issue with this logs to proof it's useful.

## Issue being fixed or feature implemented
Current log contention doesn't show information for how long time is spent inside mutex.
But this information is critical, because when looking to lock-contention you want to know which other function or method occupied it for so long time.

## What was done?
Some extra logs for lock contention (for non-shared mutex only).

Debug logs have information about all cases when mutex is occupied for longer than 0.1ms:
```
2024-12-11T09:28:46Z [lock] lock contention m_nodes_mutex, ./net.h:1383 inside 101μs
2024-12-11T09:28:46Z [lock] lock contention pnode->cs_vSend, net.cpp:2809 inside 128μs
2024-12-11T09:28:46Z [net] SocketHandlerConnected -- remove mapReceivableNodes, peer=3
2024-12-11T09:28:46Z [lock] lock contention mutexMsgProc, net.cpp:4014 inside 261μs
2024-12-11T09:28:46Z [net] received: inv (37 bytes) peer=3
2024-12-11T09:28:46Z [net] got inv: dsq c2f442bca6a89d54a53348939c6f3aa013df034eafe4807d0ffc08e99deb27db  new peer=3
2024-12-11T09:28:46Z [net] RequestObject -- inv=(dsq c2f442bca6a89d54a53348939c6f3aa013df034eafe4807d0ffc08e99deb27db), current_time=1733909326825277, process_time=1733909386824280, delta=59999003
2024-12-11T09:28:46Z [net] SocketHandlerConnected -- remove mapReceivableNodes, peer=1
2024-12-11T09:28:46Z [lock] lock contention mutexMsgProc, net.cpp:4014 inside 4819μs
2024-12-11T09:28:46Z [net] SocketHandlerConnected -- remove mapReceivableNodes, peer=5
2024-12-11T09:28:46Z [lock] lock contention m_nodes_mutex, ./net.h:1383 inside 111μs
```

Please note, though, that in some cases long mutex occupation is expected because it's triggered by timer, for example:
```
2024-12-11T09:28:46Z [lock] lock contention mut, threadinterrupt.cpp:32 inside 100071μs
```

## How Has This Been Tested?
<TODO>

## Breaking Changes
N/A

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone