### PR TITLE
feat: quorums work with a single member

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -919,6 +919,7 @@ public:
 
         UpdateLLMQTestParametersFromArgs(args, Consensus::LLMQType::LLMQ_TEST);
         UpdateLLMQTestParametersFromArgs(args, Consensus::LLMQType::LLMQ_TEST_INSTANTSEND);
+        UpdateLLMQTestParametersFromArgs(args, Consensus::LLMQType::LLMQ_TEST_PLATFORM);
         UpdateLLMQInstantSendDIP0024FromArgs(args);
     }
 
@@ -1144,12 +1145,16 @@ void CRegTestParams::UpdateBudgetParametersFromArgs(const ArgsManager& args)
 
 void CRegTestParams::UpdateLLMQTestParametersFromArgs(const ArgsManager& args, const Consensus::LLMQType llmqType)
 {
-    assert(llmqType == Consensus::LLMQType::LLMQ_TEST || llmqType == Consensus::LLMQType::LLMQ_TEST_INSTANTSEND);
+    assert(llmqType == Consensus::LLMQType::LLMQ_TEST || llmqType == Consensus::LLMQType::LLMQ_TEST_INSTANTSEND || llmqType == Consensus::LLMQType::LLMQ_TEST_PLATFORM);
 
     std::string cmd_param{"-llmqtestparams"}, llmq_name{"LLMQ_TEST"};
     if (llmqType == Consensus::LLMQType::LLMQ_TEST_INSTANTSEND) {
         cmd_param = "-llmqtestinstantsendparams";
         llmq_name = "LLMQ_TEST_INSTANTSEND";
+    }
+    if (llmqType == Consensus::LLMQType::LLMQ_TEST_PLATFORM) {
+        cmd_param = "-llmqtestplatformparams";
+        llmq_name = "LLMQ_TEST_PLATFORM";
     }
 
     if (!args.IsArgSet(cmd_param)) return;
@@ -1379,6 +1384,7 @@ void SetupChainParamsOptions(ArgsManager& argsman)
     argsman.AddArg("-llmqtestinstantsenddip0024=<quorum name>", "Override the default LLMQ type used for InstantSendDIP0024. Used mainly to test Platform. (default: llmq_test_dip0024, regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-llmqtestinstantsendparams=<size>:<threshold>", "Override the default LLMQ size for the LLMQ_TEST_INSTANTSEND quorums (default: 3:2, regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-llmqtestparams=<size>:<threshold>", "Override the default LLMQ size for the LLMQ_TEST quorum (default: 3:2, regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-llmqtestplatformparams=<size>:<threshold>", "Override the default LLMQ size for the LLMQ_TEST_PLATFORM quorum (default: 3:2, regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-minimumdifficultyblocks=<n>", "The number of blocks that can be mined with the minimum difficulty at the start of a chain (default: 0, devnet-only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-powtargetspacing=<n>", "Override the default PowTargetSpacing value in seconds (default: 2.5 minutes, devnet-only)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (bip147, bip34, dersig, cltv, csv, brr, dip0001, dip0008, dip0024, v19, v20, mn_rr). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -166,6 +166,8 @@ void CDKGSession::Contribute(CDKGPendingMessages& pendingMessages, PeerManager& 
         return;
     }
 
+    assert(params.threshold > 1); // we should not get there with single-node-quorums
+
     cxxtimer::Timer t1(true);
     logger.Batch("generating contributions");
     if (!blsWorker.GenerateContributions(params.threshold, memberIds, vvecContribution, m_sk_contributions)) {
@@ -1236,6 +1238,7 @@ std::vector<CFinalCommitment> CDKGSession::FinalizeCommitments()
         fqc.quorumVvecHash = first.quorumVvecHash;
 
         const bool isQuorumRotationEnabled{IsQuorumRotationEnabled(params, m_quorum_base_block_index)};
+        // TODO: always put `true` here: so far as v19 is activated, we always write BASIC now
         fqc.nVersion = CFinalCommitment::GetVersion(isQuorumRotationEnabled, DeploymentActiveAfter(m_quorum_base_block_index, Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
         fqc.quorumIndex = isQuorumRotationEnabled ? quorumIndex : 0;
 
@@ -1291,6 +1294,64 @@ std::vector<CFinalCommitment> CDKGSession::FinalizeCommitments()
     logger.Flush();
 
     return finalCommitments;
+}
+
+CFinalCommitment CDKGSession::FinalizeSingleCommitment()
+{
+    if (!AreWeMember()) {
+        return {};
+    }
+
+    CDKGLogger logger(*this, __func__, __LINE__);
+
+    std::vector<CBLSId> signerIds;
+    std::vector<CBLSSignature> thresholdSigs;
+
+    CFinalCommitment fqc(params, m_quorum_base_block_index->GetBlockHash());
+
+
+    fqc.signers = {true};
+    fqc.validMembers = {true};
+
+    CBLSSecretKey sk1;
+    sk1.MakeNewKey();
+
+    fqc.quorumPublicKey = sk1.GetPublicKey();
+    fqc.quorumVvecHash = {};
+
+    // use just MN's operator public key as quorum pubkey.
+    // TODO: use sk1 here instead and use recovery mechanism from shares, but that's not trivial to do
+    const bool workaround_qpublic_key = true;
+    if (workaround_qpublic_key) {
+        fqc.quorumPublicKey = m_mn_activeman->GetPubKey();
+    }
+    const bool isQuorumRotationEnabled{false};
+    fqc.nVersion = CFinalCommitment::GetVersion(isQuorumRotationEnabled,
+                                                DeploymentActiveAfter(m_quorum_base_block_index, Params().GetConsensus(),
+                                                                      Consensus::DEPLOYMENT_V19));
+    fqc.quorumIndex = 0;
+
+    uint256 commitmentHash = BuildCommitmentHash(fqc.llmqType, fqc.quorumHash, fqc.validMembers, fqc.quorumPublicKey,
+                                                 fqc.quorumVvecHash);
+    fqc.quorumSig = sk1.Sign(commitmentHash, m_use_legacy_bls);
+
+    fqc.membersSig = m_mn_activeman->Sign(commitmentHash, m_use_legacy_bls);
+
+    if (workaround_qpublic_key) {
+        fqc.quorumSig = fqc.membersSig;
+    }
+
+    if (!fqc.Verify(m_dmnman, m_qsnapman, m_quorum_base_block_index, true)) {
+        logger.Batch("failed to verify final commitment");
+        assert(false);
+    }
+
+    logger.Batch("final commitment: validMembers=%d, signers=%d, quorumPublicKey=%s", fqc.CountValidMembers(),
+                 fqc.CountSigners(), fqc.quorumPublicKey.ToString());
+
+    logger.Flush();
+
+    return fqc;
 }
 
 CDKGMember* CDKGSession::GetMember(const uint256& proTxHash) const

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -278,6 +278,7 @@ bool CDKGSession::PreVerifyMessage(const CDKGContribution& qc, bool& retBan) con
     return true;
 }
 
+// TODO: remove duplicated code between all ReceiveMessage: CDKGContribution, CDKGComplaint, CDKGJustification, CDKGPrematureCommitment
 std::optional<CInv> CDKGSession::ReceiveMessage(const CDKGContribution& qc)
 {
     CDKGLogger logger(*this, __func__, __LINE__);

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -382,6 +382,9 @@ public:
     // Phase 5: aggregate/finalize
     std::vector<CFinalCommitment> FinalizeCommitments();
 
+    // All Phases 5-in-1 for single-node-quorum
+    CFinalCommitment FinalizeSingleCommitment();
+
     [[nodiscard]] bool AreWeMember() const { return !myProTxHash.IsNull(); }
     void MarkBadMember(size_t idx);
 

--- a/src/llmq/options.cpp
+++ b/src/llmq/options.cpp
@@ -154,6 +154,7 @@ bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, gsl::not_null<con
         case Consensus::LLMQType::LLMQ_TEST_DIP0024: {
             return fDIP0024IsActive;
         }
+        // TODO: remove it in case of testnet reset
         case Consensus::LLMQType::LLMQ_25_67:
             return pindexPrev->nHeight >= TESTNET_LLMQ_25_67_ACTIVATION_HEIGHT;
 

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -37,7 +37,7 @@ enum class LLMQType : uint8_t {
     LLMQ_TEST_PLATFORM = 106,    // 3 members, 2 (66%) threshold, one per hour.
 
     // for devnets only. rotated version (v2) for devnets
-    LLMQ_DEVNET_DIP0024 = 105 // 8 members, 4 (50%) threshold, one per hour. Params might differ when -llmqdevnetparams is used
+    LLMQ_DEVNET_DIP0024 = 105, // 8 members, 4 (50%) threshold, one per hour. Params might differ when -llmqdevnetparams is used
 };
 
 // Configures a LLMQ and its DKG

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -414,6 +414,12 @@ CQuorumPtr CQuorumManager::BuildQuorumFromCommitment(const Consensus::LLMQType l
 
     quorum->Init(std::move(qc), pQuorumBaseBlockIndex, minedBlockHash, members);
 
+    if (populate_cache && llmq_params_opt->size == 1) {
+        WITH_LOCK(cs_map_quorums, mapQuorumsCache[llmqType].insert(quorumHash, quorum));
+
+        return quorum;
+    }
+
     bool hasValidVvec = false;
     if (WITH_LOCK(cs_db, return quorum->ReadContributions(*db))) {
         hasValidVvec = true;

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -175,8 +175,8 @@ static RPCHelpMan quorum_list_extended()
     };
 }
 
-static UniValue BuildQuorumInfo(const llmq::CQuorumBlockProcessor& quorum_block_processor, const llmq::CQuorumCPtr& quorum,
-                                bool includeMembers, bool includeSkShare, bool single_node_quorum = false)
+static UniValue BuildQuorumInfo(const llmq::CQuorumBlockProcessor& quorum_block_processor,
+                                const llmq::CQuorumCPtr& quorum, bool includeMembers, bool includeSkShare)
 {
     UniValue ret(UniValue::VOBJ);
 
@@ -207,7 +207,7 @@ static UniValue BuildQuorumInfo(const llmq::CQuorumBlockProcessor& quorum_block_
             mo.pushKV("pubKeyOperator", dmn->pdmnState->pubKeyOperator.ToString());
             mo.pushKV("valid", quorum->qc->validMembers[i]);
             if (quorum->qc->validMembers[i]) {
-                if (single_node_quorum) {
+                if (quorum->params.size == 1) {
                     mo.pushKV("pubKeyShare", dmn->pdmnState->pubKeyOperator.ToString());
                 } else {
                     CBLSPublicKey pubKey = quorum->GetPubKeyShare(i);
@@ -246,8 +246,7 @@ static RPCHelpMan quorum_info()
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
 
     const Consensus::LLMQType llmqType{static_cast<Consensus::LLMQType>(ParseInt32V(request.params[0], "llmqType"))};
-    auto llmq_opt = Params().GetLLMQ(llmqType);
-    if (!llmq_opt.has_value()) {
+    if (!Params().GetLLMQ(llmqType).has_value()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid LLMQ type");
     }
 
@@ -262,7 +261,7 @@ static RPCHelpMan quorum_info()
         throw JSONRPCError(RPC_INVALID_PARAMETER, "quorum not found");
     }
 
-    return BuildQuorumInfo(*llmq_ctx.quorum_block_processor, quorum, true, includeSkShare, llmq_opt->size == 1);
+    return BuildQuorumInfo(*llmq_ctx.quorum_block_processor, quorum, true, includeSkShare);
 },
     };
 }

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -253,17 +253,6 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
 
         return d
 
-    def activate_dip8(self, slow_mode=False):
-        # NOTE: set slow_mode=True if you are activating dip8 after a huge reorg
-        # or nodes might fail to catch up otherwise due to a large
-        # (MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16 blocks) reorg error.
-        self.log.info("Wait for dip0008 activation")
-        while self.nodes[0].getblockcount() < DIP0008_HEIGHT:
-            self.bump_mocktime(10)
-            self.generate(self.nodes[0], 10, sync_fun=self.no_op)
-            if slow_mode:
-                self.sync_blocks()
-        self.sync_blocks()
 
     def test_dip8_quorum_merkle_root_activation(self, with_initial_quorum, slow_mode=False):
         if with_initial_quorum:
@@ -279,7 +268,9 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         cbtx = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)["tx"][0]
         assert cbtx["cbTx"]["version"] == 1
 
-        self.activate_dip8(slow_mode)
+        self.activate_by_name('dip0008', expected_activation_height=DIP0008_HEIGHT)
+        self.log.info("Mine one more block with new rules of dip0008")
+        self.generate(self.nodes[0], 1)
 
         # Assert that merkleRootQuorums is present and 0 (we have no quorums yet)
         cbtx = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)["tx"][0]

--- a/test/functional/feature_llmq_singlenode.py
+++ b/test/functional/feature_llmq_singlenode.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2024 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+'''
+feature_llmq_singlenode.py
+
+Checks creating LLMQs signle node quorum creation and signing
+This functional test is similar to feature_llmq_signing.py but difference are big enough to make implementation common.
+
+'''
+
+import time
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import DashTestFramework
+from test_framework.util import (
+    assert_raises_rpc_error,
+    assert_greater_than,
+    wait_until_helper,
+)
+
+
+id = "0000000000000000000000000000000000000000000000000000000000000001"
+msgHash = "0000000000000000000000000000000000000000000000000000000000000002"
+msgHashConflict = "0000000000000000000000000000000000000000000000000000000000000003"
+
+
+q_type=100
+class LLMQSigningTest(DashTestFramework):
+    def set_test_params(self):
+        self.set_dash_test_params(1, 0, [["-llmqtestinstantsenddip0024=llmq_test_instantsend", "-peertimeout=300000000"]],
+                evo_count=2)
+        self.set_dash_llmq_test_params(1, 1)
+
+
+    def mine_single_node_quorum(self):
+        node = self.nodes[0]
+        quorums = node.quorum('list')['llmq_test']
+
+        skip_count = 24 - (self.nodes[0].getblockcount() % 24)
+        if skip_count != 0:
+            self.bump_mocktime(1)
+            self.generate(self.nodes[0], skip_count)
+        time.sleep(1)
+        self.generate(self.nodes[0], 30)
+        new_quorums_list = node.quorum('list')['llmq_test']
+
+        self.log.info(f"Test Quorums at height={node.getblockcount()} : {new_quorums_list}")
+        assert new_quorums_list != quorums
+
+    def check_sigs(self, hasrecsigs, isconflicting1, isconflicting2):
+        has_sig = False
+        conflicting_1 = False
+        conflicting_2 = False
+
+        for mn in self.mninfo:
+            if mn.node.quorum("hasrecsig", q_type, id, msgHash):
+                has_sig = True
+            if mn.node.quorum("isconflicting", q_type, id, msgHash):
+                conflicting_1 = True
+            if mn.node.quorum("isconflicting", q_type, id, msgHashConflict):
+                conflicting_2 = True
+        if has_sig != hasrecsigs:
+            return False
+        if conflicting_1 != isconflicting1:
+            return False
+        if conflicting_2 != isconflicting2:
+            return False
+
+        return True
+
+    def wait_for_sigs(self, hasrecsigs, isconflicting1, isconflicting2, timeout):
+        self.wait_until(lambda: self.check_sigs(hasrecsigs, isconflicting1, isconflicting2), timeout = timeout)
+
+    def assert_sigs_nochange(self, hasrecsigs, isconflicting1, isconflicting2, timeout):
+        assert not wait_until_helper(lambda: not self.check_sigs(hasrecsigs, isconflicting1, isconflicting2), timeout = timeout, do_assert = False)
+
+
+    def log_connections(self):
+        connections = []
+        for idx in range(len(self.nodes)):
+            connections.append(self.nodes[idx].getconnectioncount())
+        self.log.info(f"nodes connection count: {connections}")
+
+    def run_test(self):
+        self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        self.wait_for_sporks_same()
+
+        self.dynamically_add_masternode(evo=False)
+        self.dynamically_add_masternode(evo=True)
+        self.connect_nodes(1, 2)
+
+        self.mine_single_node_quorum()
+
+        self.log_connections()
+        assert_greater_than(len(self.nodes[0].quorum('list')['llmq_test']), 0)
+        self.log.info("We have quorum waiting for ChainLock")
+        self.wait_for_chainlocked_block(self.nodes[0], self.nodes[0].getbestblockhash())
+
+        self.log.info("Send funds and wait InstantSend lock")
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        self.wait_for_instantlock(txid, self.nodes[0])
+
+        self.log.info("Test various options to sign messages with nodes")
+        recsig_time = self.mocktime
+
+        # Initial state
+        self.wait_for_sigs(False, False, False, 1)
+
+        # Sign first share without any optional parameter, should not result in recovered sig
+        # Sign second share and test optional quorumHash parameter, should not result in recovered sig
+        # 1. Providing an invalid quorum hash should fail and cause no changes for sigs
+        assert not self.mninfo[1].node.quorum("sign", q_type, id, msgHash, msgHash)
+        self.assert_sigs_nochange(False, False, False, 3)
+        # 2. Providing a valid quorum hash should succeed and cause no changes for sigss
+        quorumHash = self.mninfo[1].node.quorum("selectquorum", q_type, id)["quorumHash"]
+
+        qnode = self.mninfo[0].node
+        try:
+            qnode.quorum("sign", q_type, id, msgHash, quorumHash, False)
+        except JSONRPCException as e:
+            if e.error['code'] == -8: # failed to create sigShare
+                qnode = self.mninfo[1].node
+                qnode.quorum("sign", q_type, id, msgHash, quorumHash, False)
+            else:
+                raise e
+
+        self.mninfo[0].node.quorum("sign", q_type, id, msgHash)
+        self.mninfo[1].node.quorum("sign", q_type, id, msgHash)
+
+        self.wait_for_sigs(True, False, True, 15)
+        has0 = self.nodes[0].quorum("hasrecsig", q_type, id, msgHash)
+        has1 = self.nodes[1].quorum("hasrecsig", q_type, id, msgHash)
+        has2 = self.nodes[2].quorum("hasrecsig", q_type, id, msgHash)
+        assert (has0 or has1 or has2)
+
+        self.log.info("Test `quorum verify` rpc")
+        node = self.mninfo[0].node
+        recsig = qnode.quorum("getrecsig", q_type, id, msgHash)
+        self.log.info("Find quorum automatically")
+        height = node.getblockcount()
+        height_bad = node.getblockheader(recsig["quorumHash"])["height"]
+        hash_bad = node.getblockhash(0)
+        assert node.quorum("verify", q_type, id, msgHash, recsig["sig"])
+        assert node.quorum("verify", q_type, id, msgHash, recsig["sig"], "", height)
+        assert not node.quorum("verify", q_type, id, msgHashConflict, recsig["sig"])
+        assert not node.quorum("verify", q_type, id, msgHash, recsig["sig"], "", height_bad)
+        self.log.info("Use specific quorum")
+        assert node.quorum("verify", q_type, id, msgHash, recsig["sig"], recsig["quorumHash"])
+        assert not node.quorum("verify", q_type, id, msgHashConflict, recsig["sig"], recsig["quorumHash"])
+        assert_raises_rpc_error(-8, "quorum not found", node.quorum, "verify", q_type, id, msgHash, recsig["sig"], hash_bad)
+
+        self.log.info("Mine one more quorum, so that we have 2 active ones, nothing should change")
+        self.mine_single_node_quorum()
+        self.assert_sigs_nochange(True, False, True, 3)
+
+
+        self.log.info("Mine 2 more quorums, so that the one used for the the recovered sig should become inactive, nothing should change")
+        self.mine_single_node_quorum()
+        self.mine_single_node_quorum()
+        self.assert_sigs_nochange(True, False, True, 3)
+
+        self.log_connections()
+        self.log.info("Fast forward until 0.5 days before cleanup is expected, recovered sig should still be valid")
+        self.bump_mocktime(recsig_time + int(60 * 60 * 24 * 6.5) - self.mocktime, update_schedulers=False)
+        self.log.info("Cleanup starts every 5 seconds")
+        self.wait_for_sigs(True, False, True, 15)
+        self.log.info("Fast forward 1 day, recovered sig should not be valid anymore")
+        self.bump_mocktime(int(60 * 60 * 24 * 1), update_schedulers=False)
+        self.log.info("Cleanup starts every 5 seconds")
+        self.wait_for_sigs(False, False, False, 15)
+
+        self.log_connections()
+        self.log.info("Test chainlocks and InstantSend with new quorums")
+        block_hash = self.nodes[0].getbestblockhash()
+        self.log.info(f"Chainlock on block: {block_hash} is expecting")
+        self.wait_for_best_chainlock(self.nodes[0], block_hash)
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        self.log.info(f"InstantSend lock on tx: {txid} is expecting")
+        self.wait_for_instantlock(txid, self.nodes[0])
+
+
+if __name__ == '__main__':
+    LLMQSigningTest().main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1259,6 +1259,7 @@ class DashTestFramework(BitcoinTestFramework):
         for i in range(0, self.num_nodes):
             self.extra_args[i].append("-llmqtestparams=%d:%d" % (self.llmq_size, self.llmq_threshold))
             self.extra_args[i].append("-llmqtestinstantsendparams=%d:%d" % (self.llmq_size, self.llmq_threshold))
+            self.extra_args[i].append("-llmqtestplatformparams=%d:%d" % (self.llmq_size, self.llmq_threshold))
 
     def create_simple_node(self, extra_args=None):
         idx = len(self.nodes)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1267,7 +1267,6 @@ class DashTestFramework(BitcoinTestFramework):
         for i in range(0, idx):
             self.connect_nodes(i, idx)
 
-    # TODO: to let creating Evo Nodes without instant-send available
     def dynamically_add_masternode(self, evo=False, rnd=None, should_be_rejected=False):
         mn_idx = len(self.nodes)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1206,7 +1206,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.quorum_data_request_expiration_timeout = 360
 
 
-    def activate_by_name(self, name, expected_activation_height=None):
+    def activate_by_name(self, name, expected_activation_height=None, slow_mode=True):
         assert not softfork_active(self.nodes[0], name)
         self.log.info("Wait for " + name + " activation")
 
@@ -1217,7 +1217,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.wait_for_sporks_same()
 
         # mine blocks in batches
-        batch_size = 50
+        batch_size = 50 if not slow_mode else 10
         if expected_activation_height is not None:
             height = self.nodes[0].getblockcount()
             assert height < expected_activation_height

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -134,6 +134,7 @@ BASE_SCRIPTS = [
     'feature_llmq_evo.py', # NOTE: needs dash_hash to pass
     'feature_llmq_is_cl_conflicts.py', # NOTE: needs dash_hash to pass
     'feature_llmq_dkgerrors.py', # NOTE: needs dash_hash to pass
+    'feature_llmq_singlenode.py', # NOTE: needs dash_hash to pass
     'feature_dip4_coinbasemerkleroots.py', # NOTE: needs dash_hash to pass
     'feature_mnehf.py', # NOTE: needs dash_hash to pass
     'feature_governance.py --legacy-wallet',


### PR DESCRIPTION
## Issue being fixed or feature implemented
Development for platform requires currently to have running 4 Dash Core instances: wallet and at least 3 Evo Nodes which forms quorum.
This issue has been partially addressed https://github.com/dashpay/dash/pull/6261 by allowing to use only 2 Evo Nodes. Though, previous solution still requires all DKG steps, heavy network communication and various instability.

## What was done?
Added support for RegTest quorums `llmq_test` and `llmq_test_instantsend` to be form and sign messages even if only one node is available.
While regular quorum with several nodes 7 steps of creation (Initialization, Contribution, Complaining, Justification, Commitment, Finalization, Mining) this type of quorum just from Initialization straight to the Finalization.
The signing process with this quorum is also simplified. So far as regular quorum requires to sign multiple shares, for single node quorum the messages are signed immediately by just one node.

Though, single-node-quorum doesn't generate new pair of private and public keys, instead it just uses operator private and public key. Not sure if there's any possible down-sides.

It is an alternate solution to https://github.com/dashpay/dash/pull/6437 which introduces brand-new quorum type.
Advantages of this solution is:
 - no breaking changes
 - no new quorums introduced
 - these quorums with one node can be both types "evo only" (as platform quorum) and regular "evo and regular" nodes
 - it's possible to sign EHF signals too

## How Has This Been Tested?
See a new functional test feature_llmq_singlenode.py

To use this feature Dash Core should be started with these 3 params: `-llmqtestparams=1:1 -llmqtestinstantsendparams=1:1 -lmqtestplatformparams=1:1`. It let to InstantSend, Chainlocks to be formed, EHF signals appears, messages to be signed, etc with just one masternode or evo node.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone