### PR TITLE
refactor: deglobalization of bls_legacy_scheme 3/N

### DIFF
--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -29,12 +29,12 @@ static void BuildTestVectors(size_t count, size_t invalidCount,
         secKeys[i].MakeNewKey();
         pubKeys[i] = secKeys[i].GetPublicKey();
         msgHashes[i] = GetRandHash();
-        sigs[i] = secKeys[i].Sign(msgHashes[i]);
+        sigs[i] = secKeys[i].Sign(msgHashes[i], false);
 
         if (invalid[i]) {
             CBLSSecretKey s;
             s.MakeNewKey();
-            sigs[i] = s.Sign(msgHashes[i]);
+            sigs[i] = s.Sign(msgHashes[i], false);
         }
     }
 }
@@ -71,8 +71,8 @@ static void BLS_SignatureAggregate_Normal(benchmark::Bench& bench)
     CBLSSecretKey secKey1, secKey2;
     secKey1.MakeNewKey();
     secKey2.MakeNewKey();
-    CBLSSignature sig1 = secKey1.Sign(hash);
-    CBLSSignature sig2 = secKey2.Sign(hash);
+    CBLSSignature sig1 = secKey1.Sign(hash, false);
+    CBLSSignature sig2 = secKey2.Sign(hash, false);
 
     // Benchmark.
     bench.run([&] {
@@ -89,7 +89,7 @@ static void BLS_Sign_Normal(benchmark::Bench& bench)
     // Benchmark.
     bench.minEpochIterations(100).run([&] {
         uint256 hash = GetRandHash();
-        sig = secKey.Sign(hash);
+        sig = secKey.Sign(hash, false);
     });
 }
 

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -117,11 +117,6 @@ CBLSPublicKey CBLSSecretKey::GetPublicKey() const
     return pubKey;
 }
 
-CBLSSignature CBLSSecretKey::Sign(const uint256& hash) const
-{
-    return Sign(hash, bls::bls_legacy_scheme.load());
-}
-
 CBLSSignature CBLSSecretKey::Sign(const uint256& hash, const bool specificLegacyScheme) const
 {
     if (!IsValid()) {

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -211,11 +211,6 @@ public:
         return true;
     }
 
-    inline bool CheckMalleable(Span<uint8_t> vecBytes) const
-    {
-        return CheckMalleable(vecBytes, bls::bls_legacy_scheme.load());
-    }
-
     inline std::string ToString(const bool specificLegacyScheme) const
     {
         std::vector<uint8_t> buf = ToByteVector(specificLegacyScheme);

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -275,7 +275,6 @@ public:
     bool SecretKeyShare(Span<CBLSSecretKey> msk, const CBLSId& id);
 
     [[nodiscard]] CBLSPublicKey GetPublicKey() const;
-    [[nodiscard]] CBLSSignature Sign(const uint256& hash) const;
     [[nodiscard]] CBLSSignature Sign(const uint256& hash, const bool specificLegacyScheme) const;
 };
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -249,6 +249,7 @@ public:
     explicit CBLSId(const uint256& nHash);
 };
 
+//! CBLSSecretKey is invariant to BLS scheme for Creation / Serialization / Deserialization
 class CBLSSecretKey : public CBLSWrapper<bls::PrivateKey, BLS_CURVE_SECKEY_SIZE, CBLSSecretKey>
 {
 public:
@@ -270,10 +271,13 @@ public:
     static CBLSSecretKey AggregateInsecure(Span<CBLSSecretKey> sks);
 
 #ifndef BUILD_BITCOIN_INTERNAL
+    //! MakeNewKey() is invariant to BLS scheme
     void MakeNewKey();
 #endif
+    //! SecretKeyShare() is invariant to BLS scheme
     bool SecretKeyShare(Span<CBLSSecretKey> msk, const CBLSId& id);
 
+    //! GetPublicKey() is invariant to BLS scheme
     [[nodiscard]] CBLSPublicKey GetPublicKey() const;
     [[nodiscard]] CBLSSignature Sign(const uint256& hash, const bool specificLegacyScheme) const;
 };

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -57,10 +57,6 @@ public:
     static constexpr size_t SerSize = _SerSize;
 
     explicit CBLSWrapper() = default;
-    explicit CBLSWrapper(Span<const unsigned char> vecBytes) : CBLSWrapper<ImplType, _SerSize, C>()
-    {
-        SetByteVector(vecBytes, bls::bls_legacy_scheme.load());
-    }
 
     CBLSWrapper(const CBLSWrapper& ref) = default;
     CBLSWrapper& operator=(const CBLSWrapper& ref) = default;
@@ -272,6 +268,11 @@ public:
     using CBLSWrapper::CBLSWrapper;
 
     CBLSSecretKey() = default;
+    explicit CBLSSecretKey(Span<const unsigned char> vecBytes)
+    {
+        // The second param here is not 'is_legacy', but `modOrder`
+        SetByteVector(vecBytes, false);
+    }
     CBLSSecretKey(const CBLSSecretKey&) = default;
     CBLSSecretKey& operator=(const CBLSSecretKey&) = default;
 
@@ -338,6 +339,10 @@ public:
     using CBLSWrapper::CBLSWrapper;
 
     CBLSSignature() = default;
+    explicit CBLSSignature(Span<const unsigned char> bytes, bool is_serialized_legacy)
+    {
+        SetByteVector(bytes, is_serialized_legacy);
+    }
     CBLSSignature(const CBLSSignature&) = default;
     CBLSSignature& operator=(const CBLSSignature&) = default;
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -127,11 +127,6 @@ public:
         return impl.Serialize(specificLegacyScheme);
     }
 
-    std::vector<uint8_t> ToByteVector() const
-    {
-        return ToByteVector(bls::bls_legacy_scheme.load());
-    }
-
     const uint256& GetHash() const
     {
         if (cachedHash.IsNull()) {

--- a/src/bls/bls_ies.cpp
+++ b/src/bls/bls_ies.cpp
@@ -9,8 +9,7 @@
 
 #include <crypto/aes.h>
 
-template <typename Out>
-static bool EncryptBlob(const void* in, size_t inSize, Out& out, const void* symKey, const void* iv)
+static bool EncryptBlob(const void* in, size_t inSize, std::vector<unsigned char>& out, const void* symKey, const void* iv)
 {
     out.resize(inSize);
 
@@ -45,7 +44,7 @@ bool CBLSIESEncryptedBlob::Decrypt(size_t idx, const CBLSSecretKey& secretKey, C
         return false;
     }
 
-    std::vector<unsigned char> symKey = pk.ToByteVector();
+    std::vector<unsigned char> symKey = pk.ToByteVector(false);
     symKey.resize(32);
 
     uint256 iv = GetIV(idx);
@@ -81,7 +80,7 @@ bool CBLSIESMultiRecipientBlobs::Encrypt(size_t idx, const CBLSPublicKey& recipi
         return false;
     }
 
-    std::vector<uint8_t> symKey = pk.ToByteVector();
+    std::vector<uint8_t> symKey = pk.ToByteVector(false);
     symKey.resize(32);
 
     return EncryptBlob(blob.data(), blob.size(), blobs[idx], symKey.data(), ivVector[idx].begin());
@@ -98,7 +97,7 @@ bool CBLSIESMultiRecipientBlobs::Decrypt(size_t idx, const CBLSSecretKey& sk, Bl
         return false;
     }
 
-    std::vector<uint8_t> symKey = pk.ToByteVector();
+    std::vector<uint8_t> symKey = pk.ToByteVector(false);
     symKey.resize(32);
 
     uint256 iv = ivSeed;

--- a/src/bls/bls_ies.h
+++ b/src/bls/bls_ies.h
@@ -22,7 +22,6 @@ public:
         READWRITE(obj.ephemeralPubKey, obj.ivSeed, obj.data);
     }
 
-    bool Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const void* data, size_t dataSize);
     bool Decrypt(size_t idx, const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const;
     bool IsValid() const;
 };
@@ -38,17 +37,6 @@ public:
         ephemeralPubKey = ephemeralPubKeyIn;
         ivSeed = ivSeedIn;
         data = dataIn;
-    }
-
-    bool Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const Object& obj, int nVersion)
-    {
-        try {
-            CDataStream ds(SER_NETWORK, nVersion);
-            ds << obj;
-            return CBLSIESEncryptedBlob::Encrypt(idx, peerPubKey, ds.data(), ds.size());
-        } catch (const std::exception&) {
-            return false;
-        }
     }
 
     bool Decrypt(size_t idx, const CBLSSecretKey& secretKey, Object& objRet, int nVersion) const
@@ -80,8 +68,6 @@ public:
     CBLSSecretKey ephemeralSecretKey;
     std::vector<uint256> ivVector;
 
-    bool Encrypt(const std::vector<CBLSPublicKey>& recipients, const BlobVector& _blobs);
-
     void InitEncrypt(size_t count);
     bool Encrypt(size_t idx, const CBLSPublicKey& recipient, const Blob& blob);
     bool Decrypt(size_t idx, const CBLSSecretKey& sk, Blob& blobRet) const;
@@ -96,28 +82,6 @@ template <typename Object>
 class CBLSIESMultiRecipientObjects : public CBLSIESMultiRecipientBlobs
 {
 public:
-    using ObjectVector = std::vector<Object>;
-
-    bool Encrypt(const std::vector<CBLSPublicKey>& recipients, const ObjectVector& _objects, int nVersion)
-    {
-        BlobVector blobs;
-        blobs.resize(_objects.size());
-
-        try {
-            CDataStream ds(SER_NETWORK, nVersion);
-            for (size_t i = 0; i < _objects.size(); i++) {
-                ds.clear();
-
-                ds << _objects[i];
-                blobs[i].assign(UCharCast(ds.data()), UCharCast(ds.data() + ds.size()));
-            }
-        } catch (const std::exception&) {
-            return false;
-        }
-
-        return CBLSIESMultiRecipientBlobs::Encrypt(recipients, blobs);
-    }
-
     bool Encrypt(size_t idx, const CBLSPublicKey& recipient, const Object& obj, int nVersion)
     {
         CDataStream ds(SER_NETWORK, nVersion);

--- a/src/bls/bls_ies.h
+++ b/src/bls/bls_ies.h
@@ -8,6 +8,11 @@
 #include <bls/bls.h>
 #include <streams.h>
 
+/**
+ * All objects in this module working from assumption that basic scheme is
+ * available on all masternodes. Serialization of public key for Encrypt and
+ * Decrypt by bls_ies.h done using Basic Scheme.
+ */
 class CBLSIESEncryptedBlob
 {
 public:

--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -762,7 +762,7 @@ bool CBLSWorker::VerifyVerificationVectors(Span<BLSVerificationVectorPtr> vvecs)
 void CBLSWorker::AsyncSign(const CBLSSecretKey& secKey, const uint256& msgHash, const CBLSWorker::SignDoneCallback& doneCallback)
 {
     workerPool.push([secKey, msgHash, doneCallback](int threadId) {
-        doneCallback(secKey.Sign(msgHash));
+        doneCallback(secKey.Sign(msgHash, bls::bls_legacy_scheme.load()));
     });
 }
 

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -62,7 +62,7 @@ bool CCoinJoinQueue::Sign(const CActiveMasternodeManager& mn_activeman)
 
 bool CCoinJoinQueue::CheckSignature(const CBLSPublicKey& blsPubKey) const
 {
-    if (!CBLSSignature(Span{vchSig}).VerifyInsecure(blsPubKey, GetSignatureHash(), false)) {
+    if (!CBLSSignature(Span{vchSig}, false).VerifyInsecure(blsPubKey, GetSignatureHash(), false)) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinQueue::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }
@@ -101,7 +101,7 @@ bool CCoinJoinBroadcastTx::Sign(const CActiveMasternodeManager& mn_activeman)
 
 bool CCoinJoinBroadcastTx::CheckSignature(const CBLSPublicKey& blsPubKey) const
 {
-    if (!CBLSSignature(Span{vchSig}).VerifyInsecure(blsPubKey, GetSignatureHash(), false)) {
+    if (!CBLSSignature(Span{vchSig}, false).VerifyInsecure(blsPubKey, GetSignatureHash(), false)) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinBroadcastTx::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }

--- a/src/evo/assetlocktx.h
+++ b/src/evo/assetlocktx.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_EVO_ASSETLOCKTX_H
 #define BITCOIN_EVO_ASSETLOCKTX_H
 
-#include <bls/bls_ies.h>
+#include <bls/bls.h>
 #include <consensus/amount.h>
 #include <gsl/pointers.h>
 #include <primitives/transaction.h>

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -51,7 +51,8 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CActiveMasternode
 
     mnauth.proRegTxHash = mn_activeman.GetProTxHash();
 
-    mnauth.sig = mn_activeman.Sign(signHash, bls::bls_legacy_scheme.load());
+    // all clients uses basic BLS
+    mnauth.sig = mn_activeman.Sign(signHash, false);
 
     LogPrint(BCLog::NET_NETCONN, "CMNAuth::%s -- Sending MNAUTH, peer=%d\n", __func__, peer.GetId());
     connman.PushMessage(&peer, CNetMsgMaker(peer.GetCommonVersion()).Make(NetMsgType::MNAUTH, mnauth));
@@ -86,7 +87,8 @@ PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, ServiceFlags node_services, CCon
     }
 
     if (!mnauth.sig.IsValid()) {
-        LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- invalid mnauth for protx=%s with sig=%s\n", mnauth.proRegTxHash.ToString(), mnauth.sig.ToString());
+        LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- invalid mnauth for protx=%s with sig=%s\n",
+                 mnauth.proRegTxHash.ToString(), mnauth.sig.ToString(false));
         return tl::unexpected{MisbehavingError{100, "invalid mnauth signature"}};
     }
 
@@ -112,7 +114,7 @@ PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, ServiceFlags node_services, CCon
     }
     LogPrint(BCLog::NET_NETCONN, "CMNAuth::%s -- constructed signHash for nVersion %d, peer=%d\n", __func__, peer.nVersion, peer.GetId());
 
-    if (!mnauth.sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator.Get(), signHash)) {
+    if (!mnauth.sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator.Get(), signHash, false)) {
         // Same as above, MN seems to not know its fate yet, so give it a chance to update. If this is a
         // malicious node (DoSing us), it'll get banned soon.
         return tl::unexpected{MisbehavingError{10, "mnauth signature verification failed"}};

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -51,7 +51,7 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CActiveMasternode
 
     mnauth.proRegTxHash = mn_activeman.GetProTxHash();
 
-    mnauth.sig = mn_activeman.Sign(signHash);
+    mnauth.sig = mn_activeman.Sign(signHash, bls::bls_legacy_scheme.load());
 
     LogPrint(BCLog::NET_NETCONN, "CMNAuth::%s -- Sending MNAUTH, peer=%d\n", __func__, peer.GetId());
     connman.PushMessage(&peer, CNetMsgMaker(peer.GetCommonVersion()).Make(NetMsgType::MNAUTH, mnauth));

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -112,7 +112,7 @@ public:
         return obj;
     }
 
-    bool IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const;
+    bool IsTriviallyValid(bool is_basic_scheme_active, TxValidationState& state) const;
 };
 
 class CProUpServTx
@@ -192,7 +192,7 @@ public:
         return obj;
     }
 
-    bool IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const;
+    bool IsTriviallyValid(bool is_basic_scheme_active, TxValidationState& state) const;
 };
 
 class CProUpRegTx
@@ -257,7 +257,7 @@ public:
         return obj;
     }
 
-    bool IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const;
+    bool IsTriviallyValid(bool is_basic_scheme_active, TxValidationState& state) const;
 };
 
 class CProUpRevTx
@@ -321,7 +321,7 @@ public:
         return obj;
     }
 
-    bool IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const;
+    bool IsTriviallyValid(bool is_basic_scheme_active, TxValidationState& state) const;
 };
 
 template <typename ProTx>

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -206,7 +206,7 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(const CBlock& block, const CB
         nTimeMnehf += nTime7 - nTime6;
         LogPrint(BCLog::BENCHMARK, "        - m_mnhfman: %.2fms [%.2fs]\n", 0.001 * (nTime7 - nTime6), nTimeMnehf * 0.000001);
 
-        if (Params().GetConsensus().V19Height == pindex->nHeight + 1) {
+        if (DeploymentActiveAfter(pindex, m_consensus_params, Consensus::DEPLOYMENT_V19) && bls::bls_legacy_scheme.load()) {
             // NOTE: The block next to the activation is the one that is using new rules.
             // V19 activated just activated, so we must switch to the new rules here.
             bls::bls_legacy_scheme.store(false);
@@ -227,7 +227,7 @@ bool CSpecialTxProcessor::UndoSpecialTxsInBlock(const CBlock& block, const CBloc
     auto bls_legacy_scheme = bls::bls_legacy_scheme.load();
 
     try {
-        if (Params().GetConsensus().V19Height == pindex->nHeight + 1) {
+        if (!DeploymentActiveAt(*pindex, m_consensus_params, Consensus::DEPLOYMENT_V19) && !bls_legacy_scheme) {
             // NOTE: The block next to the activation is the one that is using new rules.
             // Removing the activation block here, so we must switch back to the old rules.
             bls::bls_legacy_scheme.store(true);

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -84,7 +84,8 @@ CDKGSession::CDKGSession(const CBlockIndex* pQuorumBaseBlockIndex, const Consens
     m_mn_metaman(mn_metaman),
     m_mn_activeman(mn_activeman),
     m_sporkman(sporkman),
-    m_quorum_base_block_index{pQuorumBaseBlockIndex}
+    m_quorum_base_block_index{pQuorumBaseBlockIndex},
+    m_use_legacy_bls{!DeploymentActiveAfter(m_quorum_base_block_index, Params().GetConsensus(), Consensus::DEPLOYMENT_V19)}
 {
 }
 
@@ -215,7 +216,7 @@ void CDKGSession::SendContributions(CDKGPendingMessages& pendingMessages, PeerMa
 
     logger.Batch("encrypted contributions. time=%d", t1.count());
 
-    qc.sig = m_mn_activeman->Sign(qc.GetSignHash());
+    qc.sig = m_mn_activeman->Sign(qc.GetSignHash(), m_use_legacy_bls);
 
     logger.Flush();
 
@@ -527,7 +528,7 @@ void CDKGSession::SendComplaint(CDKGPendingMessages& pendingMessages, PeerManage
 
     logger.Batch("sending complaint. badCount=%d, complaintCount=%d", badCount, complaintCount);
 
-    qc.sig = m_mn_activeman->Sign(qc.GetSignHash());
+    qc.sig = m_mn_activeman->Sign(qc.GetSignHash(), m_use_legacy_bls);
 
     logger.Flush();
 
@@ -721,7 +722,7 @@ void CDKGSession::SendJustification(CDKGPendingMessages& pendingMessages, PeerMa
         return;
     }
 
-    qj.sig = m_mn_activeman->Sign(qj.GetSignHash());
+    qj.sig = m_mn_activeman->Sign(qj.GetSignHash(), m_use_legacy_bls);
 
     logger.Flush();
 
@@ -1011,19 +1012,17 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages, PeerManag
         (*commitmentHash.begin())++;
     }
 
-    qc.sig = m_mn_activeman->Sign(commitmentHash);
-    qc.quorumSig = skShare.Sign(commitmentHash);
+    qc.sig = m_mn_activeman->Sign(commitmentHash, m_use_legacy_bls);
+    qc.quorumSig = skShare.Sign(commitmentHash, m_use_legacy_bls);
 
     if (lieType == 3) {
-        const bool is_bls_legacy = bls::bls_legacy_scheme.load();
-        std::vector<uint8_t> buf = qc.sig.ToByteVector(is_bls_legacy);
+        std::vector<uint8_t> buf = qc.sig.ToByteVector(m_use_legacy_bls);
         buf[5]++;
-        qc.sig.SetByteVector(buf, is_bls_legacy);
+        qc.sig.SetByteVector(buf, m_use_legacy_bls);
     } else if (lieType == 4) {
-        const bool is_bls_legacy = bls::bls_legacy_scheme.load();
-        std::vector<uint8_t> buf = qc.quorumSig.ToByteVector(is_bls_legacy);
+        std::vector<uint8_t> buf = qc.quorumSig.ToByteVector(m_use_legacy_bls);
         buf[5]++;
-        qc.quorumSig.SetByteVector(buf, is_bls_legacy);
+        qc.quorumSig.SetByteVector(buf, m_use_legacy_bls);
     }
 
     t3.stop();

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -288,6 +288,7 @@ private:
     const CSporkManager& m_sporkman;
 
     const CBlockIndex* const m_quorum_base_block_index;
+    bool m_use_legacy_bls;
     int quorumIndex{0};
 
 private:

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -8,6 +8,7 @@
 #include <llmq/params.h>
 #include <llmq/utils.h>
 
+#include <bls/bls_ies.h>
 #include <chainparams.h>
 #include <dbwrapper.h>
 #include <deploymentstatus.h>

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -6,13 +6,17 @@
 #define BITCOIN_LLMQ_DKGSESSIONMGR_H
 
 #include <bls/bls.h>
-#include <bls/bls_ies.h>
 #include <bls/bls_worker.h>
 #include <llmq/dkgsessionhandler.h>
 #include <net_types.h>
 
 #include <map>
 #include <memory>
+
+template <class T>
+class CBLSIESMultiRecipientObjects;
+template <class T>
+class CBLSIESEncryptedObject;
 
 class CActiveMasternodeManager;
 class CBlockIndex;

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -1541,7 +1541,7 @@ std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorumCPtr& qu
     CSigShare sigShare(quorum->params.type, quorum->qc->quorumHash, id, msgHash, uint16_t(memberIdx), {});
     uint256 signHash = sigShare.buildSignHash();
 
-    sigShare.sigShare.Set(skShare.Sign(signHash), bls::bls_legacy_scheme.load());
+    sigShare.sigShare.Set(skShare.Sign(signHash, bls::bls_legacy_scheme.load()), bls::bls_legacy_scheme.load());
     if (!sigShare.sigShare.Get().IsValid()) {
         LogPrintf("CSigSharesManager::%s -- failed to sign sigShare. signHash=%s, id=%s, msgHash=%s, time=%s\n", __func__,
                   signHash.ToString(), sigShare.getId().ToString(), sigShare.getMsgHash().ToString(), t.count());

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -275,12 +275,6 @@ template bool CActiveMasternodeManager::Decrypt(const CBLSIESEncryptedObject<CBL
 template bool CActiveMasternodeManager::Decrypt(const CBLSIESMultiRecipientObjects<CBLSSecretKey>& obj, size_t idx,
                                                 CBLSSecretKey& ret_obj, int version) const;
 
-[[nodiscard]] CBLSSignature CActiveMasternodeManager::Sign(const uint256& hash) const
-{
-    AssertLockNotHeld(cs);
-    return WITH_READ_LOCK(cs, return m_info.blsKeyOperator.Sign(hash));
-}
-
 [[nodiscard]] CBLSSignature CActiveMasternodeManager::Sign(const uint256& hash, const bool is_legacy) const
 {
     AssertLockNotHeld(cs);

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -174,7 +174,6 @@ void CActiveMasternodeManager::InitInternal(const CBlockIndex* pindex)
 
     m_info.proTxHash = dmn->proTxHash;
     m_info.outpoint = dmn->collateralOutpoint;
-    m_info.legacy = dmn->pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION;
     m_state = MasternodeState::READY;
 }
 

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -22,7 +22,6 @@ struct CActiveMasternodeInfo {
     uint256 proTxHash;
     COutPoint outpoint;
     CService service;
-    bool legacy{true};
 
     CActiveMasternodeInfo(const CBLSSecretKey& blsKeyOperator, const CBLSPublicKey& blsPubKeyOperator) :
         blsKeyOperator(blsKeyOperator), blsPubKeyOperator(blsPubKeyOperator) {};
@@ -74,7 +73,6 @@ public:
     [[nodiscard]] uint256 GetProTxHash() const { READ_LOCK(cs); return m_info.proTxHash; }
     [[nodiscard]] CService GetService() const { READ_LOCK(cs); return m_info.service; }
     [[nodiscard]] CBLSPublicKey GetPubKey() const;
-    [[nodiscard]] bool IsLegacy() const { READ_LOCK(cs); return m_info.legacy; }
 
 private:
     void InitInternal(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -65,7 +65,6 @@ public:
     template <template <typename> class EncryptedObj, typename Obj>
     [[nodiscard]] bool Decrypt(const EncryptedObj<Obj>& obj, size_t idx, Obj& ret_obj, int version) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    [[nodiscard]] CBLSSignature Sign(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
     [[nodiscard]] CBLSSignature Sign(const uint256& hash, const bool is_legacy) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     /* TODO: Reconsider external locking */

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -653,7 +653,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
     tx.nVersion = 3;
     tx.nType = TRANSACTION_PROVIDER_REGISTER;
 
-    const bool use_legacy = isV19active ? specific_legacy_bls_scheme : true;
+    const bool use_legacy = specific_legacy_bls_scheme;
 
     CProRegTx ptx;
     ptx.nType = mnType;
@@ -1107,8 +1107,7 @@ static RPCHelpMan protx_update_registrar_wrapper(bool specific_legacy_bls_scheme
     ptx.keyIDVoting = dmn->pdmnState->keyIDVoting;
     ptx.scriptPayout = dmn->pdmnState->scriptPayout;
 
-    const bool isV19Active{DeploymentActiveAfter(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
-    const bool use_legacy = isV19Active ? specific_legacy_bls_scheme : true;
+    const bool use_legacy = specific_legacy_bls_scheme;
 
     if (request.params[1].get_str() != "") {
         // new pubkey

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1702,71 +1702,68 @@ static RPCHelpMan protx_help()
 
 static RPCHelpMan bls_generate()
 {
-    return RPCHelpMan{"bls generate",
+    return RPCHelpMan{
+        "bls generate",
         "\nReturns a BLS secret/public key pair.\n",
         {
             {"legacy", RPCArg::Type::BOOL, RPCArg::Default{false}, "Set it true if need in legacy BLS scheme"},
-            },
-        RPCResult{
-            RPCResult::Type::OBJ, "", "",
-            {
-                {RPCResult::Type::STR_HEX, "secret", "BLS secret key"},
-                {RPCResult::Type::STR_HEX, "public", "BLS public key"},
-                {RPCResult::Type::STR_HEX, "scheme", "BLS scheme (valid schemes: legacy, basic)"}
-            }},
-        RPCExamples{
-            HelpExampleCli("bls generate", "")
         },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    CBLSSecretKey sk;
-    sk.MakeNewKey();
-    bool bls_legacy_scheme{false};
-    if (!request.params[0].isNull()) {
-        bls_legacy_scheme = ParseBoolV(request.params[0], "bls_legacy_scheme");
-    }
-    UniValue ret(UniValue::VOBJ);
-    ret.pushKV("secret", sk.ToString());
-    ret.pushKV("public", sk.GetPublicKey().ToString(bls_legacy_scheme));
-    std::string bls_scheme_str = bls_legacy_scheme ? "legacy" : "basic";
-    ret.pushKV("scheme", bls_scheme_str);
-    return ret;
-},
+        RPCResult{RPCResult::Type::OBJ,
+                  "",
+                  "",
+                  {{RPCResult::Type::STR_HEX, "secret", "BLS secret key"},
+                   {RPCResult::Type::STR_HEX, "public", "BLS public key"},
+                   {RPCResult::Type::STR_HEX, "scheme", "BLS scheme (valid schemes: legacy, basic)"}}},
+        RPCExamples{HelpExampleCli("bls generate", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            CBLSSecretKey sk;
+            sk.MakeNewKey();
+            bool bls_legacy_scheme{false};
+            if (!request.params[0].isNull()) {
+                bls_legacy_scheme = ParseBoolV(request.params[0], "bls_legacy_scheme");
+            }
+            UniValue ret(UniValue::VOBJ);
+            ret.pushKV("secret", sk.ToString());
+            ret.pushKV("public", sk.GetPublicKey().ToString(bls_legacy_scheme));
+            std::string bls_scheme_str = bls_legacy_scheme ? "legacy" : "basic";
+            ret.pushKV("scheme", bls_scheme_str);
+            return ret;
+        },
     };
 }
 
 static RPCHelpMan bls_fromsecret()
 {
-    return RPCHelpMan{"bls fromsecret",
+    return RPCHelpMan{
+        "bls fromsecret",
         "\nParses a BLS secret key and returns the secret/public key pair.\n",
         {
             {"secret", RPCArg::Type::STR, RPCArg::Optional::NO, "The BLS secret key"},
             {"legacy", RPCArg::Type::BOOL, RPCArg::Default{false}, "Pass true if you need in legacy scheme"},
         },
-        RPCResult{
-            RPCResult::Type::OBJ, "", "",
-            {
-                {RPCResult::Type::STR_HEX, "secret", "BLS secret key"},
-                {RPCResult::Type::STR_HEX, "public", "BLS public key"},
-                {RPCResult::Type::STR_HEX, "scheme", "BLS scheme (valid schemes: legacy, basic)"},
-            }},
+        RPCResult{RPCResult::Type::OBJ,
+                  "",
+                  "",
+                  {
+                      {RPCResult::Type::STR_HEX, "secret", "BLS secret key"},
+                      {RPCResult::Type::STR_HEX, "public", "BLS public key"},
+                      {RPCResult::Type::STR_HEX, "scheme", "BLS scheme (valid schemes: legacy, basic)"},
+                  }},
         RPCExamples{
-            HelpExampleCli("bls fromsecret", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+            HelpExampleCli("bls fromsecret", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            bool bls_legacy_scheme{false};
+            if (!request.params[1].isNull()) {
+                bls_legacy_scheme = ParseBoolV(request.params[1], "bls_legacy_scheme");
+            }
+            CBLSSecretKey sk = ParseBLSSecretKey(request.params[0].get_str(), "secretKey");
+            UniValue ret(UniValue::VOBJ);
+            ret.pushKV("secret", sk.ToString());
+            ret.pushKV("public", sk.GetPublicKey().ToString(bls_legacy_scheme));
+            std::string bls_scheme_str = bls_legacy_scheme ? "legacy" : "basic";
+            ret.pushKV("scheme", bls_scheme_str);
+            return ret;
         },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    bool bls_legacy_scheme{false};
-    if (!request.params[1].isNull()) {
-        bls_legacy_scheme = ParseBoolV(request.params[1], "bls_legacy_scheme");
-    }
-    CBLSSecretKey sk = ParseBLSSecretKey(request.params[0].get_str(), "secretKey");
-    UniValue ret(UniValue::VOBJ);
-    ret.pushKV("secret", sk.ToString());
-    ret.pushKV("public", sk.GetPublicKey().ToString(bls_legacy_scheme));
-    std::string bls_scheme_str = bls_legacy_scheme ? "legacy" : "basic";
-    ret.pushKV("scheme", bls_scheme_str);
-    return ret;
-},
     };
 }
 

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -398,7 +398,7 @@ static RPCHelpMan protx_register_fund_wrapper(const bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    return protx_register_common_wrapper(request, legacy, ProTxRegisterAction::Fund, MnType::Regular);
+    return protx_register_common_wrapper(request, self.m_name == "protx register_fund_legacy", ProTxRegisterAction::Fund, MnType::Regular);
 },
     };
 }
@@ -445,7 +445,7 @@ static RPCHelpMan protx_register_wrapper(bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    return protx_register_common_wrapper(request, legacy, ProTxRegisterAction::External, MnType::Regular);
+    return protx_register_common_wrapper(request, self.m_name == "protx register_legacy", ProTxRegisterAction::External, MnType::Regular);
 },
     };
 }
@@ -493,7 +493,7 @@ static RPCHelpMan protx_register_prepare_wrapper(const bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    return protx_register_common_wrapper(request, legacy, ProTxRegisterAction::Prepare, MnType::Regular);
+    return protx_register_common_wrapper(request, self.m_name == "protx register_prepare_legacy", ProTxRegisterAction::Prepare, MnType::Regular);
 },
     };
 }
@@ -1060,7 +1060,7 @@ static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& reques
     return SignAndSendSpecialTx(request, chain_helper, chainman, tx);
 }
 
-static RPCHelpMan protx_update_registrar_wrapper(bool specific_legacy_bls_scheme)
+static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_scheme)
 {
     std::string rpc_name = specific_legacy_bls_scheme ? "update_registrar_legacy" : "update_registrar";
     std::string rpc_full_name = std::string("protx ").append(rpc_name);
@@ -1073,7 +1073,7 @@ static RPCHelpMan protx_update_registrar_wrapper(bool specific_legacy_bls_scheme
         + HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("proTxHash"),
-            specific_legacy_bls_scheme  ? GetRpcArg("operatorPubKey_update_legacy") : GetRpcArg("operatorPubKey_update"),
+            specific_legacy_bls_scheme ? GetRpcArg("operatorPubKey_update_legacy") : GetRpcArg("operatorPubKey_update"),
             GetRpcArg("votingAddress_update"),
             GetRpcArg("payoutAddress_update"),
             GetRpcArg("feeSourceAddress"),
@@ -1086,6 +1086,7 @@ static RPCHelpMan protx_update_registrar_wrapper(bool specific_legacy_bls_scheme
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    const bool use_legacy{self.m_name == "protx update_registrar_legacy"};
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const ChainstateManager& chainman = EnsureChainman(node);
 
@@ -1106,8 +1107,6 @@ static RPCHelpMan protx_update_registrar_wrapper(bool specific_legacy_bls_scheme
     }
     ptx.keyIDVoting = dmn->pdmnState->keyIDVoting;
     ptx.scriptPayout = dmn->pdmnState->scriptPayout;
-
-    const bool use_legacy = specific_legacy_bls_scheme;
 
     if (request.params[1].get_str() != "") {
         // new pubkey

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -307,13 +307,14 @@ static void SignSpecialTxPayloadByHash(const CMutableTransaction& tx, SpecialTxP
     }
 }
 
-template<typename SpecialTxPayload>
-static void SignSpecialTxPayloadByHash(const CMutableTransaction& tx, SpecialTxPayload& payload, const CBLSSecretKey& key)
+template <typename SpecialTxPayload>
+static void SignSpecialTxPayloadByHash(const CMutableTransaction& tx, SpecialTxPayload& payload,
+                                       const CBLSSecretKey& key, bool use_legacy)
 {
     UpdateSpecialTxInputsHash(tx, payload);
 
     uint256 hash = ::SerializeHash(payload);
-    payload.sig = key.Sign(hash);
+    payload.sig = key.Sign(hash, use_legacy);
 }
 
 static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, CChainstateHelper& chain_helper, const ChainstateManager& chainman, const CMutableTransaction& tx, bool fSubmit = true)
@@ -1054,7 +1055,7 @@ static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& reques
 
     FundSpecialTx(*wallet, tx, ptx, feeSource);
 
-    SignSpecialTxPayloadByHash(tx, ptx, keyOperator);
+    SignSpecialTxPayloadByHash(tx, ptx, keyOperator, !isV19active);
     SetTxPayload(tx, ptx);
 
     return SignAndSendSpecialTx(request, chain_helper, chainman, tx);
@@ -1254,7 +1255,7 @@ static RPCHelpMan protx_revoke()
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No payout or fee source addresses found, can't revoke");
     }
 
-    SignSpecialTxPayloadByHash(tx, ptx, keyOperator);
+    SignSpecialTxPayloadByHash(tx, ptx, keyOperator, !isV19active);
     SetTxPayload(tx, ptx);
 
     return SignAndSendSpecialTx(request, chain_helper, chainman, tx);

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1705,7 +1705,7 @@ static RPCHelpMan bls_generate()
     return RPCHelpMan{"bls generate",
         "\nReturns a BLS secret/public key pair.\n",
         {
-            {"legacy", RPCArg::Type::BOOL, RPCArg::DefaultHint{"true until the v19 fork is activated, otherwise false"}, "Use legacy BLS scheme"},
+            {"legacy", RPCArg::Type::BOOL, RPCArg::Default{false}, "Set it true if need in legacy BLS scheme"},
             },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -1719,12 +1719,9 @@ static RPCHelpMan bls_generate()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
     CBLSSecretKey sk;
     sk.MakeNewKey();
-    bool bls_legacy_scheme{!DeploymentActiveAfter(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
+    bool bls_legacy_scheme{false};
     if (!request.params[0].isNull()) {
         bls_legacy_scheme = ParseBoolV(request.params[0], "bls_legacy_scheme");
     }
@@ -1744,7 +1741,7 @@ static RPCHelpMan bls_fromsecret()
         "\nParses a BLS secret key and returns the secret/public key pair.\n",
         {
             {"secret", RPCArg::Type::STR, RPCArg::Optional::NO, "The BLS secret key"},
-            {"legacy", RPCArg::Type::BOOL, RPCArg::DefaultHint{"true until the v19 fork is activated, otherwise false"}, "Use legacy BLS scheme"},
+            {"legacy", RPCArg::Type::BOOL, RPCArg::Default{false}, "Pass true if you need in legacy scheme"},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -1758,10 +1755,7 @@ static RPCHelpMan bls_fromsecret()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    bool bls_legacy_scheme{!DeploymentActiveAfter(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
+    bool bls_legacy_scheme{false};
     if (!request.params[1].isNull()) {
         bls_legacy_scheme = ParseBoolV(request.params[1], "bls_legacy_scheme");
     }

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -313,11 +313,10 @@ static RPCHelpMan gobject_submit()
     if (node.mn_activeman) {
         const bool fMnFound = mnList.HasValidMNByCollateral(node.mn_activeman->GetOutPoint());
 
-        LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
-                 node.mn_activeman->GetPubKey().ToString(node.mn_activeman->IsLegacy()),
-                 node.mn_activeman->GetOutPoint().ToStringShort(),
-                 request.params.size(),
-                 fMnFound);
+        LogPrint(BCLog::GOBJECT, /* Continued */
+                 "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
+                 node.mn_activeman->GetPubKey().ToString(false), node.mn_activeman->GetOutPoint().ToStringShort(),
+                 request.params.size(), fMnFound);
     } else {
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = N/A, outpoint = N/A, params.size() = %lld, fMnFound = %d\n",
                  request.params.size(),

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -63,19 +63,21 @@ void FuncSetHexStr(const bool legacy_scheme)
 {
     bls::bls_legacy_scheme.store(legacy_scheme);
 
+    // Note: 2nd bool argument for SetHexStr for bls::PrivateKey has a meaning modOrder, not is-legacy
     CBLSSecretKey sk;
     std::string strValidSecret = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
     // Note: invalid string passed to SetHexStr() should cause it to fail and reset key internal data
-    BOOST_CHECK(sk.SetHexStr(strValidSecret, legacy_scheme));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1g", legacy_scheme)); // non-hex
+    BOOST_CHECK(sk.SetHexStr(strValidSecret, false));
+    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1g", false)); // non-hex
     BOOST_CHECK(!sk.IsValid());
     BOOST_CHECK(sk == CBLSSecretKey());
     // Try few more invalid strings
-    BOOST_CHECK(sk.SetHexStr(strValidSecret, legacy_scheme));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e", legacy_scheme)); // hex but too short
+    BOOST_CHECK(sk.SetHexStr(strValidSecret, false));
+    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e", false)); // hex but too short
     BOOST_CHECK(!sk.IsValid());
-    BOOST_CHECK(sk.SetHexStr(strValidSecret, legacy_scheme));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", legacy_scheme)); // hex but too long
+    BOOST_CHECK(sk.SetHexStr(strValidSecret, false));
+    BOOST_CHECK(
+        !sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", false)); // hex but too long
     BOOST_CHECK(!sk.IsValid());
 
     return;

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -24,8 +24,8 @@ void FuncSign(const bool legacy_scheme)
     uint256 msgHash1 = uint256::ONE;
     uint256 msgHash2 = uint256::TWO;
 
-    auto sig1 = sk1.Sign(msgHash1);
-    auto sig2 = sk2.Sign(msgHash1);
+    auto sig1 = sk1.Sign(msgHash1, legacy_scheme);
+    auto sig2 = sk2.Sign(msgHash1, legacy_scheme);
     BOOST_CHECK(sig1.VerifyInsecure(sk1.GetPublicKey(), msgHash1));
     BOOST_CHECK(!sig1.VerifyInsecure(sk1.GetPublicKey(), msgHash2));
     BOOST_CHECK(!sig2.VerifyInsecure(sk1.GetPublicKey(), msgHash1));
@@ -44,7 +44,7 @@ void FuncSerialize(const bool legacy_scheme)
     uint256 msgHash = uint256::ONE;
 
     sk.MakeNewKey();
-    CBLSSignature sig1 = sk.Sign(msgHash);
+    CBLSSignature sig1 = sk.Sign(msgHash, legacy_scheme);
     ds2 << sig1;
     ds3 << CBLSSignatureVersionWrapper(const_cast<CBLSSignature&>(sig1), !legacy_scheme);
 
@@ -102,7 +102,7 @@ void FuncKeyAgg(const bool legacy_scheme)
     uint256 msgHash1 = uint256::ONE;
     uint256 msgHash2 = uint256::TWO;
 
-    auto sig = ag_sk.Sign(msgHash1);
+    auto sig = ag_sk.Sign(msgHash1, legacy_scheme);
     BOOST_CHECK(sig.VerifyInsecure(ag_pk, msgHash1));
     BOOST_CHECK(!sig.VerifyInsecure(ag_pk, msgHash2));
 }
@@ -144,7 +144,7 @@ void FuncKeyAggVec(const bool legacy_scheme)
     uint256 msgHash1 = uint256::ONE;
     uint256 msgHash2 = uint256::TWO;
 
-    auto sig = ag_sk.Sign(msgHash1);
+    auto sig = ag_sk.Sign(msgHash1, legacy_scheme);
     BOOST_CHECK(sig.VerifyInsecure(ag_pk, msgHash1));
     BOOST_CHECK(!sig.VerifyInsecure(ag_pk, msgHash2));
 }
@@ -170,7 +170,7 @@ void FuncSigAggSub(const bool legacy_scheme)
         vec_pks.push_back(sk.GetPublicKey());
         hash = GetRandHash();
         vec_hashes.push_back(hash);
-        CBLSSignature sig_i = sk.Sign(hash);
+        CBLSSignature sig_i = sk.Sign(hash, legacy_scheme);
         vec_sigs.push_back(sig_i);
         if (i == 0) {
             // first sig is assigned directly
@@ -221,7 +221,7 @@ void FuncSigAggSecure(const bool legacy_scheme)
     for (int i = 0; i < count; i++) {
         sk.MakeNewKey();
         vec_pks.push_back(sk.GetPublicKey());
-        vec_sigs.push_back(sk.Sign(hash));
+        vec_sigs.push_back(sk.Sign(hash, legacy_scheme));
     }
 
     auto sec_agg_sig = CBLSSignature::AggregateSecure(vec_sigs, vec_pks, hash);
@@ -264,19 +264,20 @@ struct Message
 
 static void AddMessage(std::vector<Message>& vec, uint32_t sourceId, uint32_t msgId, uint8_t msgHash, bool valid)
 {
+    bool legacy_scheme = bls::bls_legacy_scheme.load();
     Message m;
     m.sourceId = sourceId;
     m.msgId = msgId;
     m.msgHash = uint256(msgHash);
     m.sk.MakeNewKey();
     m.pk = m.sk.GetPublicKey();
-    m.sig = m.sk.Sign(m.msgHash);
+    m.sig = m.sk.Sign(m.msgHash, legacy_scheme);
     m.valid = valid;
 
     if (!valid) {
         CBLSSecretKey tmp;
         tmp.MakeNewKey();
-        m.sig = tmp.Sign(m.msgHash);
+        m.sig = tmp.Sign(m.msgHash, legacy_scheme);
     }
 
     vec.emplace_back(m);
@@ -381,7 +382,7 @@ void FuncThresholdSignature(const bool legacy_scheme)
 
     CBLSSecretKey thr_sk = v_threshold_sks[0];
     CBLSPublicKey thr_pk = v_threshold_pks[0];
-    CBLSSignature thr_sig = thr_sk.Sign(hash);
+    CBLSSignature thr_sig = thr_sk.Sign(hash, legacy_scheme);
 
     std::vector<CBLSId> v_size_ids;
     std::vector<CBLSSecretKey> v_size_sk_shares;
@@ -398,7 +399,7 @@ void FuncThresholdSignature(const bool legacy_scheme)
         std::vector<CBLSSignature> v_share_sigs;
         std::vector<CBLSId> v_share_ids;
         for ([[maybe_unused]] const auto j : irange::range(m_shares)) {
-            v_share_sigs.emplace_back(v_size_sk_shares[j].Sign(hash));
+            v_share_sigs.emplace_back(v_size_sk_shares[j].Sign(hash, legacy_scheme));
             BOOST_CHECK(v_share_sigs.back().VerifyInsecure(v_size_pk_shares[j], hash));
             v_share_ids.push_back(v_size_ids[j]);
         }

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -132,7 +132,7 @@ static CMutableTransaction CreateProUpServTx(const CChain& active_chain, const C
     tx.nType = TRANSACTION_PROVIDER_UPDATE_SERVICE;
     FundTransaction(active_chain, tx, utxos, GetScriptForDestination(PKHash(coinbaseKey.GetPubKey())), 1 * COIN, coinbaseKey);
     proTx.inputsHash = CalcTxInputsHash(CTransaction(tx));
-    proTx.sig = operatorKey.Sign(::SerializeHash(proTx));
+    proTx.sig = operatorKey.Sign(::SerializeHash(proTx), bls::bls_legacy_scheme);
     SetTxPayload(tx, proTx);
     SignTransaction(mempool, tx, coinbaseKey);
 
@@ -171,7 +171,7 @@ static CMutableTransaction CreateProUpRevTx(const CChain& active_chain, const CT
     tx.nType = TRANSACTION_PROVIDER_UPDATE_REVOKE;
     FundTransaction(active_chain, tx, utxos, GetScriptForDestination(PKHash(coinbaseKey.GetPubKey())), 1 * COIN, coinbaseKey);
     proTx.inputsHash = CalcTxInputsHash(CTransaction(tx));
-    proTx.sig = operatorKey.Sign(::SerializeHash(proTx));
+    proTx.sig = operatorKey.Sign(::SerializeHash(proTx), bls::bls_legacy_scheme);
     SetTxPayload(tx, proTx);
     SignTransaction(mempool, tx, coinbaseKey);
 

--- a/src/test/evo_mnhf_tests.cpp
+++ b/src/test/evo_mnhf_tests.cpp
@@ -60,9 +60,10 @@ BOOST_AUTO_TEST_CASE(verify_mnhf_specialtx_tests)
     BOOST_CHECK(ag_sk.IsValid());
     BOOST_CHECK(ag_pk.IsValid());
 
+    const bool use_legacy{false};
     uint256 verHash = uint256S(ToString(bit));
-    auto sig = ag_sk.Sign(verHash);
-    BOOST_CHECK(sig.VerifyInsecure(ag_pk, verHash));
+    auto sig = ag_sk.Sign(verHash, use_legacy);
+    BOOST_CHECK(sig.VerifyInsecure(ag_pk, verHash, use_legacy));
 
     auto& chainman = Assert(m_node.chainman);
     auto& qman = *Assert(m_node.llmq_ctx)->qman;

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -543,7 +543,7 @@ BOOST_AUTO_TEST_CASE(rpc_bls)
     UniValue r;
 
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls generate")));
-    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "basic");
 
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls generate 1")));
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
@@ -555,15 +555,15 @@ BOOST_AUTO_TEST_CASE(rpc_bls)
     std::string secret_basic = find_value(r.get_obj(), "secret").get_str();
     std::string public_basic = find_value(r.get_obj(), "public").get_str();
 
-    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_legacy));
-    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
-    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), public_legacy);
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_basic));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "basic");
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), public_basic);
 
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_legacy + std::string(" 1")));
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), public_legacy);
 
-    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_legacy + std::string(" 0")));
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_basic + std::string(" 0")));
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "basic");
     BOOST_CHECK(find_value(r.get_obj(), "public").get_str() != public_legacy);
 
@@ -576,10 +576,10 @@ BOOST_AUTO_TEST_CASE(rpc_bls)
     BOOST_CHECK(find_value(r.get_obj(), "public").get_str() != public_basic);
 
     std::string secret = "0b072b1b8b28335b0460aa695ee8ce1f60dc01e6eb12655ece2a877379dfdb51";
-    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret));
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret + " 1"));
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), "9379c28e0f50546906fe733f1222c8f7e39574d513790034f1fec1476286eb652a350c8c0e630cd2cc60d10c26d6f6ee");
-    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret + " 0"));
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret));
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "basic");
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), "b379c28e0f50546906fe733f1222c8f7e39574d513790034f1fec1476286eb652a350c8c0e630cd2cc60d10c26d6f6ee");
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4042,6 +4042,9 @@ bool TestBlockValidity(BlockValidationState& state,
     AssertLockHeld(cs_main);
     assert(pindexPrev && pindexPrev == chainstate.m_chain.Tip());
 
+    // TODO: instead restoring bls_legacy_scheme better to keep it unchanged
+    // Moreover, current implementation is working incorrent if current function
+    // will return value too early due to error: old value won't be restored
     auto bls_legacy_scheme = bls::bls_legacy_scheme.load();
 
     uint256 hash = block.GetHash();

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -211,7 +211,7 @@ class DIP3Test(BitcoinTestFramework):
         assert old_voting_address != new_voting_address
         # also check if funds from payout address are used when no fee source address is specified
         node.sendtoaddress(mn.rewards_address, 0.001)
-        node.protx('update_registrar', mn.protx_hash, "", new_voting_address, "")
+        node.protx('update_registrar' if softfork_active(node, 'v19') else 'update_registrar_legacy', mn.protx_hash, "", new_voting_address, "")
         self.generate(node, 1)
         new_dmnState = mn.node.masternode("status")["dmnState"]
         new_voting_address_from_rpc = new_dmnState["votingAddress"]
@@ -254,7 +254,7 @@ class DIP3Test(BitcoinTestFramework):
         mn.collateral_address = node.getnewaddress()
         mn.rewards_address = node.getnewaddress()
 
-        mn.protx_hash = node.protx('register_fund', mn.collateral_address, '127.0.0.1:%d' % mn.p2p_port, mn.ownerAddr, mn.operatorAddr, mn.votingAddr, mn.operator_reward, mn.rewards_address, mn.fundsAddr)
+        mn.protx_hash = node.protx('register_fund' if softfork_active(node, 'v19') else 'register_fund_legacy', mn.collateral_address, '127.0.0.1:%d' % mn.p2p_port, mn.ownerAddr, mn.operatorAddr, mn.votingAddr, mn.operator_reward, mn.rewards_address, mn.fundsAddr)
         mn.collateral_txid = mn.protx_hash
         mn.collateral_vout = None
 
@@ -270,7 +270,7 @@ class DIP3Test(BitcoinTestFramework):
         node.sendtoaddress(mn.fundsAddr, 0.001)
         mn.rewards_address = node.getnewaddress()
 
-        mn.protx_hash = node.protx('register', mn.collateral_txid, mn.collateral_vout, '127.0.0.1:%d' % mn.p2p_port, mn.ownerAddr, mn.operatorAddr, mn.votingAddr, mn.operator_reward, mn.rewards_address, mn.fundsAddr)
+        mn.protx_hash = node.protx('register' if softfork_active(node, 'v19') else 'register_legacy', mn.collateral_txid, mn.collateral_vout, '127.0.0.1:%d' % mn.p2p_port, mn.ownerAddr, mn.operatorAddr, mn.votingAddr, mn.operator_reward, mn.rewards_address, mn.fundsAddr)
         self.generate(node, 1, sync_fun=self.no_op)
 
     def start_mn(self, mn):
@@ -288,7 +288,7 @@ class DIP3Test(BitcoinTestFramework):
 
     def update_mn_payee(self, mn, payee):
         self.nodes[0].sendtoaddress(mn.fundsAddr, 0.001)
-        self.nodes[0].protx('update_registrar', mn.protx_hash, '', '', payee, mn.fundsAddr)
+        self.nodes[0].protx('update_registrar' if softfork_active(self.nodes[0], 'v19') else 'update_registrar_legacy', mn.protx_hash, '', '', payee, mn.fundsAddr)
         self.generate(self.nodes[0], 1)
         info = self.nodes[0].protx('info', mn.protx_hash)
         assert info['state']['payoutAddress'] == payee

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -12,7 +12,7 @@ from decimal import Decimal
 from test_framework.blocktools import create_block_with_mnpayments
 from test_framework.messages import tx_from_hex
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, force_finish_mnsync, p2p_port
+from test_framework.util import assert_equal, force_finish_mnsync, p2p_port, softfork_active
 
 class Masternode(object):
     pass
@@ -226,7 +226,7 @@ class DIP3Test(BitcoinTestFramework):
         mn.p2p_port = p2p_port(mn.idx)
         mn.operator_reward = (mn.idx % self.num_initial_mn)
 
-        blsKey = node.bls('generate')
+        blsKey = node.bls('generate') if softfork_active(node, 'v19') else node.bls('generate', True)
         mn.fundsAddr = node.getnewaddress()
         mn.ownerAddr = node.getnewaddress()
         mn.operatorAddr = blsKey['public']

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1303,7 +1303,8 @@ class DashTestFramework(BitcoinTestFramework):
         return created_mn_info
 
     def dynamically_prepare_masternode(self, idx, node_p2p_port, evo=False, rnd=None):
-        bls = self.nodes[0].bls('generate') if softfork_active(self.nodes[0], 'v19') else self.nodes[0].bls('generate', True)
+        v19_active = softfork_active(self.nodes[0], 'v19')
+        bls = self.nodes[0].bls('generate') if v19_active else self.nodes[0].bls('generate', True)
         collateral_address = self.nodes[0].getnewaddress()
         funds_address = self.nodes[0].getnewaddress()
         owner_address = self.nodes[0].getnewaddress()
@@ -1336,7 +1337,7 @@ class DashTestFramework(BitcoinTestFramework):
         if evo:
             protx_result = self.nodes[0].protx("register_evo", collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, platform_node_id, platform_p2p_port, platform_http_port, funds_address, True)
         else:
-            protx_result = self.nodes[0].protx("register", collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, funds_address, True)
+            protx_result = self.nodes[0].protx("register" if v19_active else "register_legacy", collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, funds_address, True)
 
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         tip = self.generate(self.nodes[0], 1)[0]
@@ -1387,7 +1388,9 @@ class DashTestFramework(BitcoinTestFramework):
 
         register_fund = (idx % 2) == 0
 
-        bls = self.nodes[0].bls('generate') if softfork_active(self.nodes[0], 'v19') else self.nodes[0].bls('generate', True)
+        v19_active = softfork_active(self.nodes[0], 'v19')
+
+        bls = self.nodes[0].bls('generate') if v19_active else self.nodes[0].bls('generate', True)
         address = self.nodes[0].getnewaddress()
 
         collateral_amount = MASTERNODE_COLLATERAL
@@ -1416,10 +1419,10 @@ class DashTestFramework(BitcoinTestFramework):
         submit = (idx % 4) < 2
 
         if register_fund:
-            protx_result = self.nodes[0].protx('register_fund', address, ipAndPort, ownerAddr, bls['public'], votingAddr, operatorReward, rewardsAddr, address, submit)
+            protx_result = self.nodes[0].protx('register_fund' if v19_active else 'register_fund_legacy', address, ipAndPort, ownerAddr, bls['public'], votingAddr, operatorReward, rewardsAddr, address, submit)
         else:
             self.generate(self.nodes[0], 1, sync_fun=self.no_op)
-            protx_result = self.nodes[0].protx('register', txid, collateral_vout, ipAndPort, ownerAddr, bls['public'], votingAddr, operatorReward, rewardsAddr, address, submit)
+            protx_result = self.nodes[0].protx('register' if v19_active else 'register_legacy', txid, collateral_vout, ipAndPort, ownerAddr, bls['public'], votingAddr, operatorReward, rewardsAddr, address, submit)
 
         if submit:
             proTxHash = protx_result

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1303,7 +1303,7 @@ class DashTestFramework(BitcoinTestFramework):
         return created_mn_info
 
     def dynamically_prepare_masternode(self, idx, node_p2p_port, evo=False, rnd=None):
-        bls = self.nodes[0].bls('generate')
+        bls = self.nodes[0].bls('generate') if softfork_active(self.nodes[0], 'v19') else self.nodes[0].bls('generate', True)
         collateral_address = self.nodes[0].getnewaddress()
         funds_address = self.nodes[0].getnewaddress()
         owner_address = self.nodes[0].getnewaddress()
@@ -1387,7 +1387,7 @@ class DashTestFramework(BitcoinTestFramework):
 
         register_fund = (idx % 2) == 0
 
-        bls = self.nodes[0].bls('generate')
+        bls = self.nodes[0].bls('generate') if softfork_active(self.nodes[0], 'v19') else self.nodes[0].bls('generate', True)
         address = self.nodes[0].getnewaddress()
 
         collateral_amount = MASTERNODE_COLLATERAL


### PR DESCRIPTION
## Issue being fixed or feature implemented

Many usages of CBLS{Signature,PrivateKey,PublicKey} assume using global variable, even if it can be specified explicitly in some situations.

These over-usages of `bls::bls_legacy_scheme` are blocker for changing buried height of activation of fork `V19` on Regtest.
This PR helps unblock changing v19 height on RegTest, see: https://github.com/dashpay/dash/pull/6511

Prior improvements for BLS: https://github.com/dashpay/dash/pull/5443

## What was done?
This PR does:
 - fixes Undefined Behavior in rpc `protx register_legacy`, `protx register_fund_legacy`, `protx resiter_prepare_legacy`, `protx update_registrar_legacy`
 - drop flag "is legacy" from secret key initialization and serialization (as it has no difference)
 - enforce specifying legacy flag to bls functions `Sign`, `ToByteVector` and in a helper `SignSpecialTxPayloadByHash`
 - removed unused methods from bls_ies.h and optimized headers usages
 - enforce p2p message `mnauth` to use Basic BLS scheme
 - enforce using flag `legacy` in RPC `bls generate` and `bls fromsecret` instead guessing which one user want based on v19 activation status.

## How Has This Been Tested?
Run unit and functional tests; update testing framework `test_framework.py` to use `_legacy` RPCs which has been ignored before.

Reindex testnet `src/qt/dash-qt -reindex -testnet -assumevalid=0` - SUCCEED
Reindex mainnet `src/qt/dash-qt -reindex  -assumevalid=0` - SUCCEED

## Breaking Changes
On RegTest RPC: `bls generate`, `bls fromsecret` should pass flag `is_legacy` for pre-v19 blocks
On RegTest RPC: `protx register_legacy`, `protx register_fund_legacy`, `protx register_prepare_legacy`, `protx update_registrar_legacy` should be used in pre-v19 blocks.


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone