### PR TITLE
ci: run functional tests on GitHub Actions, upload functional test logs as artifacts

### DIFF
--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -15,11 +15,17 @@ on:
         description: "Key needed to access cached depends"
         required: true
         type: string
+    outputs:
+      key:
+        description: "Key needed for restoring artifacts bundle"
+        value: ${{ jobs.build-src.outputs.key }}
 
 jobs:
   build-src:
     name: Build source
     runs-on: ubuntu-24.04
+    outputs:
+      key:  ${{ steps.bundle.outputs.key }}
     container:
       image: ${{ inputs.container-path }}
       options: --user root
@@ -89,9 +95,20 @@ jobs:
           ./ci/dash/test_unittests.sh
         shell: bash
 
-      - name: Upload build artifacts
+      - name: Bundle artifacts
+        id: bundle
+        run: |
+          export BUILD_TARGET="${{ inputs.build-target }}"
+          export BUNDLE_KEY="build-${BUILD_TARGET}-$(git rev-parse --short=8 HEAD)"
+          ./ci/dash/bundle-artifacts.sh create
+          echo "key=${BUNDLE_KEY}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.build-target }}
+          name: ${{ steps.bundle.outputs.key }}
           path: |
-            /output
+            ${{ steps.bundle.outputs.key }}.tar.zst
+          compression-level: 0
+          overwrite: true
+          retention-days: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,3 +154,57 @@ jobs:
       build-target: win64
       container-path: ${{ needs.container.outputs.path }}
       depends-key: ${{ needs.depends-win64.outputs.key }}
+
+  test-linux64:
+    name: linux64-test
+    uses: ./.github/workflows/test-src.yml
+    needs: [container, depends-linux64, src-linux64]
+    with:
+      bundle-key: ${{ needs.src-linux64.outputs.key }}
+      build-target: linux64
+      container-path: ${{ needs.container.outputs.path }}
+
+  test-linux64_multiprocess:
+    name: linux64_multiprocess-test
+    uses: ./.github/workflows/test-src.yml
+    needs: [container, depends-linux64_multiprocess, src-linux64_multiprocess]
+    with:
+      bundle-key: ${{ needs.src-linux64_multiprocess.outputs.key }}
+      build-target: linux64_multiprocess
+      container-path: ${{ needs.container.outputs.path }}
+
+  test-linux64_nowallet:
+    name: linux64_nowallet-test
+    uses: ./.github/workflows/test-src.yml
+    needs: [container, depends-linux64_nowallet, src-linux64_nowallet]
+    with:
+      bundle-key: ${{ needs.src-linux64_nowallet.outputs.key }}
+      build-target: linux64_nowallet
+      container-path: ${{ needs.container.outputs.path }}
+
+  test-linux64_sqlite:
+    name: linux64_sqlite-test
+    uses: ./.github/workflows/test-src.yml
+    needs: [container, depends-linux64, src-linux64_sqlite]
+    with:
+      bundle-key: ${{ needs.src-linux64_sqlite.outputs.key }}
+      build-target: linux64_sqlite
+      container-path: ${{ needs.container.outputs.path }}
+
+  test-linux64_tsan:
+    name: linux64_tsan-test
+    uses: ./.github/workflows/test-src.yml
+    needs: [container, depends-linux64_multiprocess, src-linux64_tsan]
+    with:
+      bundle-key: ${{ needs.src-linux64_tsan.outputs.key }}
+      build-target: linux64_tsan
+      container-path: ${{ needs.container.outputs.path }}
+
+  test-linux64_ubsan:
+    name: linux64_ubsan-test
+    uses: ./.github/workflows/test-src.yml
+    needs: [container, depends-linux64, src-linux64_ubsan]
+    with:
+      bundle-key: ${{ needs.src-linux64_ubsan.outputs.key }}
+      build-target: linux64_ubsan
+      container-path: ${{ needs.container.outputs.path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,15 +164,6 @@ jobs:
       build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
 
-  test-linux64_multiprocess:
-    name: linux64_multiprocess-test
-    uses: ./.github/workflows/test-src.yml
-    needs: [container, depends-linux64_multiprocess, src-linux64_multiprocess]
-    with:
-      bundle-key: ${{ needs.src-linux64_multiprocess.outputs.key }}
-      build-target: linux64_multiprocess
-      container-path: ${{ needs.container.outputs.path }}
-
   test-linux64_nowallet:
     name: linux64_nowallet-test
     uses: ./.github/workflows/test-src.yml
@@ -189,15 +180,6 @@ jobs:
     with:
       bundle-key: ${{ needs.src-linux64_sqlite.outputs.key }}
       build-target: linux64_sqlite
-      container-path: ${{ needs.container.outputs.path }}
-
-  test-linux64_tsan:
-    name: linux64_tsan-test
-    uses: ./.github/workflows/test-src.yml
-    needs: [container, depends-linux64_multiprocess, src-linux64_tsan]
-    with:
-      bundle-key: ${{ needs.src-linux64_tsan.outputs.key }}
-      build-target: linux64_tsan
       container-path: ${{ needs.container.outputs.path }}
 
   test-linux64_ubsan:

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -39,6 +39,7 @@ jobs:
           name: ${{ inputs.bundle-key }}
 
       - name: Run functional tests
+        id: test
         run: |
           git config --global --add safe.directory "$PWD"
           export BUILD_TARGET="${{ inputs.build-target }}"
@@ -48,3 +49,27 @@ jobs:
           source ./ci/dash/matrix.sh
           ./ci/dash/test_integrationtests.sh ${INTEGRATION_TESTS_ARGS}
         shell: bash
+
+      - name: Bundle test logs
+        id: bundle
+        if: success() || (failure() && steps.test.outcome == 'failure')
+        run: |
+          export BUILD_TARGET="${{ inputs.build-target }}"
+          echo "short-sha=$(git rev-parse --short=8 HEAD)" >> "${GITHUB_OUTPUT}"
+          ( [ -d "testlogs" ] && echo "upload-logs=true" >> "${GITHUB_OUTPUT}" && ./ci/dash/bundle-logs.sh ) \
+                              || echo "upload-logs=false" >> "${GITHUB_OUTPUT}"
+        shell: bash
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v4
+        if: |
+          success() || (failure() && steps.test.outcome == 'failure')
+          && steps.bundle.outputs.upload-logs == 'true'
+        with:
+          name: test_logs-${{ inputs.build-target }}-${{ steps.bundle.outputs.short-sha }}
+          path: |
+            test_logs-${{ inputs.build-target }}.tar.zst
+            test_logs-${{ inputs.build-target }}.tar.zst.sha256
+          compression-level: 0
+          overwrite: true
+          retention-days: 1

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           name: ${{ inputs.bundle-key }}
 
+      - name: Manage releases cache
+        uses: actions/cache@v4
+        if: inputs.build-target == 'linux64'
+        with:
+          path: |
+            releases
+          key: releases-${{ hashFiles('ci/test/00_setup_env_native_qt5.sh', 'test/get_previous_releases.py') }}
+
       - name: Run functional tests
         id: test
         run: |

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -44,6 +44,7 @@ jobs:
           export BUILD_TARGET="${{ inputs.build-target }}"
           export BUNDLE_KEY="${{ inputs.bundle-key }}"
           ./ci/dash/bundle-artifacts.sh extract
+          ./ci/dash/slim-workspace.sh
           source ./ci/dash/matrix.sh
           ./ci/dash/test_integrationtests.sh ${INTEGRATION_TESTS_ARGS}
         shell: bash

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -1,0 +1,49 @@
+name: Test source
+
+on:
+  workflow_call:
+    inputs:
+      bundle-key:
+        description: "Key needed to access bundle of artifacts"
+        required: true
+        type: string
+      build-target:
+        description: "Target name as defined by inputs.sh"
+        required: true
+        type: string
+      container-path:
+        description: "Path to built container at registry"
+        required: true
+        type: string
+
+env:
+  INTEGRATION_TESTS_ARGS: "--extended --exclude feature_pruning,feature_dbcrash"
+
+jobs:
+  test-src:
+    name: Test source
+    runs-on: ubuntu-24.04
+    container:
+      image: ${{ inputs.container-path }}
+      options: --user root
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.bundle-key }}
+
+      - name: Run functional tests
+        run: |
+          git config --global --add safe.directory "$PWD"
+          export BUILD_TARGET="${{ inputs.build-target }}"
+          export BUNDLE_KEY="${{ inputs.bundle-key }}"
+          ./ci/dash/bundle-artifacts.sh extract
+          source ./ci/dash/matrix.sh
+          ./ci/dash/test_integrationtests.sh ${INTEGRATION_TESTS_ARGS}
+        shell: bash

--- a/ci/dash/bundle-artifacts.sh
+++ b/ci/dash/bundle-artifacts.sh
@@ -40,13 +40,8 @@ if [ "${VERB}" = "create" ]; then
   EXCLUSIONS=(
     "*.a"
     "*.o"
-    "build-ci/dashcore-${BUILD_TARGET}/src/bench/bench_dash"
-    "build-ci/dashcore-${BUILD_TARGET}/src/bench/bench_dash.exe"
-    "build-ci/dashcore-${BUILD_TARGET}/src/qt/test/test_dash-qt"
-    "build-ci/dashcore-${BUILD_TARGET}/src/qt/test/test_dash-qt.exe"
-    "build-ci/dashcore-${BUILD_TARGET}/src/test/test_dash"
-    "build-ci/dashcore-${BUILD_TARGET}/src/test/test_dash.exe"
-    "build-ci/dashcore-${BUILD_TARGET}/src/test/fuzz/fuzz"
+    ".deps"
+    ".libs"
   )
   EXCLUSIONS_ARG=""
   for excl in "${EXCLUSIONS[@]}"

--- a/ci/dash/bundle-artifacts.sh
+++ b/ci/dash/bundle-artifacts.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024-2025 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+set -eo pipefail
+
+SH_NAME="$(basename "${0}")"
+VERB="${1}"
+
+if [ -z "${BUILD_TARGET}" ]; then
+  echo "${SH_NAME}: BUILD_TARGET not defined, cannot continue!";
+  exit 1;
+elif [ -z "${BUNDLE_KEY}" ]; then
+  echo "${SH_NAME}: BUNDLE_KEY not defined, cannot continue!";
+  exit 1;
+elif  [ ! "$(command -v zstd)" ]; then
+  echo "${SH_NAME}: zstd not found, cannot continue!";
+  exit 1;
+elif [ -z "${VERB}" ]; then
+  echo "${SH_NAME}: Verb missing, acceptable values 'create' or 'extract'";
+  exit 1;
+elif [ "${VERB}" != "create" ] && [ "${VERB}" != "extract" ]; then
+  echo "${SH_NAME}: Invalid verb '${VERB}', expected 'create' or 'extract'";
+  exit 1;
+fi
+
+OUTPUT_ARCHIVE="${BUNDLE_KEY}.tar.zst"
+if [ -f "${OUTPUT_ARCHIVE}" ] && [ "${VERB}" = "create" ]; then
+  echo "${SH_NAME}: ${OUTPUT_ARCHIVE} already exists, cannot continue!";
+  exit 1;
+elif [ ! -f "${OUTPUT_ARCHIVE}" ] && [ "${VERB}" = "extract" ]; then
+  echo "${SH_NAME}: ${OUTPUT_ARCHIVE} missing, cannot continue!";
+  exit 1;
+fi
+
+if [ "${VERB}" = "create" ]; then
+  EXCLUSIONS=(
+    "*.a"
+    "*.o"
+    "build-ci/dashcore-${BUILD_TARGET}/src/bench/bench_dash"
+    "build-ci/dashcore-${BUILD_TARGET}/src/bench/bench_dash.exe"
+    "build-ci/dashcore-${BUILD_TARGET}/src/qt/test/test_dash-qt"
+    "build-ci/dashcore-${BUILD_TARGET}/src/qt/test/test_dash-qt.exe"
+    "build-ci/dashcore-${BUILD_TARGET}/src/test/test_dash"
+    "build-ci/dashcore-${BUILD_TARGET}/src/test/test_dash.exe"
+    "build-ci/dashcore-${BUILD_TARGET}/src/test/fuzz/fuzz"
+  )
+  EXCLUSIONS_ARG=""
+  for excl in "${EXCLUSIONS[@]}"
+  do
+    EXCLUSIONS_ARG+=" --exclude=${excl}";
+  done
+
+  # shellcheck disable=SC2086
+  tar ${EXCLUSIONS_ARG} --use-compress-program="zstd -T0 -5" -cf "${OUTPUT_ARCHIVE}" "build-ci";
+elif [ "${VERB}" = "extract" ]; then
+  tar --use-compress-program="unzstd" -xf "${OUTPUT_ARCHIVE}";
+else
+  echo "${SH_NAME}: Generic error";
+  exit 1;
+fi

--- a/ci/dash/bundle-logs.sh
+++ b/ci/dash/bundle-logs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+set -eo pipefail
+
+SH_NAME="$(basename "${0}")"
+LOG_DIRECTORY="testlogs"
+
+if [ ! -d "${LOG_DIRECTORY}" ]; then
+  echo "${SH_NAME}: '${LOG_DIRECTORY}' directory missing, will skip!";
+  exit 0;
+elif [ -z "${BUILD_TARGET}" ]; then
+  echo "${SH_NAME}: BUILD_TARGET not defined, cannot continue!";
+  exit 1;
+fi
+
+LOG_ARCHIVE="test_logs-${BUILD_TARGET}.tar.zst"
+if [ -f "${LOG_ARCHIVE}" ]; then
+  echo "${SH_NAME}: ${LOG_ARCHIVE} already exists, cannot continue!";
+  exit 1;
+fi
+
+tar --use-compress-program="zstd -T0 -5" -cf "${LOG_ARCHIVE}" "${LOG_DIRECTORY}"
+sha256sum "${LOG_ARCHIVE}" > "${LOG_ARCHIVE}.sha256";

--- a/ci/dash/slim-workspace.sh
+++ b/ci/dash/slim-workspace.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+set -eo pipefail
+
+SH_NAME="$(basename "${0}")"
+
+if [ -z "${BUILD_TARGET}" ]; then
+  echo "${SH_NAME}: BUILD_TARGET not defined, cannot continue!";
+  exit 1;
+elif [ -z "${BUNDLE_KEY}" ]; then
+  echo "${SH_NAME}: BUNDLE_KEY not defined, cannot continue!";
+  exit 1;
+fi
+
+TARGETS=(
+  # Bundle restored from artifact
+  "${BUNDLE_KEY}.tar.zst"
+  # Binaries not needed by functional tests
+  "build-ci/dashcore-${BUILD_TARGET}/src/dash-tx"
+  "build-ci/dashcore-${BUILD_TARGET}/src/bench/bench_dash"
+  "build-ci/dashcore-${BUILD_TARGET}/src/qt/dash-qt"
+  "build-ci/dashcore-${BUILD_TARGET}/src/qt/test/test_dash-qt"
+  "build-ci/dashcore-${BUILD_TARGET}/src/test/test_dash"
+  "build-ci/dashcore-${BUILD_TARGET}/src/test/fuzz/fuzz"
+  # Misc. files that can be heavy
+  "build-ci/dashcore-${BUILD_TARGET}/src/qt/qrc_bitcoin.cpp"
+  "build-ci/dashcore-${BUILD_TARGET}/src/qt/qrc_dash_locale.cpp"
+)
+
+# Delete directories we don't need
+for target in "${TARGETS[@]}"
+do
+  if [[ -d "${target}" ]] || [[ -f "${target}" ]]; then
+    rm -rf "${target}";
+  fi
+done

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -184,6 +184,7 @@ RUN apt-get update && apt-get install $APT_ARGS \
     wine-stable \
     wine64 \
     zip \
+    zstd \
     && rm -rf /var/lib/apt/lists/*
 
 # Make sure std::thread and friends is available


### PR DESCRIPTION
## Additional Information

* [`actions/cache`](https://github.com/marketplace/actions/cache) allows specification of directories that want to be cached using glob expressions, which extend further into defining exclusions, needed due keep cache sizes maintainable ([source](https://github.com/dashpay/dash/blob/bb469687d3d936f82fd8e8fbe0934eec5e17df5e/.gitlab-ci.yml#L128-L138)).

  * Unfortunately, the implementation of globbing with respect to exclusions is more-or-less broken (see [actions/toolkit#713](https://github.com/actions/toolkit/issues/713#issuecomment-2417006720)) with the requirement that the inclusion depth should match the depth of the exclusion. Attempting to play by these rules more or less fails ([build](https://github.com/kwvg/dash/actions/runs/13344612118/job/37273624710#step:5:4634)).

  * Attempting to use third party actions like [`tj-actions/glob`](https://github.com/marketplace/actions/glob-match) provide for a much more saner experience but they enumerate individual files that match patterns, not folders. This means that when we pass them to `actions/cache`, we breach the arguments length limit ([build](https://github.com/kwvg/dash/actions/runs/13343953711/job/37272121153#step:9:4409)).

    * Modifying `ulimit` to get around this isn't very feasible due to odd behavior surrounding it (see [actions/runner#3421](https://github.com/actions/runner/issues/3421)) and the general consensus is to save to a file and have the next action read from file ([source](https://stackoverflow.com/a/71349472)).
      
       [`tj-actions/glob`](https://github.com/marketplace/actions/glob-match) graciously does this with the `paths-output-file` output but it takes two to play and [`actions/cache`](https://github.com/marketplace/actions/cache) does not accept files (`path` must be a newline-delimited string).

  The path of least resistance, it seems, is to use a script to bundle our cache into a neat input and leave [`actions/cache`](https://github.com/marketplace/actions/cache) out of it entirely, this is the approach taken.

* As we aren't using self-hosted runners, we are subject to GitHub's limits for everything, runner space, total artifact storage budget, total cache storage budget.

  * Caches that not **accessed** in 7 days are evicted and there's a 10 GB budget for all caches ([source](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)) and GitHub will evict oldest (presumably by **creation**?) caches to make sure that limit is adhered to.

    * What makes this limit troubling is the immutable nature of caches as unlike GitLab, which is more conductive to shared caches ([source](https://github.com/dashpay/dash/blob/bb469687d3d936f82fd8e8fbe0934eec5e17df5e/.gitlab-ci.yml#L55-L69)), GitHub insists on its immutability (see [actions/toolkit#505](https://github.com/actions/toolkit/issues/505)) and the only way to "update" a cache is to structure your cache key to allow the updated content to reflect in the key itself or delete the cache and create a new one, which brings race condition concerns ([comment](https://github.com/dashpay/dash/pull/6406#pullrequestreview-2446102373)).

      Sidenote, overwriting contents are allowed for artifacts ([source](https://github.com/actions/upload-artifact/blob/65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08/README.md#overwriting-an-artifact)), just not caches.

    * This means we need to be proactive in getting rid of caches with a short shelf life to avoid more long lasting caches (like `depends-sources`) from being evicted due to old age as we breach the 10 GB limit. We cannot just set a short retention period as GitHub doesn't offer you to do that with caches like they do with artifacts ([source](https://github.com/actions/upload-artifact/blob/65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08/README.md#retention-period)).

      * ~~While doing this properly would require us to implement a cache reaper workflow, this still needed to be addressed now as the contents of `build-ci` need to be passed onto the functional test workflow and this creates an ephemeral cache with a short lifespan that threatens longer-living (but older) caches.~~

     ~~This is currently approached by deleting `build-ci` (output) caches when the functional test runner is successful, we let the cache stick around if the build fails to allow for rerunning failed instances.~~

     ~~If for whatever reason a successful build has to be rerun, the build workflow would need to be rerun (though the `ccache` cache will speed this up significantly) to generate the output cache again for the test workflow to succeed. Failing to do this will result in a cache miss and run failure.~~ **Edit:** Switched to using artifacts to mitigate cache thrashing concerns. Auto-expiration is a huge plus, too.

  * Runners are limited to 14 GB of **addressable** storage space ([source](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)) and breaching this limit will cause the runners to fail.

    * Our TSan ([build](https://github.com/kwvg/dash/actions/runs/13355816205/job/37298587344#step:5:1178)) and multiprocess ([build](https://github.com/kwvg/dash/actions/runs/13355816205/job/37298658464#step:5:1190)) test variants breach this limit when collecting logs and deleting the `build-ci` (see 2153b0b95c15588d19e4061f5a43f9e47e63eb98) cache doesn't make enough of a dent to help ([build](https://github.com/kwvg/dash/actions/runs/13356474530)).

      * Omitting the logs from successful runs would be a regression in content for our `test_logs` artifacts and therefore wasn't considered.

    * While third-party actions like [`AdityaGarg8/remove-unwanted-software`](https://github.com/marketplace/actions/maximize-build-disk-space-only-remove-unwanted-software) can bring significant space savings ([build](https://github.com/kwvg/dash/actions/runs/13357806504/job/37302970610#step:2:150)), they cannot be run in jobs that utilize the [`container`](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container) context (so, all jobs after the container creation workflow) as they'd be executed inside the container when we want to affect the runner underneath ([build](https://github.com/kwvg/dash/actions/runs/13357260369/job/37301757225#step:3:29), notice the step being run after "Initialize containers").
      * There are no plans to implement definable "pre-steps" (see [actions/runner#812](https://github.com/actions/runner/issues/812)) and the only way to implement "before" and "after" steps is by self-hosting ([source](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)).

     This has been sidestepped tentatively by omitting TSan and multiprocess builds as any attempted fixes would require precision gutting to get borderline space savings which could easily be nullified by future code changes that occupy more space and such measures are better reserved for future PRs.

  * Artifacts share their storage quota with GitHub Packages ([source](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-packages/about-billing-for-github-packages#about-billing-for-github-packages)) and artifacts by default linger around for 90 days ([source](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#about-workflow-artifacts)) and considering that each run can generate multi-gigabyte total artifacts, testing the upper limit runs the risk of being very expensive. **Edit:** It appears pricing is reflective of artifacts in private repos, public repos don't seem to run this risk.

    * ~~All artifacts generated have an expiry of one day (compared to GitLab's three days, [source](https://github.com/dashpay/dash/blob/bb469687d3d936f82fd8e8fbe0934eec5e17df5e/.gitlab-ci.yml#L165), but they are self-hosted).~~ **Edit:** Artifacts now have an expiry of three days, matching GitLab.

    * Artifacts are compressed as ZIP archives and there is no way around that as of now (see [actions/upload-artifact#109](https://github.com/actions/upload-artifact/issues/109#issuecomment-699030493)) and the permissions loss it entails is acknowledged by GitHub and their solution is... to put them in a tarball ([source](https://github.com/actions/upload-artifact/blob/65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08/README.md#permission-loss)).

    To keep size under control, artifacts contain `zstd-5` compressed tarballs (compression level determined by benchmarks, see below) generated by bundling scripts alongside their checksum.

    <details>

    <summary>Benchmarks:</summary>

    ```
    $ zstd -b1 -e22 -T0 artifacts-linux64_multiprocess.tar
    1#_multiprocess.tar :1586411520 -> 537552492 (x2.951), 2396.2 MB/s, 1367.8 MB/s
    2#_multiprocess.tar :1586411520 -> 499098623 (x3.179), 2131.8 MB/s, 1306.6 MB/s
    3#_multiprocess.tar :1586411520 -> 474452284 (x3.344), 1371.6 MB/s, 1245.6 MB/s
    4#_multiprocess.tar :1586411520 -> 470931621 (x3.369),  620.3 MB/s, 1239.1 MB/s
    5#_multiprocess.tar :1586411520 -> 459075785 (x3.456),  457.2 MB/s, 1230.1 MB/s
    6#_multiprocess.tar :1586411520 -> 449594612 (x3.529),  415.3 MB/s, 1289.7 MB/s
    7#_multiprocess.tar :1586411520 -> 446208421 (x3.555),  282.6 MB/s, 1296.3 MB/s
    8#_multiprocess.tar :1586411520 -> 442797797 (x3.583),  254.3 MB/s, 1338.4 MB/s
    9#_multiprocess.tar :1586411520 -> 438690318 (x3.616),  210.8 MB/s, 1331.5 MB/s
    10#_multiprocess.tar :1586411520 -> 437195147 (x3.629),  164.1 MB/s, 1337.4 MB/s
    11#_multiprocess.tar :1586411520 -> 436501141 (x3.634),  108.2 MB/s, 1342.5 MB/s
    12#_multiprocess.tar :1586411520 -> 436405679 (x3.635),  102.7 MB/s, 1344.0 MB/s
    13#_multiprocess.tar :1586411520 -> 436340981 (x3.636),   65.9 MB/s, 1344.0 MB/s
    14#_multiprocess.tar :1586411520 -> 435626720 (x3.642),   61.5 MB/s, 1346.9 MB/s
    15#_multiprocess.tar :1586411520 -> 434882716 (x3.648),   49.4 MB/s, 1352.9 MB/s
    16#_multiprocess.tar :1586411520 -> 411221852 (x3.858),   33.6 MB/s, 1049.2 MB/s
    17#_multiprocess.tar :1586411520 -> 399523001 (x3.971),   26.0 MB/s, 1003.7 MB/s
    18#_multiprocess.tar :1586411520 -> 379278765 (x4.183),   21.0 MB/s,  897.5 MB/s
    19#_multiprocess.tar :1586411520 -> 378022246 (x4.197),   14.7 MB/s,  896.0 MB/s
    20#_multiprocess.tar :1586411520 -> 375741653 (x4.222),   14.0 MB/s,  877.6 MB/s
    21#_multiprocess.tar :1586411520 -> 373303486 (x4.250),   11.9 MB/s,  866.8 MB/s
    22#_multiprocess.tar :1586411520 -> 358172556 (x4.429),   6.09 MB/s,  884.9 MB/s
    ```

    </details>

      > **Note:** As mentioned above, we use similar bundling scripts for the outputs cache but unlike artifacts, we cannot disable their compression routines or even adjust compression levels (see [actions/tookit#544](https://github.com/actions/toolkit/issues/544)) 

## Notes

* ~~If we add or remove binaries in terms of compile output, `bundle-build.sh` needs to be updated. Without updating it, it will fail if it cannot find the files it was looking for and it will not include files that it wasn't told to include.~~ No longer applicable.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
