### PR TITLE
feat: add optional argument to ignore ChainLocks for reconsiderblocks RPC

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2125,6 +2125,7 @@ static RPCHelpMan reconsiderblock()
         "This can be used to undo the effects of invalidateblock.\n",
         {
             {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "the hash of the block to reconsider"},
+            {"ignore_chainlocks", RPCArg::Type::BOOL, RPCArg::Default{false}, "if true, existing chainlocks will be ignored"},
         },
         RPCResult{RPCResult::Type::NONE, "", ""},
         RPCExamples{
@@ -2137,6 +2138,7 @@ static RPCHelpMan reconsiderblock()
     CChainState& active_chainstate = chainman.ActiveChainstate();
 
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
+    const bool ignore_chainlocks{request.params[1].isNull() ? false : request.params[1].get_bool()};
 
     {
         LOCK(cs_main);
@@ -2145,7 +2147,7 @@ static RPCHelpMan reconsiderblock()
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
         }
 
-        active_chainstate.ResetBlockFailureFlags(pblockindex);
+        active_chainstate.ResetBlockFailureFlags(pblockindex, ignore_chainlocks);
     }
 
     BlockValidationState state;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -75,6 +75,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "waitforblockheight", 0, "height" },
     { "waitforblockheight", 1, "timeout" },
     { "waitforblock", 1, "timeout" },
+    { "reconsiderblock", 1, "ignore_chainlocks" },
     { "waitfornewblock", 0, "timeout" },
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3410,7 +3410,7 @@ bool CChainState::MarkConflictingBlock(BlockValidationState& state, CBlockIndex 
     return true;
 }
 
-void CChainState::ResetBlockFailureFlags(CBlockIndex *pindex) {
+void CChainState::ResetBlockFailureFlags(CBlockIndex *pindex, bool ignore_chainlocks) {
     AssertLockHeld(cs_main);
 
     if (!pindex) {
@@ -3429,9 +3429,14 @@ void CChainState::ResetBlockFailureFlags(CBlockIndex *pindex) {
     for (auto& [_, block_index] : m_blockman.m_block_index) {
         if (!block_index.IsValid() && block_index.GetAncestor(nHeight) == pindex) {
             block_index.nStatus &= ~BLOCK_FAILED_MASK;
+            if (ignore_chainlocks) {
+                block_index.nStatus &= ~BLOCK_CONFLICT_CHAINLOCK;
+            }
             m_blockman.m_dirty_blockindex.insert(&block_index);
-            if (block_index.IsValid(BLOCK_VALID_TRANSACTIONS) && !(block_index.nStatus & BLOCK_CONFLICT_CHAINLOCK) && block_index.HaveTxsDownloaded() && setBlockIndexCandidates.value_comp()(m_chain.Tip(), &block_index)) {
-                setBlockIndexCandidates.insert(&block_index);
+            if (block_index.IsValid(BLOCK_VALID_TRANSACTIONS) && block_index.HaveTxsDownloaded() && setBlockIndexCandidates.value_comp()(m_chain.Tip(), &block_index)) {
+                if (ignore_chainlocks || !(block_index.nStatus & BLOCK_CONFLICT_CHAINLOCK)) {
+                    setBlockIndexCandidates.insert(&block_index);
+                }
             }
             if (&block_index == m_chainman.m_best_invalid) {
                 // Reset invalid block marker if it was pointing to one of those.
@@ -3443,11 +3448,16 @@ void CChainState::ResetBlockFailureFlags(CBlockIndex *pindex) {
 
     // Remove the invalidity flag from all ancestors too.
     while (pindex != nullptr) {
-        if (pindex->nStatus & BLOCK_FAILED_MASK) {
+        if (pindex->nStatus & (BLOCK_FAILED_MASK | BLOCK_CONFLICT_CHAINLOCK)) {
             pindex->nStatus &= ~BLOCK_FAILED_MASK;
+            if (ignore_chainlocks) {
+                pindex->nStatus &= ~BLOCK_CONFLICT_CHAINLOCK;
+            }
             m_blockman.m_dirty_blockindex.insert(pindex);
-            if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && !(pindex->nStatus & BLOCK_CONFLICT_CHAINLOCK) && pindex->HaveTxsDownloaded() && setBlockIndexCandidates.value_comp()(m_chain.Tip(), pindex)) {
-                setBlockIndexCandidates.insert(pindex);
+            if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && pindex->HaveTxsDownloaded() && setBlockIndexCandidates.value_comp()(m_chain.Tip(), pindex)) {
+                if (ignore_chainlocks || !(pindex->nStatus & BLOCK_CONFLICT_CHAINLOCK)) {
+                    setBlockIndexCandidates.insert(pindex);
+                }
             }
             if (pindex == m_chainman.m_best_invalid) {
                 // Reset invalid block marker if it was pointing to one of those.

--- a/src/validation.h
+++ b/src/validation.h
@@ -713,7 +713,7 @@ public:
         LOCKS_EXCLUDED(::cs_main);
 
     /** Remove invalidity status from a block and its descendants. */
-    void ResetBlockFailureFlags(CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void ResetBlockFailureFlags(CBlockIndex* pindex, bool ignore_chainlocks = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Replay blocks that aren't fully applied to the database. */
     bool ReplayBlocks();


### PR DESCRIPTION
## Issue being fixed or feature implemented
More general way to implement #6500 which can be merged to develop.

## What was done?
It allows removing BLOCK_CONFLICT_CHAINLOCK flag via ResetBlockFailureFlags


## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

