### PR TITLE
fix: ReconnectionInfo should also store Dash-specific flags

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2247,7 +2247,9 @@ void CConnman::DisconnectNodes()
                         .grant = std::move(pnode->grantOutbound),
                         .destination = pnode->m_dest,
                         .conn_type = pnode->m_conn_type,
-                        .use_v2transport = false});
+                        .use_v2transport = false,
+                        .masternode_connection = pnode->m_masternode_connection,
+                        .masternode_probe_connection = pnode->m_masternode_probe_connection});
                     LogPrint(BCLog::NET, "retrying with v1 transport protocol for peer=%d\n", pnode->GetId());
                 }
 
@@ -5171,7 +5173,9 @@ void CConnman::PerformReconnections()
                               std::move(item.grant),
                               item.destination.empty() ? nullptr : item.destination.c_str(),
                               item.conn_type,
-                              item.use_v2transport);
+                              item.use_v2transport,
+                              item.masternode_connection ? MasternodeConn::IsConnection : MasternodeConn::IsNotConnection,
+                              item.masternode_probe_connection ? MasternodeProbeConn::IsConnection : MasternodeProbeConn::IsNotConnection);
     }
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -1981,6 +1981,8 @@ private:
         std::string destination;
         ConnectionType conn_type;
         bool use_v2transport;
+        bool masternode_connection;
+        bool masternode_probe_connection;
     };
 
     /**


### PR DESCRIPTION
## Issue being fixed or feature implemented
Mixing with p2p v2 protocol enabled on p2p v1 masternodes triggers reconnection which "forgets" about Dash-specific flags so these connections aren't dropped on mixing session timeouts like they should. Most nodes on testnet are upgraded so the issue wan't noticeable there unfortunately.

## What was done?
Store Dash-specific flags in `ReconnectionInfo` and use them in `PerformReconnections()` later

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

