### PR TITLE
ci: attempt to fix docker builds by building arm64 and amd64 separately

### DIFF
--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -5,17 +5,12 @@ on:
     types: [published]
 
 jobs:
-  release:
-    name: Release to Docker Hub
+  release-amd64:
+    name: Release to Docker Hub (amd64)
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -60,8 +55,8 @@ jobs:
         flavor: |
           suffix=${{ steps.suffix.outputs.result }},onlatest=true
 
-    - name: Build and push
-      id: docker_build
+    - name: Build and push (amd64)
+      id: docker_build_amd64
       uses: docker/build-push-action@v3
       with:
         context: ./contrib/containers/deploy
@@ -76,7 +71,44 @@ jobs:
           GITHUB_REPOSITORY=${{ github.repository }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
 
     - name: Image digest
-      run: echo ${{ steps.docker_build.outputs.digest }}
+      run: echo ${{ steps.docker_build_amd64.outputs.digest }}
+
+  release-arm64:
+    name: Release to Docker Hub (arm64)
+    runs-on: ubuntu-22.04-arm
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push (arm64)
+      id: docker_build_arm64
+      uses: docker/build-push-action@v3
+      with:
+        context: ./contrib/containers/deploy
+        file: ./contrib/containers/deploy/Dockerfile.GitHubActions.Release
+        push: true
+        provenance: mode=max
+        sbom: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        build-args: |
+          TAG=${{ steps.get_tag.outputs.build_tag }}
+          GITHUB_REPOSITORY=${{ github.repository }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/arm64
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build_arm64.outputs.digest }}


### PR DESCRIPTION
## Issue being fixed or feature implemented
this is a follow-up to https://github.com/dashpay/dash/pull/6586; because that fix did not appear to work https://github.com/dashpay/dash/actions/runs/13376032021/job/37424076219

## What was done?
Stop using qemu, and build on arm runners

## How Has This Been Tested?
Hasn't; to be tested once merged

## Breaking Changes
Can't break which is broken

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

