### PR TITLE
fix: refuse to create new clsig if we switched to a different fork while we were signing

### DIFF
--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -519,7 +519,11 @@ MessageProcessingResult CChainLocksHandler::HandleNewRecoveredSig(const llmq::CR
             // already got the same or a better CLSIG through the CLSIG message
             return {};
         }
-
+        const auto pindex = m_chainstate.m_chain.Tip()->GetAncestor(lastSignedHeight);
+        if (pindex == nullptr || pindex->GetBlockHash() != lastSignedMsgHash) {
+            // we switched to a different fork while we were signing
+            return {};
+        }
 
         clsig = CChainLockSig(lastSignedHeight, lastSignedMsgHash, recoveredSig.sig.Get());
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Signing is async so it's possible that our clsig is no longer relevant

## What was done?

## How Has This Been Tested?

## Breaking Changes

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

