### PR TITLE
perf: wallet balance in dash-qt

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -223,9 +223,6 @@ public:
     //! Get anonymizable balance.
     virtual CAmount getAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfirmed) = 0;
 
-    //! Get denominated balance.
-    virtual CAmount getDenominatedBalance(bool unconfirmed) = 0;
-
     //! Get normalized anonymized balance.
     virtual CAmount getNormalizedAnonymizedBalance() = 0;
 
@@ -385,6 +382,8 @@ struct WalletBalances
     CAmount watch_only_balance = 0;
     CAmount unconfirmed_watch_only_balance = 0;
     CAmount immature_watch_only_balance = 0;
+    CAmount denominated_untrusted_pending = 0;
+    CAmount denominated_trusted = 0;
 
     bool balanceChanged(const WalletBalances& prev) const
     {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -223,9 +223,6 @@ public:
     //! Get anonymizable balance.
     virtual CAmount getAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfirmed) = 0;
 
-    //! Get anonymized balance.
-    virtual CAmount getAnonymizedBalance() = 0;
-
     //! Get denominated balance.
     virtual CAmount getDenominatedBalance(bool unconfirmed) = 0;
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -423,13 +423,12 @@ void OverviewPage::updateCoinJoinProgress()
 
     if (!fShowAdvancedCJUI) return;
 
-    CAmount nDenominatedConfirmedBalance;
-    CAmount nDenominatedUnconfirmedBalance;
+    const interfaces::WalletBalances balances = walletModel->wallet().getBalances();
+    CAmount nDenominatedConfirmedBalance = balances.denominated_trusted;
+    CAmount nDenominatedUnconfirmedBalance = balances.denominated_untrusted_pending;
     CAmount nNormalizedAnonymizedBalance;
     float nAverageAnonymizedRounds;
 
-    nDenominatedConfirmedBalance = walletModel->wallet().getDenominatedBalance(false);
-    nDenominatedUnconfirmedBalance = walletModel->wallet().getDenominatedBalance(true);
     nNormalizedAnonymizedBalance = walletModel->wallet().getNormalizedAnonymizedBalance();
     nAverageAnonymizedRounds = walletModel->wallet().getAverageAnonymizedRounds();
 

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -412,10 +412,6 @@ public:
     {
         return m_wallet->GetAnonymizableBalance(fSkipDenominated, fSkipUnconfirmed);
     }
-    CAmount getAnonymizedBalance() override
-    {
-        return m_wallet->GetBalance().m_anonymized;
-    }
     CAmount getDenominatedBalance(bool unconfirmed) override
     {
         const auto bal = m_wallet->GetBalance();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -432,7 +432,7 @@ public:
     CAmount getAvailableBalance(const CCoinControl& coin_control) override
     {
         if (coin_control.IsUsingCoinJoin()) {
-            return m_wallet->GetBalance(0, coin_control.m_avoid_address_reuse, false, &coin_control).m_anonymized;
+            return m_wallet->GetBalanceAnonymized(coin_control);
         } else {
             return m_wallet->GetAvailableBalance(&coin_control);
         }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -392,6 +392,8 @@ public:
             result.unconfirmed_watch_only_balance = bal.m_watchonly_untrusted_pending;
             result.immature_watch_only_balance = bal.m_watchonly_immature;
         }
+        result.denominated_untrusted_pending = bal.m_denominated_untrusted_pending;
+        result.denominated_trusted = bal.m_denominated_trusted;
         return result;
     }
     bool tryGetBalances(WalletBalances& balances, uint256& block_hash) override
@@ -411,15 +413,6 @@ public:
     CAmount getAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfirmed) override
     {
         return m_wallet->GetAnonymizableBalance(fSkipDenominated, fSkipUnconfirmed);
-    }
-    CAmount getDenominatedBalance(bool unconfirmed) override
-    {
-        const auto bal = m_wallet->GetBalance();
-        if (unconfirmed) {
-            return bal.m_denominated_untrusted_pending;
-        } else {
-            return bal.m_denominated_trusted;
-        }
     }
     CAmount getNormalizedAnonymizedBalance() override
     {

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -351,12 +351,12 @@ CWallet::Balance CWallet::GetBalance(const int min_depth, const bool avoid_reuse
             ret.m_mine_immature += wtx.GetImmatureCredit();
             ret.m_watchonly_immature += wtx.GetImmatureWatchOnlyCredit();
             if (cj_enabled) {
-                const auto balance_anonymized = wtx.GetAnonymizedBalance();
+                const auto balance_anonymized = wtx.GetAvailableCoinJoinCredits();
                 ret.m_anonymized += balance_anonymized.m_anonymized;
                 if (balance_anonymized.is_unconfirmed) {
-                    ret.m_denominated_untrusted_pending += balance_anonymized.m_denom_credit;
+                    ret.m_denominated_untrusted_pending += balance_anonymized.m_denominated;
                 } else {
-                    ret.m_denominated_trusted += balance_anonymized.m_denom_credit;
+                    ret.m_denominated_trusted += balance_anonymized.m_denominated;
                 }
             }
         }

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -313,7 +313,19 @@ bool CWalletTx::IsTrusted() const
     return pwallet->IsTrusted(*this, trusted_parents);
 }
 
-CWallet::Balance CWallet::GetBalance(const int min_depth, const bool avoid_reuse, const bool fAddLocked, const CCoinControl* coinControl) const
+CAmount CWallet::GetBalanceAnonymized(const CCoinControl& coinControl) const
+{
+    if (!CCoinJoinClientOptions::IsEnabled()) return 0;
+
+    CAmount anonymized_amount{0};
+    LOCK(cs_wallet);
+    for (auto pcoin : GetSpendableTXs()) {
+        anonymized_amount += pcoin->GetAnonymizedCredit(coinControl);
+    }
+    return anonymized_amount;
+}
+
+CWallet::Balance CWallet::GetBalance(const int min_depth, const bool avoid_reuse, const bool fAddLocked) const
 {
     Balance ret;
     isminefilter reuse_filter = avoid_reuse ? ISMINE_NO : ISMINE_USED;
@@ -338,9 +350,13 @@ CWallet::Balance CWallet::GetBalance(const int min_depth, const bool avoid_reuse
             ret.m_mine_immature += wtx.GetImmatureCredit();
             ret.m_watchonly_immature += wtx.GetImmatureWatchOnlyCredit();
             if (CCoinJoinClientOptions::IsEnabled()) {
-                ret.m_anonymized += wtx.GetAnonymizedCredit(coinControl);
-                ret.m_denominated_trusted += wtx.GetDenominatedCredit(false);
-                ret.m_denominated_untrusted_pending += wtx.GetDenominatedCredit(true);
+                ret.m_anonymized += wtx.GetAnonymizedCredit();
+                const auto balance_anonymized = wtx.GetDenominatedCredit();
+                if (balance_anonymized.is_unconfirmed) {
+                    ret.m_denominated_untrusted_pending += balance_anonymized.m_denom_credit;
+                } else {
+                    ret.m_denominated_trusted += balance_anonymized.m_denom_credit;
+                }
             }
         }
     }

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -350,8 +350,8 @@ CWallet::Balance CWallet::GetBalance(const int min_depth, const bool avoid_reuse
             ret.m_mine_immature += wtx.GetImmatureCredit();
             ret.m_watchonly_immature += wtx.GetImmatureWatchOnlyCredit();
             if (CCoinJoinClientOptions::IsEnabled()) {
-                ret.m_anonymized += wtx.GetAnonymizedCredit();
-                const auto balance_anonymized = wtx.GetDenominatedCredit();
+                const auto balance_anonymized = wtx.GetAnonymizedBalance();
+                ret.m_anonymized += balance_anonymized.m_anonymized;
                 if (balance_anonymized.is_unconfirmed) {
                     ret.m_denominated_untrusted_pending += balance_anonymized.m_denom_credit;
                 } else {

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -329,6 +329,7 @@ CWallet::Balance CWallet::GetBalance(const int min_depth, const bool avoid_reuse
 {
     Balance ret;
     isminefilter reuse_filter = avoid_reuse ? ISMINE_NO : ISMINE_USED;
+    const bool cj_enabled = CCoinJoinClientOptions::IsEnabled();
     {
         LOCK(cs_wallet);
         std::set<uint256> trusted_parents;
@@ -349,7 +350,7 @@ CWallet::Balance CWallet::GetBalance(const int min_depth, const bool avoid_reuse
             }
             ret.m_mine_immature += wtx.GetImmatureCredit();
             ret.m_watchonly_immature += wtx.GetImmatureWatchOnlyCredit();
-            if (CCoinJoinClientOptions::IsEnabled()) {
+            if (cj_enabled) {
                 const auto balance_anonymized = wtx.GetAnonymizedBalance();
                 ret.m_anonymized += balance_anonymized.m_anonymized;
                 if (balance_anonymized.is_unconfirmed) {

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -291,6 +291,7 @@ public:
 
     struct BalanceAnonymized
     {
+        CAmount m_anonymized{0};
         CAmount m_denom_credit{0};
         bool is_unconfirmed{false};
     };
@@ -299,9 +300,8 @@ public:
     // annotation "EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)". The
     // annotation "NO_THREAD_SAFETY_ANALYSIS" was temporarily added to avoid
     // having to resolve the issue of member access into incomplete type CWallet.
-    CAmount GetAnonymizedCredit() const NO_THREAD_SAFETY_ANALYSIS;
     CAmount GetAnonymizedCredit(const CCoinControl& coinControl) const NO_THREAD_SAFETY_ANALYSIS;
-    BalanceAnonymized GetDenominatedCredit() const NO_THREAD_SAFETY_ANALYSIS;
+    BalanceAnonymized GetAnonymizedBalance() const NO_THREAD_SAFETY_ANALYSIS;
 
     /** Get the marginal bytes if spending the specified output from this transaction */
     int GetSpendSize(unsigned int out, bool use_max_sig = false) const

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -300,7 +300,9 @@ public:
     // annotation "EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)". The
     // annotation "NO_THREAD_SAFETY_ANALYSIS" was temporarily added to avoid
     // having to resolve the issue of member access into incomplete type CWallet.
+    /* Requires cs_wallet lock. */
     CAmount GetAnonymizedCredit(const CCoinControl& coinControl) const NO_THREAD_SAFETY_ANALYSIS;
+    /* Requires cs_wallet lock. */
     CoinJoinCredits GetAvailableCoinJoinCredits() const NO_THREAD_SAFETY_ANALYSIS;
 
     /** Get the marginal bytes if spending the specified output from this transaction */

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -289,12 +289,19 @@ public:
     CAmount GetImmatureWatchOnlyCredit(const bool fUseCache = true) const;
     CAmount GetChange() const;
 
+    struct BalanceAnonymized
+    {
+        CAmount m_denom_credit{0};
+        bool is_unconfirmed{false};
+    };
+
     // TODO: Remove "NO_THREAD_SAFETY_ANALYSIS" and replace it with the correct
     // annotation "EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)". The
     // annotation "NO_THREAD_SAFETY_ANALYSIS" was temporarily added to avoid
     // having to resolve the issue of member access into incomplete type CWallet.
-    CAmount GetAnonymizedCredit(const CCoinControl* coinControl = nullptr) const NO_THREAD_SAFETY_ANALYSIS;
-    CAmount GetDenominatedCredit(bool unconfirmed, bool fUseCache=true) const NO_THREAD_SAFETY_ANALYSIS;
+    CAmount GetAnonymizedCredit() const NO_THREAD_SAFETY_ANALYSIS;
+    CAmount GetAnonymizedCredit(const CCoinControl& coinControl) const NO_THREAD_SAFETY_ANALYSIS;
+    BalanceAnonymized GetDenominatedCredit() const NO_THREAD_SAFETY_ANALYSIS;
 
     /** Get the marginal bytes if spending the specified output from this transaction */
     int GetSpendSize(unsigned int out, bool use_max_sig = false) const

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -289,10 +289,10 @@ public:
     CAmount GetImmatureWatchOnlyCredit(const bool fUseCache = true) const;
     CAmount GetChange() const;
 
-    struct BalanceAnonymized
+    struct CoinJoinCredits
     {
         CAmount m_anonymized{0};
-        CAmount m_denom_credit{0};
+        CAmount m_denominated{0};
         bool is_unconfirmed{false};
     };
 
@@ -301,7 +301,7 @@ public:
     // annotation "NO_THREAD_SAFETY_ANALYSIS" was temporarily added to avoid
     // having to resolve the issue of member access into incomplete type CWallet.
     CAmount GetAnonymizedCredit(const CCoinControl& coinControl) const NO_THREAD_SAFETY_ANALYSIS;
-    BalanceAnonymized GetAnonymizedBalance() const NO_THREAD_SAFETY_ANALYSIS;
+    CoinJoinCredits GetAvailableCoinJoinCredits() const NO_THREAD_SAFETY_ANALYSIS;
 
     /** Get the marginal bytes if spending the specified output from this transaction */
     int GetSpendSize(unsigned int out, bool use_max_sig = false) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1993,7 +1993,7 @@ std::set<uint256> CWalletTx::GetConflicts() const
     return result;
 }
 
-CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
+CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl& coinControl) const
 {
     if (!pwallet)
         return 0;
@@ -2004,9 +2004,6 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
     if (IsCoinBase() || GetDepthInMainChain() < 0)
         return 0;
 
-    if (coinControl == nullptr && m_amounts[ANON_CREDIT].m_cached[ISMINE_SPENDABLE])
-        return m_amounts[ANON_CREDIT].m_value[ISMINE_SPENDABLE];
-
     CAmount nCredit = 0;
     uint256 hashTx = GetHash();
     for (unsigned int i = 0; i < tx->vout.size(); i++)
@@ -2014,7 +2011,7 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
         const CTxOut &txout = tx->vout[i];
         const COutPoint outpoint = COutPoint(hashTx, i);
 
-        if (coinControl != nullptr && coinControl->HasSelected() && !coinControl->IsSelected(outpoint)) {
+        if (coinControl.HasSelected() && !coinControl.IsSelected(outpoint)) {
             continue;
         }
 
@@ -2027,39 +2024,67 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
         }
     }
 
-    if (coinControl == nullptr) {
-        m_amounts[ANON_CREDIT].Set(ISMINE_SPENDABLE, nCredit);
+    return nCredit;
+}
+
+CAmount CWalletTx::GetAnonymizedCredit() const
+{
+    if (!pwallet)
+        return 0;
+
+    AssertLockHeld(pwallet->cs_wallet);
+
+    // Exclude coinbase and conflicted txes
+    if (IsCoinBase() || GetDepthInMainChain() < 0)
+        return 0;
+
+    if (m_amounts[ANON_CREDIT].m_cached[ISMINE_SPENDABLE])
+        return m_amounts[ANON_CREDIT].m_value[ISMINE_SPENDABLE];
+
+    CAmount nCredit = 0;
+    uint256 hashTx = GetHash();
+    for (unsigned int i = 0; i < tx->vout.size(); i++)
+    {
+        const CTxOut &txout = tx->vout[i];
+        const COutPoint outpoint = COutPoint(hashTx, i);
+
+        if (pwallet->IsSpent(hashTx, i) || !CoinJoin::IsDenominatedAmount(txout.nValue)) continue;
+
+        if (pwallet->IsFullyMixed(outpoint)) {
+            nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
+            if (!MoneyRange(nCredit))
+                throw std::runtime_error(std::string(__func__) + ": value out of range");
+        }
     }
+
+    m_amounts[ANON_CREDIT].Set(ISMINE_SPENDABLE, nCredit);
 
     return nCredit;
 }
 
-CAmount CWalletTx::GetDenominatedCredit(bool unconfirmed, bool fUseCache) const
+CWalletTx::BalanceAnonymized CWalletTx::GetDenominatedCredit() const
 {
+    CWalletTx::BalanceAnonymized ret{0, false};
     if (pwallet == nullptr)
-        return 0;
+        return ret;
 
     AssertLockHeld(pwallet->cs_wallet);
 
     // Must wait until coinbase is safely deep enough in the chain before valuing it
     if (IsCoinBase() && GetBlocksToMaturity() > 0)
-        return 0;
+        return ret;
 
     int nDepth = GetDepthInMainChain();
-    if (nDepth < 0) return 0;
+    if (nDepth < 0) return ret;
 
-    bool isUnconfirmed = IsTrusted() && nDepth == 0;
-    if (unconfirmed != isUnconfirmed) return 0;
+    ret.is_unconfirmed = IsTrusted() && nDepth == 0;
 
-    if (fUseCache) {
-        if(unconfirmed && m_amounts[DENOM_UCREDIT].m_cached[ISMINE_SPENDABLE]) {
-            return m_amounts[DENOM_UCREDIT].m_value[ISMINE_SPENDABLE];
-        } else if (!unconfirmed && m_amounts[DENOM_CREDIT].m_cached[ISMINE_SPENDABLE]) {
-            return m_amounts[DENOM_CREDIT].m_value[ISMINE_SPENDABLE];
-        }
+    if(ret.is_unconfirmed && m_amounts[DENOM_UCREDIT].m_cached[ISMINE_SPENDABLE]) {
+        return {m_amounts[DENOM_UCREDIT].m_value[ISMINE_SPENDABLE], ret.is_unconfirmed};
+    } else if (!ret.is_unconfirmed && m_amounts[DENOM_CREDIT].m_cached[ISMINE_SPENDABLE]) {
+        return {m_amounts[DENOM_CREDIT].m_value[ISMINE_SPENDABLE], ret.is_unconfirmed};
     }
 
-    CAmount nCredit = 0;
     uint256 hashTx = GetHash();
     for (unsigned int i = 0; i < tx->vout.size(); i++)
     {
@@ -2067,17 +2092,17 @@ CAmount CWalletTx::GetDenominatedCredit(bool unconfirmed, bool fUseCache) const
 
         if (pwallet->IsSpent(hashTx, i) || !CoinJoin::IsDenominatedAmount(txout.nValue)) continue;
 
-        nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
-        if (!MoneyRange(nCredit))
+        ret.m_denom_credit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
+        if (!MoneyRange(ret.m_denom_credit))
             throw std::runtime_error(std::string(__func__) + ": value out of range");
     }
 
-    if (unconfirmed) {
-        m_amounts[DENOM_UCREDIT].Set(ISMINE_SPENDABLE, nCredit);
+    if (ret.is_unconfirmed) {
+        m_amounts[DENOM_UCREDIT].Set(ISMINE_SPENDABLE, ret.m_denom_credit);
     } else {
-        m_amounts[DENOM_CREDIT].Set(ISMINE_SPENDABLE, nCredit);
+        m_amounts[DENOM_CREDIT].Set(ISMINE_SPENDABLE, ret.m_denom_credit);
     }
-    return nCredit;
+    return ret;
 }
 
 // Rebroadcast transactions from the wallet. We do this on a random timer

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2027,9 +2027,9 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl& coinControl) const
     return nCredit;
 }
 
-CWalletTx::BalanceAnonymized CWalletTx::GetAnonymizedBalance() const
+CWalletTx::CoinJoinCredits CWalletTx::GetAvailableCoinJoinCredits() const
 {
-    CWalletTx::BalanceAnonymized ret{0, false};
+    CWalletTx::CoinJoinCredits ret{0, false};
     if (pwallet == nullptr)
         return ret;
 
@@ -2066,16 +2066,16 @@ CWalletTx::BalanceAnonymized CWalletTx::GetAnonymizedBalance() const
                 throw std::runtime_error(std::string(__func__) + ": value out of range");
         }
 
-        ret.m_denom_credit += credit;
-        if (!MoneyRange(ret.m_denom_credit))
+        ret.m_denominated += credit;
+        if (!MoneyRange(ret.m_denominated))
             throw std::runtime_error(std::string(__func__) + ": value out of range");
     }
 
     m_amounts[ANON_CREDIT].Set(ISMINE_SPENDABLE, ret.m_anonymized);
     if (ret.is_unconfirmed) {
-        m_amounts[DENOM_UCREDIT].Set(ISMINE_SPENDABLE, ret.m_denom_credit);
+        m_amounts[DENOM_UCREDIT].Set(ISMINE_SPENDABLE, ret.m_denominated);
     } else {
-        m_amounts[DENOM_CREDIT].Set(ISMINE_SPENDABLE, ret.m_denom_credit);
+        m_amounts[DENOM_CREDIT].Set(ISMINE_SPENDABLE, ret.m_denominated);
     }
     return ret;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2029,7 +2029,7 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl& coinControl) const
 
 CWalletTx::CoinJoinCredits CWalletTx::GetAvailableCoinJoinCredits() const
 {
-    CWalletTx::CoinJoinCredits ret{0, false};
+    CWalletTx::CoinJoinCredits ret;
     if (pwallet == nullptr)
         return ret;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -709,7 +709,8 @@ public:
         CAmount m_denominated_trusted{0};
         CAmount m_denominated_untrusted_pending{0};
     };
-    Balance GetBalance(const int min_depth = 0, const bool avoid_reuse = true, const bool fAddLocked = false, const CCoinControl* coinControl = nullptr) const;
+    Balance GetBalance(const int min_depth = 0, const bool avoid_reuse = true, const bool fAddLocked = false) const;
+    CAmount GetBalanceAnonymized(const CCoinControl& coinControl) const;
 
     CAmount GetAnonymizableBalance(bool fSkipDenominated = false, bool fSkipUnconfirmed = true) const;
     float GetAverageAnonymizedRounds() const;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Wallets with big amount of transactions are loading too long time.

## What was done?
Optimized heavy calculations of balance by Wallet. See commits for details.
It makes Dash-Qt also a bit more responsible because a lot of balance calculations are done in `main` thread to update balances, though "the lagging" is not easy to measure.

## How Has This Been Tested?
Import pubkey with a lot transaction, for example `yVXDAM73Tg6A44Bm3qduXsMCYxzuqBCT48`
call `unloadwallet` + `loadwallet`, check time.

Loading of wallet is speed up from 24seconds to 23.5 seconds (average by mutiple runs).

here's detailed breakdown to particular functions (see branch with extra logs https://github.com/knst/dash/commits/perf-wallet-balance-with-logs/):
```
origin/develop (2f15c2bd81c65bba399b03a8c5186540412d7c7d)
2025-02-01T11:12:29Z [qt-rpcconsole] [w1] Wallet completed loading in            3279ms
2025-02-01T11:12:29Z [qt-rpcconsole] [w1] Rescan completed in              43ms
2025-02-01T11:12:43Z [      main] knst getBalances() 589.92ms
2025-02-01T11:12:43Z [      main] knst getAnonymizableBalance() 173.80ms
2025-02-01T11:12:43Z [      main] knst getDenominatedBalance() 186.28ms
2025-02-01T11:12:43Z [      main] knst getDenominatedBalance() 186.01ms
2025-02-01T11:12:43Z [      main] knst getNormalizedAnonymizedBalance() 27.66ms
2025-02-01T11:12:43Z [      main] knst getAverageAnonymizedRounds() 37.94ms
2025-02-01T11:12:44Z [      main] knst getAnonymizableBalance() 174.10ms
2025-02-01T11:12:44Z [      main] knst getDenominatedBalance() 189.23ms
2025-02-01T11:12:44Z [      main] knst getDenominatedBalance() 187.73ms
2025-02-01T11:12:44Z [      main] knst getNormalizedAnonymizedBalance() 27.77ms
2025-02-01T11:12:44Z [      main] knst getAverageAnonymizedRounds() 38.13ms
2025-02-01T11:12:47Z [      main] knst getBalances() 187.53ms
2025-02-01T11:12:47Z [      main] knst getBalances() 195.72ms
2025-02-01T11:12:48Z [      main] knst getBalances() 192.20ms
2025-02-01T11:12:48Z [      main] knst getBalances() 184.09ms
2025-02-01T11:12:48Z [      main] knst getAnonymizableBalance() 171.66ms
2025-02-01T11:12:48Z [      main] knst getDenominatedBalance() 185.26ms
2025-02-01T11:12:48Z [      main] knst getDenominatedBalance() 186.41ms
2025-02-01T11:12:48Z [      main] knst getNormalizedAnonymizedBalance() 25.77ms
2025-02-01T11:12:48Z [      main] knst getAverageAnonymizedRounds() 36.41ms
2025-02-01T11:12:49Z [      main] knst getBalances() 190.71ms
2025-02-01T11:12:49Z [      main] knst getAnonymizableBalance() 171.36ms
2025-02-01T11:12:49Z [      main] knst getDenominatedBalance() 185.21ms
2025-02-01T11:12:49Z [      main] knst getDenominatedBalance() 185.09ms
2025-02-01T11:12:49Z [      main] knst getNormalizedAnonymizedBalance() 26.28ms
2025-02-01T11:12:49Z [      main] knst getAverageAnonymizedRounds() 36.08ms

In total: 3279  +43  +589.92  +173.80  +186.28  +186.01  +27.66  +37.94  +174.10  +189.23  +187.73  +27.77  +38.13  +187.53  +195.72  +192.20  +184.09  +171.66  +185.26  +186.41  +25.77  +36.41  +190.71  +171.36  +185.21  +185.09  +26.28  +36.08
=7300.35
```

This PR:
```
perf-wallet-balance  (b0f71b4d3c714671a7174f7521988030a7a5708f)
# new HEAD
2025-02-01T11:20:11Z [qt-rpcconsole] [w1] Wallet completed loading in            3404ms
2025-02-01T11:20:11Z [qt-rpcconsole] [w1] Rescan completed in               0ms
2025-02-01T11:20:24Z [      main] knst getBalances() 544.79ms
2025-02-01T11:20:25Z [      main] knst getAnonymizableBalance() 173.77ms
2025-02-01T11:20:25Z [      main] knst getBalances() 139.59ms
2025-02-01T11:20:25Z [      main] knst getNormalizedAnonymizedBalance() 25.87ms
2025-02-01T11:20:25Z [      main] knst getAverageAnonymizedRounds() 35.35ms
2025-02-01T11:20:25Z [      main] knst getAnonymizableBalance() 171.82ms
2025-02-01T11:20:25Z [      main] knst getBalances() 141.07ms
2025-02-01T11:20:25Z [      main] knst getNormalizedAnonymizedBalance() 25.77ms
2025-02-01T11:20:25Z [      main] knst getAverageAnonymizedRounds() 35.45ms
2025-02-01T11:20:28Z [      main] knst getBalances() 142.88ms
2025-02-01T11:20:28Z [      main] knst getBalances() 137.15ms
2025-02-01T11:20:29Z [      main] knst getBalances() 136.33ms
2025-02-01T11:20:29Z [      main] knst getBalances() 137.43ms
2025-02-01T11:20:29Z [      main] knst getAnonymizableBalance() 172.26ms
2025-02-01T11:20:29Z [      main] knst getBalances() 140.42ms
2025-02-01T11:20:29Z [      main] knst getNormalizedAnonymizedBalance() 25.78ms
2025-02-01T11:20:29Z [      main] knst getAverageAnonymizedRounds() 34.88ms
2025-02-01T11:20:29Z [      main] knst getBalances() 144.52ms
2025-02-01T11:20:29Z [      main] knst getAnonymizableBalance() 170.65ms
2025-02-01T11:20:30Z [      main] knst getBalances() 141.37ms
2025-02-01T11:20:30Z [      main] knst getNormalizedAnonymizedBalance() 26.05ms
2025-02-01T11:20:30Z [      main] knst getAverageAnonymizedRounds() 36.16ms
2025-02-01T11:20:30Z [      main] knst getBalances() 143.27ms

3404  +0  +544.79  +173.77  +139.59  +25.87  +35.35  +171.82  +141.07  +25.77  +35.45  +142.88  +137.15  +136.33  +137.43  +172.26  +140.42  +25.78  +34.88  +144.52  +170.65  +141.37  +26.05  +36.16  +143.27
=6286.63
```

Sum-up improvement is slightly higher then real improvement of call `loadwallet` (1 second as sum of function vs 0.5 second as total RPC time) due to fact that calculations distributed between 2 threads: `main` and `qt-rpcconsole`.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone