### PR TITLE
backport: partial bitcoin#25507; fix selection of fully mixed coins, disable BnB

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -383,7 +383,8 @@ bool CWallet::AttemptSelection(const CAmount& nTargetValue, const CoinEligibilit
     CAmount target_with_change = nTargetValue;
     // While nTargetValue includes the transaction fees for non-input things, it does not include the fee for creating a change output.
     // So we need to include that for KnapsackSolver as well, as we are expecting to create a change output.
-    if (!coin_selection_params.m_subtract_fee_outputs) {
+    // There is also no change output when spending fully mixed coins.
+    if (!coin_selection_params.m_subtract_fee_outputs && nCoinType != CoinType::ONLY_FULLY_MIXED) {
         target_with_change += coin_selection_params.m_change_fee;
     }
     std::set<CInputCoin> knapsack_coins;

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -373,7 +373,7 @@ bool CWallet::AttemptSelection(const CAmount& nTargetValue, const CoinEligibilit
     std::vector<OutputGroup> positive_groups = GroupOutputs(coins, coin_selection_params, eligibility_filter, true /* positive_only */);
     std::set<CInputCoin> bnb_coins;
     CAmount bnb_value;
-    if (SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change, bnb_coins, bnb_value)) {
+    if (false && SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change, bnb_coins, bnb_value)) {
         const auto waste = GetSelectionWaste(bnb_coins, /* cost of change */ CAmount(0), nTargetValue, !coin_selection_params.m_subtract_fee_outputs);
         results.emplace_back(std::make_tuple(waste, std::move(bnb_coins), bnb_value));
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Coin selection is a bit broken on develop rn, there are few issues:
- we should never use BnB because it has no idea about mixing;
- the target value should not be altered in cases when the tx fee is subtracted from outputs or no change is created at all.

Issues were introduced via recent wallet backports, so it's on `develop` only, no released versions are affected.

## What was done?


## How Has This Been Tested?
Run `./src/test/test_dash -t spend_tests` and `./test/functional/wallet_basic.py`

`develop` + 5544542fd8ceaaf955e753ffa9baa84c1629c62e - > failure
This branch -> success

## Breaking Changes

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

