### PR TITLE
ci: use arm runners for guix

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     outputs:
       image-tag: ${{ steps.prepare.outputs.image-tag }}
       repo-name: ${{ steps.prepare.outputs.repo-name }}
@@ -64,7 +64,7 @@ jobs:
   build:
     needs: build-image
     # runs-on: [ "self-hosted", "linux", "x64", "ubuntu-core" ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 #    if: ${{ contains(github.event.pull_request.labels.*.name, 'guix-build') }}
     strategy:
       matrix:


### PR DESCRIPTION
## Issue being fixed or feature implemented
(At least currently, in public beta, maybe they'll be worse when more congested) Arm runners appear about 20% faster.

## What was done?
Use arm64 runners for guix instead of x86.

## How Has This Been Tested?
Udjin's patch recently: https://github.com/UdjinM6/dash/actions/runs/13187795136
vs this commit: (with his as well)
https://github.com/PastaPastaPasta/dash/actions/runs/13188732140

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

