### PR TITLE
feat(net): add "system ports" and Bitcoin ports to "bad" ports list

### DIFF
--- a/doc/p2p-bad-ports.md
+++ b/doc/p2p-bad-ports.md
@@ -11,78 +11,18 @@ nodes.
 and usually require authentication. A connection attempt (by Dash Core,
 trying to connect because it thinks there is a Dash node on that
 address:port) to such service may be considered a malicious action by an
-ultra-paranoid administrator. An example for such a port is 22 (ssh). On the
-other hand, connection attempts to public services that usually do not require
-authentication are unlikely to be considered a malicious action,
-e.g. port 80 (http).
+ultra-paranoid administrator. An example for such a port is 22 (ssh).
+
+Additionally, ports below 1024 are classified as "system ports" by RFC 6335
+and on some platforms, require administrative privileges in order to use them.
+They are also considered "bad" ports as they require clients to either run Dash
+Core with elevated privileges or configure their system to relax such requirements,
+which may not be possible or desirable in some deployments.
 
 Below is a list of "bad" ports which Dash Core avoids when choosing a peer to
 connect to. If a node is listening on such a port, it will likely receive fewer
 incoming connections.
 
-    1:     tcpmux
-    7:     echo
-    9:     discard
-    11:    systat
-    13:    daytime
-    15:    netstat
-    17:    qotd
-    19:    chargen
-    20:    ftp data
-    21:    ftp access
-    22:    ssh
-    23:    telnet
-    25:    smtp
-    37:    time
-    42:    name
-    43:    nicname
-    53:    domain
-    69:    tftp
-    77:    priv-rjs
-    79:    finger
-    87:    ttylink
-    95:    supdup
-    101:   hostname
-    102:   iso-tsap
-    103:   gppitnp
-    104:   acr-nema
-    109:   pop2
-    110:   pop3
-    111:   sunrpc
-    113:   auth
-    115:   sftp
-    117:   uucp-path
-    119:   nntp
-    123:   NTP
-    135:   loc-srv /epmap
-    137:   netbios
-    139:   netbios
-    143:   imap2
-    161:   snmp
-    179:   BGP
-    389:   ldap
-    427:   SLP (Also used by Apple Filing Protocol)
-    465:   smtp+ssl
-    512:   print / exec
-    513:   login
-    514:   shell
-    515:   printer
-    526:   tempo
-    530:   courier
-    531:   chat
-    532:   netnews
-    540:   uucp
-    548:   AFP (Apple Filing Protocol)
-    554:   rtsp
-    556:   remotefs
-    563:   nntp+ssl
-    587:   smtp (rfc6409)
-    601:   syslog-conn (rfc3195)
-    636:   ldap+ssl
-    989:   ftps-data
-    990:   ftps
-    993:   ldap+ssl
-    995:   pop3+ssl
     1719:  h323gatestat
     1720:  h323hostcall
     1723:  pptp
@@ -112,3 +52,5 @@ For further information see:
 [chromium.googlesource.com](https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/net/base/port_util.cc)
 
 [hg.mozilla.org](https://hg.mozilla.org/mozilla-central/file/tip/netwerk/base/nsIOService.cpp)
+
+[RFC 6335, Section 6 ("Port Number Ranges")](https://datatracker.ietf.org/doc/html/rfc6335#section-6)

--- a/doc/p2p-bad-ports.md
+++ b/doc/p2p-bad-ports.md
@@ -39,7 +39,11 @@ incoming connections.
     6668:  Alternate IRC
     6669:  Alternate IRC
     6697:  IRC + TLS
+    8882:  Bitcoin RPC
+    8883:  Bitcoin P2P
     10080: Amanda
+    18882: Bitcoin testnet RPC
+    18883: Bitcoin testnet P2P
 
 For further information see:
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -709,70 +709,8 @@ bool IsBadPort(uint16_t port)
 {
     /* Don't forget to update doc/p2p-bad-ports.md if you change this list. */
 
+    if (port <= PRIVILEGED_PORTS_THRESHOLD) return true;
     switch (port) {
-    case 1:     // tcpmux
-    case 7:     // echo
-    case 9:     // discard
-    case 11:    // systat
-    case 13:    // daytime
-    case 15:    // netstat
-    case 17:    // qotd
-    case 19:    // chargen
-    case 20:    // ftp data
-    case 21:    // ftp access
-    case 22:    // ssh
-    case 23:    // telnet
-    case 25:    // smtp
-    case 37:    // time
-    case 42:    // name
-    case 43:    // nicname
-    case 53:    // domain
-    case 69:    // tftp
-    case 77:    // priv-rjs
-    case 79:    // finger
-    case 87:    // ttylink
-    case 95:    // supdup
-    case 101:   // hostname
-    case 102:   // iso-tsap
-    case 103:   // gppitnp
-    case 104:   // acr-nema
-    case 109:   // pop2
-    case 110:   // pop3
-    case 111:   // sunrpc
-    case 113:   // auth
-    case 115:   // sftp
-    case 117:   // uucp-path
-    case 119:   // nntp
-    case 123:   // NTP
-    case 135:   // loc-srv /epmap
-    case 137:   // netbios
-    case 139:   // netbios
-    case 143:   // imap2
-    case 161:   // snmp
-    case 179:   // BGP
-    case 389:   // ldap
-    case 427:   // SLP (Also used by Apple Filing Protocol)
-    case 465:   // smtp+ssl
-    case 512:   // print / exec
-    case 513:   // login
-    case 514:   // shell
-    case 515:   // printer
-    case 526:   // tempo
-    case 530:   // courier
-    case 531:   // chat
-    case 532:   // netnews
-    case 540:   // uucp
-    case 548:   // AFP (Apple Filing Protocol)
-    case 554:   // rtsp
-    case 556:   // remotefs
-    case 563:   // nntp+ssl
-    case 587:   // smtp (rfc6409)
-    case 601:   // syslog-conn (rfc3195)
-    case 636:   // ldap+ssl
-    case 989:   // ftps-data
-    case 990:   // ftps
-    case 993:   // ldap+ssl
-    case 995:   // pop3+ssl
     case 1719:  // h323gatestat
     case 1720:  // h323hostcall
     case 1723:  // pptp

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -727,7 +727,11 @@ bool IsBadPort(uint16_t port)
     case 6668:  // Alternate IRC
     case 6669:  // Alternate IRC
     case 6697:  // IRC + TLS
+    case 8332:  // Bitcoin RPC
+    case 8333:  // Bitcoin P2P
     case 10080: // Amanda
+    case 18332: // Bitcoin testnet RPC
+    case 18333: // Bitcoin testnet RPC
         return true;
     }
     return false;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -246,6 +246,9 @@ void InterruptSocks5(bool interrupt);
  */
 bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* auth, const Sock& socket);
 
+//! Upper range of ports classified as "System Ports" under RFC 6335
+static constexpr uint16_t PRIVILEGED_PORTS_THRESHOLD{1023};
+
 /**
  * Determine if a port is "bad" from the perspective of attempting to connect
  * to a node on that port.

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -444,18 +444,24 @@ BOOST_AUTO_TEST_CASE(isbadport)
     BOOST_CHECK(IsBadPort(80));
     BOOST_CHECK(IsBadPort(443));
 
+    // We shouldn't use ports used by Bitcoin Core
+    BOOST_CHECK(IsBadPort(8332));
+    BOOST_CHECK(IsBadPort(8333));
+    BOOST_CHECK(IsBadPort(18332));
+    BOOST_CHECK(IsBadPort(18333));
+
     BOOST_CHECK(!IsBadPort(9998));
     BOOST_CHECK(!IsBadPort(9999));
     BOOST_CHECK(!IsBadPort(26656));
 
-    // Check all ports, there must be 17 bad ports in addition to the restriction on privileged ports.
+    // Check all ports, there must be 21 bad ports in addition to the restriction on privileged ports.
     size_t total_bad_ports{0};
     for (uint16_t port = std::numeric_limits<uint16_t>::max(); port > 0; --port) {
         if (IsBadPort(port)) {
             ++total_bad_ports;
         }
     }
-    BOOST_CHECK_EQUAL(total_bad_ports - PRIVILEGED_PORTS_THRESHOLD, 17);
+    BOOST_CHECK_EQUAL(total_bad_ports - PRIVILEGED_PORTS_THRESHOLD, 21);
 }
 
 BOOST_AUTO_TEST_CASE(netbase_parsenetwork)

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -440,18 +440,22 @@ BOOST_AUTO_TEST_CASE(isbadport)
     BOOST_CHECK(IsBadPort(22));
     BOOST_CHECK(IsBadPort(6000));
 
-    BOOST_CHECK(!IsBadPort(80));
-    BOOST_CHECK(!IsBadPort(443));
-    BOOST_CHECK(!IsBadPort(9999));
+    // We don't expect Dash Core to operate over HTTP(S)
+    BOOST_CHECK(IsBadPort(80));
+    BOOST_CHECK(IsBadPort(443));
 
-    // Check all ports, there must be 80 bad ports in total.
+    BOOST_CHECK(!IsBadPort(9998));
+    BOOST_CHECK(!IsBadPort(9999));
+    BOOST_CHECK(!IsBadPort(26656));
+
+    // Check all ports, there must be 17 bad ports in addition to the restriction on privileged ports.
     size_t total_bad_ports{0};
     for (uint16_t port = std::numeric_limits<uint16_t>::max(); port > 0; --port) {
         if (IsBadPort(port)) {
             ++total_bad_ports;
         }
     }
-    BOOST_CHECK_EQUAL(total_bad_ports, 80);
+    BOOST_CHECK_EQUAL(total_bad_ports - PRIVILEGED_PORTS_THRESHOLD, 17);
 }
 
 BOOST_AUTO_TEST_CASE(netbase_parsenetwork)


### PR DESCRIPTION
## Additional Information

* Ports <1024 are considered to be "system ports" (see [RFC 6335, Section 6](https://datatracker.ietf.org/doc/html/rfc6335#section-6)) and on some platforms, require superuser privileges in order to bind to them ([source](https://linux.die.net/man/5/services)).

  > Port numbers below 1024 (so-called "low numbered" ports) can only be bound to by root (see bind(2), tcp(7), and udp(7)). This is so clients connecting to low numbered ports can trust that the service running on the port is the standard implementation, and not a rogue service run by a user of the machine. Well-known port numbers specified by the IANA are normally located in this root-only space.

  This is undesirable as:
    * We don't want users to run Dash Core with elevated privileges; and
    * We don't want deployments to resort to carving out exceptions to allow for using these ports.

  To deter this behavior, specifically the latter, all "system ports" have been added to the "bad" ports list. This comes with the coincidental benefit of trimming down the blocklist of ports substantially.

* To avoid conflicts with Bitcoin, as an additional measure, the RPC and P2P ports for mainnet and testnet have been included in the blocklist.

## Breaking Changes

* ~~Dash Core will now permits peers on mainnet to connect to each other using a non-default P2P port.~~ Superseded by  [dash#6538](https://github.com/dashpay/dash/pull/6538).
  * ~~This port restriction still _de facto_ applies on masternodes, as masternodes will not connect to other masternodes if they're using the differing listening port from themselves ([source](https://github.com/dashpay/dash/blob/0972dfe13c958a2866a189e386dd3ae38ac1ce46/src/net.cpp#L3563)).~~

* The "bad" ports list has been extended to include all ports <1024 and the RPC and P2P ports for Bitcoin mainnet and testnet.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
