### PR TITLE
fix: follow-up #6546 to bump copyright year in COPYING and debian's package

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,8 +1,8 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2024 The Bitcoin Core developers
-Copyright (c) 2009-2024 Bitcoin Developers
-Copyright (c) 2014-2024 The Dash Core developers
+Copyright (c) 2009-2025 The Bitcoin Core developers
+Copyright (c) 2009-2025 Bitcoin Developers
+Copyright (c) 2014-2025 The Dash Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -4,8 +4,8 @@ Upstream-Contact: Dash Core Group, Inc https://www.dash.org/dcg/
 Source: https://github.com/dashpay/dash
 
 Files: *
-Copyright: 2009-2024, Bitcoin Core Developers,
-           2019-2024, Dash Core Developers
+Copyright: 2009-2025, Bitcoin Core Developers,
+           2019-2025, Dash Core Developers
 License: Expat
 Comment: The Bitcoin Core Developers encompasses the current developers listed on bitcoin.org,
          as well as the numerous contributors to the project. The Dash Core Developers


### PR DESCRIPTION
## What was done?
Bump copyright for 2025 for leftover files

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone