### PR TITLE
perf: speedup of CBLSLazyPublicKey::operator== when comparing to the default / null object; speedup CDeterministicMNList::AddMN by avoiding check to IsValid when a nullcheck is sufficient

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -509,8 +509,8 @@ public:
     bool operator==(const CBLSLazyWrapper& r) const
     {
         // If neither bufValid or objInitialized are set, then the object is the default object.
-        const bool is_default{bufValid || objInitialized};
-        const bool r_is_default{r.bufValid || r.objInitialized};
+        const bool is_default{!bufValid && !objInitialized};
+        const bool r_is_default{!r.bufValid && !r.objInitialized};
         // If both are default; they are equal.
         if (is_default && r_is_default) return true;
         // If one is default and the other isn't, we are not equal

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -391,6 +391,7 @@ private:
     mutable std::mutex mutex;
 
     mutable std::array<uint8_t, BLSObject::SerSize> vecBytes;
+    // Indicates if the value contained in vecBytes is valid
     mutable bool bufValid{false};
     mutable bool bufLegacyScheme{true};
 
@@ -462,7 +463,7 @@ public:
     {
         std::unique_lock<std::mutex> l(mutex);
         s.read(AsWritableBytes(Span{vecBytes.data(), BLSObject::SerSize}));
-        bufValid = true;
+        bufValid = std::any_of(vecBytes.begin(), vecBytes.end(), [](uint8_t c) { return c != 0; });
         bufLegacyScheme = specificLegacyScheme;
         objInitialized = false;
         hash.SetNull();
@@ -507,6 +508,14 @@ public:
 
     bool operator==(const CBLSLazyWrapper& r) const
     {
+        // If neither bufValid or objInitialized are set, then the object is the default object.
+        const bool is_default{bufValid || objInitialized};
+        const bool r_is_default{r.bufValid || r.objInitialized};
+        // If both are default; they are equal.
+        if (is_default && r_is_default) return true;
+        // If one is default and the other isn't, we are not equal
+        if (is_default != r_is_default) return false;
+
         if (bufValid && r.bufValid && bufLegacyScheme == r.bufLegacyScheme) {
             return vecBytes == r.vecBytes;
         }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -477,7 +477,7 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTota
         throw(std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate keyIDOwner=%s", __func__,
                 dmn->proTxHash.ToString(), EncodeDestination(PKHash(dmn->pdmnState->keyIDOwner)))));
     }
-    if (dmn->pdmnState->pubKeyOperator.Get().IsValid() && !AddUniqueProperty(*dmn, dmn->pdmnState->pubKeyOperator)) {
+    if (dmn->pdmnState->pubKeyOperator != CBLSLazyPublicKey() && !AddUniqueProperty(*dmn, dmn->pdmnState->pubKeyOperator)) {
         mnUniquePropertyMap = mnUniquePropertyMapSaved;
         throw(std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate pubKeyOperator=%s", __func__,
                 dmn->proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.ToString())));

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -578,7 +578,8 @@ void CDeterministicMNList::RemoveMN(const uint256& proTxHash)
         throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with a keyIDOwner=%s", __func__,
                 proTxHash.ToString(), EncodeDestination(PKHash(dmn->pdmnState->keyIDOwner)))));
     }
-    if (dmn->pdmnState->pubKeyOperator != CBLSLazyPublicKey() && !DeleteUniqueProperty(*dmn, dmn->pdmnState->pubKeyOperator)) {
+    if (dmn->pdmnState->pubKeyOperator != CBLSLazyPublicKey() &&
+        !DeleteUniqueProperty(*dmn, dmn->pdmnState->pubKeyOperator)) {
         mnUniquePropertyMap = mnUniquePropertyMapSaved;
         throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with a pubKeyOperator=%s", __func__,
                 proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.ToString())));
@@ -840,7 +841,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, gsl::no
             }
             if (newState->IsBanned()) {
                 // only revive when all keys are set
-                if (newState->pubKeyOperator != CBLSLazyPublicKey() && !newState->keyIDVoting.IsNull() && !newState->keyIDOwner.IsNull()) {
+                if (newState->pubKeyOperator != CBLSLazyPublicKey() && !newState->keyIDVoting.IsNull() &&
+                    !newState->keyIDOwner.IsNull()) {
                     newState->Revive(nHeight);
                     if (debugLogs) {
                         LogPrintf("CDeterministicMNManager::%s -- MN %s revived at height %d\n",

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -578,7 +578,7 @@ void CDeterministicMNList::RemoveMN(const uint256& proTxHash)
         throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with a keyIDOwner=%s", __func__,
                 proTxHash.ToString(), EncodeDestination(PKHash(dmn->pdmnState->keyIDOwner)))));
     }
-    if (dmn->pdmnState->pubKeyOperator.Get().IsValid() && !DeleteUniqueProperty(*dmn, dmn->pdmnState->pubKeyOperator)) {
+    if (dmn->pdmnState->pubKeyOperator != CBLSLazyPublicKey() && !DeleteUniqueProperty(*dmn, dmn->pdmnState->pubKeyOperator)) {
         mnUniquePropertyMap = mnUniquePropertyMapSaved;
         throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with a pubKeyOperator=%s", __func__,
                 proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.ToString())));
@@ -840,7 +840,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, gsl::no
             }
             if (newState->IsBanned()) {
                 // only revive when all keys are set
-                if (newState->pubKeyOperator.Get().IsValid() && !newState->keyIDVoting.IsNull() && !newState->keyIDOwner.IsNull()) {
+                if (newState->pubKeyOperator != CBLSLazyPublicKey() && !newState->keyIDVoting.IsNull() && !newState->keyIDOwner.IsNull()) {
                     newState->Revive(nHeight);
                     if (debugLogs) {
                         LogPrintf("CDeterministicMNManager::%s -- MN %s revived at height %d\n",

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -8,6 +8,7 @@
 #include <random.h>
 #include <streams.h>
 #include <util/irange.h>
+#include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -501,14 +502,7 @@ public:
     void Reset() { data.fill(0); }
 
     // Produce a string representation.
-    std::string ToString(bool /*legacy*/) const
-    {
-        std::ostringstream oss;
-        for (auto b : data) {
-            oss << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(b);
-        }
-        return oss.str();
-    }
+    std::string ToString(bool /*legacy*/) const { return HexStr(data); }
 
     // Equality operator.
     bool operator==(const DummyBLS& other) const { return data == other.data; }
@@ -532,7 +526,7 @@ BOOST_AUTO_TEST_CASE(test_non_default_vs_default)
     LazyDummyBLS lazy_default;
     LazyDummyBLS lazy_set;
     DummyBLS obj;
-    obj.data = {1, 2, 3, 4}; // nonzero data makes the object valid
+    obj.data = {1, 0, 0, 0}; // nonzero data makes the object valid
     lazy_set.Set(obj, false);
     BOOST_CHECK(!(lazy_default == lazy_set));
     BOOST_CHECK(lazy_default != lazy_set);

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -473,43 +473,36 @@ BOOST_AUTO_TEST_CASE(bls_threshold_signature_tests)
 }
 
 // A dummy BLS object that satisfies the minimal interface expected by CBLSLazyWrapper.
-class DummyBLS {
+class DummyBLS
+{
 public:
     // Define a fixed serialization size (for testing purposes).
     static const size_t SerSize = 4;
     std::array<uint8_t, SerSize> data{};
 
-    DummyBLS() {
-        data.fill(0);
-    }
+    DummyBLS() { data.fill(0); }
 
     // A dummy validity check: valid if any byte is non-zero.
-    bool IsValid() const {
-        return std::any_of(data.begin(), data.end(), [](uint8_t c){ return c != 0; });
+    bool IsValid() const
+    {
+        return std::any_of(data.begin(), data.end(), [](uint8_t c) { return c != 0; });
     }
 
     // Convert to bytes; ignore the legacy flag for simplicity.
-    std::array<uint8_t, SerSize> ToBytes(bool /*legacy*/) const {
-        return data;
-    }
+    std::array<uint8_t, SerSize> ToBytes(bool /*legacy*/) const { return data; }
 
     // Set from bytes; again, ignore the legacy flag.
-    void SetBytes(const std::array<uint8_t, SerSize>& bytes, bool /*legacy*/) {
-        data = bytes;
-    }
+    void SetBytes(const std::array<uint8_t, SerSize>& bytes, bool /*legacy*/) { data = bytes; }
 
     // A dummy malleability check: simply compares the stored data to the given bytes.
-    bool CheckMalleable(const std::array<uint8_t, SerSize>& bytes, bool /*legacy*/) const {
-        return data == bytes;
-    }
+    bool CheckMalleable(const std::array<uint8_t, SerSize>& bytes, bool /*legacy*/) const { return data == bytes; }
 
     // Reset the object to an "empty" state.
-    void Reset() {
-        data.fill(0);
-    }
+    void Reset() { data.fill(0); }
 
     // Produce a string representation.
-    std::string ToString(bool /*legacy*/) const {
+    std::string ToString(bool /*legacy*/) const
+    {
         std::ostringstream oss;
         for (auto b : data) {
             oss << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(b);
@@ -518,9 +511,7 @@ public:
     }
 
     // Equality operator.
-    bool operator==(const DummyBLS& other) const {
-        return data == other.data;
-    }
+    bool operator==(const DummyBLS& other) const { return data == other.data; }
 };
 
 // Define a type alias for our lazy wrapper instantiated with DummyBLS.
@@ -541,7 +532,7 @@ BOOST_AUTO_TEST_CASE(test_non_default_vs_default)
     LazyDummyBLS lazy_default;
     LazyDummyBLS lazy_set;
     DummyBLS obj;
-    obj.data = {1, 2, 3, 4};  // nonzero data makes the object valid
+    obj.data = {1, 2, 3, 4}; // nonzero data makes the object valid
     lazy_set.Set(obj, false);
     BOOST_CHECK(!(lazy_default == lazy_set));
     BOOST_CHECK(lazy_default != lazy_set);
@@ -553,9 +544,9 @@ BOOST_AUTO_TEST_CASE(test_non_default_vs_different)
     LazyDummyBLS lazy_a;
     LazyDummyBLS lazy_b;
     DummyBLS obj;
-    obj.data = {1, 2, 3, 4};  // nonzero data makes the object valid
+    obj.data = {1, 2, 3, 4}; // nonzero data makes the object valid
     lazy_a.Set(obj, false);
-    obj.data = {4, 3, 2, 1};  // nonzero data makes the object valid
+    obj.data = {2, 2, 3, 4}; // nonzero data makes the object valid
     lazy_b.Set(obj, false);
     BOOST_CHECK(lazy_a != lazy_b);
 }


### PR DESCRIPTION
## Profiling Analysis
before
￼<img width="1926" alt="Pasted Graphic 11" src="https://github.com/user-attachments/assets/3d333419-eea3-4ba3-a0e1-daa1670e4d52" />

after
<img width="1909" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/b019b62d-5033-4ed9-9fdb-34e4e1d9e76a" />

## Methods
Below, is some analysis on the results of running the `protx diff` RPC 500 times. The diffs had a start block between MIN and MAX as defined below; and an end block no more than MAX_DIFF from the selected start block. We then perform some statistical analysis on the data.

MIN_VALUE = 1500050
MAX_VALUE = 2000050
MAX_DIFF = 50000
￼
## Statistical Analysis, outliers included

### Before
Five-Number Summary of Execution Times:
Min:    0.024492 sec
Q1:     0.124626 sec
Median: 0.243000 sec
Q3:     0.358459 sec
Max:    15.583948 sec

Mean Execution Time: 0.428296 sec
Standard Deviation: 0.933486 sec

Linear Regression Results:
y = 0.000001 * x + 0.308662
R-squared: 0.008160 (Goodness of Fit)
![Observed Data](https://github.com/user-attachments/assets/12fdd894-0f2c-4cba-9945-5e9d084c9b24)
![Pasted Graphic 6](https://github.com/user-attachments/assets/97706786-73b1-417d-9036-caaa3add1290)

### After
Five-Number Summary of Execution Times:
Min:    0.038174 sec
Q1:     0.121363 sec
Median: 0.158175 sec
Q3:     0.215866 sec
Max:    16.587903 sec

Mean Execution Time: 0.239239 sec
Standard Deviation: 0.762387 sec

Linear Regression Results:
y = 0.000001 * x + 0.151169
R-squared: 0.006918 (Goodness of Fit)
P-value: 0.063105 (Significance)
![Observed Data](https://github.com/user-attachments/assets/d50e5b5b-1a67-47c9-980c-564adab083ba)
![Observed Data](https://github.com/user-attachments/assets/cecc0394-f484-410a-ad21-1a9bbd5a1dc7)

## Statistical Analysis, outliers excluded

### Before
removed 76 data points
Five-Number Summary of Execution Times (After Outlier Removal):
Min:    0.035916 sec
Q1:     0.211060 sec
Median: 0.319278 sec
Q3:     0.357963 sec
Max:    0.572785 sec

Mean Execution Time: 0.289764 sec
Standard Deviation: 0.101140 sec

Linear Regression Results (After Outlier Removal):
y = 0.0000000199 * x + 0.286447
R-squared: 0.000496 (Goodness of Fit)
![Pasted Graphic 10](https://github.com/user-attachments/assets/1f0f6389-dc8f-48a5-80b7-9b5ccb3869dc)


### After

removed 32 data points
Five-Number Summary of Execution Times (After Outlier Removal):
Min:    0.038174 sec
Q1:     0.119880 sec
Median: 0.151724 sec
Q3:     0.205017 sec
Max:    0.355078 sec

Mean Execution Time: 0.164165 sec
Standard Deviation: 0.060919 sec

Linear Regression Results (After Outlier Removal):
y = 0.0000003119 * x + 0.111002
R-squared: 0.399298 (Goodness of Fit)

![Observed Data](https://github.com/user-attachments/assets/91e97214-6afb-4c3a-a98a-cd7e5704e724)


## How Has This Been Tested?
Ran unit tests locally; reindexing currently, going to let CI run functional tests

## Breaking Changes
Should be none; but please think through the diff specifically related to https://github.com/dashpay/dash/compare/develop...PastaPastaPasta:dash:perf-build-simplified-mn-list-diff-bls-compare-to-null?expand=1#diff-0998f8dfc4c1089e90cbaafe9607b361035b904cd103df31e3c2339a3cbf790dR480

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

