### PR TITLE
ci: dockerimage multi cache

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -48,7 +48,11 @@ jobs:
           file: ./contrib/containers/ci/Dockerfile
           push: true
           tags: |
+            ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:${{ hashFiles('./contrib/containers/ci/Dockerfile') }}
             ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:${{ steps.prepare.outputs.tag }}
             ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:latest
-          cache-from: type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:latest
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:${{ hashFiles('./contrib/containers/ci/Dockerfile') }}
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:${{ steps.prepare.outputs.tag }}
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/dashcore-ci-runner:latest
           cache-to: type=inline


### PR DESCRIPTION
## Issue being fixed or feature implemented
docker/build-push-action allows us to cache from multiple refs; let's use it!

I've noticed a lot recently when we are changing docker image we get a lot of cache misses we shouldn't. Now we push an image based on the hash of the dockerfile, and restore from that. Additionally, we can now cache from the branch name.

Previously we'd get into situations where:
develop is pushed, build image: HIT
PR opened that changes image, build image: MISS and push
develop is pushed with a different PR, build image: MISS and push
PR has new commit added or rebased, build image: MISS and push

This PR should allow all of these to hit now.

## What was done?
Cache from and push to a tag that is the hash of the dockerfile. Additionally, allow caching from the branch name, or latest if needed.

## How Has This Been Tested?
In my own repo, did a situation similiar to as described above, and got cache hits as expected.

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

