### PR TITLE
fix: revert deployment images back to Ubuntu 22.04 LTS (`jammy`)

### DIFF
--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Release to Docker Hub
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/contrib/containers/deploy/Dockerfile
+++ b/contrib/containers/deploy/Dockerfile
@@ -2,12 +2,17 @@ FROM phusion/baseimage:noble-1.0.0
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore, built from CI"
 
-# Setup unprivileged user
-ARG USER_ID=1000 \
-    GROUP_ID=1000
-RUN groupmod -g ${GROUP_ID} -n dash ubuntu; \
-    usermod -u ${USER_ID} -md /home/dash -l dash ubuntu; \
-    mkdir -p /home/dash/.dashcore && \
+ARG USER_ID
+ARG GROUP_ID
+
+ENV HOME="/home/dash"
+
+# add user with specified (or default) user/group ids
+ENV USER_ID="${USER_ID:-1000}"
+ENV GROUP_ID="${GROUP_ID:-1000}"
+RUN groupadd -g ${GROUP_ID} dash && \
+    useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash && \
+    mkdir /home/dash/.dashcore && \
     chown ${USER_ID}:${GROUP_ID} -R /home/dash
 
 COPY bin/* /usr/local/bin/

--- a/contrib/containers/deploy/Dockerfile
+++ b/contrib/containers/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:noble-1.0.0
+FROM phusion/baseimage:jammy-1.0.4
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore, built from CI"
 

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
@@ -52,12 +52,12 @@ ARG TAG
 
 ENV HOME="/home/dash"
 
-# Setup unprivileged user
-ARG USER_ID=1000 \
-    GROUP_ID=1000
-RUN groupmod -g ${GROUP_ID} -n dash ubuntu; \
-    usermod -u ${USER_ID} -md /home/dash -l dash ubuntu; \
-    mkdir -p /home/dash/.dashcore && \
+# add user with specified (or default) user/group ids
+ENV USER_ID="${USER_ID:-1000}"
+ENV GROUP_ID="${GROUP_ID:-1000}"
+RUN groupadd -g ${GROUP_ID} dash && \
+    useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash  && \
+    mkdir /home/dash/.dashcore && \
     chown ${USER_ID}:${GROUP_ID} -R /home/dash
 
 RUN apt-get update && \

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Dispatch
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-FROM --platform=$BUILDPLATFORM ubuntu:noble as builder
+FROM --platform=$BUILDPLATFORM ubuntu:jammy as builder
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
     automake \
@@ -42,7 +42,7 @@ RUN mkdir built-target && \
   "linux/amd64") cp depends/x86_64-pc-linux-gnu/bin/dash* /home/dash/built-target ;; \
 esac
 
-FROM ubuntu:noble
+FROM ubuntu:jammy
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore"
 

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -9,12 +9,12 @@ ARG GITHUB_REPOSITORY
 
 ENV HOME /home/dash
 
-# Setup unprivileged user
-ARG USER_ID=1000 \
-    GROUP_ID=1000
-RUN groupmod -g ${GROUP_ID} -n dash ubuntu; \
-    usermod -u ${USER_ID} -md /home/dash -l dash ubuntu; \
-    mkdir -p /home/dash/.dashcore && \
+# add user with specified (or default) user/group ids
+ENV USER_ID ${USER_ID:-1000}
+ENV GROUP_ID ${GROUP_ID:-1000}
+RUN groupadd -g ${GROUP_ID} dash && \
+    useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /home/dash dash  && \
+    mkdir /home/dash/.dashcore && \
     chown ${USER_ID}:${GROUP_ID} -R /home/dash
 
 RUN apt-get update && \

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:jammy
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore"
 


### PR DESCRIPTION
## Additional Information

* There is a regression in `noble` that has caused a build failure in trying to package our release container ([build](https://github.com/dashpay/dash/actions/runs/13376032021)) linked to [actions/runner-images#11471](https://github.com/actions/runner-images/issues/11471#issuecomment-2662463190).

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
