### PR TITLE
fix: multiple fixes to conditions we check while opening new connections

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -284,7 +284,6 @@ public:
         fRequireRoutableExternalIP = true;
         m_is_test_chain = false;
         fAllowMultipleAddressesFromGroup = false;
-        fAllowMultiplePorts = false;
         nLLMQConnectionRetryTimeout = 60;
         m_is_mockable_chain = false;
 
@@ -476,7 +475,6 @@ public:
         fRequireRoutableExternalIP = true;
         m_is_test_chain = true;
         fAllowMultipleAddressesFromGroup = false;
-        fAllowMultiplePorts = true;
         nLLMQConnectionRetryTimeout = 60;
         m_is_mockable_chain = false;
 
@@ -659,7 +657,6 @@ public:
         fRequireRoutableExternalIP = true;
         m_is_test_chain = true;
         fAllowMultipleAddressesFromGroup = true;
-        fAllowMultiplePorts = true;
         nLLMQConnectionRetryTimeout = 60;
         m_is_mockable_chain = false;
 
@@ -861,7 +858,6 @@ public:
         fRequireRoutableExternalIP = false;
         m_is_test_chain = true;
         fAllowMultipleAddressesFromGroup = true;
-        fAllowMultiplePorts = true;
         nLLMQConnectionRetryTimeout = 1; // must be lower then the LLMQ signing session timeout so that tests have control over failing behavior
         m_is_mockable_chain = true;
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -117,8 +117,6 @@ public:
     bool MineBlocksOnDemand() const { return consensus.fPowNoRetargeting; }
     /** Allow multiple addresses to be selected from the same network group (e.g. 192.168.x.x) */
     bool AllowMultipleAddressesFromGroup() const { return fAllowMultipleAddressesFromGroup; }
-    /** Allow nodes with the same address and multiple ports */
-    bool AllowMultiplePorts() const { return fAllowMultiplePorts; }
     /** How long to wait until we allow retrying of a LLMQ connection  */
     int LLMQConnectionRetryTimeout() const { return nLLMQConnectionRetryTimeout; }
     /** Return the network string */
@@ -176,7 +174,6 @@ protected:
     bool fRequireRoutableExternalIP;
     bool m_is_test_chain;
     bool fAllowMultipleAddressesFromGroup;
-    bool fAllowMultiplePorts;
     bool m_is_mockable_chain;
     int nLLMQConnectionRetryTimeout;
     CCheckpointData checkpointData;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3522,7 +3522,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, CDe
 
             // don't try to connect to masternodes that we already have a connection to (most likely inbound)
             if (isMasternode && setConnectedMasternodes.count(dmn->proTxHash))
-                break;
+                continue;
 
             // don't connect to ourselves
             if (addr.GetPort() == GetListenPort() && IsLocal(addr)) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3541,9 +3541,9 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, CDe
             // for non-feelers, require all the services we'll want,
             // for feelers, only require they be a full node (only because most
             // SPV clients don't have a good address DB available)
-            if (!isMasternode && !fFeeler && !HasAllDesirableServiceFlags(addr.nServices)) {
+            if (!fFeeler && !HasAllDesirableServiceFlags(addr.nServices)) {
                 continue;
-            } else if (!isMasternode && fFeeler && !MayHaveUsefulAddressDB(addr.nServices)) {
+            } else if (fFeeler && !MayHaveUsefulAddressDB(addr.nServices)) {
                 continue;
             }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3540,9 +3540,6 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, CDe
                 continue;
             }
 
-            const uint16_t default_port{Params().GetDefaultPort(addr.GetNetwork())};
-            assert(!IsBadPort(default_port)); // Make sure we never set the default port to a bad port
-
             // Do not connect to prohibited ports, unless 50 invalid addresses have been selected already.
             if (nTries < 50 && IsBadPort(addr.GetPort())) {
                 continue;
@@ -4198,6 +4195,12 @@ CConnman::CConnman(uint64_t nSeed0In, uint64_t nSeed1In, AddrMan& addrman_in,
     , nSeed0(nSeed0In)
     , nSeed1(nSeed1In)
 {
+    // Make sure we never set the default port to a bad port
+    for (int n = 0; n < NET_MAX; ++n) {
+        const bool is_bad_port = IsBadPort(Params().GetDefaultPort(static_cast<Network>(n)));
+        assert(!is_bad_port);
+    }
+
     SetTryNewOutboundPeer(false);
 
     Options connOptions;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3517,8 +3517,9 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, CDe
             }
 
             // if we selected an invalid address, restart
-            if (!addr.IsValid() || outbound_ipv46_peer_netgroups.count(m_netgroupman.GetGroup(addr)))
+            if (!addr.IsValid()) {
                 break;
+            }
 
             // don't try to connect to masternodes that we already have a connection to (most likely inbound)
             if (isMasternode && setConnectedMasternodes.count(dmn->proTxHash))

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -32,15 +32,13 @@ CNetFulfilledRequestManager::~CNetFulfilledRequestManager()
 void CNetFulfilledRequestManager::AddFulfilledRequest(const CService& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    CService addrSquashed = Params().AllowMultiplePorts() ? addr : CService(addr, 0);
-    mapFulfilledRequests[addrSquashed][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
+    mapFulfilledRequests[addr][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
 }
 
 bool CNetFulfilledRequestManager::HasFulfilledRequest(const CService& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    CService addrSquashed = Params().AllowMultiplePorts() ? addr : CService(addr, 0);
-    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addrSquashed);
+    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
 
     return  it != mapFulfilledRequests.end() &&
             it->second.find(strRequest) != it->second.end() &&
@@ -50,8 +48,7 @@ bool CNetFulfilledRequestManager::HasFulfilledRequest(const CService& addr, cons
 void CNetFulfilledRequestManager::RemoveAllFulfilledRequests(const CService& addr)
 {
     LOCK(cs_mapFulfilledRequests);
-    CService addrSquashed = Params().AllowMultiplePorts() ? addr : CService(addr, 0);
-    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addrSquashed);
+    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
 
     if (it != mapFulfilledRequests.end()) {
         mapFulfilledRequests.erase(it++);


### PR DESCRIPTION
## Issue being fixed or feature implemented

Changes:
- c4819b950e69663077c4fbf9ae7e1b9c04a137fb: we backported 15486 in #4213 incorrectly, feeler connections from the same net group should be allowed
- e5a19c33fddf17731ab6e90d2f5e25207b9f3527: `fAllowMultiplePorts` was introduced in https://github.com/dashpay/dash/pull/1967 to preserve the behaviour of the old non-deterministic masternode list while fixing `netfulfilledman`. Most of that code is gone because we use DMN now and `fAllowMultiplePorts` is kind of useless (and even confusing). Should be safe to drop it completely imo. Inspired by 6451dd7ffa7cf88c1dcfb3f1d159a34401db56d4 in #6535.
- 47f47d861676646f69b9408f90a253a54c7f68b3: there is no reason not to check MN addresses for required net services
- 8872ba379fe2348dc075a35db3eaffd743f94c0a: we shouldn't break the loop if `addr` belongs to the set of already connected masternodes, should simply continue just like we do when we find `addr` from the same net group
- db7f4cf62d69c9982cb574e4f44cd9ea5efd836b: should allow non-Dash-specific conditions to trigger first for better compatibility

## What was done?
See above/individual commits

## How Has This Been Tested?
- [x] Run tests
- [x] Run testnet/mainnet masternode for a day or two

## Breaking Changes
It's now possible to have regular nodes with the same address but different ports on mainnet too but that's not a breaking change hopefully.

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

