### PR TITLE
ci: exclude more files from artifacts, better names for downloaded files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,6 +136,8 @@ builder-image:
       - build-ci
     # Exclude some less important binaries to reduce the size of the artifacts
     exclude:
+      - build-ci/dashcore-$BUILD_TARGET/src/**/*.a
+      - build-ci/dashcore-$BUILD_TARGET/src/**/*.o
       - build-ci/dashcore-$BUILD_TARGET/src/bench/bench_dash
       - build-ci/dashcore-$BUILD_TARGET/src/bench/bench_dash.exe
       - build-ci/dashcore-$BUILD_TARGET/src/qt/test/test_dash-qt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ builder-image:
       - depends/built
       - depends/sdk-sources
   artifacts:
-    name: depends
+    name: depends-${CI_JOB_NAME}
     when: on_success
     paths:
       - depends/$HOST
@@ -130,7 +130,7 @@ builder-image:
     paths:
       - cache/ccache
   artifacts:
-    name: binaries
+    name: build-${BUILD_TARGET}
     when: always
     paths:
       - build-ci


### PR DESCRIPTION
## Issue being fixed or feature implemented
We include too many files in artifacts on `build` ci step, some of which (`*.a` and `*.o`) can be pretty heavy. This was ok-ish for some time but artifacts size is getting closer to the limit and even starts to cause issues, see #6462.

## What was done?
Exclude `*.a` and `*.o` files from artifacts. Also, change artifacts name to make it easier to distinguish them when you get a few of them from the same pipeline - `build-arm-linux.zip`, `build-linux64.zip` etc. instead of `binaries.zip`, `binaries (1).zip` etc., same for `depends`.

A simpler alternative to #6483

As a result the size of tsan artifacts for example is down from 508MB in 6462 to 154MB in this PR.

## How Has This Been Tested?

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

