### PR TITLE
stats: remove deprecated arguments `-stats{enabled,hostname,ns}`

### DIFF
--- a/doc/release-notes-6505.md
+++ b/doc/release-notes-6505.md
@@ -1,0 +1,5 @@
+Statistics
+-----------
+
+- The arguments `-statsenabled`, `-statsns`, `-statshostname` have been removed. They were
+  previously deprecated in v22.0 and will no longer be recognized on runtime.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -755,7 +755,6 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
-    hidden_args.emplace_back("-statsenabled");
     argsman.AddArg("-statsbatchsize=<bytes>", strprintf("Specify the size of each batch of stats messages (default: %d)", DEFAULT_STATSD_BATCH_SIZE), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsduration=<ms>", strprintf("Specify the number of milliseconds between stats messages (default: %d)", DEFAULT_STATSD_DURATION), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statshost=<ip>", strprintf("Specify statsd host (default: %s)", DEFAULT_STATSD_HOST), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -760,7 +760,6 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-statshost=<ip>", strprintf("Specify statsd host (default: %s)", DEFAULT_STATSD_HOST), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     hidden_args.emplace_back("-statshostname");
     argsman.AddArg("-statsport=<port>", strprintf("Specify statsd port (default: %u)", DEFAULT_STATSD_PORT), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
-    hidden_args.emplace_back("-statsns");
     argsman.AddArg("-statsperiod=<seconds>", strprintf("Specify the number of seconds between periodic measurements (default: %d)", DEFAULT_STATSD_PERIOD), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsprefix=<string>", strprintf("Specify an optional string prepended to every stats key (default: %s)", DEFAULT_STATSD_PREFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statssuffix=<string>", strprintf("Specify an optional string appended to every stats key (default: %s)", DEFAULT_STATSD_SUFFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -758,7 +758,6 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-statsbatchsize=<bytes>", strprintf("Specify the size of each batch of stats messages (default: %d)", DEFAULT_STATSD_BATCH_SIZE), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsduration=<ms>", strprintf("Specify the number of milliseconds between stats messages (default: %d)", DEFAULT_STATSD_DURATION), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statshost=<ip>", strprintf("Specify statsd host (default: %s)", DEFAULT_STATSD_HOST), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
-    hidden_args.emplace_back("-statshostname");
     argsman.AddArg("-statsport=<port>", strprintf("Specify statsd port (default: %u)", DEFAULT_STATSD_PORT), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsperiod=<seconds>", strprintf("Specify the number of seconds between periodic measurements (default: %d)", DEFAULT_STATSD_PERIOD), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsprefix=<string>", strprintf("Specify an optional string prepended to every stats key (default: %s)", DEFAULT_STATSD_PREFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -33,21 +33,6 @@ std::unique_ptr<StatsdClient> g_stats_client;
 
 std::unique_ptr<StatsdClient> InitStatsClient(const ArgsManager& args)
 {
-    auto is_enabled = args.GetBoolArg("-statsenabled", /*fDefault=*/false);
-    auto host = args.GetArg("-statshost", /*fDefault=*/DEFAULT_STATSD_HOST);
-
-    if (is_enabled && host.empty()) {
-        // Stats are enabled but host has not been specified, then use
-        // default legacy host. This is to preserve old behavior.
-        host = "127.0.0.1";
-    } else if (!host.empty()) {
-        // Host is specified but stats are not explcitly enabled. Assume
-        // that if a host has been specified, we want stats enabled. This
-        // is new behaviour and will substitute old behaviour in a future
-        // release.
-        is_enabled = true;
-    }
-
     auto sanitize_string = [](std::string& string) {
         // Remove key delimiters from the front and back as they're added back
         if (!string.empty()) {
@@ -83,22 +68,21 @@ std::unique_ptr<StatsdClient> InitStatsClient(const ArgsManager& args)
     }
 
     return std::make_unique<StatsdClient>(
-        host,
+        args.GetArg("-statshost", DEFAULT_STATSD_HOST),
         args.GetArg("-statsport", DEFAULT_STATSD_PORT),
         args.GetArg("-statsbatchsize", DEFAULT_STATSD_BATCH_SIZE),
         args.GetArg("-statsduration", DEFAULT_STATSD_DURATION),
         prefix,
-        suffix,
-        is_enabled
+        suffix
     );
 }
 
 StatsdClient::StatsdClient(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
-                           const std::string& prefix, const std::string& suffix, bool enabled) :
+                           const std::string& prefix, const std::string& suffix) :
     m_prefix{prefix},
     m_suffix{[suffix]() { return !suffix.empty() ? STATSD_NS_DELIMITER + suffix : suffix; }()}
 {
-    if (!enabled) {
+    if (host.empty()) {
         LogPrintf("Transmitting stats are disabled, will not init StatsdClient\n");
         return;
     }

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -43,22 +43,13 @@ std::unique_ptr<StatsdClient> InitStatsClient(const ArgsManager& args)
         return string;
     };
 
-    auto suffix = args.GetArg("-statssuffix", DEFAULT_STATSD_SUFFIX);
-    if (suffix.empty()) {
-        suffix = args.GetArg("-statshostname", DEFAULT_STATSD_SUFFIX);
-    } else {
-        // We restrict sanitization logic to our newly added arguments to
-        // prevent breaking changes.
-        sanitize_string(suffix);
-    }
-
     return std::make_unique<StatsdClient>(
         args.GetArg("-statshost", DEFAULT_STATSD_HOST),
         args.GetArg("-statsport", DEFAULT_STATSD_PORT),
         args.GetArg("-statsbatchsize", DEFAULT_STATSD_BATCH_SIZE),
         args.GetArg("-statsduration", DEFAULT_STATSD_DURATION),
         sanitize_string(args.GetArg("-statsprefix", DEFAULT_STATSD_PREFIX)),
-        suffix
+        sanitize_string(args.GetArg("-statssuffix", DEFAULT_STATSD_SUFFIX))
     );
 }
 

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -33,30 +33,15 @@ std::unique_ptr<StatsdClient> g_stats_client;
 
 std::unique_ptr<StatsdClient> InitStatsClient(const ArgsManager& args)
 {
-    auto sanitize_string = [](std::string& string) {
-        // Remove key delimiters from the front and back as they're added back
+    auto sanitize_string = [](std::string string) {
+        // Remove key delimiters from the front and back as they're added back in
+        // the constructor
         if (!string.empty()) {
             if (string.front() == STATSD_NS_DELIMITER) string.erase(string.begin());
             if (string.back() == STATSD_NS_DELIMITER) string.pop_back();
         }
+        return string;
     };
-
-    // Get our prefix and suffix and if we get nothing, try again with the
-    // deprecated argument. If we still get nothing, that's fine, they're optional.
-    auto prefix = args.GetArg("-statsprefix", DEFAULT_STATSD_PREFIX);
-    if (prefix.empty()) {
-        prefix = args.GetArg("-statsns", DEFAULT_STATSD_PREFIX);
-    } else {
-        // We restrict sanitization logic to our newly added arguments to
-        // prevent breaking changes.
-        sanitize_string(prefix);
-        // We need to add the delimiter here for backwards compatibility with
-        // the deprecated argument.
-        //
-        // TODO: Move this step into the constructor when removing deprecated
-        //       args support
-        prefix += STATSD_NS_DELIMITER;
-    }
 
     auto suffix = args.GetArg("-statssuffix", DEFAULT_STATSD_SUFFIX);
     if (suffix.empty()) {
@@ -72,14 +57,14 @@ std::unique_ptr<StatsdClient> InitStatsClient(const ArgsManager& args)
         args.GetArg("-statsport", DEFAULT_STATSD_PORT),
         args.GetArg("-statsbatchsize", DEFAULT_STATSD_BATCH_SIZE),
         args.GetArg("-statsduration", DEFAULT_STATSD_DURATION),
-        prefix,
+        sanitize_string(args.GetArg("-statsprefix", DEFAULT_STATSD_PREFIX)),
         suffix
     );
 }
 
 StatsdClient::StatsdClient(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
                            const std::string& prefix, const std::string& suffix) :
-    m_prefix{prefix},
+    m_prefix{[prefix]() { return !prefix.empty() ? prefix + STATSD_NS_DELIMITER : prefix; }()},
     m_suffix{[suffix]() { return !suffix.empty() ? STATSD_NS_DELIMITER + suffix : suffix; }()}
 {
     if (host.empty()) {

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -40,7 +40,7 @@ class StatsdClient
 {
 public:
     explicit StatsdClient(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
-                          const std::string& prefix, const std::string& suffix, bool enabled);
+                          const std::string& prefix, const std::string& suffix);
     ~StatsdClient();
 
 public:


### PR DESCRIPTION
## Breaking Changes

- The arguments `-statsenabled`, `-statsns`, `-statshostname` have been removed. They were previously deprecated in v22.0 and will no longer be recognized on runtime.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
