### PR TITLE
chore: drop deprecated RPCs `masternode current`, `masternode winner` and `getpoolinfo`

### DIFF
--- a/doc/release-notes-6567.md
+++ b/doc/release-notes-6567.md
@@ -1,0 +1,5 @@
+Updated RPCs
+------------
+
+* The RPCs `masternode current` and `masternode winner` were deprecated in Dash Core
+  v0.17 and are now removed.

--- a/doc/release-notes-6567.md
+++ b/doc/release-notes-6567.md
@@ -3,3 +3,4 @@ Updated RPCs
 
 * The RPCs `masternode current` and `masternode winner` were deprecated in Dash Core
   v0.17 and are now removed.
+* The `getpoolinfo` RPC was deprecated in Dash Core v0.15 and is now removed.

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -365,21 +365,6 @@ static RPCHelpMan coinjoinsalt_set()
 }
 #endif // ENABLE_WALLET
 
-// TODO: remove it completely
-static RPCHelpMan getpoolinfo()
-{
-    return RPCHelpMan{"getpoolinfo",
-                "DEPRECATED. Please use getcoinjoininfo instead.\n",
-                {},
-                RPCResults{},
-                RPCExamples{""},
-                [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-        throw JSONRPCError(RPC_METHOD_DEPRECATED, "Please use getcoinjoininfo instead");
-},
-    };
-}
-
 static RPCHelpMan getcoinjoininfo()
 {
             return RPCHelpMan{"getcoinjoininfo",
@@ -480,8 +465,6 @@ static const CRPCCommand commands[] =
     { "dash",                &coinjoinsalt_generate,  },
     { "dash",                &coinjoinsalt_get,       },
     { "dash",                &coinjoinsalt_set,       },
-
-    { "hidden",              &getpoolinfo,            },
 #endif // ENABLE_WALLET
 };
 // clang-format on


### PR DESCRIPTION
## Additional Information

* `masternode current`, `masternode winner` were deprecated in [dash#4060](https://github.com/dashpay/dash/pull/4060), which was included in Dash Core v0.17
* `getpoolinfo` was deprecated in [dash#3140](https://github.com/dashpay/dash/pull/3140), which was included in Dash Core v0.15.

## Breaking Changes

Deprecated RPCs will no longer be available.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_