### PR TITLE
backport: merge bitcoin#22903, #24753, #24831, #28240, #27012, #25713, #24971, #25047 (clang-tidy and IWYU)

### DIFF
--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -73,6 +73,8 @@ if [ "${RUN_TIDY}" = "true" ]; then
   iwyu_tool.py \
     "src/compat" \
     "src/init" \
+    "src/rpc/fees.cpp" \
+    "src/rpc/signmessage.cpp" \
     -p . "${MAKEJOBS}" \
     -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
     |& tee "/tmp/iwyu_ci.out"

--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -66,8 +66,9 @@ if [ -n "$USE_VALGRIND" ]; then
 fi
 
 if [ "${RUN_TIDY}" = "true" ]; then
+  set -eo pipefail
   cd src
-  run-clang-tidy "${MAKEJOBS}"
+  ( run-clang-tidy -quiet "${MAKEJOBS}" ) | grep -C5 "error"
   cd ..
   iwyu_tool.py \
     "src/compat" \

--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -69,6 +69,10 @@ if [ "${RUN_TIDY}" = "true" ]; then
   cd src
   run-clang-tidy "${MAKEJOBS}"
   cd ..
+  iwyu_tool.py \
+    "src/compat" \
+    "src/init" \
+    -p . "${MAKEJOBS}" -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp"
 fi
 
 if [ "$RUN_SECURITY_TESTS" = "true" ]; then

--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -72,7 +72,12 @@ if [ "${RUN_TIDY}" = "true" ]; then
   iwyu_tool.py \
     "src/compat" \
     "src/init" \
-    -p . "${MAKEJOBS}" -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp"
+    -p . "${MAKEJOBS}" \
+    -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
+    |& tee "/tmp/iwyu_ci.out"
+  cd src
+  fix_includes.py --nosafe_headers < /tmp/iwyu_ci.out
+  git --no-pager diff
 fi
 
 if [ "$RUN_SECURITY_TESTS" = "true" ]; then

--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -52,7 +52,7 @@ cd dashcore-$BUILD_TARGET
 bash -c "./configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG" || ( cat config.log && false)
 
 if [ "${RUN_TIDY}" = "true" ]; then
-  MAYBE_BEAR="bear"
+  MAYBE_BEAR="bear --config src/.bear-tidy-config"
   MAYBE_TOKEN="--"
 fi
 

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -38,6 +38,7 @@ export USE_BUSY_BOX=${USE_BUSY_BOX:-false}
 
 export RUN_UNIT_TESTS=${RUN_UNIT_TESTS:-true}
 export RUN_FUNCTIONAL_TESTS=${RUN_FUNCTIONAL_TESTS:-true}
+export RUN_TIDY=${RUN_TIDY:-false}
 export RUN_SECURITY_TESTS=${RUN_SECURITY_TESTS:-false}
 # By how much to scale the test_runner timeouts (option --timeout-factor).
 # This is needed because some ci machines have slow CPU or disk, so sanitizers

--- a/ci/test/00_setup_env_native_multiprocess.sh
+++ b/ci/test/00_setup_env_native_multiprocess.sh
@@ -10,7 +10,10 @@ export CONTAINER_NAME=ci_native_multiprocess
 export HOST=x86_64-pc-linux-gnu
 export PACKAGES="cmake python3 llvm clang"
 export DEP_OPTS="MULTIPROCESS=1 CC=clang-18 CXX=clang++-18"
+export RUN_TIDY=true
 export GOAL="install"
 export TEST_RUNNER_EXTRA="--v2transport"
 export BITCOIN_CONFIG="--with-boost-process --enable-debug CC=clang-18 CXX=clang++-18" # Use clang to avoid OOM
+# Additional flags for RUN_TIDY
+export BITCOIN_CONFIG="${BITCOIN_CONFIG} --disable-hardening CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0'"
 export BITCOIND=dash-node  # Used in functional tests

--- a/configure.ac
+++ b/configure.ac
@@ -1921,6 +1921,7 @@ AC_CONFIG_LINKS([contrib/devtools/test-security-check.py:contrib/devtools/test-s
 AC_CONFIG_LINKS([contrib/devtools/symbol-check.py:contrib/devtools/symbol-check.py])
 AC_CONFIG_LINKS([contrib/devtools/test-symbol-check.py:contrib/devtools/test-symbol-check.py])
 AC_CONFIG_LINKS([contrib/filter-lcov.py:contrib/filter-lcov.py])
+AC_CONFIG_LINKS([src/.bear-tidy-config:src/.bear-tidy-config])
 AC_CONFIG_LINKS([src/.clang-tidy:src/.clang-tidy])
 AC_CONFIG_LINKS([test/functional/test_runner.py:test/functional/test_runner.py])
 AC_CONFIG_LINKS([test/fuzz/test_runner.py:test/fuzz/test_runner.py])

--- a/configure.ac
+++ b/configure.ac
@@ -1921,6 +1921,7 @@ AC_CONFIG_LINKS([contrib/devtools/test-security-check.py:contrib/devtools/test-s
 AC_CONFIG_LINKS([contrib/devtools/symbol-check.py:contrib/devtools/symbol-check.py])
 AC_CONFIG_LINKS([contrib/devtools/test-symbol-check.py:contrib/devtools/test-symbol-check.py])
 AC_CONFIG_LINKS([contrib/filter-lcov.py:contrib/filter-lcov.py])
+AC_CONFIG_LINKS([src/.clang-tidy:src/.clang-tidy])
 AC_CONFIG_LINKS([test/functional/test_runner.py:test/functional/test_runner.py])
 AC_CONFIG_LINKS([test/fuzz/test_runner.py:test/fuzz/test_runner.py])
 AC_CONFIG_LINKS([test/util/test_runner.py:test/util/test_runner.py])

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -84,8 +84,10 @@ RUN set -ex; \
     "clang-tidy-${LLVM_VERSION}" \
     "libc++-${LLVM_VERSION}-dev" \
     "libc++abi-${LLVM_VERSION}-dev" \
+    "libclang-${LLVM_VERSION}-dev" \
     "libclang-rt-${LLVM_VERSION}-dev" \
-    "lld-${LLVM_VERSION}"; \
+    "lld-${LLVM_VERSION}" \
+    "llvm-${LLVM_VERSION}-dev"; \
     rm -rf /var/lib/apt/lists/*; \
     echo "Setting defaults..."; \
     lldbUpdAltArgs="update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${LLVM_VERSION} 100"; \
@@ -140,6 +142,14 @@ RUN set -ex; \
     git clone --depth 1 --no-tags --branch=${DASH_HASH_VERSION} https://github.com/dashpay/dash_hash; \
     cd dash_hash && pip3 install -r requirements.txt .; \
     cd .. && rm -rf dash_hash
+
+RUN set -ex; \
+    git clone --depth=1 "https://github.com/include-what-you-use/include-what-you-use" -b "clang_${LLVM_VERSION}" /opt/iwyu; \
+    cd /opt/iwyu; \
+    mkdir build && cd build; \
+    cmake -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-${LLVM_VERSION} ..; \
+    make install -j "$(( $(nproc) - 1 ))"; \
+    cd /opt && rm -rf /opt/iwyu;
 
 ARG SHELLCHECK_VERSION=v0.7.1
 RUN set -ex; \

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex; \
     autotools-dev \
     automake \
     autoconf \
+    bear \
     bison \
     build-essential \
     bsdmainutils \
@@ -88,7 +89,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*; \
     echo "Setting defaults..."; \
     lldbUpdAltArgs="update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${LLVM_VERSION} 100"; \
-    for binName in clang clang++ clang-format clang-tidy clangd dsymutil lld lldb lldb-server llvm-ar llvm-cov llvm-nm llvm-objdump llvm-ranlib llvm-strip; do \
+    for binName in clang clang++ clang-apply-replacements clang-format clang-tidy clangd dsymutil lld lldb lldb-server llvm-ar llvm-cov llvm-nm llvm-objdump llvm-ranlib llvm-strip run-clang-tidy; do \
         lldbUpdAltArgs="${lldbUpdAltArgs} --slave /usr/bin/${binName} ${binName} /usr/bin/${binName}-${LLVM_VERSION}"; \
     done; \
     for binName in ld64.lld ld.lld lld-link wasm-ld; do \

--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -1,0 +1,6 @@
+# Fixups / upstreamed changes
+[
+  { include: [ "<bits/termios-c_lflag.h>", private, "<termios.h>", public ] },
+  { include: [ "<bits/termios-struct.h>", private, "<termios.h>", public ] },
+  { include: [ "<bits/termios-tcflow.h>", private, "<termios.h>", public ] },
+]

--- a/src/.bear-tidy-config
+++ b/src/.bear-tidy-config
@@ -1,0 +1,23 @@
+{
+  "output": {
+    "content": {
+      "include_only_existing_source": true,
+      "paths_to_include": [],
+      "paths_to_exclude": [
+        "src/crc32",
+        "src/crypto/x11",
+        "src/dashbls",
+        "src/gsl",
+        "src/immer",
+        "src/leveldb",
+        "src/minisketch",
+        "src/univalue",
+        "src/secp256k1"
+      ]
+    },
+    "format": {
+      "command_as_array": true,
+      "drop_output_field": false
+    }
+  }
+}

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,2 @@
+Checks:          '-*,bugprone-argument-comment'
+WarningsAsErrors: bugprone-argument-comment

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,2 +1,2 @@
-Checks:          '-*,bugprone-argument-comment'
-WarningsAsErrors: bugprone-argument-comment
+Checks:          '-*,bugprone-argument-comment,modernize-use-nullptr'
+WarningsAsErrors: 'bugprone-argument-comment,modernize-use-nullptr'

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,2 +1,11 @@
-Checks:          '-*,bugprone-argument-comment,modernize-use-nullptr'
-WarningsAsErrors: 'bugprone-argument-comment,modernize-use-nullptr'
+Checks: '
+-*,
+bugprone-argument-comment,
+modernize-use-nullptr,
+readability-redundant-declaration,
+'
+WarningsAsErrors: '
+bugprone-argument-comment,
+modernize-use-nullptr,
+readability-redundant-declaration,
+'

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -51,7 +51,7 @@ static void CoinSelection(benchmark::Bench& bench)
     const CoinSelectionParams coin_selection_params(/* change_output_size= */ 34,
                                                     /* change_spend_size= */ 148, /* effective_feerate= */ CFeeRate(0),
                                                     /* long_term_feerate= */ CFeeRate(0), /* discard_feerate= */ CFeeRate(0),
-                                                    /* tx_no_inputs_size= */ 0, /* avoid_partial= */ false);
+                                                    /* tx_noinputs_size= */ 0, /* avoid_partial= */ false);
     bench.run([&] {
         std::set<CInputCoin> setCoinsRet;
         CAmount nValueRet;

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -9,7 +9,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(HAVE_BYTESWAP_H)
 #include <byteswap.h>

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -22,19 +22,18 @@
 #include <ws2tcpip.h>
 #include <cstdint>
 #else
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <net/if.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <arpa/inet.h>
-#include <ifaddrs.h>
-#include <limits.h>
-#include <netdb.h>
-#include <unistd.h>
+#include <arpa/inet.h>   // IWYU pragma: export
+#include <fcntl.h>       // IWYU pragma: export
+#include <ifaddrs.h>     // IWYU pragma: export
+#include <net/if.h>      // IWYU pragma: export
+#include <netdb.h>       // IWYU pragma: export
+#include <netinet/in.h>  // IWYU pragma: export
+#include <netinet/tcp.h> // IWYU pragma: export
+#include <sys/mman.h>    // IWYU pragma: export
+#include <sys/select.h>  // IWYU pragma: export
+#include <sys/socket.h>  // IWYU pragma: export
+#include <sys/types.h>   // IWYU pragma: export
+#include <unistd.h>      // IWYU pragma: export
 #endif
 
 // We map Linux / BSD error functions and codes, to the equivalent

--- a/src/compat/cpuid.h
+++ b/src/compat/cpuid.h
@@ -10,6 +10,8 @@
 
 #include <cpuid.h>
 
+#include <cstdint>
+
 // We can't use cpuid.h's __get_cpuid as it does not support subleafs.
 void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
 {

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -11,7 +11,7 @@
 
 #include <compat/byteswap.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(HAVE_ENDIAN_H)
 #include <endian.h>

--- a/src/compat/stdin.cpp
+++ b/src/compat/stdin.cpp
@@ -2,22 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
-#endif
+#include <compat/stdin.h>
 
-#include <cstdio>       // for fileno(), stdin
+#include <cstdio>
 
 #ifdef WIN32
-#include <windows.h>    // for SetStdinEcho()
-#include <io.h>         // for isatty()
+#include <windows.h>
+#include <io.h>
 #else
-#include <termios.h>    // for SetStdinEcho()
-#include <unistd.h>     // for SetStdinEcho(), isatty()
-#include <poll.h>       // for StdinReady()
+#include <termios.h>
+#include <unistd.h>
+#include <poll.h>
 #endif
-
-#include <compat/stdin.h>
 
 // https://stackoverflow.com/questions/1413445/reading-a-password-from-stdcin
 void SetStdinEcho(bool enable)

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1545,7 +1545,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex* pindex, CConnman& co
 
 void CGovernanceManager::RequestOrphanObjects(CConnman& connman)
 {
-    const CConnman::NodesSnapshot snap{connman, /* filter = */ CConnman::FullyConnectedOnly};
+    const CConnman::NodesSnapshot snap{connman, /* cond = */ CConnman::FullyConnectedOnly};
 
     std::vector<uint256> vecHashesFiltered;
     {

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -9,16 +9,20 @@
 #include <bls/bls.h>
 #include <clientversion.h>
 #include <crypto/sha256.h>
+#include <fs.h>
 #include <key.h>
 #include <logging.h>
 #include <node/interface_ui.h>
 #include <random.h>
+#include <tinyformat.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 
-#include <memory>
+#include <algorithm>
+#include <string>
+#include <vector>
 
 namespace init {
 void SetGlobals()

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -1113,7 +1113,7 @@ bool CSigSharesManager::SendMessages(CConnman& connman)
         return session->sendSessionId;
     };
 
-    const CConnman::NodesSnapshot snap{connman, /* filter = */ CConnman::FullyConnectedOnly};
+    const CConnman::NodesSnapshot snap{connman, /* cond = */ CConnman::FullyConnectedOnly};
     {
         LOCK(cs);
         CollectSigSharesToRequest(sigSharesToRequest);

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -195,7 +195,7 @@ static bool ProcessUpnp()
         std::string strDesc = PACKAGE_NAME " " + FormatFullVersion();
 
         do {
-            r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype, port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0, "0");
+            r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype, port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", nullptr, "0");
 
             if (r != UPNPCOMMAND_SUCCESS) {
                 ret = false;
@@ -208,7 +208,7 @@ static bool ProcessUpnp()
         } while (g_mapport_interrupt.sleep_for(PORT_MAPPING_REANNOUNCE_PERIOD));
         g_mapport_interrupt.reset();
 
-        r = UPNP_DeletePortMapping(urls.controlURL, data.first.servicetype, port.c_str(), "TCP", 0);
+        r = UPNP_DeletePortMapping(urls.controlURL, data.first.servicetype, port.c_str(), "TCP", nullptr);
         LogPrintf("UPNP_DeletePortMapping() returned: %d\n", r);
         freeUPNPDevlist(devlist); devlist = nullptr;
         FreeUPNPUrls(&urls);

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -139,7 +139,7 @@ void CMasternodeSync::ProcessTick(const PeerManager& peerman, const CGovernanceM
     }
 
     nTimeLastProcess = GetTime();
-    const CConnman::NodesSnapshot snap{connman, /* filter = */ CConnman::FullyConnectedOnly};
+    const CConnman::NodesSnapshot snap{connman, /* cond = */ CConnman::FullyConnectedOnly};
 
     // gradually request the rest of the votes after sync finished
     if(IsSynced()) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -134,9 +134,6 @@ static const uint64_t SELECT_TIMEOUT_MILLISECONDS = 500;
 
 const std::string NET_MESSAGE_TYPE_OTHER = "*other*";
 
-constexpr const CConnman::CFullyConnectedOnly CConnman::FullyConnectedOnly;
-constexpr const CConnman::CAllNodes CConnman::AllNodes;
-
 static const uint64_t RANDOMIZER_ID_NETGROUP = 0x6c0edd8036ef4036ULL; // SHA256("netgroup")[0:8]
 static const uint64_t RANDOMIZER_ID_LOCALHOSTNONCE = 0xd93e69e2bbfa5735ULL; // SHA256("localhostnonce")[0:8]
 static const uint64_t RANDOMIZER_ID_ADDRCACHE = 0x1cf2e4ddd306dda9ULL; // SHA256("addrcache")[0:8]

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2336,7 +2336,7 @@ void CConnman::CalculateNumConnectionsChangedStats()
     }
     mapRecvBytesMsgStats[NET_MESSAGE_TYPE_OTHER] = 0;
     mapSentBytesMsgStats[NET_MESSAGE_TYPE_OTHER] = 0;
-    const NodesSnapshot snap{*this, /* filter = */ CConnman::FullyConnectedOnly};
+    const NodesSnapshot snap{*this, /* cond = */ CConnman::FullyConnectedOnly};
     for (auto pnode : snap.Nodes()) {
         WITH_LOCK(pnode->cs_vRecv, pnode->UpdateRecvMapWithStats(mapRecvBytesMsgStats));
         WITH_LOCK(pnode->cs_vSend, pnode->UpdateSentMapWithStats(mapSentBytesMsgStats));
@@ -2705,7 +2705,7 @@ void CConnman::SocketHandler(CMasternodeSync& mn_sync)
     }();
 
     {
-        const NodesSnapshot snap{*this, /* filter = */ CConnman::AllNodes, /* shuffle = */ false};
+        const NodesSnapshot snap{*this, /* cond = */ CConnman::AllNodes, /* shuffle = */ false};
 
         // Check for the readiness of the already connected sockets and the
         // listening sockets in one call ("readiness" as in poll(2) or
@@ -3977,7 +3977,7 @@ void CConnman::ThreadMessageHandler()
         // Randomize the order in which we process messages from/to our peers.
         // This prevents attacks in which an attacker exploits having multiple
         // consecutive connections in the m_nodes list.
-        const NodesSnapshot snap{*this, /* filter = */ CConnman::AllNodes, /* shuffle = */ true};
+        const NodesSnapshot snap{*this, /* cond = */ CConnman::AllNodes, /* shuffle = */ true};
 
         for (CNode* pnode : snap.Nodes()) {
             if (pnode->fDisconnect)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4763,7 +4763,7 @@ void PeerManagerImpl::ProcessMessage(
             // the peer if the header turns out to be for an invalid block.
             // Note that if a peer tries to build on an invalid chain, that
             // will be detected and the peer will be disconnected/discouraged.
-            return ProcessHeadersMessage(pfrom, *peer, {cmpctblock.header}, /*punish_duplicate_invalid=*/true);
+            return ProcessHeadersMessage(pfrom, *peer, {cmpctblock.header}, /*via_compact_block=*/true);
         }
 
         if (fBlockReconstructed) {

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -19,9 +19,6 @@
 #include <ios>
 #include <tuple>
 
-constexpr size_t CNetAddr::V1_SERIALIZATION_SIZE;
-constexpr size_t CNetAddr::MAX_ADDRV2_SIZE;
-
 CNetAddr::BIP155Network CNetAddr::GetBIP155Network() const
 {
     switch (m_net) {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -658,7 +658,7 @@ bool ConnectThroughProxy(const Proxy& proxy, const std::string& strDest, uint16_
             return false;
         }
     } else {
-        if (!Socks5(strDest, port, 0, sock)) {
+        if (!Socks5(strDest, port, nullptr, sock)) {
             return false;
         }
     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -532,7 +532,7 @@ int GuiMain(int argc, char* argv[])
     if (gArgs.IsArgSet("-printcrashinfo")) {
         auto crashInfo = GetCrashInfoStrFromSerializedStr(gArgs.GetArg("-printcrashinfo", ""));
         std::cout << crashInfo << std::endl;
-        QMessageBox::critical(0, PACKAGE_NAME, QString::fromStdString(crashInfo));
+        QMessageBox::critical(nullptr, PACKAGE_NAME, QString::fromStdString(crashInfo));
         return EXIT_SUCCESS;
     }
 
@@ -630,7 +630,7 @@ int GuiMain(int argc, char* argv[])
     GUIUtil::LogQtInfo();
     // Load custom application fonts and setup font management
     if (!GUIUtil::loadFonts()) {
-        QMessageBox::critical(0, PACKAGE_NAME,
+        QMessageBox::critical(nullptr, PACKAGE_NAME,
                               QObject::tr("Error: Failed to load application fonts."));
         return EXIT_FAILURE;
     }
@@ -643,7 +643,7 @@ int GuiMain(int argc, char* argv[])
         try {
             family = GUIUtil::fontFamilyFromString(strFamily);
         } catch (const std::exception& e) {
-            QMessageBox::critical(0, PACKAGE_NAME,
+            QMessageBox::critical(nullptr, PACKAGE_NAME,
                                   QObject::tr("Error: Specified font-family invalid. Valid values: %1.").arg("SystemDefault, Montserrat"));
             return EXIT_FAILURE;
         }
@@ -653,7 +653,7 @@ int GuiMain(int argc, char* argv[])
     if (gArgs.IsArgSet("-font-weight-normal")) {
         QFont::Weight weight;
         if (!GUIUtil::weightFromArg(gArgs.GetIntArg("-font-weight-normal", GUIUtil::weightToArg(GUIUtil::getFontWeightNormal())), weight)) {
-            QMessageBox::critical(0, PACKAGE_NAME,
+            QMessageBox::critical(nullptr, PACKAGE_NAME,
                                   QObject::tr("Error: Specified font-weight-normal invalid. Valid range %1 to %2.").arg(0).arg(8));
             return EXIT_FAILURE;
         }
@@ -663,7 +663,7 @@ int GuiMain(int argc, char* argv[])
     if (gArgs.IsArgSet("-font-weight-bold")) {
         QFont::Weight weight;
         if (!GUIUtil::weightFromArg(gArgs.GetIntArg("-font-weight-bold", GUIUtil::weightToArg(GUIUtil::getFontWeightBold())), weight)) {
-            QMessageBox::critical(0, PACKAGE_NAME,
+            QMessageBox::critical(nullptr, PACKAGE_NAME,
                                   QObject::tr("Error: Specified font-weight-bold invalid. Valid range %1 to %2.").arg(0).arg(8));
             return EXIT_FAILURE;
         }
@@ -674,7 +674,7 @@ int GuiMain(int argc, char* argv[])
         const int nScaleMin = -100, nScaleMax = 100;
         int nScale = gArgs.GetIntArg("-font-scale", GUIUtil::getFontScale());
         if (nScale < nScaleMin || nScale > nScaleMax) {
-            QMessageBox::critical(0, PACKAGE_NAME,
+            QMessageBox::critical(nullptr, PACKAGE_NAME,
                                   QObject::tr("Error: Specified font-scale invalid. Valid range %1 to %2.").arg(nScaleMin).arg(nScaleMax));
             return EXIT_FAILURE;
         }
@@ -688,7 +688,7 @@ int GuiMain(int argc, char* argv[])
         QString strFile;
 
         if (!fs::is_directory(customDir)) {
-            QMessageBox::critical(0, PACKAGE_NAME,
+            QMessageBox::critical(nullptr, PACKAGE_NAME,
                                   QObject::tr("Error: Invalid -custom-css-dir path.") + "\n\n" + strCustomDir);
             return EXIT_FAILURE;
         }
@@ -708,7 +708,7 @@ int GuiMain(int argc, char* argv[])
             for (const auto& strMissingFile : vecRequiredFiles) {
                 strMissingFiles += strMissingFile + "\n";
             }
-            QMessageBox::critical(0, PACKAGE_NAME,
+            QMessageBox::critical(nullptr, PACKAGE_NAME,
                                   QObject::tr("Error: %1 CSS file(s) missing in -custom-css-dir path.").arg(vecRequiredFiles.size()) + "\n\n" + strMissingFiles);
             return EXIT_FAILURE;
         }
@@ -717,7 +717,7 @@ int GuiMain(int argc, char* argv[])
     }
     // Validate -debug-ui
     if (gArgs.GetBoolArg("-debug-ui", false)) {
-        QMessageBox::warning(0, PACKAGE_NAME,
+        QMessageBox::warning(nullptr, PACKAGE_NAME,
                                 "Warning: UI debug mode (-debug-ui) enabled" + QString(gArgs.IsArgSet("-custom-css-dir") ? "." : " without a custom css directory set with -custom-css-dir."));
     }
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -229,7 +229,7 @@ bool Intro::showIfNeeded(bool& did_show_intro, int64_t& prune_MiB)
         }
 
         /* Let the user choose one */
-        Intro intro(0, Params().AssumedBlockchainSize(), Params().AssumedChainStateSize());
+        Intro intro(nullptr, Params().AssumedBlockchainSize(), Params().AssumedChainStateSize());
         GUIUtil::disableMacFocusRect(&intro);
         GUIUtil::loadStyleSheet(true);
         intro.setDataDirectory(dataDirDefaultCurrent);

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -376,10 +376,10 @@ void RandAddStaticEnv(CSHA512& hasher)
 
 #if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
     // Network interfaces
-    struct ifaddrs *ifad = NULL;
+    struct ifaddrs *ifad = nullptr;
     getifaddrs(&ifad);
     struct ifaddrs *ifit = ifad;
-    while (ifit != NULL) {
+    while (ifit != nullptr) {
         hasher.Write((const unsigned char*)&ifit, sizeof(ifit));
         hasher.Write((const unsigned char*)ifit->ifa_name, strlen(ifit->ifa_name) + 1);
         hasher.Write((const unsigned char*)&ifit->ifa_flags, sizeof(ifit->ifa_flags));

--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -21,7 +21,11 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <list>
 #include <string>
+#include <vector>
+
+struct NodeContext;
 
 static RPCHelpMan estimatesmartfee()
 {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -539,7 +539,7 @@ static RPCHelpMan mnauth()
     }
 
     CBLSPublicKey publicKey;
-    publicKey.SetHexStr(request.params[2].get_str(), /*bls_legacy_scheme=*/false);
+    publicKey.SetHexStr(request.params[2].get_str(), /*specificLegacyScheme=*/false);
     if (!publicKey.IsValid()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "publicKey invalid");
     }

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -33,10 +33,6 @@
 #include <iomanip>
 #include <optional>
 
-namespace llmq {
-extern const std::string CLSIG_REQUESTID_PREFIX;
-}
-
 static RPCHelpMan quorum_list()
 {
     return RPCHelpMan{"quorum list",

--- a/src/rpc/signmessage.cpp
+++ b/src/rpc/signmessage.cpp
@@ -13,6 +13,7 @@
 #include <util/message.h>
 
 #include <string>
+#include <vector>
 
 static RPCHelpMan verifymessage()
 {

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -38,7 +38,7 @@ struct secure_allocator : public std::allocator<T> {
         typedef secure_allocator<_Other> other;
     };
 
-    T* allocate(std::size_t n, const void* hint = 0)
+    T* allocate(std::size_t n, const void* hint = nullptr)
     {
         T* allocation = static_cast<T*>(LockedPoolManager::Instance().alloc(sizeof(T) * n));
         if (!allocation) {

--- a/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
+++ b/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
@@ -128,7 +128,7 @@ void ECRYPT_encrypt_bytes(ECRYPT_ctx* x, const u8* m, u8* c, u32 bytes)
 {
     u32 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
     u32 j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
-    u8* ctarget = NULL;
+    u8* ctarget = nullptr;
     u8 tmp[64];
     uint32_t i;
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -314,7 +314,7 @@ std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
 
 TorController::TorController(struct event_base* _base, const std::string& tor_control_center, const CService& target):
     base(_base),
-    m_tor_control_center(tor_control_center), conn(base), reconnect(true), reconnect_ev(0),
+    m_tor_control_center(tor_control_center), conn(base), reconnect(true), reconnect_ev(nullptr),
     reconnect_timeout(RECONNECT_TIMEOUT_START),
     m_target(target)
 {

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -12,15 +12,26 @@
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <random.h>
+#include <tinyformat.h>
+#include <util/check.h>
 #include <util/readwritefile.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/system.h>
 #include <util/thread.h>
 #include <util/time.h>
 
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
 #include <deque>
 #include <functional>
+#include <map>
+#include <optional>
 #include <set>
+#include <thread>
+#include <utility>
 #include <vector>
 
 #include <event2/buffer.h>
@@ -78,15 +89,15 @@ void TorControlConnection::readcb(struct bufferevent *bev, void *ctx)
         if (s.size() < 4) // Short line
             continue;
         // <status>(-|+| )<data><CRLF>
-        self->message.code = LocaleIndependentAtoi<int>(s.substr(0,3));
+        self->message.code = ToIntegral<int>(s.substr(0, 3)).value_or(0);
         self->message.lines.push_back(s.substr(4));
         char ch = s[3]; // '-','+' or ' '
         if (ch == ' ') {
             // Final line, dispatch reply and clean up
             if (self->message.code >= 600) {
+                // (currently unused)
                 // Dispatch async notifications to async handler
                 // Synchronous and asynchronous messages are never interleaved
-                self->async_handler(*self, self->message);
             } else {
                 if (!self->reply_handlers.empty()) {
                     // Invoke reply handler with message

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -11,18 +11,13 @@
 #include <fs.h>
 #include <netaddress.h>
 
-#include <boost/signals2/signal.hpp>
+#include <event2/util.h>
 
-#include <event2/bufferevent.h>
-#include <event2/event.h>
-
-#include <cstdlib>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <string>
 #include <vector>
-
-class CService;
 
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;
@@ -83,8 +78,6 @@ public:
      */
     bool Command(const std::string &cmd, const ReplyHandlerCB& reply_handler);
 
-    /** Response handlers for async replies */
-    boost::signals2::signal<void(TorControlConnection &,const TorControlReply &)> async_handler;
 private:
     /** Callback when ready for use */
     std::function<void(TorControlConnection&)> connected;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -457,7 +457,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
     }
 
     // Call CheckInputScripts() to cache signature and script validity against current tip consensus rules.
-    return CheckInputScripts(tx, state, view, flags, /* cacheSigStore = */ true, /* cacheFullSciptStore = */ true, txdata);
+    return CheckInputScripts(tx, state, view, flags, /* cacheSigStore = */ true, /* cacheFullScriptStore = */ true, txdata);
 }
 
 namespace {

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -10,8 +10,6 @@
 #include <boost/test/unit_test.hpp>
 #include <wallet/test/wallet_test_fixture.h>
 
-extern bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath);
-
 BOOST_FIXTURE_TEST_SUITE(psbt_wallet_tests, WalletTestingSetup)
 
 BOOST_AUTO_TEST_CASE(psbt_updater_test)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3377,7 +3377,7 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain* chain, interfaces::C
     } else if (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS) {
         // Make it impossible to disable private keys after creation
         error = strprintf(_("Error loading %s: Private keys can only be disabled during creation"), walletFile);
-        return NULL;
+        return nullptr;
     } else if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         for (auto spk_man : walletInstance->GetActiveScriptPubKeyMans()) {
             if (spk_man->HavePrivateKeys()) {


### PR DESCRIPTION
## Additional Information

* While linting is generally reserved for our `arm_linux` build variant, utilizing IWYU (which in turns relies on `bear` for the compilation database, also relied upon by `clang-tidy`) requires a version paired to the Clang version ([source](https://github.com/dashpay/dash/blob/0b42caa2e84636e9a2901b485ea87627014a013b/contrib/containers/ci/Dockerfile#L139)) used to build the target codebase.

  This means it has to be run on a build variant that uses Clang. We have opted to use `linux64_multiprocess` as it the most lightweight Clang build variant available (compared to fuzz, UBSan and TSan variants which come with sanitizers tacked on).

* An earlier version of this PR ([source](https://github.com/dashpay/dash/tree/2676eb914d7a1ca6a0f194fe5c573294c3ebee2f)) attempted to apply IWYU to Dash-specific code. This attempt was aborted because IWYU was found to behave non-deterministically.

  Furthermore, while IWYU will tell you what headers to use, it will not do the following:
  * Respect the usage of angle brackets for source headers (it will almost always suggest quotation marks)
  * Use C++-style headers (it will prefer `string.h` over `cstring` and changing it is a manual errand)
  * Apply its suggestions in alphabetical order (they will pool up at the bottom)
  * Respect newlines meant to separate sets of headers
  * Remain consistent (even if IWYU passes locally, there is no guarantee that it would translate to a green CI run)

  But it will do the following:
  * Change its suggestions based on the ordering of headers
  * Make suggestions to add headers/forward declarations and then when run a second time, urge you to remove them
  * Pull in implementation headers that shouldn't be directly included. IWYU currently ships with mappings to avoid this for the standard library ([source](https://github.com/include-what-you-use/include-what-you-use/blob/f88f045131bfa0ac709d1e0c103580666254b2c6/gcc.libc.imp)), Qt ([source](https://github.com/include-what-you-use/include-what-you-use/blob/f88f045131bfa0ac709d1e0c103580666254b2c6/qt5_11.imp)) and Boost ([source](https://github.com/include-what-you-use/include-what-you-use/blob/f88f045131bfa0ac709d1e0c103580666254b2c6/boost-all.imp)) but for all else, you're on your own.

  It was determined for now that we will simply take guidance from upstream on the matter and extend it to Dash code at some point in the future.

* Both [bitcoin#25029](https://github.com/bitcoin/bitcoin/pull/25029) and [bitcoin#25013](https://github.com/bitcoin/bitcoin/pull/25013) made sure they pass IWYU, changes needed to ensure that the linter is satisfied were made in this PR.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
