### PR TITLE
docs: prefer `docker compose` over `docker-compose`

### DIFF
--- a/contrib/containers/README.md
+++ b/contrib/containers/README.md
@@ -11,7 +11,7 @@ leverages Docker [BuildKit](https://docs.docker.com/develop/develop-images/build
 the amount of repetitive code.
 
 As BuildKit is opt-in within many currently supported versions of Docker (as of this writing), you need to
-set the following environment variables before continuing. While not needed after the initial `docker-compose build`
+set the following environment variables before continuing. While not needed after the initial `docker compose build`
 (barring updates to the `Dockerfile`), we recommend placing this in your `~/.bash_profile`/`~/.zshrc` or equivalent
 
 ```bash
@@ -25,6 +25,6 @@ to run terminal commands from inside the terminal and build Dash Core.
 
 ```bash
 cd contrib/containers/develop
-docker-compose build
-docker-compose run container
+docker compose build
+docker compose run container
 ```


### PR DESCRIPTION
## Issue being fixed or feature implemented
docker-compose is obsolete, use `docker compose` instead.

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

