### PR TITLE
ci: optimize docker image size

### DIFF
--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -1,4 +1,29 @@
+# cppcheck builder
+FROM debian:bookworm-slim AS cppcheck-builder
+ARG CPPCHECK_VERSION=2.13.0
+RUN set -ex; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        cmake \
+        make \
+        g++ \
+    && rm -rf /var/lib/apt/lists/*; \
+    echo "Downloading Cppcheck version: ${CPPCHECK_VERSION}"; \
+    curl -fL "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" -o /tmp/cppcheck.tar.gz; \
+    mkdir -p /src/cppcheck && tar -xzf /tmp/cppcheck.tar.gz -C /src/cppcheck --strip-components=1; \
+    rm /tmp/cppcheck.tar.gz; \
+    cd /src/cppcheck; \
+    mkdir build && cd build && cmake .. && cmake --build . -j"$(nproc)"; \
+    strip bin/cppcheck
+
+# Final Image
 FROM ubuntu:noble
+COPY --from=cppcheck-builder /src/cppcheck/build/bin/cppcheck /usr/local/bin/cppcheck
+COPY --from=cppcheck-builder /src/cppcheck/cfg /usr/local/share/Cppcheck/cfg
+
+# Set Path
+ENV PATH="/usr/local/bin:${PATH}"
 
 # Needed to prevent tzdata hanging while expecting user input
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
@@ -114,16 +139,6 @@ RUN set -ex; \
     git clone --depth 1 --no-tags --branch=${DASH_HASH_VERSION} https://github.com/dashpay/dash_hash; \
     cd dash_hash && pip3 install -r requirements.txt .; \
     cd .. && rm -rf dash_hash
-
-ARG CPPCHECK_VERSION=2.13.0
-RUN set -ex; \
-    curl -fL "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" -o /tmp/cppcheck.tar.gz; \
-    mkdir -p /opt/cppcheck && tar -xzf /tmp/cppcheck.tar.gz -C /opt/cppcheck --strip-components=1 && rm /tmp/cppcheck.tar.gz; \
-    cd /opt/cppcheck; \
-    mkdir build && cd build && cmake .. && cmake --build . -j "$(( $(nproc) - 1 ))"; \
-    mkdir /usr/local/share/Cppcheck && ln -s /opt/cppcheck/cfg/ /usr/local/share/Cppcheck/cfg; \
-    rm -rf /tmp/cppcheck.tar.gz
-ENV PATH="/opt/cppcheck/build/bin:${PATH}"
 
 ARG SHELLCHECK_VERSION=v0.7.1
 RUN set -ex; \

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -123,7 +123,7 @@ RUN curl https://pyenv.run | bash \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
     && pyenv rehash
-RUN pip3 install \
+RUN pip3 install --no-cache-dir \
     codespell==1.17.1 \
     flake8==3.8.3 \
     jinja2 \


### PR DESCRIPTION
## Issue being fixed or feature implemented
This reduced the docker image size as built locally from 4.91GB to 3.49GB; hopefully this will also speed up the "Initialize Containers" step in each stage of CI. **BREAKING NEWS** It does! Initialize Containers step goes from ~45 seconds to ~35 seconds. Still not perfect but roughly proportional to the bytes saved. I think there's more potential with pyenv, but I wasn't able to figure it out.

## What was done?
see commits

## How Has This Been Tested?
built locally; ci: https://github.com/PastaPastaPasta/dash/actions/runs/13270659375/job/37049252054

## Breaking Changes
Should be none

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

