### PR TITLE
fix: Do not assert special tx type for cbtx in simplified mn list diff output

### DIFF
--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -280,7 +280,7 @@ UniValue CSimplifiedMNListDiff::ToJson(bool extended) const
     obj.pushKV("newQuorums", newQuorumsArr);
 
     // Do not assert special tx type here since this can be called prior to DIP0003 activation
-    if (const auto opt_cbTxPayload = GetTxPayload<CCbTx>(*cbTx, false)) {
+    if (const auto opt_cbTxPayload = GetTxPayload<CCbTx>(*cbTx, /*assert_type=*/false)) {
         obj.pushKV("merkleRootMNList", opt_cbTxPayload->merkleRootMNList.ToString());
         if (opt_cbTxPayload->nVersion >= CCbTx::Version::MERKLE_ROOT_QUORUMS) {
             obj.pushKV("merkleRootQuorums", opt_cbTxPayload->merkleRootQuorums.ToString());

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -279,7 +279,8 @@ UniValue CSimplifiedMNListDiff::ToJson(bool extended) const
     }
     obj.pushKV("newQuorums", newQuorumsArr);
 
-    if (const auto opt_cbTxPayload = GetTxPayload<CCbTx>(*cbTx)) {
+    // Do not assert special tx type here since this can be called prior to DIP0003 activation
+    if (const auto opt_cbTxPayload = GetTxPayload<CCbTx>(*cbTx, false)) {
         obj.pushKV("merkleRootMNList", opt_cbTxPayload->merkleRootMNList.ToString());
         if (opt_cbTxPayload->nVersion >= CCbTx::Version::MERKLE_ROOT_QUORUMS) {
             obj.pushKV("merkleRootQuorums", opt_cbTxPayload->merkleRootQuorums.ToString());


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes an edge case for debug builds, release builds aren't affected.

## What was done?


## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

