### PR TITLE
docs: fixes for Release Notes v22.0.0 and v21.0.0

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -86,10 +86,10 @@ likely require a reindex.
 - **glibc Requirement**
     - The minimum required glibc to run Dash Core is now **2.31**. This means that **RHEL 8** and **Ubuntu 18.04 (Bionic)** are no longer supported.
 
-## New RPCs
+- **FreeBSD Improvements**
+    - Fixed issues with building Dash Core on FreeBSD.
 
-- **`quorum platformsign`**
-    - A new subcommand has been introduced, offering a structured way to perform platform-related quorum signing operations.
+## New RPCs
 
 - **`coinjoinsalt`**
     - Allows manipulation of a CoinJoin salt stored in a wallet.
@@ -153,7 +153,7 @@ likely require a reindex.
 ## Devnet Breaking Changes
 
 - **Hardfork Activation Changes**
-    - `BRR` (`realloc`), `DIP0020`, `DIP0024`, `V19`, `V20`, and `MN_R` hardforks are now activated at **block 2** instead of block **300** on devnets.
+    - `BRR` (`realloc`), `DIP0020`, `DIP0024`, `V19`, `V20`, and `MN_RR` hardforks are now activated at **block 2** instead of block **300** on devnets.
     - **Implications:**
         - Breaking change.
         - Inability to sync on devnets created with earlier Dash Core versions and vice versa.

--- a/doc/release-notes/dash/release-notes-21.0.0.md
+++ b/doc/release-notes/dash/release-notes-21.0.0.md
@@ -235,7 +235,7 @@ Remote Procedure Calls (RPCs)
   support for coin selection and a custom fee rate. The `send` RPC is experimental
   and may change in subsequent releases. Using it is encouraged once it's no
   longer experimental: `sendmany` and `sendtoaddress` may be deprecated in a future release.
-- A new `quorum signplatform` RPC is added for Platform needs. This composite command limits Platform to only request signatures from the Platform quorum type. It is equivalent to `quorum sign <platform type>`.
+- A new `quorum platformsign` RPC is added for Platform needs. This composite command limits Platform to only request signatures from the Platform quorum type. It is equivalent to `quorum sign <platform type>`.
 
 ### RPC changes
 - `createwallet` has an updated argument list: `createwallet "wallet_name" ( disable_private_keys blank "passphrase" avoid_reuse descriptors load_on_startup )`


### PR DESCRIPTION

## Issue being fixed or feature implemented
I noticed that we announced in current release new RPC `quorum platformsign` which has been actually released with v21.
Though, in release notes for v21 it has a wrong name.


## What was done?
Removed `quorum platformsign` from v22 release notes; fixed name in v21.
Also mentioned build for Freebsd and minor typo `s/MN_R/MN_RR/` with name of forks on regtest.

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone