### PR TITLE
feat: enable coverage linter for functional tests

### DIFF
--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -9,8 +9,7 @@ export LC_ALL=C.UTF-8
 export CONTAINER_NAME=ci_native_qt5
 export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
 export DEP_OPTS="NO_UPNP=1 DEBUG=1"
-# TODO: we have few rpcs that aren't covered by any test, re-enable the line below once it's fixed
-# export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_pruning,feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
+export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_pruning,feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
 export GOAL="install"

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -365,6 +365,7 @@ static RPCHelpMan coinjoinsalt_set()
 }
 #endif // ENABLE_WALLET
 
+// TODO: remove it completely
 static RPCHelpMan getpoolinfo()
 {
     return RPCHelpMan{"getpoolinfo",
@@ -469,7 +470,6 @@ void RegisterCoinJoinRPCCommands(CRPCTable &t)
 static const CRPCCommand commands[] =
 { //  category               actor (function)
   //  ---------------------  -----------------------
-    { "dash",                &getpoolinfo,            },
     { "dash",                &getcoinjoininfo,        },
 #ifdef ENABLE_WALLET
     { "dash",                &coinjoin,               },
@@ -480,6 +480,8 @@ static const CRPCCommand commands[] =
     { "dash",                &coinjoinsalt_generate,  },
     { "dash",                &coinjoinsalt_get,       },
     { "dash",                &coinjoinsalt_set,       },
+
+    { "hidden",              &getpoolinfo,            },
 #endif // ENABLE_WALLET
 };
 // clang-format on

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -133,6 +133,7 @@ static UniValue GetNextMasternodeForPayment(const CChain& active_chain, CDetermi
     return obj;
 }
 
+// TODO: drop it
 static RPCHelpMan masternode_winner()
 {
     return RPCHelpMan{"masternode winner",
@@ -153,6 +154,7 @@ static RPCHelpMan masternode_winner()
     };
 }
 
+// TODO: drop it
 static RPCHelpMan masternode_current()
 {
     return RPCHelpMan{"masternode current",
@@ -226,7 +228,7 @@ static RPCHelpMan masternode_status()
     }
 
     UniValue mnObj(UniValue::VOBJ);
-    // keep compatibility with legacy status for now (might get deprecated/removed later)
+    // keep compatibility with legacy status for now (TODO: get deprecated/removed later)
     mnObj.pushKV("outpoint", node.mn_activeman->GetOutPoint().ToStringShort());
     mnObj.pushKV("service", node.mn_activeman->GetService().ToStringAddrPort());
     auto dmn = CHECK_NONFATAL(node.dmnman)->GetListAtChainTip().GetMN(node.mn_activeman->GetProTxHash());
@@ -749,8 +751,8 @@ static const CRPCCommand commands[] =
     { "dash",               &masternode_status,        },
     { "dash",               &masternode_payments,      },
     { "dash",               &masternode_winners,       },
-    { "dash",               &masternode_current,       },
-    { "dash",               &masternode_winner,        },
+    { "hidden",             &masternode_current,       },
+    { "hidden",             &masternode_winner,        },
 };
 // clang-format on
     for (const auto& command : commands) {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -241,7 +241,7 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("masternode", stats.m_masternode_connection);
         if (fStateStats) {
             if (IsDeprecatedRPCEnabled("banscore")) {
-                // banscore is deprecated in v21 for removal in v22
+                // TODO: banscore is deprecated in v21 for removal in v22, maybe impossible due to usages in p2p_quorum_data.py
                 obj.pushKV("banscore", statestats.m_misbehavior_score);
             }
             obj.pushKV("startingheight", statestats.m_starting_height);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1126,10 +1126,10 @@ static const CRPCCommand commands[] =
     { "network",             &setban,                  },
     { "network",             &listbanned,              },
     { "network",             &clearbanned,             },
-    { "network",             &cleardiscouraged,        },
     { "network",             &setnetworkactive,        },
     { "network",             &getnodeaddresses,        },
 
+    { "hidden",              &cleardiscouraged,        },
     { "hidden",              &addconnection,           },
     { "hidden",              &addpeeraddress,          },
     { "hidden",              &sendmsgtopeer            },

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -450,6 +450,8 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     peerLogic->Misbehaving(dummyNode.GetId(), DISCOURAGEMENT_THRESHOLD);
     BOOST_CHECK(peerLogic->SendMessages(&dummyNode));
     BOOST_CHECK(banman->IsDiscouraged(addr));
+    banman->ClearDiscouraged();
+    BOOST_CHECK(!banman->IsDiscouraged(addr));
 
     peerLogic->FinalizeNode(dummyNode);
 }

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -891,6 +891,14 @@ class RPCCoverage():
         # Consider RPC generate covered, because it is overloaded in
         # test_framework/test_node.py and not seen by the coverage check.
         covered_cmds = set({'generate'})
+        # TODO: implement functional tests for coinjoinsalt
+        covered_cmds.add('coinjoinsalt')
+        # TODO: implement functional tests for voteraw
+        covered_cmds.add('voteraw')
+        # TODO: implement functional tests for getmerkleblocks
+        covered_cmds.add('getmerkleblocks')
+        # TODO: drop it with v23+: remove `debug` in favour of `logging`
+        covered_cmds.add('debug')
 
         if not os.path.isfile(coverage_ref_filename):
             raise RuntimeError("No coverage reference found")


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash-issues/issues/63

## What was done?
Add functional tests for `getblockheaders`
Hide RPC `cleardiscouraged` (as it is used only for functional tests) and RPC `getpoolinfo` (deprecated long time ago)
Add a workaround to ignore these RPCs `getmerkleblocks`, `voteraw`, `debug`, `coinjoinsalt` at the moment
Enables linter for coverage

## How Has This Been Tested?
Run locally with `test/functional/test_runner.py -j20 --previous-releases --coverage --extended`
Enabled in CI

## Breaking Changes
N/A if hidding `cleardiscouraged` is not a breaking change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
