### PR TITLE
ci: avoid killing the CI script itself on functional test error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ image: "ubuntu:jammy"
 variables:
   DOCKER_DRIVER: overlay2
   FAST_MODE: "false" # when "true", only run linter on arm and unit/functional tests on linux64, skip everything else
+  CI_FAILFAST_TEST_LEAVE_DANGLING: "1"  # Gitlab CI does not care about dangling process and setting this variable avoids killing the CI script itself on error
 
 workflow:
   rules:


### PR DESCRIPTION
## Issue being fixed or feature implemented
We kill CI script on test errors and it can't collect logs.

## What was done?
Set `CI_FAILFAST_TEST_LEAVE_DANGLING` env variable to avoid that.

## How Has This Been Tested?
1a692269649af582e2cc142a2c0759d58511b33e: https://gitlab.com/dashpay/dash/-/jobs/8727924503

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

