### PR TITLE
fix: port 0 is not a bad one

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -709,7 +709,7 @@ bool IsBadPort(uint16_t port)
 {
     /* Don't forget to update doc/p2p-bad-ports.md if you change this list. */
 
-    if (port <= PRIVILEGED_PORTS_THRESHOLD) return true;
+    if (port > 0 && port <= PRIVILEGED_PORTS_THRESHOLD) return true;
     switch (port) {
     case 1719:  // h323gatestat
     case 1720:  // h323hostcall

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -450,6 +450,7 @@ BOOST_AUTO_TEST_CASE(isbadport)
     BOOST_CHECK(IsBadPort(18332));
     BOOST_CHECK(IsBadPort(18333));
 
+    BOOST_CHECK(!IsBadPort(0));
     BOOST_CHECK(!IsBadPort(9998));
     BOOST_CHECK(!IsBadPort(9999));
     BOOST_CHECK(!IsBadPort(26656));


### PR DESCRIPTION
## Issue being fixed or feature implemented

```
An ephemeral port is allocated to a socket in the following circumstances:

          *  the port number in a socket address is specified as 0 when
             calling bind(2);
```
[source](https://man7.org/linux/man-pages/man7/ip.7.html#:~:text=An%20ephemeral%20port%20is%20allocated%20to%20a%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20socket%20in%20the%20following%20circumstances%3A%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%80%A2%20%20the%20port%20number%20in%20a%20socket%20address%20is%20specified%20as%200%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20when%20calling%20bind(2)%3B)

#6535 follow-up


## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

