### PR TITLE
fix: avoid extra work in GetListForBlockInternal before dip0003 activation

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1026,8 +1026,14 @@ void CDeterministicMNManager::HandleQuorumCommitment(const llmq::CFinalCommitmen
 
 CDeterministicMNList CDeterministicMNManager::GetListForBlockInternal(gsl::not_null<const CBlockIndex*> pindex)
 {
-    AssertLockHeld(cs);
     CDeterministicMNList snapshot;
+
+    if (!DeploymentActiveAt(*pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0003)) {
+        return snapshot;
+    }
+
+    AssertLockHeld(cs);
+
     std::list<const CBlockIndex*> listDiffIndexes;
 
     while (true) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
There could be no DMN before DIP0003, so let's bail out early. The result is less evodb reads and no `initial snapshot` spam in logs when syncing from scratch.

## What was done?


## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

