### PR TITLE
fix(qt): avoid leaking balance and CJ info in GUI when in discreet mode

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -208,6 +208,7 @@ void OverviewPage::setPrivacy(bool privacy)
     m_privacy = privacy;
     if (m_balances.balance != -1) {
         setBalance(m_balances);
+        coinJoinStatus(true);
     }
 
     ui->listTransactions->setVisible(!m_privacy);
@@ -402,7 +403,10 @@ void OverviewPage::updateCoinJoinProgress()
 
     if(nMaxToAnonymize == 0) return;
 
-    if (nMaxToAnonymize >= clientModel->coinJoinOptions().getAmount() * COIN) {
+    if (m_privacy) {
+        strAmountAndRounds = "#### DASH / ## Rounds";
+        ui->labelAmountRounds->setToolTip("");
+    } else if (nMaxToAnonymize >= clientModel->coinJoinOptions().getAmount() * COIN) {
         ui->labelAmountRounds->setToolTip(tr("Found enough compatible inputs to mix %1")
                                           .arg(strCoinJoinAmount));
         strCoinJoinAmount = strCoinJoinAmount.remove(strCoinJoinAmount.indexOf("."), BitcoinUnits::decimals(nDisplayUnit) + 1);
@@ -660,7 +664,7 @@ void OverviewPage::coinJoinStatus(bool fForce)
 
     setWidgetsVisible(true);
 
-    ui->labelSubmittedDenom->setText(QString(walletModel->coinJoin()->getSessionDenoms().c_str()));
+    ui->labelSubmittedDenom->setText(m_privacy ? "####" : QString(walletModel->coinJoin()->getSessionDenoms().c_str()));
 }
 
 void OverviewPage::toggleCoinJoin(){

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -404,7 +404,7 @@ void OverviewPage::updateCoinJoinProgress()
     if(nMaxToAnonymize == 0) return;
 
     if (m_privacy) {
-        strAmountAndRounds = "#### DASH / ## Rounds";
+        strAmountAndRounds = "#### " + BitcoinUnits::name(nDisplayUnit) + " / " + tr("%n Rounds", "", 0);
         ui->labelAmountRounds->setToolTip("");
     } else if (nMaxToAnonymize >= clientModel->coinJoinOptions().getAmount() * COIN) {
         ui->labelAmountRounds->setToolTip(tr("Found enough compatible inputs to mix %1")


### PR DESCRIPTION
## Issue being fixed or feature implemented
develop:
<img width="721" alt="Screenshot 2025-02-10 at 16 14 52" src="https://github.com/user-attachments/assets/742dc502-64c4-4c99-adb2-97009d387143" />

this PR:
<img width="715" alt="Screenshot 2025-02-10 at 16 17 52" src="https://github.com/user-attachments/assets/854a8de9-2f5b-447b-b618-593ce8cf9225" />


## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

