### PR TITLE
refactor: make SEMToString / SEMFromString constexpr by using string_view

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -688,9 +688,9 @@ static RPCHelpMan getnetworkinfo()
         obj.pushKV("connections_mn",   (int)node.connman->GetNodeCount(ConnectionDirection::Verified));
         obj.pushKV("connections_mn_in",   (int)node.connman->GetNodeCount(ConnectionDirection::VerifiedIn));
         obj.pushKV("connections_mn_out",   (int)node.connman->GetNodeCount(ConnectionDirection::VerifiedOut));
-        std::string sem_str = SEMToString(node.connman->GetSocketEventsMode());
+        std::string_view sem_str = SEMToString(node.connman->GetSocketEventsMode());
         CHECK_NONFATAL(sem_str != "unknown");
-        obj.pushKV("socketevents", sem_str);
+        obj.pushKV("socketevents", std::string(sem_str));
     }
     obj.pushKV("networks",      GetNetworksInfo());
     obj.pushKV("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK()));

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -29,8 +29,7 @@ enum class SocketEventsMode : int8_t {
 };
 
 /* Converts SocketEventsMode value to string with additional check to report modes not compiled for as unknown */
-static std::string SEMToString(const SocketEventsMode val)
-{
+constexpr std::string_view SEMToString(const SocketEventsMode val) {
     switch (val) {
         case (SocketEventsMode::Select):
             return "select";
@@ -52,19 +51,18 @@ static std::string SEMToString(const SocketEventsMode val)
 }
 
 /* Converts string to SocketEventsMode value with additional check to report modes not compiled for as unknown */
-static SocketEventsMode SEMFromString(const std::string str)
-{
+constexpr SocketEventsMode SEMFromString(std::string_view str) {
     if (str == "select") { return SocketEventsMode::Select; }
 #ifdef USE_POLL
-    else if (str == "poll")   { return SocketEventsMode::Poll;   }
+    if (str == "poll")   { return SocketEventsMode::Poll;   }
 #endif /* USE_POLL */
 #ifdef USE_EPOLL
-    else if (str == "epoll")  { return SocketEventsMode::EPoll;  }
+    if (str == "epoll")  { return SocketEventsMode::EPoll;  }
 #endif /* USE_EPOLL */
 #ifdef USE_KQUEUE
-    else if (str == "kqueue") { return SocketEventsMode::KQueue; }
+    if (str == "kqueue") { return SocketEventsMode::KQueue; }
 #endif /* USE_KQUEUE */
-    else { return SocketEventsMode::Unknown; }
+    return SocketEventsMode::Unknown;
 }
 
 /**


### PR DESCRIPTION
## Issue being fixed or feature implemented
Apple clang version 16.0.0 (clang-1600.0.26.6) reports warnings such as:
```
./util/sock.h:32:20: warning: unused function 'SEMToString' [-Wunused-function]
   32 | static std::string SEMToString(const SocketEventsMode val)
      |                    ^~~~~~~~~~~
./util/sock.h:55:25: warning: unused function 'SEMFromString' [-Wunused-function]
   55 | static SocketEventsMode SEMFromString(const std::string str)
      |                         ^~~~~~~~~~~~~
```


## What was done?
Converted these functions from static to constexpr, this results in these warnings being resolved

## How Has This Been Tested?
Compiled

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

