### PR TITLE
ci: specify exact paths and better names for gitlab artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,16 +133,21 @@ builder-image:
     name: binaries
     when: always
     paths:
-      - build-ci
-    # Exclude some less important binaries to reduce the size of the artifacts
-    exclude:
-      - build-ci/dashcore-$BUILD_TARGET/src/bench/bench_dash
-      - build-ci/dashcore-$BUILD_TARGET/src/bench/bench_dash.exe
-      - build-ci/dashcore-$BUILD_TARGET/src/qt/test/test_dash-qt
-      - build-ci/dashcore-$BUILD_TARGET/src/qt/test/test_dash-qt.exe
-      - build-ci/dashcore-$BUILD_TARGET/src/test/test_dash
-      - build-ci/dashcore-$BUILD_TARGET/src/test/test_dash.exe
-      - build-ci/dashcore-$BUILD_TARGET/src/test/fuzz/*
+      - build-ci/dashcore-${BUILD_TARGET}/contrib/linearize/linearize-data.py # for feature_loadblock.py
+      - build-ci/dashcore-${BUILD_TARGET}/contrib/linearize/linearize-hashes.py # for feature_loadblock.py
+      - build-ci/dashcore-${BUILD_TARGET}/share/rpcauth/rpcauth.py # for rpc_users.py
+      - build-ci/dashcore-${BUILD_TARGET}/src/**/*.log # unit test logs
+      - build-ci/dashcore-${BUILD_TARGET}/src/dashd*
+      - build-ci/dashcore-${BUILD_TARGET}/src/dash-cli*
+      - build-ci/dashcore-${BUILD_TARGET}/src/dash-gui
+      - build-ci/dashcore-${BUILD_TARGET}/src/dash-node
+      - build-ci/dashcore-${BUILD_TARGET}/src/dash-tx*
+      - build-ci/dashcore-${BUILD_TARGET}/src/dash-wallet*
+      - build-ci/dashcore-${BUILD_TARGET}/src/qt/dash-qt*
+      - build-ci/dashcore-${BUILD_TARGET}/src/rpc/client.cpp # for rpc_help.py
+      - build-ci/dashcore-${BUILD_TARGET}/src/test/data/asmap.raw # for feature_asmap.py
+      - build-ci/dashcore-${BUILD_TARGET}/test/
+      - build-ci/test/
     expire_in: 3 days
 
 .test-template:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ builder-image:
       - depends/built
       - depends/sdk-sources
   artifacts:
-    name: depends
+    name: depends-${CI_JOB_NAME}
     when: on_success
     paths:
       - depends/$HOST
@@ -130,7 +130,7 @@ builder-image:
     paths:
       - cache/ccache
   artifacts:
-    name: binaries
+    name: build-${BUILD_TARGET}
     when: always
     paths:
       - build-ci/dashcore-${BUILD_TARGET}/contrib/linearize/linearize-data.py # for feature_loadblock.py


### PR DESCRIPTION
## Issue being fixed or feature implemented
We include too many files in artifacts on `build` ci step, some of which (`*.a` and `*.o`) can be pretty heavy. This was ok-ish for some time but artifacts size is getting closer to the limit and even starts to cause issues, see #6462.

## What was done?
Specify exact files that are needed for functional tests (`test` ci step) and for users who wants to get binaries from artifacts. Also, change artifacts name to make it easier to distinguish them when you get a few of them from the same pipeline - `build-arm-linux.zip`, `build-linux64.zip` etc. instead of `binaries.zip`, `binaries (1).zip` etc., same for `depends`.

As a result the size of tsan artifacts for example is down from 508MB in 6462 to 116MB in this PR (or 78MB if we exclude logs 47ae9a4abe2896301bb99d4adffd465280d41e38).

## How Has This Been Tested?

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

