### PR TITLE
revert: Revert "feat: re-bury DIP0024 with new height when quorums actually appeared"

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -189,6 +189,7 @@ public:
         consensus.DIP0008Height = 1088640; // 00000000000000112e41e4b3afda8b233b8cc07c532d2eac5de097b68358c43e
         consensus.BRRHeight = 1374912; // 000000000000000c5a124f3eccfbe6e17876dca79cec9e63dfa70d269113c926
         consensus.DIP0020Height = 1516032; // 000000000000000f64ed3bd9af1078177ac026f6aa2677aa4d8beeae43be56cc
+        consensus.DIP0024Height = 1737792; // 0000000000000001342be9c0b75ad40c276beaad91616423c4d9cb101b3db438
         consensus.DIP0024QuorumsHeight = 1738698; // 000000000000001aa25181e4c466e593992c98f9eb21c69ee757b8bb0af50244
         consensus.V19Height = 1899072; // 0000000000000015e32e73052d663626327004c81c5c22cb8b42c361015c0eae
         consensus.V20Height = 1987776; // 000000000000001bf41cff06b76780050682ca29e61a91c391893d4745579777
@@ -386,6 +387,7 @@ public:
         consensus.DIP0008Height = 78800; // 000000000e9329d964d80e7dab2e704b43b6bd2b91fea1e9315d38932e55fb55
         consensus.BRRHeight = 387500; // 0000001537dbfd09dea69f61c1f8b2afa27c8dc91c934e144797761c9f10367b
         consensus.DIP0020Height = 414100; // 000000cf961868662fbfbb5d1af6f1caa1809f6a4e390efe5f8cd3031adea668
+        consensus.DIP0024Height = 769700; // 0000008d84e4efd890ae95c70a7a6126a70a80e5c19e4cb264a5b3469aeef172
         consensus.DIP0024QuorumsHeight = 770730; // 0000003c43b3ae7fffe61278ca5537a0e256ebf4d709d45f0ab040271074d51e
         consensus.V19Height = 850100; // 000004728b8ff2a16b9d4eebb0fd61eeffadc9c7fe4b0ec0b5a739869401ab5b
         consensus.V20Height = 905100; // 0000020c5e0f86f385cbf8e90210de9a9fd63633f01433bf47a6b3227a2851fd
@@ -558,11 +560,12 @@ public:
         consensus.DIP0008Height = 2; // DIP0008 activated immediately on devnet
         consensus.BRRHeight = 2;     // BRR (realloc) activated immediately on devnet
         consensus.DIP0020Height = 2; // DIP0020 activated immediately on devnet
+        consensus.DIP0024Height = 2; // DIP0024 activated immediately on devnet
         consensus.DIP0024QuorumsHeight = 2; // DIP0024 activated immediately on devnet
         consensus.V19Height = 2;     // V19 activated immediately on devnet
         consensus.V20Height = 2;     // V20 activated immediately on devnet
         consensus.MN_RRHeight = 2;   // MN_RR activated immediately on devnet
-        consensus.MinBIP9WarningHeight = 2 + 2016; // mn_rr activation height + miner confirmation window
+        consensus.MinBIP9WarningHeight = 2 + 2016; // v19 activation height + miner confirmation window
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -794,6 +797,7 @@ public:
         consensus.DIP0008Height = 1; // Always active unless overridden
         consensus.BRRHeight = 1;     // Always active unless overridden
         consensus.DIP0020Height = 1; // Always active unless overridden
+        consensus.DIP0024Height = 1; // Always have dip0024 quorums unless overridden
         consensus.DIP0024QuorumsHeight = 1; // Always have dip0024 quorums unless overridden
         consensus.V19Height = 900;
         consensus.V20Height = 900;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -137,6 +137,8 @@ struct Params {
     int BRRHeight;
     /** Block height at which DIP0020, DIP0021 and LLMQ_100_67 quorums become active */
     int DIP0020Height;
+    /** Block height at which DIP0024 (Quorum Rotation) and decreased governance proposal fee becomes active */
+    int DIP0024Height;
     /** Block height at which the first DIP0024 quorum was mined */
     int DIP0024QuorumsHeight;
     /** Block height at which V19 (Basic BLS and EvoNodes) becomes active */
@@ -203,7 +205,7 @@ struct Params {
         case DEPLOYMENT_DIP0020:
             return DIP0020Height;
         case DEPLOYMENT_DIP0024:
-            return DIP0024QuorumsHeight;
+            return DIP0024Height;
         case DEPLOYMENT_BRR:
             return BRRHeight;
         case DEPLOYMENT_V19:

--- a/src/llmq/options.cpp
+++ b/src/llmq/options.cpp
@@ -116,26 +116,26 @@ std::map<Consensus::LLMQType, QvvecSyncMode> GetEnabledQuorumVvecSyncEntries()
 
 bool IsQuorumTypeEnabled(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindexPrev)
 {
-    return IsQuorumTypeEnabledInternal(llmqType, pindexPrev, std::nullopt);
+    return IsQuorumTypeEnabledInternal(llmqType, pindexPrev, std::nullopt, std::nullopt);
 }
 
 bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindexPrev,
-                                 std::optional<bool> optIsDIP0024Active)
+                                std::optional<bool> optDIP0024IsActive, std::optional<bool> optHaveDIP0024Quorums)
 {
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
-    const bool fDIP0024IsActive{
-        optIsDIP0024Active.value_or(DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DIP0024))};
+    const bool fDIP0024IsActive{optDIP0024IsActive.value_or(DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DIP0024))};
+    const bool fHaveDIP0024Quorums{optHaveDIP0024Quorums.value_or(pindexPrev->nHeight >= consensusParams.DIP0024QuorumsHeight)};
     switch (llmqType)
     {
         case Consensus::LLMQType::LLMQ_DEVNET:
             return true;
         case Consensus::LLMQType::LLMQ_50_60:
-            return !fDIP0024IsActive || Params().NetworkIDString() == CBaseChainParams::TESTNET ||
+            return !fDIP0024IsActive || !fHaveDIP0024Quorums || Params().NetworkIDString() == CBaseChainParams::TESTNET ||
                    Params().NetworkIDString() == CBaseChainParams::DEVNET;
         case Consensus::LLMQType::LLMQ_TEST_INSTANTSEND:
-            return !fDIP0024IsActive ||
-                   consensusParams.llmqTypeDIP0024InstantSend == Consensus::LLMQType::LLMQ_TEST_INSTANTSEND;
+            return !fDIP0024IsActive || !fHaveDIP0024Quorums ||
+                    consensusParams.llmqTypeDIP0024InstantSend == Consensus::LLMQType::LLMQ_TEST_INSTANTSEND;
         case Consensus::LLMQType::LLMQ_TEST:
         case Consensus::LLMQType::LLMQ_TEST_PLATFORM:
         case Consensus::LLMQType::LLMQ_400_60:

--- a/src/llmq/options.h
+++ b/src/llmq/options.h
@@ -44,8 +44,7 @@ bool IsWatchQuorumsEnabled();
 std::map<Consensus::LLMQType, QvvecSyncMode> GetEnabledQuorumVvecSyncEntries();
 
 bool IsQuorumTypeEnabled(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindexPrev);
-bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindexPrev,
-                                 std::optional<bool> optHaveDIP0024Quorums);
+bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindexPrev, std::optional<bool> optDIP0024IsActive, std::optional<bool> optHaveDIP0024Quorums);
 
 std::vector<Consensus::LLMQType> GetEnabledQuorumTypes(gsl::not_null<const CBlockIndex*> pindex);
 std::vector<std::reference_wrapper<const Consensus::LLMQParams>> GetEnabledQuorumParams(gsl::not_null<const CBlockIndex*> pindex);

--- a/src/test/evo_utils_tests.cpp
+++ b/src/test/evo_utils_tests.cpp
@@ -21,14 +21,18 @@ void Test(NodeContext& node)
     using namespace llmq;
     auto tip = node.chainman->ActiveTip();
     const auto& consensus_params = Params().GetConsensus();
-    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeDIP0024InstantSend, tip, false), false);
-    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeDIP0024InstantSend, tip, true), true);
-    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeChainLocks, tip, false), true);
-    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeChainLocks, tip, true), true);
-    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypePlatform, tip, false), Params().IsTestChain());
-    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypePlatform, tip, true), Params().IsTestChain());
-    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeMnhf, tip, false), true);
-    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeMnhf, tip, true), true);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeDIP0024InstantSend, tip, false, false), false);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeDIP0024InstantSend, tip, true, false), true);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeDIP0024InstantSend, tip, true, true), true);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeChainLocks, tip, false, false), true);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeChainLocks, tip, true, false), true);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeChainLocks, tip, true, true), true);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypePlatform, tip, false, false), Params().IsTestChain());
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypePlatform, tip, true, false), Params().IsTestChain());
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypePlatform, tip, true, true), Params().IsTestChain());
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeMnhf, tip, false, false), true);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeMnhf, tip, true, false), true);
+    BOOST_CHECK_EQUAL(IsQuorumTypeEnabledInternal(consensus_params.llmqTypeMnhf, tip, true, true), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(utils_IsQuorumTypeEnabled_tests_regtest, RegTestingSetup)


### PR DESCRIPTION
## Issue being fixed or feature implemented
`-assumevalid=0` sync is broken on develop, v22 and master aren't affected

mainnet:
```
[   loadblk] [util/system.h:57] [error] ERROR: ConnectBlock(DASH): ProcessSpecialTxsInBlock for block 00000000000000195f69a348a14fddc7c8ff61036348e95b818ca42c6c724bbb failed with bad-qc-dup 
[   loadblk] [validation.cpp:1365] [InvalidChainFound] InvalidChainFound: invalid block=00000000000000195f69a348a14fddc7c8ff61036348e95b818ca42c6c724bbb  height=1737834  log2_work=78.911419  date=2022-09-13T22:36:20Z
[   loadblk] [validation.cpp:1370] [InvalidChainFound] InvalidChainFound:  current best=0000000000000002e91bac9f95f96885a89de2c46846d197933c8c5f03cb806f  height=1737833  log2_work=78.911418  date=2022-09-13T22:35:44Z
[   loadblk] [util/system.h:57] [error] ERROR: ConnectTip: ConnectBlock 00000000000000195f69a348a14fddc7c8ff61036348e95b818ca42c6c724bbb failed, bad-qc-dup
```

testnet:
```
[   loadblk] [util/system.h:57] [error] ERROR: ConnectBlock(DASH): ProcessSpecialTxsInBlock for block 00000050ec7aa1b187c3a9df0d80a2ed2821d5836b596b962bcbc4c261b4bcd5 failed with bad-qc-dup 
[   loadblk] [validation.cpp:1357] [InvalidChainFound] InvalidChainFound: invalid block=00000050ec7aa1b187c3a9df0d80a2ed2821d5836b596b962bcbc4c261b4bcd5  height=769866  log2_work=57.312136  date=2022-07-28T03:32:01Z
[   loadblk] [validation.cpp:1362] [InvalidChainFound] InvalidChainFound:  current best=0000001acc25de06893220ed663f35ef8b8e82ec951963c4092c1e9ee103af6f  height=769865  log2_work=57.312136  date=2022-07-28T03:28:21Z
[   loadblk] [util/system.h:57] [error] ERROR: ConnectTip: ConnectBlock 00000050ec7aa1b187c3a9df0d80a2ed2821d5836b596b962bcbc4c261b4bcd5 failed, bad-qc-dup
```

## What was done?
This reverts commit 632c4c4bcd0bff39483dc82284edad8a389929ec.


## How Has This Been Tested?
Hint: sync to pre-dip24 block with `--stopatheight=1737790` and no `-assumevalid` to speed things up, then start from that block with `-assumevalid=0`

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

