### PR TITLE
test: increase timeout in `p2p_invalid_messages.py` to reduce flakiness

### DIFF
--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -70,7 +70,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         # However the pong from conn in reply to the ping from the node has not
         # been processed and recorded in totalbytesrecv.
         # Flush the pong from conn by sending a ping from conn.
-        conn.sync_with_ping(timeout=1)
+        conn.sync_with_ping(timeout=2)
         # Create valid message
         msg = conn.build_message(msg_ping(nonce=12345))
         cut_pos = 12  # Chosen at an arbitrary position within the header
@@ -82,7 +82,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         middle = self.nodes[0].getnettotals()['totalbytesrecv']
         assert_equal(middle, before + cut_pos)
         conn.send_raw_message(msg[cut_pos:])
-        conn.sync_with_ping(timeout=1)
+        conn.sync_with_ping(timeout=2)
         self.nodes[0].disconnect_p2ps()
 
     def test_duplicate_version_msg(self):


### PR DESCRIPTION
## Additional Information

* Dependency for https://github.com/dashpay/dash/pull/6504
*  `p2p_invalid_messages.py` has a tendency to occasionally fail and when working on [dash#6504](https://github.com/dashpay/dash/pull/6504), the test had a higher failure rate than usual (despite the rest of the test suite passing and with exception to the `test_buffer` subtest, the rest of `p2p_invalid_messages.py` passing)
  
   This pull request bumps the timeout from 1s to 2s only in the `test_buffer` subtest.

## Breaking Changes

None expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (note: N/A)
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation (note: N/A)
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
