### PR TITLE
fix: resolve potential deadlock in coinjoin_tests

### DIFF
--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -139,11 +139,13 @@ public:
             LOCK2(wallet->cs_wallet, cs_main);
             wallet->GetLegacyScriptPubKeyMan()->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
             wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());
-            WalletRescanReserver reserver(*wallet);
-            reserver.reserve();
-            CWallet::ScanResult result = wallet->ScanForWalletTransactions(m_node.chainman->ActiveChain().Genesis()->GetBlockHash(),  0 /* start_height */, {} /* max_height */, reserver, true /* fUpdate */);
-            BOOST_CHECK_EQUAL(result.status, CWallet::ScanResult::SUCCESS);
         }
+        WalletRescanReserver reserver(*wallet);
+        reserver.reserve();
+        CWallet::ScanResult result = wallet->ScanForWalletTransactions(/*start_block=*/wallet->chain().getBlockHash(0),
+                                                                       /*start_height=*/0, /*max_height=*/{}, reserver,
+                                                                       /*fUpdate=*/true);
+        BOOST_CHECK_EQUAL(result.status, CWallet::ScanResult::SUCCESS);
     }
 
     ~CTransactionBuilderTestSetup()


### PR DESCRIPTION
## Issue being fixed or feature implemented
`ScanForWalletTransactions` should be called outside of `cs_wallet` lock scope which is not the case for `CTransactionBuilderTestSetup ` ctor in `coinjoin_tests.cpp` atm.

Should fix tsan test failures like https://github.com/PastaPastaPasta/dash/actions/runs/13467587625/job/37636500963#step:8:1.

## What was done?

## How Has This Been Tested?

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

