### PR TITLE
refactor: drop unneeded cs_main lock

### DIFF
--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -506,7 +506,6 @@ bool ProcessPendingMessageBatch(const CConnman& connman, CDKGSession& session, C
 
     auto badNodes = BatchVerifyMessageSigs(session, preverifiedMessages);
     if (!badNodes.empty()) {
-        LOCK(cs_main);
         for (auto nodeId : badNodes) {
             LogPrint(BCLog::LLMQ_DKG, "%s -- failed to verify signature, peer=%d\n", __func__, nodeId);
             pendingMessages.Misbehaving(nodeId, 100, peerman);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Don't lock cs_main where not needed

## What was done?
Don't hold cs_main where annotations don't say it's needed

## How Has This Been Tested?
Compiled w/o error

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

