### PR TITLE
backport: Merge #23474: test: scripted-diff cleanups after generate* changes

### DIFF
--- a/test/functional/feature_backwards_compatibility.py
+++ b/test/functional/feature_backwards_compatibility.py
@@ -65,8 +65,6 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
     def run_test(self):
         self.generatetoaddress(self.nodes[0], 101, self.nodes[0].getnewaddress())
 
-        self.sync_blocks()
-
         # Sanity check the test framework:
         res = self.nodes[self.num_nodes - 1].getblockchaininfo()
         assert_equal(res['blocks'], 101)
@@ -93,7 +91,6 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(address, 1)
         self.sync_mempools()
         self.generate(self.nodes[0], 1)
-        self.sync_blocks()
 
         # w1_v19: regular wallet, created with v0.19
         node_v19.rpc.createwallet(wallet_name="w1_v19")

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -86,8 +86,6 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         self.wallet.send_self_transfer(from_node=node)
         self.generate(node, 1)
 
-        self.sync_blocks(timeout=120)
-
         self.log.info("Test that gettxoutsetinfo() output is consistent with or without coinstatsindex option")
         res0 = node.gettxoutsetinfo('none')
 

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -314,6 +314,7 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
             if not found_unconfirmed:
                 break
             self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+        self.sync_blocks()
 
 if __name__ == '__main__':
     LLMQCoinbaseCommitmentsTest().main()

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -314,7 +314,6 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
             if not found_unconfirmed:
                 break
             self.generate(self.nodes[0], 1, sync_fun=self.no_op)
-        self.sync_blocks()
 
 if __name__ == '__main__':
     LLMQCoinbaseCommitmentsTest().main()

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2015-2024 The Dash Core developers
+# Copyright (c) 2015-2025 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -205,7 +205,6 @@ class EstimateFeeTest(BitcoinTestFramework):
                 self.fees_per_kb.append(float(fee) / tx_kbytes)
             self.sync_mempools(wait=.1)
             mined = mining_node.getblock(self.generate(mining_node, 1)[0], True)["tx"]
-            self.sync_blocks(wait=.1)
             # update which txouts are confirmed
             newmem = []
             for utx in self.memutxo:
@@ -277,8 +276,6 @@ class EstimateFeeTest(BitcoinTestFramework):
         # Finish by mining a normal-sized block:
         while len(self.nodes[1].getrawmempool()) > 0:
             self.generate(self.nodes[1], 1)
-
-        self.sync_blocks(self.nodes[0:3], wait=.1)
         self.log.info("Final estimates after emptying mempools")
         check_estimates(self.nodes[1], self.fees_per_kb)
 

--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -48,7 +48,6 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         for _ in range(n):
             self.generate(self.nodes[0], 250)
         self.generate(self.nodes[0], blocks % 250)
-        self.sync_blocks()
 
     def restart_without_indices(self):
         for i in range(3):
@@ -152,7 +151,6 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log(['basic block filter index prune lock moved back to 2480']):
             self.nodes[3].invalidateblock(self.nodes[0].getblockhash(2480))
             self.generate(self.nodes[3], 30)
-            self.sync_blocks()
 
         for idx in range(self.num_nodes):
             self.nodes[idx].stop_node(expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE if idx != 3 else "")

--- a/test/functional/feature_llmq_dkgerrors.py
+++ b/test/functional/feature_llmq_dkgerrors.py
@@ -86,7 +86,6 @@ class LLMQDKGErrors(DashTestFramework):
         for _ in range(blockCount):
             self.bump_mocktime(1)
             self.generate(self.nodes[0], 1, sync_fun=self.no_op)
-        self.sync_all()
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.wait_for_sporks_same()
 

--- a/test/functional/feature_llmq_dkgerrors.py
+++ b/test/functional/feature_llmq_dkgerrors.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2015-2024 The Dash Core developers
+# Copyright (c) 2015-2025 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/feature_llmq_dkgerrors.py
+++ b/test/functional/feature_llmq_dkgerrors.py
@@ -86,6 +86,7 @@ class LLMQDKGErrors(DashTestFramework):
         for _ in range(blockCount):
             self.bump_mocktime(1)
             self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+        self.sync_all()
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.wait_for_sporks_same()
 

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -84,7 +84,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         h_100_1 = QuorumId(100, int(h_1, 16))
 
         self.log.info("Mine single block, wait for chainlock")
-        self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+        self.generate(self.nodes[0], 1)
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
 
         b_h_1 = self.nodes[0].getbestblockhash()
@@ -115,7 +115,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         assert_equal(projected_activation_height, softfork_info['height'])
 
         # v20 is active for the next block, not for the tip
-        self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+        self.generate(self.nodes[0], 1)
 
         self.log.info("Wait for chainlock")
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
@@ -196,7 +196,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         self.sync_blocks(nodes)
         quorum_list = self.nodes[0].quorum("list", llmq_type)
         quorum_blockhash = self.nodes[0].getbestblockhash()
-        fallback_blockhash = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
+        fallback_blockhash = self.generate(self.nodes[0], 1)[0]
         self.log.info("h("+str(self.nodes[0].getblockcount())+") quorum_list:"+str(quorum_list))
 
         assert_greater_than_or_equal(len(intersection(quorum_members_0_0, quorum_members_1_0)), 3)
@@ -388,8 +388,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         skip_count = cycle_length - (cur_block % cycle_length)
         if skip_count != 0:
             self.bump_mocktime(1)
-            self.generate(self.nodes[0], skip_count, sync_fun=self.no_op)
-        self.sync_blocks(nodes)
+            self.generate(self.nodes[0], skip_count, sync_fun=lambda: self.sync_blocks(nodes))
         self.log.info('Moved from block %d to %d' % (cur_block, self.nodes[0].getblockcount()))
 
 

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2015-2024 The Dash Core developers
+# Copyright (c) 2015-2025 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -109,8 +109,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         skip_count = 24 - (self.nodes[0].getblockcount() % 24)
         if skip_count != 0:
             self.bump_mocktime(skip_count, nodes=nodes)
-            self.generate(self.nodes[0], skip_count, sync_fun=self.no_op)
-        self.sync_blocks(nodes)
+            self.generate(self.nodes[0], skip_count, sync_fun=lambda: self.sync_blocks(nodes))
 
         q = self.nodes[0].getbestblockhash()
         self.log.info("Expected quorum_hash: "+str(q))

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2015-2024 The Dash Core developers
+# Copyright (c) 2015-2025 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -183,7 +183,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
         self.generate(self.nodes[0], 1)
-        self.sync_blocks()
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         # Prioritise a transaction that has been mined, then add it back to the
         # mempool by using invalidateblock.
@@ -276,7 +275,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # Test reorg handling
         # First, the basics:
         self.generate(self.nodes[0], 1)
-        self.sync_blocks()
         self.nodes[1].invalidateblock(self.nodes[0].getbestblockhash())
         self.nodes[1].reconsiderblock(self.nodes[0].getbestblockhash())
 

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -63,7 +63,6 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
 
         # Add enough mature utxos to the wallets, so that all txs spend confirmed coins
         self.generate(self.nodes[0], 100)
-        self.sync_blocks()
 
         self.log.info("Test that introducing a new transaction into the mempool will terminate the longpoll")
         thr = LongpollThread(self.nodes[0])

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -57,7 +57,6 @@ class CompactFiltersTest(BitcoinTestFramework):
 
         # Nodes 0 & 1 share the same first 999 blocks in the chain.
         self.generate(self.nodes[0], 999)
-        self.sync_blocks(timeout=600)
 
         # Stale blocks by disconnecting nodes 0 & 1, mining, then reconnecting
         self.disconnect_nodes(0, 1)

--- a/test/functional/p2p_compactblocks_hb.py
+++ b/test/functional/p2p_compactblocks_hb.py
@@ -31,7 +31,6 @@ class CompactBlocksConnectionTest(BitcoinTestFramework):
         """Relay a new block through peer peer, and return HB status between 1 and [2,3,4,5]."""
         self.connect_nodes(peer, 0)
         self.generate(self.nodes[0], 1)
-        self.sync_blocks()
         self.disconnect_nodes(peer, 0)
 
         def status_to():
@@ -50,7 +49,6 @@ class CompactBlocksConnectionTest(BitcoinTestFramework):
         for i in range(1, 6):
             self.connect_nodes(i, 0)
         self.generate(self.nodes[0], 2)
-        self.sync_blocks()
         for i in range(1, 6):
             self.disconnect_nodes(i, 0)
 

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -67,8 +67,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
 
         self.log.info("Mine enough blocks to reach the NODE_NETWORK_LIMITED range.")
         self.connect_nodes(0, 1)
-        blocks = self.generate(self.nodes[1], 292, sync_fun=self.no_op)
-        self.sync_blocks([self.nodes[0], self.nodes[1]])
+        blocks = self.generate(self.nodes[1], 292, sync_fun=lambda: self.sync_blocks([self.nodes[0], self.nodes[1]]))
 
         self.log.info("Make sure we can max retrieve block at tip-288.")
         node.send_getdata_for_block(blocks[1])  # last block in valid range

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -216,7 +216,6 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # make sure all invalidated blocks are node0's
         self.generatetoaddress(self.nodes[0], length, self.nodes[0].get_deterministic_priv_key().address)
-        self.sync_blocks(wait=0.1)
         for x in self.nodes[0].p2ps:
             x.wait_for_block_announcement(int(self.nodes[0].getbestblockhash(), 16))
             x.clear_block_announcements()
@@ -225,7 +224,6 @@ class SendHeadersTest(BitcoinTestFramework):
         hash_to_invalidate = self.nodes[1].getblockhash(tip_height - (length - 1))
         self.nodes[1].invalidateblock(hash_to_invalidate)
         all_hashes = self.generatetoaddress(self.nodes[1], length + 1, self.nodes[1].get_deterministic_priv_key().address)  # Must be longer than the orig chain
-        self.sync_blocks(wait=0.1)
         return [int(x, 16) for x in all_hashes]
 
     def run_test(self):

--- a/test/functional/rpc_coinjoin.py
+++ b/test/functional/rpc_coinjoin.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019-2024 The Dash Core developers
+# Copyright (c) 2019-2025 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -366,7 +366,6 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         self.log.info("Test sendrawtransaction/testmempoolaccept with tx already in the chain")
         self.generate(self.nodes[2], 1)
-        self.sync_blocks()
         for node in self.nodes:
             testres = node.testmempoolaccept([rawTxSigned['hex']])[0]
             assert_equal(testres['allowed'], False)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1842,8 +1842,7 @@ class DashTestFramework(BitcoinTestFramework):
         skip_count = 24 - (self.nodes[0].getblockcount() % 24)
         if skip_count != 0:
             self.bump_mocktime(1)
-            self.generate(self.nodes[0], skip_count, sync_fun=self.no_op)
-        self.sync_blocks(nodes)
+            self.generate(self.nodes[0], skip_count, sync_fun=lambda: self.sync_blocks(nodes))
 
         q = self.nodes[0].getbestblockhash()
         self.log.info("Expected quorum_hash:"+str(q))

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -33,7 +33,6 @@ class AbandonConflictTest(BitcoinTestFramework):
 
     def run_test(self):
         self.generate(self.nodes[1], COINBASE_MATURITY)
-        self.sync_blocks()
         balance = self.nodes[0].getbalance()
         txA = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         txB = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -85,7 +85,6 @@ class WalletBackupTest(BitcoinTestFramework):
         # Must sync mempools before mining.
         self.sync_mempools()
         self.generate(self.nodes[3], 1)
-        self.sync_blocks()
 
     # As above, this mirrors the original bash test.
     def start_three(self, args=()):
@@ -137,13 +136,9 @@ class WalletBackupTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Generating initial blockchain")
         self.generate(self.nodes[0], 1)
-        self.sync_blocks()
         self.generate(self.nodes[1], 1)
-        self.sync_blocks()
         self.generate(self.nodes[2], 1)
-        self.sync_blocks()
         self.generate(self.nodes[3], COINBASE_MATURITY)
-        self.sync_blocks()
 
         assert_equal(self.nodes[0].getbalance(), 500)
         assert_equal(self.nodes[1].getbalance(), 500)

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -261,7 +261,6 @@ class WalletTest(BitcoinTestFramework):
 
         # Now confirm tx_replace
         block_reorg = self.generatetoaddress(self.nodes[1], 1, ADDRESS_WATCHONLY)[0]
-        self.sync_all()
         assert_equal(self.nodes[0].getbalance(minconf=0), total_amount)
 
         self.log.info('Put txs back into mempool of node 1 (not node 0)')

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -510,7 +510,6 @@ class WalletTest(BitcoinTestFramework):
             txid = self.nodes[2].sendtoaddress(address=address, amount=amount, fee_rate=str(fee_rate_sat_vb))
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])
             self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
-            self.sync_all(self.nodes[0:3])
             postbalance = self.nodes[2].getbalance()
             fee = prebalance - postbalance - amount
             # TODO: remove workaround after bitcoin/bitcoin#22949 done

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -237,7 +237,6 @@ class WalletHDTest(BitcoinTestFramework):
             txid = self.nodes[0].sendtoaddress(addr, 1)
             origin_rpc.sendrawtransaction(self.nodes[0].gettransaction(txid)['hex'])
             self.generate(self.nodes[0], 1)
-            self.sync_blocks()
             origin_rpc.gettransaction(txid)
             assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', restore_rpc.gettransaction, txid)
             out_of_kp_txid = txid
@@ -248,7 +247,6 @@ class WalletHDTest(BitcoinTestFramework):
             txid = self.nodes[0].sendtoaddress(last_addr, 1)
             origin_rpc.sendrawtransaction(self.nodes[0].gettransaction(txid)['hex'])
             self.generate(self.nodes[0], 1)
-            self.sync_blocks()
             origin_rpc.gettransaction(txid)
             restore_rpc.gettransaction(txid)
             assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', restore_rpc.gettransaction, out_of_kp_txid)

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -384,7 +384,6 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                      ismine=True)
         txid = w0.sendtoaddress(address, 49.99995540)
         self.generatetoaddress(self.nodes[0], 6, w0.getnewaddress())
-        self.sync_blocks()
         tx = wpriv.createrawtransaction([{"txid": txid, "vout": 0}], {w0.getnewaddress(): 49.999})
         signed_tx = wpriv.signrawtransactionwithwallet(tx)
         w1.sendrawtransaction(signed_tx['hex'])

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -55,7 +55,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         result = wrpc.importdescriptors([req])
         observed_warnings = []
         if 'warnings' in result[0]:
-           observed_warnings = result[0]['warnings']
+            observed_warnings = result[0]['warnings']
         assert_equal("\n".join(sorted(warnings)), "\n".join(sorted(observed_warnings)))
         assert_equal(result[0]['success'], success)
         if error_code is not None:

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -61,7 +61,6 @@ class KeypoolRestoreTest(BitcoinTestFramework):
             self.generate(self.nodes[0], 1)
             self.nodes[0].sendtoaddress(addr_extpool, 5)
             self.generate(self.nodes[0], 1)
-            self.sync_blocks()
 
             self.log.info("Restart node with wallet backup")
             self.stop_node(idx)

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -27,7 +27,6 @@ class ReceivedByTest(BitcoinTestFramework):
     def run_test(self):
         # Generate block to get out of IBD
         self.generate(self.nodes[0], 1)
-        self.sync_blocks()
 
         # save the number of coinbase reward addresses so far
         num_cb_reward_addresses = len(self.nodes[1].listreceivedbyaddress(minconf=0, include_empty=True, include_watchonly=True))

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023-2024 The Dash Core developers
+# Copyright (c) 2023-2025 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test -mnemonicbits wallet option."""

--- a/test/functional/wallet_multisig_descriptor_psbt.py
+++ b/test/functional/wallet_multisig_descriptor_psbt.py
@@ -111,7 +111,6 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
         self.log.info("Send funds to the resulting multisig receiving address...")
         coordinator_wallet.sendtoaddress(multisig_receiving_address, deposit_amount)
         self.generate(self.nodes[0], 1)
-        self.sync_all()
         for participant in participants["multisigs"]:
             assert_approx(participant.getbalance(), deposit_amount, vspan=0.001)
 
@@ -137,7 +136,6 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
 
         self.log.info("Check that balances are correct after the transaction has been included in a block.")
         self.generate(self.nodes[0], 1)
-        self.sync_all()
         assert_approx(participants["multisigs"][0].getbalance(), deposit_amount - value, vspan=0.001)
         assert_equal(participants["signers"][self.N - 1].getbalance(), value)
 
@@ -154,7 +152,6 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
 
         self.log.info("Check that balances are correct after the transaction has been included in a block.")
         self.generate(self.nodes[0], 1)
-        self.sync_all()
         assert_approx(participants["multisigs"][0].getbalance(), deposit_amount - (value * 2), vspan=0.001)
         assert_equal(participants["signers"][self.N - 1].getbalance(), value * 2)
 

--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -27,12 +27,10 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
         # it later.
         self.sync_blocks()
         blk = self.generate(self.nodes[1], 1)[0]
-        self.sync_blocks()
 
         # Let the block reward mature and send coins including both
         # the existing balance and the block reward.
         self.generate(self.nodes[0], 150)
-        self.sync_blocks()
         assert_equal(self.nodes[1].getbalance(), Decimal("474.28571429"))
         txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 30)
 
@@ -40,7 +38,6 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
         # from the wallet can still be spent.
         self.nodes[0].invalidateblock(blk)
         self.generate(self.nodes[0], 152)
-        self.sync_blocks()
         # Without the following abandontransaction call, the coins are
         # not considered available yet.
         assert_equal(self.nodes[1].getbalances()["mine"], {

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -33,7 +33,6 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         # Send a tx from which to conflict outputs later
         txid_conflict_from = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         self.generate(self.nodes[0], 1)
-        self.sync_blocks()
 
         # Disconnect node1 from others to reorg its chain later
         self.disconnect_nodes(0, 1)
@@ -44,7 +43,6 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         tx = self.nodes[0].gettransaction(txid)
         self.generate(self.nodes[0], 4, sync_fun=self.no_op)
-        self.sync_blocks([self.nodes[0], self.nodes[2]])
         tx_before_reorg = self.nodes[0].gettransaction(txid)
         assert_equal(tx_before_reorg["confirmations"], 4)
 

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -235,7 +235,6 @@ class WalletSendTest(BitcoinTestFramework):
 
         w0.sendtoaddress(a2_receive, 10) # fund w3
         self.generate(self.nodes[0], 1)
-        self.sync_blocks()
 
         if not self.options.descriptors:
             # w4 has private keys enabled, but only contains watch-only keys (from w2)
@@ -254,7 +253,6 @@ class WalletSendTest(BitcoinTestFramework):
 
             w0.sendtoaddress(a2_receive, 10) # fund w4
             self.generate(self.nodes[0], 1)
-            self.sync_blocks()
 
         self.log.info("Send to address...")
         self.test_send(from_wallet=w0, to_wallet=w1, amount=1)

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -109,7 +109,6 @@ class TxnMallTest(BitcoinTestFramework):
         self.nodes[2].sendrawtransaction(node0_tx2["hex"])
         self.nodes[2].sendrawtransaction(tx2["hex"])
         self.generate(self.nodes[2], 1)  # Mine another block to make sure we sync
-        self.sync_blocks()
 
         # Re-fetch transaction info:
         tx1 = self.nodes[0].gettransaction(txid1)

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -115,7 +115,6 @@ class TxnMallTest(BitcoinTestFramework):
         # Reconnect the split network, and sync chain:
         self.connect_nodes(1, 2)
         self.generate(self.nodes[2], 1)  # Mine another block to make sure we sync
-        self.sync_blocks()
         assert_equal(self.nodes[0].gettransaction(doublespend_txid)["confirmations"], 2)
 
         # Re-fetch transaction info:


### PR DESCRIPTION
## What was done?
The majority of changes in this backport are scripted, better to keep commits as they are rather than squash together.

Original description:
> Some cleanups after #6288 (see bitcoin/bitcoin#23300)

## How Has This Been Tested?
Run unit functional tests.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

