### PR TITLE
fix(qt): Fix overlapping directory lock attempts when restarting Dash Qt

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -359,6 +359,13 @@ void PrepareShutdown(NodeContext& node)
 
     UnregisterAllValidationInterfaces();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
+
+    // We need to manually release our directory locks if we are expected to restart
+    // because the replacement instance will start before this instance stops and the
+    // global context won't be torn down in time to release the locks automatically.
+    if (RestartRequested()) {
+        ReleaseDirectoryLocks();
+    }
 }
 
 /**

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -98,6 +98,7 @@ std::streampos GetFileSize(const char* path, std::streamsize max = std::numeric_
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.
  */
+/** Dash: We also use this to release locks earlier when restarting the client */
 void ReleaseDirectoryLocks();
 
 bool TryCreateDirectories(const fs::path& p);


### PR DESCRIPTION
## Expected Behavior

* Start Dash Qt
* Go to **Window > Wallet Repair** and click on "Rebuild Index"
* Dash Qt restarts and starts reindexing chain
* 🎉 

## Actual Behavior

* Start Dash Qt
* Go to **Window > Wallet Repair** and click on "Rebuild Index"
* Dash Qt exits and on the restart, get greeted by "Error: Cannot obtain a lock on data directory /home/dash/.dashcore. Dash Core is probably already running."

## Additional Information

* ~~Running the client after reindexing is requested (i.e. on restart) was found to result in a `nullptr`-induced crash (see below) even though `DeploymentActiveAfter()` handles a `nullptr` case ([source](https://github.com/dashpay/dash/blob/0972dfe13c958a2866a189e386dd3ae38ac1ce46/src/deploymentstatus.h#L20)). This has been resolved by returning early if `pindex` is a `nullptr`.~~ Addressed by [dash#6537](https://github.com/dashpay/dash/pull/6537), fix dropped from this PR.

  <details>

  <summary>Crash trace:</summary>

  ```
  Posix Signal: Segmentation fault
    0#: (0x557D376F7454) stacktraces.cpp          - HandlePosixSignal(int)
    1#: (0x7F1F6B65B050) <unknown-file>           - ???
    2#: (0x557D36FA2C4F) deploymentstatus.h:20    - DeploymentActiveAfter(CBlockIndex const*, Consensus::Params const&, Consensus::BuriedDeployment)
    3#: (0x557D36FA2C4F) deterministicmns.cpp:220 - CDeterministicMNList::GetProjectedMNPayees(gsl::not_null<CBlockIndex const* const>, int) const
    4#: (0x557D36F2A271) stl_iterator.h:1028      - __gnu_cxx::__normal_iterator<std::shared_ptr<CDeterministicMN const> const*, std::vector<std::shared_ptr<CDeterministicMN const>, std::allocator<std::shared_ptr<CDeterministicMN const> > > >::__normal_iterator(std::shared_ptr<CDeterministicMN const> const* const&)
    5#: (0x557D36F2A271) stl_vector.h:821         - std::vector<std::shared_ptr<CDeterministicMN const>, std::allocator<std::shared_ptr<CDeterministicMN const> > >::begin() const
    6#: (0x557D36F2A271) stl_vector.h:1008        - std::vector<std::shared_ptr<CDeterministicMN const>, std::allocator<std::shared_ptr<CDeterministicMN const> > >::empty() const
    7#: (0x557D36F2A271) masternodelist.cpp:169   - MasternodeList::updateDIP3List()
    8#: (0x557D36F29D30) masternodelist.cpp:147   - MasternodeList::updateDIP3ListScheduled()
    9#: (0x557D37FEE969) <unknown-file>           - ???
   10#: (0x557D37FF4AA2) <unknown-file>           - ???
   11#: (0x557D37FE7843) <unknown-file>           - ???
   12#: (0x557D3821AC0C) <unknown-file>           - ???
   13#: (0x557D3821BEDE) <unknown-file>           - ???
   14#: (0x557D37FCA888) <unknown-file>           - ???
   15#: (0x557D3800C223) <unknown-file>           - ???
   16#: (0x557D3800A02D) <unknown-file>           - ???
   17#: (0x557D3813FD4E) <unknown-file>           - ???
   18#: (0x557D36F57849) sendcoinsdialog.cpp:607  - SendCoinsDialog::addEntry()
  ```

  </details>

## Breaking Changes

None expected

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
