### PR TITLE
ci: add nowallet functional tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -377,6 +377,15 @@ linux64_multiprocess-test:
   variables:
     BUILD_TARGET: linux64_multiprocess
 
+linux64_nowallet-test:
+  extends:
+    - .test-template
+    - .skip-in-fast-mode-template
+  needs:
+    - linux64_nowallet-build
+  variables:
+    BUILD_TARGET: linux64_nowallet
+
 #linux64_valgrind-test:
 #  extends:
 #    - .test-template


### PR DESCRIPTION
Many functional tests can be run if Dash Core is built as no-wallet, but we currently do not test whether they actually work in no-wallet mode. Additionally, many functional tests can run with a simple dummy wallet, increasing the number of functional tests that can run without a wallet. However, we also do not test this scenario.

Now that extra functional tests have become available to run with the dummy-wallet MiniWallet (see #6520), we should finally add a job to our CI pipeline to run functional tests in no-wallet mode.

Though using MiniWallet for DashTestFramework to let register masternodes without using a real Dash Core wallet currently impossible due to limitation of MiniWallet:

            Note that this method fails if there is no single internal utxo
            available that can cover the cost for the amount and the fixed fee
            (the utxo with the largest value is taken).

This limitation may be addressed in future PRs, but it is out of scope for this PR.


## What was done?
Add new CI job to run functional tests for nowallet.



## How Has This Been Tested?
See CI: https://gitlab.com/dashpay/dash/-/jobs/8805673945

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

