### PR TITLE
perf: introduce ToBytes in bls.h and use it in all spots trivially possible, convert vecBytes to std::array

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -240,10 +240,7 @@ struct CBLSIdImplicit : public uint256
     {
         return {begin(), end()};
     }
-    [[nodiscard]] std::array<uint8_t, 32> SerializeToArray(const bool fLegacy) const
-    {
-        return m_data;
-    }
+    [[nodiscard]] std::array<uint8_t, 32> SerializeToArray(const bool fLegacy) const { return m_data; }
 };
 
 class CBLSId : public CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>
@@ -399,8 +396,8 @@ private:
 
 public:
     CBLSLazyWrapper() :
-            vecBytes{0},
-            bufLegacyScheme(bls::bls_legacy_scheme.load())
+        vecBytes{0},
+        bufLegacyScheme(bls::bls_legacy_scheme.load())
     {}
 
     explicit CBLSLazyWrapper(const CBLSLazyWrapper& r)

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -129,6 +129,9 @@ public:
 
     std::array<uint8_t, SerSize> ToBytes(const bool specificLegacyScheme) const
     {
+        if (!fValid) {
+            return std::array<uint8_t, SerSize>{};
+        }
         return impl.SerializeToArray(specificLegacyScheme);
     }
 
@@ -163,7 +166,8 @@ public:
     template <typename Stream>
     inline void Serialize(Stream& s, const bool specificLegacyScheme) const
     {
-        s.write(AsBytes(Span{ToBytes(specificLegacyScheme).data(), SerSize}));
+        const auto bytes{ToBytes(specificLegacyScheme)};
+        s.write(AsBytes(Span{bytes.data(), SerSize}));
     }
 
     template <typename Stream>
@@ -202,7 +206,8 @@ public:
 
     inline bool CheckMalleable(Span<uint8_t> vecBytes, const bool specificLegacyScheme) const
     {
-        if (memcmp(vecBytes.data(), ToBytes(specificLegacyScheme).data(), SerSize)) {
+        const auto bytes{ToBytes(specificLegacyScheme)};
+        if (memcmp(vecBytes.data(), bytes.data(), SerSize)) {
             // TODO not sure if this is actually possible with the BLS libs. I'm assuming here that somewhere deep inside
             // these libs masking might happen, so that 2 different binary representations could result in the same object
             // representation
@@ -396,7 +401,7 @@ private:
 
 public:
     CBLSLazyWrapper() :
-        vecBytes{0},
+        vecBytes{},
         bufLegacyScheme(bls::bls_legacy_scheme.load())
     {}
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -99,7 +99,7 @@ public:
         *(static_cast<C*>(this)) = C();
     }
 
-    void SetByteVector(Span<const uint8_t> vecBytes, const bool specificLegacyScheme)
+    void SetBytes(Span<const uint8_t> vecBytes, const bool specificLegacyScheme)
     {
         if (vecBytes.size() != SerSize) {
             Reset();
@@ -146,7 +146,7 @@ public:
             Reset();
             return false;
         }
-        SetByteVector(b, specificLegacyScheme);
+        SetBytes(b, specificLegacyScheme);
         return IsValid();
     }
 
@@ -172,12 +172,12 @@ public:
     {
         std::array<uint8_t, SerSize> vecBytes{};
         s.read(AsWritableBytes(Span{vecBytes.data(), SerSize}));
-        SetByteVector(vecBytes, specificLegacyScheme);
+        SetBytes(vecBytes, specificLegacyScheme);
 
         if (!CheckMalleable(vecBytes, specificLegacyScheme)) {
             // If CheckMalleable failed with specificLegacyScheme, we need to try again with the opposite scheme.
             // Probably we received the BLS object sent with legacy scheme, but in the meanwhile the fork activated.
-            SetByteVector(vecBytes, !specificLegacyScheme);
+            SetBytes(vecBytes, !specificLegacyScheme);
             if (!CheckMalleable(vecBytes, !specificLegacyScheme)) {
                 // Both attempts failed
                 throw std::ios_base::failure("malleable BLS object");
@@ -262,7 +262,7 @@ public:
     explicit CBLSSecretKey(Span<const unsigned char> vecBytes)
     {
         // The second param here is not 'is_legacy', but `modOrder`
-        SetByteVector(vecBytes, false);
+        SetBytes(vecBytes, false);
     }
     CBLSSecretKey(const CBLSSecretKey&) = default;
     CBLSSecretKey& operator=(const CBLSSecretKey&) = default;
@@ -334,7 +334,7 @@ public:
     CBLSSignature() = default;
     explicit CBLSSignature(Span<const unsigned char> bytes, bool is_serialized_legacy)
     {
-        SetByteVector(bytes, is_serialized_legacy);
+        SetBytes(bytes, is_serialized_legacy);
     }
     CBLSSignature(const CBLSSignature&) = default;
     CBLSSignature& operator=(const CBLSSignature&) = default;
@@ -482,7 +482,7 @@ public:
             return invalidObj;
         }
         if (!objInitialized) {
-            obj.SetByteVector(vecBytes, bufLegacyScheme);
+            obj.SetBytes(vecBytes, bufLegacyScheme);
             if (!obj.IsValid()) {
                 bufValid = false;
                 return invalidObj;

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -127,6 +127,11 @@ public:
         return impl.Serialize(specificLegacyScheme);
     }
 
+    std::array<uint8_t, SerSize> ToBytes(const bool specificLegacyScheme) const
+    {
+        return impl.SerializeToArray(specificLegacyScheme);
+    }
+
     const uint256& GetHash() const
     {
         if (cachedHash.IsNull()) {
@@ -158,7 +163,7 @@ public:
     template <typename Stream>
     inline void Serialize(Stream& s, const bool specificLegacyScheme) const
     {
-        s.write(AsBytes(Span{ToByteVector(specificLegacyScheme).data(), SerSize}));
+        s.write(AsBytes(Span{ToBytes(specificLegacyScheme).data(), SerSize}));
     }
 
     template <typename Stream>
@@ -197,7 +202,7 @@ public:
 
     inline bool CheckMalleable(Span<uint8_t> vecBytes, const bool specificLegacyScheme) const
     {
-        if (memcmp(vecBytes.data(), ToByteVector(specificLegacyScheme).data(), SerSize)) {
+        if (memcmp(vecBytes.data(), ToBytes(specificLegacyScheme).data(), SerSize)) {
             // TODO not sure if this is actually possible with the BLS libs. I'm assuming here that somewhere deep inside
             // these libs masking might happen, so that 2 different binary representations could result in the same object
             // representation
@@ -208,7 +213,7 @@ public:
 
     inline std::string ToString(const bool specificLegacyScheme) const
     {
-        std::vector<uint8_t> buf = ToByteVector(specificLegacyScheme);
+        auto buf = ToBytes(specificLegacyScheme);
         return HexStr(buf);
     }
 
@@ -234,6 +239,10 @@ struct CBLSIdImplicit : public uint256
     [[nodiscard]] std::vector<uint8_t> Serialize(const bool fLegacy) const
     {
         return {begin(), end()};
+    }
+    [[nodiscard]] std::array<uint8_t, 32> SerializeToArray(const bool fLegacy) const
+    {
+        return m_data;
     }
 };
 
@@ -379,7 +388,7 @@ class CBLSLazyWrapper
 private:
     mutable std::mutex mutex;
 
-    mutable std::vector<uint8_t> vecBytes;
+    mutable std::array<uint8_t, BLSObject::SerSize> vecBytes;
     mutable bool bufValid{false};
     mutable bool bufLegacyScheme{true};
 
@@ -390,7 +399,7 @@ private:
 
 public:
     CBLSLazyWrapper() :
-            vecBytes(BLSObject::SerSize, 0),
+            vecBytes{0},
             bufLegacyScheme(bls::bls_legacy_scheme.load())
     {}
 
@@ -408,7 +417,6 @@ public:
         if (r.bufValid) {
             vecBytes = r.vecBytes;
         } else {
-            vecBytes.resize(BLSObject::SerSize);
             std::fill(vecBytes.begin(), vecBytes.end(), 0);
         }
         objInitialized = r.objInitialized;
@@ -431,10 +439,9 @@ public:
     {
         std::unique_lock<std::mutex> l(mutex);
         if (!objInitialized && !bufValid) {
-            vecBytes.resize(BLSObject::SerSize);
             std::fill(vecBytes.begin(), vecBytes.end(), 0);
         } else if (!bufValid || (bufLegacyScheme != specificLegacyScheme)) {
-            vecBytes = obj.ToByteVector(specificLegacyScheme);
+            vecBytes = obj.ToBytes(specificLegacyScheme);
             bufValid = true;
             bufLegacyScheme = specificLegacyScheme;
             hash.SetNull();
@@ -516,11 +523,10 @@ public:
     {
         std::unique_lock<std::mutex> l(mutex);
         if (!objInitialized && !bufValid) {
-            vecBytes.resize(BLSObject::SerSize);
             std::fill(vecBytes.begin(), vecBytes.end(), 0);
             hash.SetNull();
         } else if (!bufValid) {
-            vecBytes = obj.ToByteVector(bufLegacyScheme);
+            vecBytes = obj.ToBytes(bufLegacyScheme);
             bufValid = true;
             hash.SetNull();
         }

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -265,7 +265,7 @@ bool CGovernanceObject::Sign(const CActiveMasternodeManager& mn_activeman)
 bool CGovernanceObject::CheckSignature(const CBLSPublicKey& pubKey) const
 {
     CBLSSignature sig;
-    sig.SetByteVector(m_obj.vchSig, false);
+    sig.SetBytes(m_obj.vchSig, false);
     if (!sig.VerifyInsecure(pubKey, GetSignatureHash(), false)) {
         LogPrintf("CGovernanceObject::CheckSignature -- VerifyInsecure() failed\n");
         return false;

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -182,7 +182,7 @@ bool CGovernanceVote::Sign(const CActiveMasternodeManager& mn_activeman)
 bool CGovernanceVote::CheckSignature(const CBLSPublicKey& pubKey) const
 {
     CBLSSignature sig;
-    sig.SetByteVector(vchSig, false);
+    sig.SetBytes(vchSig, false);
     if (!sig.VerifyInsecure(pubKey, GetSignatureHash(), false)) {
         LogPrintf("CGovernanceVote::CheckSignature -- VerifyInsecure() failed\n");
         return false;

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -1019,11 +1019,11 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages, PeerManag
     qc.quorumSig = skShare.Sign(commitmentHash, m_use_legacy_bls);
 
     if (lieType == 3) {
-        std::vector<uint8_t> buf = qc.sig.ToByteVector(m_use_legacy_bls);
+        auto buf = qc.sig.ToBytes(m_use_legacy_bls);
         buf[5]++;
         qc.sig.SetBytes(buf, m_use_legacy_bls);
     } else if (lieType == 4) {
-        std::vector<uint8_t> buf = qc.quorumSig.ToByteVector(m_use_legacy_bls);
+        auto buf = qc.quorumSig.ToBytes(m_use_legacy_bls);
         buf[5]++;
         qc.quorumSig.SetBytes(buf, m_use_legacy_bls);
     }

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -1021,11 +1021,11 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages, PeerManag
     if (lieType == 3) {
         std::vector<uint8_t> buf = qc.sig.ToByteVector(m_use_legacy_bls);
         buf[5]++;
-        qc.sig.SetByteVector(buf, m_use_legacy_bls);
+        qc.sig.SetBytes(buf, m_use_legacy_bls);
     } else if (lieType == 4) {
         std::vector<uint8_t> buf = qc.quorumSig.ToByteVector(m_use_legacy_bls);
         buf[5]++;
-        qc.quorumSig.SetByteVector(buf, m_use_legacy_bls);
+        qc.quorumSig.SetBytes(buf, m_use_legacy_bls);
     }
 
     t3.stop();


### PR DESCRIPTION
## Issue being fixed or feature implemented
we made changes to bls library library to allow std::array based serialization, which resulted in ~10% speedups in serialization in library benchmarks. I noticed today: 

pre-this change:
<img width="1562" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/cd7824c7-de75-4faa-892c-10270c6e4a02" />

post this change:￼￼
<img width="1555" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/ba939f10-47f0-4f86-b675-b99077ca0393" />

this shows that roughly 2.5% of total cycles during reindex are spent on vector new in our bls.h object.

## What was done?
Convert to array to avoid dynamic allocation slowdown

## How Has This Been Tested?
reindexing atm, looks good so far, and performance is improved as expected

## Breaking Changes
None

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

