### PR TITLE
ci: do not check `--ff-only` on master branch

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -25,16 +25,20 @@ jobs:
 
       - name: Check merge --ff-only
         run: |
-          git fetch origin master:master
-          if [[ "${{ github.event_name }}" == "pull_request"* ]]; then
-            git fetch origin ${{ github.event.pull_request.base.ref }}:base_branch
-            git checkout base_branch
-            git pull --rebase=false origin pull/${{ github.event.pull_request.number }}/head
-            git checkout master
-            git merge --ff-only base_branch
+          if [[ "${{ github.ref_name }}" == "master" ]]; then
+            echo "Already on master, no need to check --ff-only"
           else
-            git checkout master
-            git merge --ff-only ${{ github.sha }}
+            git fetch origin master:master
+            if [[ "${{ github.event_name }}" == "pull_request"* ]]; then
+              git fetch origin ${{ github.event.pull_request.base.ref }}:base_branch
+              git checkout base_branch
+              git pull --rebase=false origin pull/${{ github.event.pull_request.number }}/head
+              git checkout master
+              git merge --ff-only base_branch
+            else
+              git checkout master
+              git merge --ff-only ${{ github.sha }}
+            fi
           fi
 
       - name: add labels


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash/actions/runs/12303817802/job/34340079798

It makes no sense to check it anyway.

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

