### PR TITLE
chore: fix typos in Dash-specific comments

### DIFF
--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -54,7 +54,7 @@ struct LLMQParams {
     // the size of the quorum, e.g. 50 or 400
     int size;
 
-    // The minimum number of valid members after the DKK. If less members are determined valid, no commitment can be
+    // The minimum number of valid members after the DKG. If less members are determined valid, no commitment can be
     // created. Should be higher then the threshold to allow some room for failing nodes, otherwise quorum might end up
     // not being able to ever created a recovered signature if more nodes fail after the DKG
     int minSize;

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -638,7 +638,7 @@ CQuorumCPtr CQuorumManager::GetQuorum(Consensus::LLMQType llmqType, const uint25
     const CBlockIndex* pQuorumBaseBlockIndex = [&]() {
         // Lock contention may still be high here; consider using a shared lock
         // We cannot hold cs_quorumBaseBlockIndexCache the whole time as that creates lock-order inversion with cs_main;
-        // We cannot aquire cs_main if we have cs_quorumBaseBlockIndexCache held
+        // We cannot acquire cs_main if we have cs_quorumBaseBlockIndexCache held
         const CBlockIndex* pindex;
         if (!WITH_LOCK(cs_quorumBaseBlockIndexCache, return quorumBaseBlockIndexCache.get(quorumHash, pindex))) {
             pindex = WITH_LOCK(cs_main, return m_chainstate.m_blockman.LookupBlockIndex(quorumHash));

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -290,7 +290,7 @@ CTxDestination AddAndGetMultisigDestination(const int required, const std::vecto
         throw JSONRPCError(RPC_INVALID_PARAMETER, (strprintf("redeemScript exceeds size limit: %d > %d", script_out.size(), MAX_SCRIPT_ELEMENT_SIZE)));
     }
 
-    // Make the address (simplier implementation in compare to bitcoin)
+    // Make the address (simpler implementation in compare to bitcoin)
     return AddAndGetDestinationForScript(keystore, script_out);
 }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -193,7 +193,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     m_node.connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman); // Deterministic randomness for tests.
 
     // while g_wallet_init_interface is init here at very early stage
-    // we can't get rid of unique_ptr from wallet/contex.h
+    // we can't get rid of unique_ptr from wallet/context.h
     // TODO: remove unique_ptr from wallet/context.h after bitcoin/bitcoin#22219
     g_wallet_init_interface.Construct(m_node);
     fCheckBlockIndex = true;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1103,12 +1103,12 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
 }
 
 /**
-  * Called when a lenght of chain is increased. Removes from mempool expired asset-unlock transactions
+  * Called when a length of chain is increased. Removes from mempool expired asset-unlock transactions
   */
 void CTxMemPool::removeExpiredAssetUnlock(int nBlockHeight)
 {
     AssertLockHeld(cs);
-    // items to removed should be firstly collected to independed list,
+    // items to removed should be firstly collected to independent list,
     // because removing items by `removeRecursive` changes the mapAssetUnlockExpiry
     std::vector<CTransactionRef> entries;
     for (const auto& item: mapAssetUnlockExpiry) {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -43,7 +43,7 @@ class CChain;
 class CChainState;
 extern RecursiveMutex cs_main;
 
-// Forward declation for CBLSLazyPublicKey:
+// Forward declaration for CBLSLazyPublicKey:
 template<typename T> class CBLSLazyWrapper;
 class CBLSPublicKey;
 using CBLSLazyPublicKey = CBLSLazyWrapper<CBLSPublicKey>;

--- a/test/functional/rpc_whitelist.py
+++ b/test/functional/rpc_whitelist.py
@@ -24,7 +24,7 @@ def rpccall(node, user, method):
     conn.connect()
 
     # composite commands are presented without space in whitelist
-    # but space can't be ommitted when using CLI/http rpc
+    # but space can't be omitted when using CLI/http rpc
     # for sack of test, substitute missing space for quorum composite command
     params = []
     if re.match(r"^quorum[^ ]", method):

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -66,7 +66,7 @@ def create_block(hashprev=None, coinbase=None, ntime=None, *, version=None, tmpl
     block.calc_sha256()
     return block
 
-# TODO: imlement MN_RR support here or remove it
+# TODO: implement MN_RR support here or remove it
 def create_block_with_mnpayments(mninfo, node, vtx=None, mn_payee=None, mn_amount=None):
     if vtx is None:
         vtx = []


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fix typos in Dash-specific comments only (not touching typos derived from bitcoin)

## What was done?


## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

