### PR TITLE
ci: update containers and CI to use Ubuntu 24.04 LTS (`noble`), merge bitcoin#29985

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Build container
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
       repo: ${{ steps.prepare.outputs.repo }}

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build-depends:
     name: Build depends
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       key:  ${{ steps.restore.outputs.cache-primary-key }}
     container:

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build-src:
     name: Build source
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: ${{ inputs.container-path }}
       options: --user root

--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Release to Docker Hub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: "ubuntu:jammy"
+image: "ubuntu:noble"
 
 variables:
   DOCKER_DRIVER: overlay2

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -138,12 +138,12 @@ RUN set -ex; \
     mkdir -p /opt/shellcheck && tar -xf /tmp/shellcheck.tar.xz -C /opt/shellcheck --strip-components=1 && rm /tmp/shellcheck.tar.xz
 ENV PATH="/opt/shellcheck:${PATH}"
 
-# Add user with specified (or default) user/group ids and setup configuration files
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+# Setup unprivileged user and configuration files
+ARG USER_ID=1000 \
+    GROUP_ID=1000
 RUN set -ex; \
-    groupadd -g ${GROUP_ID} dash; \
-    useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash; \
+    groupmod -g ${GROUP_ID} -n dash ubuntu; \
+    usermod -u ${USER_ID} -md /home/dash -l dash ubuntu; \
     mkdir -p /home/dash/.config/gdb; \
     echo "add-auto-load-safe-path /usr/lib/llvm-${LLVM_VERSION}/lib" | tee /home/dash/.config/gdb/gdbinit; \
     chown ${USER_ID}:${GROUP_ID} -R /home/dash

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -156,7 +156,6 @@ RUN apt-get update && apt-get install $APT_ARGS \
     g++-mingw-w64-x86-64 \
     jq \
     libz-dev \
-    libncurses5 \
     nsis \
     python3-zmq \
     parallel \

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -10,12 +10,6 @@ ENV APT_ARGS="-y --no-install-recommends --no-upgrade"
 # Install common packages
 RUN set -ex; \
     apt-get update && \
-    if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-        dpkg --add-architecture i386 && \
-        apt-get update && \
-        apt-get install $APT_ARGS \
-        wine32; \
-    fi; \
     apt-get install $APT_ARGS \
     autotools-dev \
     automake \

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 # Needed to prevent tzdata hanging while expecting user input
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -7,14 +7,13 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 # (zlib1g-dev is needed for the Qt host binary builds, but should not be used by target binaries)
 ENV APT_ARGS="-y --no-install-recommends --no-upgrade"
 
-# Install packages for i386 on amd64 hosts, then install common packages
+# Install common packages
 RUN set -ex; \
     apt-get update && \
     if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
         dpkg --add-architecture i386 && \
         apt-get update && \
         apt-get install $APT_ARGS \
-        g++-multilib \
         wine32; \
     fi; \
     apt-get install $APT_ARGS \
@@ -164,12 +163,6 @@ RUN apt-get update && apt-get install $APT_ARGS \
     wine64 \
     zip \
     && rm -rf /var/lib/apt/lists/*
-
-# This is a hack. It is needed because gcc-multilib and g++-multilib are conflicting with g++-arm-linux-gnueabihf. This is
-# due to gcc-multilib installing the following symbolic link, which is needed for -m32 support. However, this causes
-# arm builds to also have the asm folder implicitly in the include search path. This is kind of ok, because the asm folder
-# for arm has precedence.
-RUN ln -s x86_64-linux-gnu/asm /usr/include/asm
 
 # Make sure std::thread and friends is available
 RUN \

--- a/contrib/containers/deploy/Dockerfile
+++ b/contrib/containers/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:jammy-1.0.4
+FROM phusion/baseimage:noble-1.0.0
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore, built from CI"
 

--- a/contrib/containers/deploy/Dockerfile
+++ b/contrib/containers/deploy/Dockerfile
@@ -2,17 +2,12 @@ FROM phusion/baseimage:noble-1.0.0
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore, built from CI"
 
-ARG USER_ID
-ARG GROUP_ID
-
-ENV HOME="/home/dash"
-
-# add user with specified (or default) user/group ids
-ENV USER_ID="${USER_ID:-1000}"
-ENV GROUP_ID="${GROUP_ID:-1000}"
-RUN groupadd -g ${GROUP_ID} dash && \
-    useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash && \
-    mkdir /home/dash/.dashcore && \
+# Setup unprivileged user
+ARG USER_ID=1000 \
+    GROUP_ID=1000
+RUN groupmod -g ${GROUP_ID} -n dash ubuntu; \
+    usermod -u ${USER_ID} -md /home/dash -l dash ubuntu; \
+    mkdir -p /home/dash/.dashcore && \
     chown ${USER_ID}:${GROUP_ID} -R /home/dash
 
 COPY bin/* /usr/local/bin/

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-FROM --platform=$BUILDPLATFORM ubuntu:jammy as builder
+FROM --platform=$BUILDPLATFORM ubuntu:noble as builder
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
     automake \
@@ -42,7 +42,7 @@ RUN mkdir built-target && \
   "linux/amd64") cp depends/x86_64-pc-linux-gnu/bin/dash* /home/dash/built-target ;; \
 esac
 
-FROM ubuntu:jammy
+FROM ubuntu:noble
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore"
 

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
@@ -52,12 +52,12 @@ ARG TAG
 
 ENV HOME="/home/dash"
 
-# add user with specified (or default) user/group ids
-ENV USER_ID="${USER_ID:-1000}"
-ENV GROUP_ID="${GROUP_ID:-1000}"
-RUN groupadd -g ${GROUP_ID} dash && \
-    useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash  && \
-    mkdir /home/dash/.dashcore && \
+# Setup unprivileged user
+ARG USER_ID=1000 \
+    GROUP_ID=1000
+RUN groupmod -g ${GROUP_ID} -n dash ubuntu; \
+    usermod -u ${USER_ID} -md /home/dash -l dash ubuntu; \
+    mkdir -p /home/dash/.dashcore && \
     chown ${USER_ID}:${GROUP_ID} -R /home/dash
 
 RUN apt-get update && \

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -9,12 +9,12 @@ ARG GITHUB_REPOSITORY
 
 ENV HOME /home/dash
 
-# add user with specified (or default) user/group ids
-ENV USER_ID ${USER_ID:-1000}
-ENV GROUP_ID ${GROUP_ID:-1000}
-RUN groupadd -g ${GROUP_ID} dash && \
-    useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash  && \
-    mkdir /home/dash/.dashcore && \
+# Setup unprivileged user
+ARG USER_ID=1000 \
+    GROUP_ID=1000
+RUN groupmod -g ${GROUP_ID} -n dash ubuntu; \
+    usermod -u ${USER_ID} -md /home/dash -l dash ubuntu; \
+    mkdir -p /home/dash/.dashcore && \
     chown ${USER_ID}:${GROUP_ID} -R /home/dash
 
 RUN apt-get update && \

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore"
 

--- a/contrib/containers/develop/Dockerfile
+++ b/contrib/containers/develop/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = edrevo/dockerfile-plus
 
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 INCLUDE+ ci/Dockerfile
 

--- a/contrib/containers/guix/Dockerfile
+++ b/contrib/containers/guix/Dockerfile
@@ -65,15 +65,11 @@ RUN groupadd --system guixbuild && \
               "guixbuilder${i}" ;                \
     done
 
-# Create unprivileged user
+# Setup unprivileged user and grant it passwordless sudo
 ARG USER_ID=1000 \
-    GROUP_ID=1000 \
-    USERNAME=ubuntu
-RUN groupadd -g ${GROUP_ID} ${USERNAME} && \
-    useradd -u ${USER_ID} -g ${USERNAME} -s /bin/bash -m -d /home/${USERNAME} ${USERNAME}
-
-# Grant it passwordless admin permissions
-RUN usermod -aG sudo ${USERNAME} && \
+    GROUP_ID=1000
+RUN groupmod -g ${GROUP_ID} ubuntu; \
+    usermod -u ${USER_ID} -aG sudo ubuntu; \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Copy required files to container
@@ -85,16 +81,16 @@ COPY --from=docker_root ./scripts/setup-sdk    /usr/local/bin/setup-sdk
 
 # Create directories for mounting to save/restore cache and grant necessary permissions
 RUN mkdir -p \
-        /home/${USERNAME}/.cache \
+        /home/ubuntu/.cache \
         /src/dash/depends/{built,sources,work}; \
     chown -R ${USER_ID}:${GROUP_ID} \
-        /home/${USERNAME}/.cache \
+        /home/ubuntu/.cache \
         /src;
 
 WORKDIR "/src/dash"
 
 # Switch to unprivileged context
-USER ${USERNAME}
+USER ubuntu
 
 # Set entrypoint to copied file
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/contrib/containers/guix/Dockerfile
+++ b/contrib/containers/guix/Dockerfile
@@ -2,7 +2,7 @@
 #       to use 'docker compose run guix_ubuntu' to drop into an
 #       interactive shell
 
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 SHELL ["/bin/bash", "-c"]
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -25,6 +25,7 @@ $(package)_patches += memory_resource.patch
 $(package)_patches += clang_18_libpng.patch
 $(package)_patches += utc_from_string_no_optimize.patch
 $(package)_patches += windows_lto.patch
+$(package)_patches += zlib-timebits64.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=5b94d1a11b566908622fcca2f8b799744d2f8a68da20be4caa5953ed63b10489
@@ -257,6 +258,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fast_fixed_dtoa_no_optimize.patch && \
   patch -p1 -i $($(package)_patch_dir)/guix_cross_lib_path.patch && \
   patch -p1 -i $($(package)_patch_dir)/windows_lto.patch && \
+  patch -p1 -i $($(package)_patch_dir)/zlib-timebits64.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/zlib-timebits64.patch
+++ b/depends/patches/qt/zlib-timebits64.patch
@@ -1,0 +1,31 @@
+From a566e156b3fa07b566ddbf6801b517a9dba04fa3 Mon Sep 17 00:00:00 2001
+From: Mark Adler <madler@alumni.caltech.edu>
+Date: Sat, 29 Jul 2023 22:13:09 -0700
+Subject: [PATCH] Avoid compiler complaints if _TIME_BITS defined when building
+ zlib.
+
+zlib does not use time_t, so _TIME_BITS is irrelevant. However it
+may be defined anyway as part of a sledgehammer indiscriminately
+applied to all builds.
+
+From https://github.com/madler/zlib/commit/a566e156b3fa07b566ddbf6801b517a9dba04fa3.patch
+---
+ qtbase/src/3rdparty/zlib/src/gzguts.h | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/qtbase/src/3rdparty/zlib/src/gzguts.h b/qtbase/src/3rdparty/zlib/src/gzguts.h
+index e23f831f5..f9375047e 100644
+--- a/qtbase/src/3rdparty/zlib/src/gzguts.h
++++ b/qtbase/src/3rdparty/zlib/src/gzguts.h
+@@ -26,9 +26,8 @@
+ #  ifndef _LARGEFILE_SOURCE
+ #    define _LARGEFILE_SOURCE 1
+ #  endif
+-#  ifdef _FILE_OFFSET_BITS
+-#    undef _FILE_OFFSET_BITS
+-#  endif
++#  undef _FILE_OFFSET_BITS
++#  undef _TIME_BITS
+ #endif
+ 
+ #ifdef HAVE_HIDDEN

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -100,3 +100,8 @@ shift-base:streams.h
 shift-base:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 shift-base:util/bip32.cpp
 vptr:bls/bls.h
+
+# -fsanitize=float-cast-overflow suppressions
+# ===============================
+# See QTBUG-133261
+float-cast-overflow:qRound


### PR DESCRIPTION
## Motivation

Since [dash#6389](https://github.com/dashpay/dash/pull/6389), the minimum supported version of GCC has been 11.1 or later. Our current base, Ubuntu 22.04 LTS (`jammy`) ships with GCC 11.2 ([source](https://packages.ubuntu.com/jammy/gcc)). The cross-compilation package for `arm-linux-gnueabihf` is GCC 11.2 as well ([source](https://packages.ubuntu.com/jammy/gcc-arm-linux-gnueabihf)). Unfortunately, this isn't the case for `mingw-w64-x86-64`, which ships with GCC 10.3 ([source](https://packages.ubuntu.com/jammy/gcc-mingw-w64-x86-64-posix)).

So far, an workaround was utilized to allow GCC 10.3 to pass muster upstream through bitcoin#28379 ([source](https://github.com/bitcoin/bitcoin/pull/28349/commits/fa67f096bdea9db59dd20c470c9e32f3dac5be94#diff-0baeabda402ee522682c25cef25a248ff6d9e2904f6d66f93f6babf55b576675L986)). Dash Core's enablement of C++20 experimental support in [dash#4600](https://github.com/dashpay/dash/pull/4600) was relatively even more permissive ([source](https://github.com/dashpay/dash/pull/4600/files#diff-0baeabda402ee522682c25cef25a248ff6d9e2904f6d66f93f6babf55b576675R168)). 

Though since then, enforcement of those newer minimum requirements through backports like [bitcoin#30228](https://github.com/bitcoin/bitcoin/pull/30228) are frustrated by the version of GCC shipped for Windows cross-compilation. 

This can be resolved by bumping the image to the next available LTS release, Ubuntu 24.04 (`noble`), which ships with GCC 13.2 natively ([source](https://packages.ubuntu.com/noble/gcc)), for ARM Linux ([source](https://packages.ubuntu.com/noble/gcc-arm-linux-gnueabihf)) and AMD64 Windows ([source](https://packages.ubuntu.com/noble/gcc-mingw-w64-x86-64-posix)), moreover, it is acknowledged as a _de facto_ lowest supported distro needed for Windows cross compilation by [bitcoin#30580](https://github.com/bitcoin/bitcoin/pull/30580#issue-2446285526).

Skipping the enforcement of newer minimum requirements is inadvisable, primarily because it will eventually conflict with upcoming code changes ([comment](https://github.com/bitcoin/bitcoin/pull/30228#issuecomment-2149496033)) like [dash#6378](https://github.com/dashpay/dash/pull/6378).

## Additional Information

* Dependency for https://github.com/dashpay/dash/pull/6380

* A default unprivileged user named `ubuntu` was introduced in Ubuntu 22.10 ([source](https://bugs.launchpad.net/cloud-images/+bug/2005129)) with UID `1000` and GID `1000`. 

  We allow specifying UID and GID to ensure they match with the ownership of directories expected to be mounted to avoid permissions issues (especially on platforms like macOS where the user can have a UID of `501` and GID of `20`).
  * To retain this behavior, the `ubuntu` user and the `ubuntu` group will have its UID and GID updated. This is a no-op if defaults are selected.
  * In some cases where it may be undesirable to have the username or home directory deviate from the present name  (`dash`), it will be additionally renamed from `ubuntu`.
    * GitLab is unhappy if the container doesn't have a user named `dash` ([build](https://gitlab.com/dashpay/dash/-/jobs/9082688485#L24)) and it results in a runner failure.

* Due to a conflict between `gcc-multilib` and `gcc-arm-linux-gnueabihf`, installation of the latter will result in the uninstallation of the former. This has been documented behavior for a while now ([source](https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1300211)) and continues till today (see below).


  <details>

  <summary>Error message:</summary>

  ```
  ubuntu@ec46b76eeb2c:/src/dash$ sudo apt install gcc-multilib gcc-arm-linux-gnueabihf
  Reading package lists... Done
  Building dependency tree... Done
  Reading state information... Done
  gcc-arm-linux-gnueabihf is already the newest version (4:13.2.0-7ubuntu1).
  gcc-arm-linux-gnueabihf set to manually installed.
  Some packages could not be installed. This may mean that you have
  requested an impossible situation or if you are using the unstable
  distribution that some required packages have not yet been created
  or been moved out of Incoming.
  The following information may help to resolve the situation:
  
  The following packages have unmet dependencies:
   gcc-arm-linux-gnueabihf : Depends: gcc-13-arm-linux-gnueabihf (>= 13.2.0-11~) but it is not installable
  E: Unable to correct problems, you have held broken packages.
  ```

  </details>

  Since [dash#5372](https://github.com/dashpay/dash/pull/5372), we have stopped supporting i686 and dropped support for 32-bit Windows even earlier. There doesn't seem to be much reason to keep `gcc-multilib` around, especially since it _cannot_ be around and has been silently uninstalled for a while now, so the package has now been dropped.

  * Since Wine 7.0, WoW64 support has been included ([source](https://www.winehq.org/announce/7.0)), which allows for some applications to run without a corresponding `wine32` setup ([source](https://wiki.debian.org/Wine#Step_1:_Enable_multiarch)). Support has improved furthermore in Wine 9.0 ([source](https://gitlab.winehq.org/wine/wine/-/releases/wine-9.0)), which is available in `noble` ([source](https://packages.ubuntu.com/noble/wine64)). This allows us to drop the i386 conditional altogether.

* `libncurses5`, while a valid package on `jammy` ([source](https://packages.ubuntu.com/jammy/libncurses5)), is not in any future version, including `noble` ([source](https://packages.ubuntu.com/noble/libncurses5), error page) though `libncurses5-dev` continues to remain a valid package ([source](https://packages.ubuntu.com/noble/libncurses5-dev)) and remains used as a Python dependency ([source](https://github.com/dashpay/dash/blob/1930572b05c53d2d8335bcfc22270871d5b0bf2f/contrib/containers/ci/Dockerfile#L91)). As a result, `libncurses5` has been dropped.

* A bump in distro base also causes a bump in glibc version, which causes zlib, a Qt dependency to fail a compile-time check ([build](https://github.com/dashpay/dash/actions/runs/13220255380/job/36904408129?pr=6564#step:6:8050)), this is avoided by backporting [bitcoin#29985](https://github.com/bitcoin/bitcoin/pull/29985).

* Due to [QTBUG-133261](https://bugreports.qt.io/browse/QTBUG-133261), UBSan will raise a `float-cast-overflow` originating from `qRound(double)` ([build](https://gitlab.com/dashpay/dash/-/jobs/9083558880#L3132)), as of this writing, a fix is currently underway ([source](https://codereview.qt-project.org/c/qt/qtbase/+/621931)) but it is unclear when it would be available in the next Qt 5.15 revision.

  As this doesn't seem to be a regression ([source](https://bugreports.qt.io/browse/QTBUG-133261?focusedId=860311&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-860311)) despite being undesirable behavior, we can suppress the alarm.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

