### PR TITLE
feat: deprecate RPC 'debug' to favor of 'logging'

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -47,14 +47,10 @@
 static RPCHelpMan debug()
 {
     return RPCHelpMan{"debug",
-        "Change debug category on the fly. Specify single category or use '+' to specify many.\n"
-        "The valid logging categories are: " + LogInstance().LogCategoriesString() + ".\n"
-        "libevent logging is configured on startup and cannot be modified by this RPC during runtime.\n"
-        "There are also a few meta-categories:\n"
-        " - \"all\", \"1\" and \"\" activate all categories at once;\n"
-        " - \"dash\" activates all Dash-specific categories at once;\n"
-        " - \"none\" (or \"0\") deactivates all categories at once.\n"
-        "Note: If specified category doesn't match any of the above, no error is thrown.\n",
+        "DEPRECATED. Use instead the 'logging' RPC instead.\n"
+        "For 'debug all': logging [\\\"all\\\"]\n"
+        "For 'debug none': logging []\n"
+        "For 'debug X+Y': logging \"[\\\"X\\\", \\\"Y\\\"]\"",
         {
             {"category", RPCArg::Type::STR, RPCArg::Optional::NO, "The name of the debug category to turn on."},
         },
@@ -67,6 +63,9 @@ static RPCHelpMan debug()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (!IsDeprecatedRPCEnabled("debug")) {
+        throw JSONRPCError(RPC_METHOD_DEPRECATED, "Please use logging instead");
+    }
 
     std::string strMode = request.params[0].get_str();
     LogInstance().DisableCategory(BCLog::ALL);
@@ -1512,7 +1511,6 @@ void RegisterMiscRPCCommands(CRPCTable &t)
 static const CRPCCommand commands[] =
 { //  category              actor (function)
   //  --------------------- ------------------------
-    { "control",            &debug,                   },
     { "control",            &getmemoryinfo,           },
     { "control",            &logging,                 },
     { "util",               &validateaddress,         },
@@ -1537,6 +1535,7 @@ static const CRPCCommand commands[] =
     { "dash",               &sporkupdate,             },
 
     /* Not shown in help */
+    { "hidden",             &debug,                   },
     { "hidden",             &setmocktime,             },
     { "hidden",             &mockscheduler,           },
     { "hidden",             &echo,                    },


### PR DESCRIPTION
## Issue being fixed or feature implemented
The rpc `debug` duplicates functionality of RPC `logging`.
Beside that  it has next disadvantages:
 - `debug` doesn't have any tests
 - `debug` has our own implementation while `logging` is supported by mainstream
 - `logging` can work in both modes "all except..." and "only ...", while `debug` doesn't have a feature "all except..."

Though, there's particular case when `debug` is more convenient: if you have several categories it's simplier to write `debug X+Y` rather than `logging "[\"X\", \"Y\"]"`

Discovered while doing https://github.com/dashpay/dash-issues/issues/63

## What was done?
Deprecated rpc `debug`.
There's some HowTo for `debug` users for smooth switch to `logging`:
For `debug all`: `logging [\"all\"]`
For `debug none`: `logging '[]' '["all"]'`
For `debug X+Y`: `logging "[\"X\", \"Y\"]"`

## How Has This Been Tested?
Run unit and functional tests

## Breaking Changes
It removes RPC `debug`

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

