### PR TITLE
fix: cache descriptors of wallet unlock - missing changes from bitcoin/bitcoin#21329

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5648,6 +5648,8 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool fForMixingOnl
             if (Unlock(_vMasterKey, fForMixingOnly, accept_no_keys)) {
                 // Now that we've unlocked, upgrade the key metadata
                 UpgradeKeyMetadata();
+                // Now that we've unlocked, upgrade the descriptor cache
+                UpgradeDescriptorCache();
                 if(nWalletBackups == -2) {
                     TopUpKeyPool();
                     WalletLogPrintf("Keypool replenished, re-initializing automatic backups.\n");


### PR DESCRIPTION
## Issue being fixed or feature implemented
Steps to reproduce:
 - create descriptor wallet with passphrase
 - lock wallet
 - call rpc `listdescriptors` and `listdescriptors true`

Both RPC calls are failed, while first call `listdescriptors` should succeed: it doesn't need any private key but fails if descriptor wallet is locked

## What was done?
Added missing changes from backport bitcoin#21329

## How Has This Been Tested?
 - unlock descriptor wallet (to update caches)
 - lock wallet
 - `listdescriptors` succeeded as expected, `listdescriptors true` failed as expected because it requires private keys.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone