### PR TITLE
chore: ignore coderabbit reviews in github merge script

### DIFF
--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -174,7 +174,7 @@ def get_acks_from_comments(head_commit, comments):
     acks = []
     for c in comments:
         review = [l for l in c['body'].split('\r\n') if 'ACK' in l and head_abbrev in l]
-        if review:
+        if review and 'coderabbit' not in c['user']['login']:
             acks.append((c['user']['login'], review[0]))
     return acks
 


### PR DESCRIPTION

## Issue being fixed or feature implemented
coderabbit creates very very long messages that inventiably include "ack" even though it doesn't actually ACK, and then this causes commit messages to be giant, unless I go in and edit their comment before I merge

## What was done?

## How Has This Been Tested?
merged recent PR with this new script w/o code rabbit message being flagged

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

