### PR TITLE
ci: Disable apparmor user namespace restrictions in GH Guix action

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -72,6 +72,10 @@ jobs:
 
     timeout-minutes: 480
     steps:
+      - name: Disable apparmor user namespace restrictions
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/actions/runner-images/issues/10015

## What was done?
https://github.com/actions/runner-images/issues/10443#issuecomment-2616616457

## How Has This Been Tested?
develop: https://github.com/UdjinM6/dash/actions/runs/13187780750
this PR: https://github.com/UdjinM6/dash/actions/runs/13187795136

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

