### PR TITLE
feat: mnemonic support for descriptor wallets

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -25,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include <support/allocators/secure.h>
 #include <prevector.h>
 #include <span.h>
 
@@ -816,9 +817,16 @@ struct VectorFormatter
 /**
  *  string
  */
-template<typename Stream, typename C> void Serialize(Stream& os, const std::basic_string<C>& str);
-template<typename Stream, typename C> void Unserialize(Stream& is, std::basic_string<C>& str);
+template<typename Stream, typename A, typename B, typename C> void Serialize(Stream& os, const std::basic_string<A, B, C>& str);
+template<typename Stream, typename A, typename B, typename C> void Unserialize(Stream& is, std::basic_string<A, B, C>& str);
 
+/**
+ *  SecureString
+ */
+/*
+template<typename Stream, typename C> void Serialize(Stream& os, const SecureString& str);
+template<typename Stream, typename C> void Unserialize(Stream& is, SecureString& str);
+*/
 /**
  * prevector
  * prevectors of unsigned char are a special case and are intended to be serialized as a single opaque blob.
@@ -947,16 +955,16 @@ struct DefaultFormatter
 /**
  * string
  */
-template<typename Stream, typename C>
-void Serialize(Stream& os, const std::basic_string<C>& str)
+template<typename Stream, typename A, typename B, typename C>
+void Serialize(Stream& os, const std::basic_string<A, B, C>& str)
 {
     WriteCompactSize(os, str.size());
     if (!str.empty())
         os.write(MakeByteSpan(str));
 }
 
-template<typename Stream, typename C>
-void Unserialize(Stream& is, std::basic_string<C>& str)
+template<typename Stream, typename A, typename B, typename C>
+void Unserialize(Stream& is, std::basic_string<A, B, C>& str)
 {
     unsigned int nSize = ReadCompactSize(is);
     str.resize(nSize);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1964,6 +1964,8 @@ RPCHelpMan listdescriptors()
             {
                 {RPCResult::Type::OBJ, "", "", {
                     {RPCResult::Type::STR, "desc", "Descriptor string representation"},
+                    {RPCResult::Type::STR, "mnemonic", "The mnemonic for this Descriptor wallet (bip39, english words). Presented only if private=true and created with mnemonic"},
+                    {RPCResult::Type::STR, "mnemonicpassphrase", "The mnemonic passphrase for this Descriptor wallet (bip39). Presented only if private=true and created with mnemonic"},
                     {RPCResult::Type::NUM, "timestamp", "The creation time of the descriptor"},
                     {RPCResult::Type::BOOL, "active", "Whether this descriptor is currently used to generate new addresses"},
                     {RPCResult::Type::BOOL, "internal", /*optional=*/true, "True if this descriptor is used to generate change addresses. False if this descriptor is used to generate receiving addresses; defined only for active descriptors"},
@@ -2009,6 +2011,15 @@ RPCHelpMan listdescriptors()
 
         if (!desc_spk_man->GetDescriptorString(descriptor, priv)) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Can't get descriptor string.");
+        }
+        if (priv) {
+            SecureString mnemonic;
+            SecureString mnemonic_passphrase;
+            if (!desc_spk_man->GetMnemonicString(mnemonic, mnemonic_passphrase)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Can't get mnemonic for descripotor.");
+            }
+            spk.pushKV("mnemonic", mnemonic.c_str());
+            spk.pushKV("mnemonicpassphrase", mnemonic_passphrase.c_str());
         }
         spk.pushKV("desc", descriptor);
         spk.pushKV("timestamp", wallet_descriptor.creation_time);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -13,6 +13,7 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
+#include <wallet/bip39.h>
 #include <wallet/scriptpubkeyman.h>
 
 bool LegacyScriptPubKeyMan::GetNewDestination(CTxDestination& dest, bilingual_str& error)
@@ -1813,7 +1814,7 @@ bool DescriptorScriptPubKeyMan::GetNewDestination(CTxDestination& dest, bilingua
             throw std::runtime_error(std::string(__func__) + ": Types are inconsistent. Stored type does not match type of newly generated address");
         }
         m_wallet_descriptor.next_index++;
-        WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
+        WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor, m_mnemonic, m_mnemonic_passphrase);
         return true;
     }
 }
@@ -1877,11 +1878,27 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
         }
         m_map_crypted_keys[pubkey.GetID()] = make_pair(pubkey, crypted_secret);
         batch->WriteCryptedDescriptorKey(GetID(), pubkey, crypted_secret);
+
     }
+    // TODO encrypt mnemonic
     m_map_keys.clear();
     return true;
 }
-
+/*
+    if (m_storage.HasEncryptionKeys() && !m_storage.IsLocked(true)) {
+        KeyMap keys;
+        for (auto key_pair : m_map_crypted_keys) {
+            const CPubKey& pubkey = key_pair.second.first;
+            const std::vector<unsigned char>& crypted_secret = key_pair.second.second;
+            CKey key;
+            m_storage.WithEncryptionKey([&](const CKeyingMaterial& encryption_key) {
+                return DecryptKey(encryption_key, crypted_secret, pubkey, key);
+            });
+            keys[pubkey.GetID()] = key;
+        }
+        return keys;
+    }
+*/
 bool DescriptorScriptPubKeyMan::GetReservedDestination(bool internal, CTxDestination& address, int64_t& index, CKeyPool& keypool)
 {
     LOCK(cs_desc_man);
@@ -1898,7 +1915,7 @@ void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, 
     if (m_wallet_descriptor.next_index - 1 == index) {
         m_wallet_descriptor.next_index--;
     }
-    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
+    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor, m_mnemonic, m_mnemonic_passphrase);
     NotifyCanGetAddressesChanged();
 }
 
@@ -1975,7 +1992,7 @@ bool DescriptorScriptPubKeyMan::TopUp(unsigned int size)
         m_max_cached_index++;
     }
     m_wallet_descriptor.range_end = new_range_end;
-    batch.WriteDescriptor(GetID(), m_wallet_descriptor);
+    batch.WriteDescriptor(GetID(), m_wallet_descriptor, m_mnemonic, m_mnemonic_passphrase);
 
     // By this point, the cache size should be the size of the entire range
     assert(m_wallet_descriptor.range_end - 1 == m_max_cached_index);
@@ -2040,7 +2057,7 @@ bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const
     }
 }
 
-bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_key, bool internal)
+bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_key, const SecureString& secure_mnemonic, const SecureString& secure_mnemonic_passphrase, bool internal)
 {
     LOCK(cs_desc_man);
     assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
@@ -2049,6 +2066,18 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     if (m_wallet_descriptor.descriptor) {
         return false;
     }
+
+    if (!secure_mnemonic.empty()) {
+        SecureVector seed_key_tmp;
+        CMnemonic::ToSeed(secure_mnemonic, secure_mnemonic_passphrase, seed_key_tmp);
+
+        CExtKey master_key_tmp;
+        master_key_tmp.SetSeed(MakeByteSpan(seed_key_tmp));
+        assert(master_key == master_key_tmp);
+    }
+
+    m_mnemonic = secure_mnemonic;
+    m_mnemonic_passphrase = secure_mnemonic_passphrase;
 
     int64_t creation_time = GetTime();
 
@@ -2073,7 +2102,7 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
     }
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor, m_mnemonic, m_mnemonic_passphrase)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
     }
 
@@ -2382,7 +2411,7 @@ void DescriptorScriptPubKeyMan::WriteDescriptor()
 {
     LOCK(cs_desc_man);
     WalletBatch batch(m_storage.GetDatabase());
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor, m_mnemonic, m_mnemonic_passphrase)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
     }
 }
@@ -2419,6 +2448,16 @@ bool DescriptorScriptPubKeyMan::GetDescriptorString(std::string& out, const bool
     }
 
     return m_wallet_descriptor.descriptor->ToNormalizedString(provider, out, &m_wallet_descriptor.cache);
+}
+
+bool DescriptorScriptPubKeyMan::GetMnemonicString(SecureString& mnemonic, SecureString& mnemonic_passphrase) const
+{
+    LOCK(cs_desc_man);
+
+    if (m_storage.IsLocked(false)) return false;
+    mnemonic = m_mnemonic;
+    mnemonic_passphrase = m_mnemonic_passphrase;
+    return true;
 }
 
 void DescriptorScriptPubKeyMan::UpgradeDescriptorCache()

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -505,6 +505,9 @@ class DescriptorScriptPubKeyMan : public ScriptPubKeyMan
 private:
     WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
 
+    SecureString m_mnemonic GUARDED_BY(cs_desc_man);
+    SecureString m_mnemonic_passphrase GUARDED_BY(cs_desc_man);
+
     using ScriptPubKeyMap = std::map<CScript, int32_t>; // Map of scripts to descriptor range index
     using PubKeyMap = std::map<CPubKey, int32_t>; // Map of pubkeys involved in scripts to descriptor range index
     using CryptedKeyMap = std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char>>>;
@@ -532,14 +535,15 @@ private:
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(int32_t index, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
 public:
-    DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor)
+    DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor, SecureString& mnemonic, SecureString& mnemonic_passphrase)
         :   ScriptPubKeyMan(storage),
-            m_wallet_descriptor(descriptor)
+            m_wallet_descriptor(descriptor),
+            m_mnemonic(mnemonic),
+            m_mnemonic_passphrase(mnemonic_passphrase)
         {}
     DescriptorScriptPubKeyMan(WalletStorage& storage)
         :   ScriptPubKeyMan(storage)
         {}
-
     mutable RecursiveMutex cs_desc_man;
 
     bool GetNewDestination(CTxDestination& dest, bilingual_str& error) override;
@@ -562,7 +566,7 @@ public:
     bool IsHDEnabled() const override;
 
     //! Setup descriptors based on the given CExtkey
-    bool SetupDescriptorGeneration(const CExtKey& master_key, bool internal);
+    bool SetupDescriptorGeneration(const CExtKey& master_key, const SecureString& secure_mnemonic, const SecureString& secure_mnemonic_passphrase, bool internal);
 
     bool HavePrivateKeys() const override;
 
@@ -601,6 +605,7 @@ public:
     const std::vector<CScript> GetScriptPubKeys() const;
 
     bool GetDescriptorString(std::string& out, const bool priv) const;
+    bool GetMnemonicString(SecureString& mnemonic_out, SecureString& mnemonic_passphrase_out) const;
 
     void UpgradeDescriptorCache();
 };

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -38,6 +38,7 @@
 #ifdef USE_BDB
 #include <wallet/bdb.h>
 #endif
+#include <wallet/bip39.h> // TODO - maybe remove from wallet
 #include <wallet/coincontrol.h>
 #include <wallet/coinselection.h>
 #include <wallet/fees.h>
@@ -4304,9 +4305,9 @@ void CWallet::UpdateProgress(const std::string& title, int nProgress)
     ShowProgress(title, nProgress);
 }
 
-void CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc)
+void CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc, SecureString& mnemonic, SecureString& mnemonic_passphrase)
 {
-    auto spk_manager = std::unique_ptr<ScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this, desc));
+    auto spk_manager = std::unique_ptr<ScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this, desc, mnemonic, mnemonic_passphrase));
     m_spk_managers[id] = std::move(spk_manager);
 }
 
@@ -4315,10 +4316,14 @@ void CWallet::SetupDescriptorScriptPubKeyMans()
     AssertLockHeld(cs_wallet);
 
     // Make a seed
-    CKey seed_key;
-    seed_key.MakeNewKey(true);
-    CPubKey seed = seed_key.GetPubKey();
-    assert(seed_key.VerifyPubKey(seed));
+    // TODO: remove duplicated code with CHDChain::SetMnemonic
+    const SecureString mnemonic = CMnemonic::Generate(gArgs.GetIntArg("-mnemonicbits", CHDChain::DEFAULT_MNEMONIC_BITS));
+    const SecureString mnemonic_passphrase = ""; // if not defined, it's empty
+    if (!CMnemonic::Check(mnemonic)) {
+        throw std::runtime_error(std::string(__func__) + ": invalid mnemonic: `" + std::string(mnemonic.c_str()) + "`");
+    }
+    SecureVector seed_key;
+    CMnemonic::ToSeed(mnemonic, mnemonic_passphrase, seed_key);
 
     // Get the extended key
     CExtKey master_key;
@@ -4335,7 +4340,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans()
                     throw std::runtime_error(std::string(__func__) + ": Could not encrypt new descriptors");
                 }
             }
-            spk_manager->SetupDescriptorGeneration(master_key, internal);
+            spk_manager->SetupDescriptorGeneration(master_key, mnemonic, mnemonic_passphrase, internal);
             uint256 id = spk_manager->GetID();
             m_spk_managers[id] = std::move(spk_manager);
             AddActiveScriptPubKeyMan(id, internal);
@@ -4416,13 +4421,17 @@ ScriptPubKeyMan* CWallet::AddWalletDescriptor(WalletDescriptor& desc, const Flat
         return nullptr;
     }
 
+    // TODO: implement mnemonic for AddDescriptor()
+    SecureString mnemonic;
+    SecureString mnemonic_passphrase;
+
     LOCK(cs_wallet);
     auto spk_man = GetDescriptorScriptPubKeyMan(desc);
     if (spk_man) {
         WalletLogPrintf("Update existing descriptor: %s\n", desc.descriptor->ToString());
         spk_man->UpdateWalletDescriptor(desc);
     } else {
-        auto new_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this, desc));
+        auto new_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this, desc, mnemonic, mnemonic_passphrase));
         spk_man = new_spk_man.get();
 
         // Save the descriptor to memory

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -335,7 +335,7 @@ std::shared_ptr<CWallet> CreateWallet(interfaces::Chain& chain, interfaces::Coin
             // Set a seed for the wallet
             if (wallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
                 LOCK(wallet->cs_wallet);
-                wallet->SetupDescriptorScriptPubKeyMans();
+                wallet->SetupDescriptorScriptPubKeyMans("", "");
             } else {
                 // TODO: drop this condition after removing option to create non-HD wallets
                 // related backport bitcoin#11250
@@ -724,7 +724,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 
         // If we are using descriptors, make new descriptors with a new seed
         if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS) && !IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
-            SetupDescriptorScriptPubKeyMans();
+            SetupDescriptorScriptPubKeyMans("", "");
         } else if (auto spk_man = GetLegacyScriptPubKeyMan()) {
             // if we are not using HD, generate new keypool
             if (spk_man->IsHDEnabled()) {
@@ -3350,7 +3350,11 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain* chain, interfaces::C
 
             LOCK(walletInstance->cs_wallet);
             if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
-                walletInstance->SetupDescriptorScriptPubKeyMans();
+                SecureString mnemonic = gArgs.GetArg("-mnemonic", "").c_str();
+                SecureString mnemonic_passphrase = gArgs.GetArg("-mnemonicpassphrase", "").c_str();
+                gArgs.ForceRemoveArg("mnemonic");
+                gArgs.ForceRemoveArg("mnemonicpassphrase");
+                walletInstance->SetupDescriptorScriptPubKeyMans(mnemonic, mnemonic_passphrase);
                 // SetupDescriptorScriptPubKeyMans already calls SetupGeneration for us so we don't need to call SetupGeneration separately
             } else { // Top up the keypool
                 // Legacy wallets need SetupGeneration here.
@@ -3687,17 +3691,16 @@ bool CWallet::UpgradeToHD(const SecureString& secureMnemonic, const SecureString
         return false;
     }
 
-    if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
-        error = Untranslated("Use RPC 'importdescriptors' to add new descriptors to Descriptor Wallets");
-        return false;
-    }
-
     WalletLogPrintf("Upgrading wallet to HD\n");
     SetMinVersion(FEATURE_HD);
 
-    if (!GenerateNewHDChain(secureMnemonic, secureMnemonicPassphrase, secureWalletPassphrase)) {
-        error = Untranslated("Failed to generate HD wallet");
-        return false;
+    if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+        SetupDescriptorScriptPubKeyMans(secureMnemonic, secureMnemonicPassphrase);
+    } else {
+        if (!GenerateNewHDChain(secureMnemonic, secureMnemonicPassphrase, secureWalletPassphrase)) {
+            error = Untranslated("Failed to generate HD wallet");
+            return false;
+        }
     }
     return true;
 }
@@ -4311,14 +4314,13 @@ void CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc, 
     m_spk_managers[id] = std::move(spk_manager);
 }
 
-void CWallet::SetupDescriptorScriptPubKeyMans()
+void CWallet::SetupDescriptorScriptPubKeyMans(const SecureString& mnemonic_arg, const SecureString mnemonic_passphrase)
 {
     AssertLockHeld(cs_wallet);
 
     // Make a seed
     // TODO: remove duplicated code with CHDChain::SetMnemonic
-    const SecureString mnemonic = CMnemonic::Generate(gArgs.GetIntArg("-mnemonicbits", CHDChain::DEFAULT_MNEMONIC_BITS));
-    const SecureString mnemonic_passphrase = ""; // if not defined, it's empty
+    const SecureString mnemonic = mnemonic_arg.empty() ? CMnemonic::Generate(gArgs.GetIntArg("-mnemonicbits", CHDChain::DEFAULT_MNEMONIC_BITS)) : mnemonic_arg;
     if (!CMnemonic::Check(mnemonic)) {
         throw std::runtime_error(std::string(__func__) + ": invalid mnemonic: `" + std::string(mnemonic.c_str()) + "`");
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1083,7 +1083,7 @@ public:
     void ConnectScriptPubKeyManNotifiers();
 
     //! Instantiate a descriptor ScriptPubKeyMan from the WalletDescriptor and load it
-    void LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc);
+    void LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc, SecureString& mnemonic, SecureString& mnemonic_passphrase);
 
     //! Adds the active ScriptPubKeyMan for the specified type and internal. Writes it to the wallet file
     //! @param[in] id The unique id for the ScriptPubKeyMan

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1101,7 +1101,7 @@ public:
     void DeactivateScriptPubKeyMan(uint256 id, bool internal);
 
     //! Create new DescriptorScriptPubKeyMans and add them to the wallet
-    void SetupDescriptorScriptPubKeyMans() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void SetupDescriptorScriptPubKeyMans(const SecureString& mnemonic, const SecureString mnemonic_passphrase) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Return the DescriptorScriptPubKeyMan for a WalletDescriptor if it is already in the wallet
     DescriptorScriptPubKeyMan* GetDescriptorScriptPubKeyMan(const WalletDescriptor& desc) const;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -60,6 +60,7 @@ const std::string SETTINGS{"settings"};
 const std::string TX{"tx"};
 const std::string VERSION{"version"};
 const std::string WALLETDESCRIPTOR{"walletdescriptor"};
+const std::string WALLETDESCRIPTORMNEMONIC{"walletdescriptormnemonic"};
 const std::string WALLETDESCRIPTORCACHE{"walletdescriptorcache"};
 const std::string WALLETDESCRIPTORLHCACHE{"walletdescriptorlhcache"};
 const std::string WALLETDESCRIPTORCKEY{"walletdescriptorckey"};
@@ -261,9 +262,14 @@ bool WalletBatch::WriteCryptedDescriptorKey(const uint256& desc_id, const CPubKe
     return true;
 }
 
-bool WalletBatch::WriteDescriptor(const uint256& desc_id, const WalletDescriptor& descriptor)
+bool WalletBatch::WriteDescriptor(const uint256& desc_id, const WalletDescriptor& descriptor, const SecureString& mnemonic, const SecureString& mnemonic_passphrase)
 {
-    return WriteIC(make_pair(DBKeys::WALLETDESCRIPTOR, desc_id), descriptor);
+    if (mnemonic.empty()) {
+        return WriteIC(make_pair(DBKeys::WALLETDESCRIPTOR, desc_id), descriptor);
+    } else {
+        WalletDescriptorMnemonic descriptor_mnemonic{descriptor, mnemonic, mnemonic_passphrase};
+        return WriteIC(make_pair(DBKeys::WALLETDESCRIPTORMNEMONIC, desc_id), descriptor_mnemonic);
+    }
 }
 
 bool WalletBatch::WriteDescriptorDerivedCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index, uint32_t der_index)
@@ -623,7 +629,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
             spk_mans[static_cast<OutputType>(type)] = id;
-        } else if (strType == DBKeys::WALLETDESCRIPTOR) {
+        } else if (strType == DBKeys::WALLETDESCRIPTOR || strType == DBKeys::WALLETDESCRIPTORMNEMONIC) {
             uint256 id;
             ssKey >> id;
             WalletDescriptor desc;
@@ -631,7 +637,13 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             if (wss.m_descriptor_caches.count(id) == 0) {
                 wss.m_descriptor_caches[id] = DescriptorCache();
             }
-            pwallet->LoadDescriptorScriptPubKeyMan(id, desc);
+            SecureString mnemonic;
+            SecureString mnemonic_passphrase;
+            if (strType == DBKeys::WALLETDESCRIPTORMNEMONIC) {
+                ssValue >> mnemonic;
+                ssValue >> mnemonic_passphrase;
+            }
+            pwallet->LoadDescriptorScriptPubKeyMan(id, desc, mnemonic, mnemonic_passphrase);
         } else if (strType == DBKeys::WALLETDESCRIPTORCACHE) {
             bool parent = true;
             uint256 desc_id;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -214,7 +214,7 @@ public:
 
     bool WriteDescriptorKey(const uint256& desc_id, const CPubKey& pubkey, const CPrivKey& privkey);
     bool WriteCryptedDescriptorKey(const uint256& desc_id, const CPubKey& pubkey, const std::vector<unsigned char>& secret);
-    bool WriteDescriptor(const uint256& desc_id, const WalletDescriptor& descriptor);
+    bool WriteDescriptor(const uint256& desc_id, const WalletDescriptor& descriptor, const SecureString& mnemonic, const SecureString& mnemonic_string);
     bool WriteDescriptorDerivedCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index, uint32_t der_index);
     bool WriteDescriptorParentCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index);
     bool WriteDescriptorLastHardenedCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index);

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -49,7 +49,7 @@ static void WalletCreate(CWallet* wallet_instance, uint64_t wallet_creation_flag
             spk_man->GenerateNewHDChain(/*secureMnemonic=*/"", /*secureMnemonicPassphrase=*/"");
         }
     } else {
-        wallet_instance->SetupDescriptorScriptPubKeyMans();
+        wallet_instance->SetupDescriptorScriptPubKeyMans("", "");
     }
 
     tfm::format(std::cout, "Topping up keypool...\n");

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -97,4 +97,19 @@ public:
     WalletDescriptor(std::shared_ptr<Descriptor> descriptor, uint64_t creation_time, int32_t range_start, int32_t range_end, int32_t next_index) : descriptor(descriptor), id(DescriptorID(*descriptor)), creation_time(creation_time), range_start(range_start), range_end(range_end), next_index(next_index) { }
 };
 
+struct WalletDescriptorMnemonic
+{
+    const WalletDescriptor& descriptor;
+    const SecureString& mnemonic;
+    const SecureString& mnemonic_passphrase;
+
+    SERIALIZE_METHODS(WalletDescriptorMnemonic, obj)
+    {
+        READWRITE(
+                obj.descriptor,
+                obj.mnemonic,
+                obj.mnemonic_passphrase
+        );
+    }
+};
 #endif // BITCOIN_WALLET_WALLETUTIL_H

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -314,6 +314,7 @@ BASE_SCRIPTS = [
     'wallet_encryption.py --legacy-wallet',
     'wallet_encryption.py --descriptors',
     'wallet_upgradetohd.py --legacy-wallet',
+    'wallet_upgradetohd.py --descriptors',
     'feature_dersig.py',
     'feature_cltv.py',
     'feature_new_quorum_type_activation.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -294,7 +294,7 @@ BASE_SCRIPTS = [
     'wallet_upgradewallet.py --legacy-wallet',
     'wallet_importdescriptors.py --descriptors',
     'wallet_mnemonicbits.py --legacy-wallet',
-    # 'wallet_mnemonicbits.py --descriptors', # TODO : implement mnemonics for descriptor wallets
+    'wallet_mnemonicbits.py --descriptors',
     'rpc_bind.py --ipv4',
     'rpc_bind.py --ipv6',
     'rpc_bind.py --nonloopback',

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -87,7 +87,7 @@ class WalletDumpTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.disable_mocktime = True
-        self.extra_args = [["-keypool=90", "-usehd=1"]]
+        self.extra_args = [["-keypool=90"]]
         self.rpc_timeout = 120
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -37,7 +37,6 @@ class ImportMultiTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [['-usehd=1']] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_keypool_hd.py
+++ b/test/functional/wallet_keypool_hd.py
@@ -18,7 +18,6 @@ class KeyPoolTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [['-usehd=1']]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -82,7 +82,9 @@ class ListDescriptorsTest(BitcoinTestFramework):
                  'timestamp': 1296688602,
                  'active': False,
                  'range': [0, 0],
-                 'next': 0},
+                 'next': 0,
+                 'mnemonic':'',
+                 'mnemonic_passphrase':''},
             ],
         }
         assert_equal(expected_private, wallet.listdescriptors(True))

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -24,7 +24,14 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.stop_node(0)
         self.nodes[0].assert_start_raises_init_error(['-mnemonicbits=123'], "Error: Invalid '-mnemonicbits'. Allowed values: 128, 160, 192, 224, 256.")
         self.start_node(0)
-        assert_equal(len(self.nodes[0].dumphdinfo()["mnemonic"].split()), 12)  # 12 words by default
+        if self.options.descriptors:
+            assert not "mnemonic" in self.nodes[0].listdescriptors()
+            descriptors = self.nodes[0].listdescriptors(True)['descriptors']
+            assert_equal(len(descriptors[0]['mnemonic'].split()), 12)
+            assert_equal(len(descriptors[1]['mnemonic'].split()), 12)
+            assert_equal(descriptors[0]['mnemonic'], descriptors[1]['mnemonic'])
+        else:
+            assert_equal(len(self.nodes[0].dumphdinfo()["mnemonic"].split()), 12)  # 12 words by default
 
         self.log.info("Can have multiple wallets with different mnemonic length loaded at the same time")
         self.restart_node(0, extra_args=["-mnemonicbits=160"])
@@ -37,13 +44,19 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].loadwallet("wallet_160")
         self.nodes[0].loadwallet("wallet_192")
         self.nodes[0].loadwallet("wallet_224")
-        self.nodes[0].createwallet("wallet_256", False, True)  # blank
-        self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
-        assert_equal(len(self.nodes[0].get_wallet_rpc(self.default_wallet_name).dumphdinfo()["mnemonic"].split()), 12)  # 12 words by default
-        assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").dumphdinfo()["mnemonic"].split()), 15)              # 15 words
-        assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").dumphdinfo()["mnemonic"].split()), 18)              # 18 words
-        assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").dumphdinfo()["mnemonic"].split()), 21)              # 21 words
-        assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").dumphdinfo()["mnemonic"].split()), 24)              # 24 words
+        if self.options.descriptors:
+            assert_equal(len(self.nodes[0].get_wallet_rpc(self.default_wallet_name).listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 12)  # 12 words by default
+            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 15)              # 15 words
+            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 18)              # 18 words
+            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 21)              # 21 words
+        else:
+            self.nodes[0].createwallet("wallet_256", False, True)  # blank HD legacy
+            self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
+            assert_equal(len(self.nodes[0].get_wallet_rpc(self.default_wallet_name).dumphdinfo()["mnemonic"].split()), 12)  # 12 words by default
+            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").dumphdinfo()["mnemonic"].split()), 15)              # 15 words
+            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").dumphdinfo()["mnemonic"].split()), 18)              # 18 words
+            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").dumphdinfo()["mnemonic"].split()), 21)              # 21 words
+            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").dumphdinfo()["mnemonic"].split()), 24)              # 24 words
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -45,10 +45,13 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].loadwallet("wallet_192")
         self.nodes[0].loadwallet("wallet_224")
         if self.options.descriptors:
+            self.nodes[0].createwallet("wallet_256", False, True, "", False, True)  # blank Descriptors
+            self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
             assert_equal(len(self.nodes[0].get_wallet_rpc(self.default_wallet_name).listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 12)  # 12 words by default
             assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 15)              # 15 words
             assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 18)              # 18 words
             assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 21)              # 21 words
+            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 24)              # 24 words
         else:
             self.nodes[0].createwallet("wallet_256", False, True)  # blank HD legacy
             self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently, it's possible to create wallet with mnemonic (BIP39) only for legacy (non-descriptor) wallet.

## What was done?
This PR adds basic support BIP39 to descriptor wallets:
 - new created wallets will have mnemonic
 - RPC `upgradetohd` now support descriptor wallets and let to set specifict mnemonic with passphrase to newly created wallet
 - mnemonic is shown when calling RPC `listdescriptors` if exists

# Known issue: encrypted wallets are not supported yet, I will update PR later soon

## How Has This Been Tested?
Functional test `wallet_mnemonicbits.py` support `--descriptors` now
Functional test `wallet_upgradetohd.py` is updated also

## Breaking Changes
N/A

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

