### PR TITLE
ci: Let GH CI skip build targets specified in GH CI settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ permissions:
 
 env:
   DOCKER_DRIVER: overlay2
-  FAST_MODE: false
 
 jobs:
   container:
@@ -21,6 +20,7 @@ jobs:
     name: arm-linux-gnueabihf
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
+    if: ${{ vars.SKIP_ARM_LINUX == '' }}
     with:
       build-target: arm-linux
       container-path: ${{ needs.container.outputs.path }}
@@ -29,6 +29,11 @@ jobs:
     name: x86_64-pc-linux-gnu
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
+    if: |
+      vars.SKIP_LINUX64 == '' ||
+      vars.SKIP_LINUX64_FUZZ == '' ||
+      vars.SKIP_LINUX64_SQLITE == '' ||
+      vars.SKIP_LINUX64_UBSAN == ''
     with:
       build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
@@ -37,6 +42,9 @@ jobs:
     name: x86_64-pc-linux-gnu_multiprocess
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
+    if: |
+      vars.SKIP_LINUX64_MULTIPROCESS == '' ||
+      vars.SKIP_LINUX64_TSAN == ''
     with:
       build-target: linux64_multiprocess
       container-path: ${{ needs.container.outputs.path }}
@@ -45,6 +53,7 @@ jobs:
     name: x86_64-pc-linux-gnu_nowallet
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
+    if: ${{ vars.SKIP_LINUX64_NOWALLET == '' }}
     with:
       build-target: linux64_nowallet
       container-path: ${{ needs.container.outputs.path }}
@@ -53,6 +62,7 @@ jobs:
     name: x86_64-apple-darwin
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
+    if: ${{ vars.SKIP_MAC == '' }}
     with:
       build-target: mac
       container-path: ${{ needs.container.outputs.path }}
@@ -61,6 +71,7 @@ jobs:
     name: x86_64-w64-mingw32
     uses: ./.github/workflows/build-depends.yml
     needs: [container]
+    if: ${{ vars.SKIP_WIN64 == '' }}
     with:
       build-target: win64
       container-path: ${{ needs.container.outputs.path }}
@@ -78,6 +89,7 @@ jobs:
     name: linux64-build
     uses: ./.github/workflows/build-src.yml
     needs: [container, depends-linux64]
+    if: ${{ vars.SKIP_LINUX64 == '' }}
     with:
       build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
@@ -87,6 +99,7 @@ jobs:
     name: linux64_fuzz-build
     uses: ./.github/workflows/build-src.yml
     needs: [container, depends-linux64]
+    if: ${{ vars.SKIP_LINUX64_FUZZ == '' }}
     with:
       build-target: linux64_fuzz
       container-path: ${{ needs.container.outputs.path }}
@@ -96,6 +109,7 @@ jobs:
     name: linux64_multiprocess-build
     uses: ./.github/workflows/build-src.yml
     needs: [container, depends-linux64_multiprocess]
+    if: ${{ vars.SKIP_LINUX64_MULTIPROCESS == '' }}
     with:
       build-target: linux64_multiprocess
       container-path: ${{ needs.container.outputs.path }}
@@ -114,6 +128,7 @@ jobs:
     name: linux64_sqlite-build
     uses: ./.github/workflows/build-src.yml
     needs: [container, depends-linux64]
+    if: ${{ vars.SKIP_LINUX64_SQLITE == '' }}
     with:
       build-target: linux64_sqlite
       container-path: ${{ needs.container.outputs.path }}
@@ -123,6 +138,7 @@ jobs:
     name: linux64_tsan-build
     uses: ./.github/workflows/build-src.yml
     needs: [container, depends-linux64_multiprocess]
+    if: ${{ vars.SKIP_LINUX64_TSAN == '' }}
     with:
       build-target: linux64_tsan
       container-path: ${{ needs.container.outputs.path }}
@@ -132,6 +148,7 @@ jobs:
     name: linux64_ubsan-build
     uses: ./.github/workflows/build-src.yml
     needs: [container, depends-linux64]
+    if: ${{ vars.SKIP_LINUX64_UBSAN == '' }}
     with:
       build-target: linux64_ubsan
       container-path: ${{ needs.container.outputs.path }}


### PR DESCRIPTION
## Issue being fixed or feature implemented
Unfortunately `if` on Github can't handle regex so a solution implemented for Gitlab (#6591) can't be used as easily here and requires implementing pretty large workarounds, see https://github.com/dashpay/dash/pull/6591#discussion_r1970280777. This PR implements an alternative approach where instead of specifying which targets you want to build you'd instead specify targets you don't need, one by one.

## What was done?


## How Has This Been Tested?
<img width="784" alt="Screenshot 2025-02-26 at 01 27 01" src="https://github.com/user-attachments/assets/8622a2f8-d8ca-4738-a73a-2937cc72ff58" />

https://github.com/UdjinM6/dash/actions/runs/13532112313

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

