### PR TITLE
test: actually use masternode with basic bls pubkey in mnauth test

### DIFF
--- a/test/functional/rpc_mnauth.py
+++ b/test/functional/rpc_mnauth.py
@@ -21,8 +21,9 @@ class FakeMNAUTHTest(DashTestFramework):
 
     def run_test(self):
         self.activate_v19(expected_activation_height=900)
+        self.dynamically_add_masternode()
 
-        masternode = self.mninfo[0]
+        masternode = self.mninfo[1]
         masternode.node.add_p2p_connection(P2PInterface())
 
         protx_hash = masternode.proTxHash

--- a/test/functional/rpc_mnauth.py
+++ b/test/functional/rpc_mnauth.py
@@ -17,13 +17,13 @@ Tests mnauth RPC command
 
 class FakeMNAUTHTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(2, 1)
+        self.set_dash_test_params(1, 0)
 
     def run_test(self):
         self.activate_v19(expected_activation_height=900)
         self.dynamically_add_masternode()
 
-        masternode = self.mninfo[1]
+        masternode = self.mninfo[0]
         masternode.node.add_p2p_connection(P2PInterface())
 
         protx_hash = masternode.proTxHash

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1279,7 +1279,7 @@ class DashTestFramework(BitcoinTestFramework):
             return
 
         self.dynamically_initialize_datadir(node_p2p_port, node_rpc_port)
-        node_info = self.add_dynamically_node(self.extra_args[1])
+        node_info = self.add_dynamically_node(self.extra_args[0])
 
         args = ['-masternodeblsprivkey=%s' % created_mn_info.keyOperator] + node_info.extra_args
         self.start_node(mn_idx, args)


### PR DESCRIPTION
## Issue being fixed or feature implemented
`rpc_manuth` is failing in ~50% cases locally because we still use legacy pubkeys (not in 100% cases because sometimes they look like basic ones). In CI it fails too but we retry failed tests a few times so it's less noticeable. Example of "unlucky" tests: https://gitlab.com/dashpay/dash/-/jobs/8613271300#L1867.

#6467 follow-up

## What was done?
Add another masternode after v19 activaition to actually use basic bls pubkey

## How Has This Been Tested?
run tests

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

