### PR TITLE
fix(qt): update CoinJoin frame and tx list on client model update

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -299,6 +299,8 @@ void OverviewPage::setClientModel(ClientModel *model)
         // Show warning, for example if this is a prerelease version
         connect(model, &ClientModel::alertsChanged, this, &OverviewPage::updateAlerts);
         updateAlerts(model->getStatusBarWarnings());
+        // explicitly update CoinJoin frame and transaction list to reflect actual settings
+        updateAdvancedCJUI(model->getOptionsModel()->getShowAdvancedCJUI());
     }
 }
 
@@ -321,9 +323,6 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(model, &WalletModel::notifyWatchonlyChanged, [this](bool showWatchOnly) {
             updateWatchOnlyLabels(showWatchOnly && !walletModel->wallet().privateKeysDisabled());
         });
-
-        // explicitly update PS frame and transaction list to reflect actual settings
-        updateAdvancedCJUI(model->getOptionsModel()->getShowAdvancedCJUI());
 
         connect(model->getOptionsModel(), &OptionsModel::coinJoinRoundsChanged, this, &OverviewPage::updateCoinJoinProgress);
         connect(model->getOptionsModel(), &OptionsModel::coinJoinAmountChanged, this, &OverviewPage::updateCoinJoinProgress);


### PR DESCRIPTION
## Issue being fixed or feature implemented
3f9dca5b26474ca5d04ab84f4fc21630d8705e6b (#6541) broke Overview Page.

Wallet model is set earlier now (via WalletView ctor and not via `addWallet` https://github.com/dashpay/dash/pull/6541/commits/3f9dca5b26474ca5d04ab84f4fc21630d8705e6b#diff-c0330db51c25c4bb621fca0b908dc6fc597db2077f74855eed1b16e0739748a6L88) but we need Client model too to call `updateAdvancedCJUI()` correctly and it's not yet available.


## What was done?
Move `updateAdvancedCJUI()` call to `setClientModel()`.

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

