### PR TITLE
backport: bitcoin-core/gui#509: Respect dialog modality and fix a regression in wallet unlock

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -192,7 +192,7 @@ void AddressBookPage::onEditAction()
     dlg->setModel(model);
     QModelIndex origIndex = proxyModel->mapToSource(indexes.at(0));
     dlg->loadRow(origIndex.row());
-    GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 
 void AddressBookPage::on_newAddress_clicked()

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -260,7 +260,11 @@ void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
     connect(window, &BitcoinGUI::quitRequested, this, &BitcoinApplication::requestShutdown);
 
     pollShutdownTimer = new QTimer(window);
-    connect(pollShutdownTimer, &QTimer::timeout, window, &BitcoinGUI::detectShutdown);
+    connect(pollShutdownTimer, &QTimer::timeout, [this]{
+        if (!QApplication::activeModalWidget()) {
+            window->detectShutdown();
+        }
+    });
 }
 
 void BitcoinApplication::createSplashScreen(const NetworkStyle *networkStyle)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -801,8 +801,10 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
             // Note: on macOS, the Dock icon is also used to provide menu functionality
             // similar to one for tray icon
             MacDockIconHandler *dockIconHandler = MacDockIconHandler::instance();
-            connect(dockIconHandler, &MacDockIconHandler::dockIconClicked, this, &BitcoinGUI::macosDockIconActivated);
-
+            connect(dockIconHandler, &MacDockIconHandler::dockIconClicked, [this] {
+                showNormalIfMinimized();
+                activateWindow();
+            });
             dockIconMenu = new QMenu(this);
             dockIconMenu->setAsDockMenu();
 
@@ -1074,12 +1076,6 @@ void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
         // Click on system tray icon triggers show/hide of the main window
         toggleHidden();
     }
-}
-#else
-void BitcoinGUI::macosDockIconActivated()
-{
-    showNormalIfMinimized();
-    activateWindow();
 }
 #endif
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1123,7 +1123,7 @@ void BitcoinGUI::aboutClicked()
         return;
 
     auto dlg = new HelpMessageDialog(this, HelpMessageDialog::about);
-    GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 
 void BitcoinGUI::showDebugWindow()
@@ -1385,7 +1385,7 @@ void BitcoinGUI::openOptionsDialogWithTab(OptionsDialog::Tab tab)
     connect(dlg, &OptionsDialog::appearanceChanged, [this]() {
         updateWidth();
     });
-    GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
 
     updateCoinJoinVisibility();
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -393,8 +393,6 @@ void BitcoinGUI::createActions()
     optionsAction->setStatusTip(tr("Modify configuration options for %1").arg(PACKAGE_NAME));
     optionsAction->setMenuRole(QAction::PreferencesRole);
     optionsAction->setEnabled(false);
-    toggleHideAction = new QAction(tr("&Show / Hide"), this);
-    toggleHideAction->setStatusTip(tr("Show or hide the main Window"));
 
     encryptWalletAction = new QAction(tr("&Encrypt Wallet…"), this);
     encryptWalletAction->setStatusTip(tr("Encrypt the private keys that belong to your wallet"));
@@ -478,7 +476,6 @@ void BitcoinGUI::createActions()
     connect(aboutAction, &QAction::triggered, this, &BitcoinGUI::aboutClicked);
     connect(aboutQtAction, &QAction::triggered, qApp, QApplication::aboutQt);
     connect(optionsAction, &QAction::triggered, this, &BitcoinGUI::optionsClicked);
-    connect(toggleHideAction, &QAction::triggered, this, &BitcoinGUI::toggleHidden);
     connect(showHelpMessageAction, &QAction::triggered, this, &BitcoinGUI::showHelpMessageClicked);
     connect(showCoinJoinHelpAction, &QAction::triggered, this, &BitcoinGUI::showCoinJoinHelpClicked);
 
@@ -863,8 +860,6 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
             connect(optionsModel, &OptionsModel::coinJoinEnabledChanged, this, &BitcoinGUI::updateCoinJoinVisibility);
         }
     } else {
-        // Disable possibility to show main window via action
-        toggleHideAction->setEnabled(false);
         if(trayIconMenu)
         {
             // Disable context menu on tray icon
@@ -1040,10 +1035,11 @@ void BitcoinGUI::createTrayIcon()
 void BitcoinGUI::createIconMenu(QMenu *pmenu)
 {
     // Configuration of the tray icon (or dock icon) icon menu
+    QAction* show_hide_action{nullptr};
 #ifndef Q_OS_MAC
     // Note: On macOS, the Dock icon is used to provide the tray's functionality.
-    trayIconMenu->addAction(toggleHideAction);
-    trayIconMenu->addSeparator();
+    show_hide_action = pmenu->addAction(tr("Show / &Hide"), this, &BitcoinGUI::toggleHidden);
+    pmenu->addSeparator();
 #endif // Q_OS_MAC
 
     if (enableWallet) {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1081,19 +1081,33 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
         // Using QSystemTrayIcon::Context is not reliable.
         // See https://bugreports.qt.io/browse/QTBUG-91697
         pmenu, &QMenu::aboutToShow,
-        [this, show_hide_action, send_action, cj_send_action, receive_action, sign_action, verify_action, repair_action, backups_action] {
+        [this, show_hide_action, send_action, cj_send_action, receive_action, sign_action, verify_action, options_action, node_window_action, quit_action, repair_action, backups_action, info_action, graph_action, peer_action, conf_action] {
             if (show_hide_action) show_hide_action->setText(
                 (!isHidden() && !isMinimized() && !GUIUtil::isObscured(this)) ?
                     tr("&Hide") :
                     tr("S&how"));
-            if (enableWallet) {
-                send_action->setEnabled(sendCoinsAction->isEnabled());
-                cj_send_action->setEnabled(coinJoinCoinsAction->isEnabled());
-                receive_action->setEnabled(receiveCoinsAction->isEnabled());
-                sign_action->setEnabled(signMessageAction->isEnabled());
-                verify_action->setEnabled(verifyMessageAction->isEnabled());
-                repair_action->setEnabled(openRepairAction->isEnabled());
-                backups_action->setEnabled(showBackupsAction->isEnabled());
+            if (QApplication::activeModalWidget()) {
+                for (QAction* a : trayIconMenu.get()->actions()) {
+                    a->setEnabled(false);
+                }
+            } else {
+                if (show_hide_action) show_hide_action->setEnabled(true);
+                if (enableWallet) {
+                    send_action->setEnabled(sendCoinsAction->isEnabled());
+                    cj_send_action->setEnabled(coinJoinCoinsAction->isEnabled());
+                    receive_action->setEnabled(receiveCoinsAction->isEnabled());
+                    sign_action->setEnabled(signMessageAction->isEnabled());
+                    verify_action->setEnabled(verifyMessageAction->isEnabled());
+                    repair_action->setEnabled(openRepairAction->isEnabled());
+                    backups_action->setEnabled(showBackupsAction->isEnabled());
+                }
+                options_action->setEnabled(optionsAction->isEnabled());
+                info_action->setEnabled(openInfoAction->isEnabled());
+                node_window_action->setEnabled(openRPCConsoleAction->isEnabled());
+                graph_action->setEnabled(openGraphAction->isEnabled());
+                peer_action->setEnabled(openPeersAction->isEnabled());
+                conf_action->setEnabled(openConfEditorAction->isEnabled());
+                if (quit_action) quit_action->setEnabled(true);
             }
         });
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -805,15 +805,15 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
 #else
             // Note: on macOS, the Dock icon is also used to provide menu functionality
             // similar to one for tray icon
+            dockIconMenu = new QMenu(this);
+            dockIconMenu->setAsDockMenu();
+            createIconMenu(dockIconMenu);
+
             MacDockIconHandler *dockIconHandler = MacDockIconHandler::instance();
             connect(dockIconHandler, &MacDockIconHandler::dockIconClicked, [this] {
                 showNormalIfMinimized();
                 activateWindow();
             });
-            dockIconMenu = new QMenu(this);
-            dockIconMenu->setAsDockMenu();
-
-            createIconMenu(dockIconMenu);
 #endif
         }
 
@@ -1044,7 +1044,8 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
     // Note: On macOS, the Dock icon is used to provide the tray's functionality.
     trayIconMenu->addAction(toggleHideAction);
     trayIconMenu->addSeparator();
-#endif
+#endif // Q_OS_MAC
+
     if (enableWallet) {
         pmenu->addAction(sendCoinsMenuAction);
         pmenu->addAction(coinJoinCoinsMenuAction);
@@ -1067,10 +1068,11 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
     if (enableWallet) {
         pmenu->addAction(showBackupsAction);
     }
-#ifndef Q_OS_MAC // This is built-in on macOS
+#ifndef Q_OS_MAC
+    // Note: On macOS, the Dock icon's menu already has Quit action.
     pmenu->addSeparator();
     pmenu->addAction(quitAction);
-#endif
+#endif // Q_OS_MAC
 }
 
 void BitcoinGUI::optionsClicked()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -796,7 +796,12 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
 #ifndef Q_OS_MAC
             // Show main window on tray icon click
             // Note: ignore this on Mac - this is not the way tray should work there
-            connect(trayIcon, &QSystemTrayIcon::activated, this, &BitcoinGUI::trayIconActivated);
+            connect(trayIcon, &QSystemTrayIcon::activated, [this](QSystemTrayIcon::ActivationReason reason) {
+                if (reason == QSystemTrayIcon::Trigger) {
+                    // Click on system tray icon triggers show/hide of the main window
+                    toggleHidden();
+                }
+            });
 #else
             // Note: on macOS, the Dock icon is also used to provide menu functionality
             // similar to one for tray icon
@@ -1067,17 +1072,6 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
     pmenu->addAction(quitAction);
 #endif
 }
-
-#ifndef Q_OS_MAC
-void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
-{
-    if(reason == QSystemTrayIcon::Trigger)
-    {
-        // Click on system tray icon triggers show/hide of the main window
-        toggleHidden();
-    }
-}
-#endif
 
 void BitcoinGUI::optionsClicked()
 {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -354,28 +354,26 @@ void BitcoinGUI::stopConnectingAnimation()
 
 void BitcoinGUI::createActions()
 {
-    sendCoinsMenuAction = new QAction(tr("&Send"), this);
-    sendCoinsMenuAction->setStatusTip(tr("Send coins to a Dash address"));
-    sendCoinsMenuAction->setToolTip(sendCoinsMenuAction->statusTip());
-
+    sendCoinsAction = new QAction(tr("&Send"), this);
+    sendCoinsAction->setStatusTip(tr("Send coins to a Dash address"));
     QString strCoinJoinName = QString::fromStdString(gCoinJoinName);
-    coinJoinCoinsMenuAction = new QAction(QString("&%1").arg(strCoinJoinName), this);
-    coinJoinCoinsMenuAction->setStatusTip(tr("Send %1 funds to a Dash address").arg(strCoinJoinName));
-    coinJoinCoinsMenuAction->setToolTip(coinJoinCoinsMenuAction->statusTip());
+    coinJoinCoinsAction = new QAction(QString("&%1").arg(strCoinJoinName), this);
+    coinJoinCoinsAction->setStatusTip(tr("Send %1 funds to a Dash address").arg(strCoinJoinName));
+    coinJoinCoinsAction->setToolTip(coinJoinCoinsAction->statusTip());
 
-    receiveCoinsMenuAction = new QAction(tr("&Receive"), this);
-    receiveCoinsMenuAction->setStatusTip(tr("Request payments (generates QR codes and dash: URIs)"));
-    receiveCoinsMenuAction->setToolTip(receiveCoinsMenuAction->statusTip());
+    receiveCoinsAction = new QAction(tr("&Receive"), this);
+    receiveCoinsAction->setStatusTip(tr("Request payments (generates QR codes and dash: URIs)"));
+    receiveCoinsAction->setToolTip(receiveCoinsAction->statusTip());
 
 #ifdef ENABLE_WALLET
     // These showNormalIfMinimized are needed because Send Coins and Receive Coins
     // can be triggered from the tray menu, and need to show the GUI to be useful.
-    connect(sendCoinsMenuAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
-    connect(coinJoinCoinsMenuAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
-    connect(receiveCoinsMenuAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
-    connect(sendCoinsMenuAction, &QAction::triggered, [this]{ gotoSendCoinsPage(); });
-    connect(coinJoinCoinsMenuAction, &QAction::triggered, [this]{ gotoCoinJoinCoinsPage(); });
-    connect(receiveCoinsMenuAction, &QAction::triggered, this, &BitcoinGUI::gotoReceiveCoinsPage);
+    connect(sendCoinsAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
+    connect(sendCoinsAction, &QAction::triggered, [this]{ gotoSendCoinsPage(); });
+    connect(coinJoinCoinsAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
+    connect(coinJoinCoinsAction, &QAction::triggered, [this]{ gotoCoinJoinCoinsPage(); });
+    connect(receiveCoinsAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
+    connect(receiveCoinsAction, &QAction::triggered, this, &BitcoinGUI::gotoReceiveCoinsPage);
 #endif
 
     quitAction = new QAction(tr("E&xit"), this);
@@ -681,13 +679,13 @@ void BitcoinGUI::createToolBars()
         tabGroup->addButton(overviewButton);
 
         sendCoinsButton = new QToolButton(this);
-        sendCoinsButton->setText(sendCoinsMenuAction->text());
-        sendCoinsButton->setStatusTip(sendCoinsMenuAction->statusTip());
+        sendCoinsButton->setText(sendCoinsAction->text());
+        sendCoinsButton->setStatusTip(sendCoinsAction->statusTip());
         tabGroup->addButton(sendCoinsButton);
 
         receiveCoinsButton = new QToolButton(this);
-        receiveCoinsButton->setText(receiveCoinsMenuAction->text());
-        receiveCoinsButton->setStatusTip(receiveCoinsMenuAction->statusTip());
+        receiveCoinsButton->setText(receiveCoinsAction->text());
+        receiveCoinsButton->setStatusTip(receiveCoinsAction->statusTip());
         tabGroup->addButton(receiveCoinsButton);
 
         historyButton = new QToolButton(this);
@@ -696,8 +694,8 @@ void BitcoinGUI::createToolBars()
         tabGroup->addButton(historyButton);
 
         coinJoinCoinsButton = new QToolButton(this);
-        coinJoinCoinsButton->setText(coinJoinCoinsMenuAction->text());
-        coinJoinCoinsButton->setStatusTip(coinJoinCoinsMenuAction->statusTip());
+        coinJoinCoinsButton->setText(coinJoinCoinsAction->text());
+        coinJoinCoinsButton->setStatusTip(coinJoinCoinsAction->statusTip());
         tabGroup->addButton(coinJoinCoinsButton);
 
         QSettings settings;
@@ -999,13 +997,13 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     }
 #endif // ENABLE_WALLET
 
-    sendCoinsMenuAction->setEnabled(enabled);
+    sendCoinsAction->setEnabled(enabled);
 #ifdef ENABLE_WALLET
-    coinJoinCoinsMenuAction->setEnabled(enabled && clientModel->coinJoinOptions().isEnabled());
+    coinJoinCoinsAction->setEnabled(enabled && clientModel->coinJoinOptions().isEnabled());
 #else
-    coinJoinCoinsMenuAction->setEnabled(enabled);
+    coinJoinCoinsAction->setEnabled(enabled);
 #endif // ENABLE_WALLET
-    receiveCoinsMenuAction->setEnabled(enabled);
+    receiveCoinsAction->setEnabled(enabled);
 
     encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
@@ -1042,10 +1040,13 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
     pmenu->addSeparator();
 #endif // Q_OS_MAC
 
+    QAction* send_action{nullptr};
+    QAction* cj_send_action{nullptr};
+    QAction* receive_action{nullptr};
     if (enableWallet) {
-        pmenu->addAction(sendCoinsMenuAction);
-        pmenu->addAction(coinJoinCoinsMenuAction);
-        pmenu->addAction(receiveCoinsMenuAction);
+        send_action = pmenu->addAction(sendCoinsAction->text(), sendCoinsAction, &QAction::trigger);
+        cj_send_action = pmenu->addAction(coinJoinCoinsAction->text(), coinJoinCoinsAction, &QAction::trigger);
+        receive_action = pmenu->addAction(receiveCoinsAction->text(), receiveCoinsAction, &QAction::trigger);
         pmenu->addSeparator();
         pmenu->addAction(signMessageAction);
         pmenu->addAction(verifyMessageAction);
@@ -1074,11 +1075,16 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
         // Using QSystemTrayIcon::Context is not reliable.
         // See https://bugreports.qt.io/browse/QTBUG-91697
         pmenu, &QMenu::aboutToShow,
-        [this, show_hide_action] {
+        [this, show_hide_action, send_action, cj_send_action, receive_action] {
             if (show_hide_action) show_hide_action->setText(
                 (!isHidden() && !isMinimized() && !GUIUtil::isObscured(this)) ?
                     tr("&Hide") :
                     tr("S&how"));
+            if (enableWallet) {
+                send_action->setEnabled(sendCoinsAction->isEnabled());
+                cj_send_action->setEnabled(coinJoinCoinsAction->isEnabled());
+                receive_action->setEnabled(receiveCoinsAction->isEnabled());
+            }
         });
 }
 
@@ -1390,7 +1396,7 @@ void BitcoinGUI::updateCoinJoinVisibility()
         coinJoinCoinsButton->setVisible(fEnabled);
         GUIUtil::updateButtonGroupShortcuts(tabGroup);
     }
-    coinJoinCoinsMenuAction->setVisible(fEnabled);
+    coinJoinCoinsAction->setVisible(fEnabled);
     showCoinJoinHelpAction->setVisible(fEnabled);
     updateWidth();
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1043,39 +1043,45 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
     QAction* send_action{nullptr};
     QAction* cj_send_action{nullptr};
     QAction* receive_action{nullptr};
+    QAction* sign_action{nullptr};
+    QAction* verify_action{nullptr};
     if (enableWallet) {
         send_action = pmenu->addAction(sendCoinsAction->text(), sendCoinsAction, &QAction::trigger);
         cj_send_action = pmenu->addAction(coinJoinCoinsAction->text(), coinJoinCoinsAction, &QAction::trigger);
         receive_action = pmenu->addAction(receiveCoinsAction->text(), receiveCoinsAction, &QAction::trigger);
         pmenu->addSeparator();
-        pmenu->addAction(signMessageAction);
-        pmenu->addAction(verifyMessageAction);
+        sign_action = pmenu->addAction(signMessageAction->text(), signMessageAction, &QAction::trigger);
+        verify_action = pmenu->addAction(verifyMessageAction->text(), verifyMessageAction, &QAction::trigger);
         pmenu->addSeparator();
     }
-    pmenu->addAction(optionsAction);
-    pmenu->addAction(openInfoAction);
-    pmenu->addAction(openRPCConsoleAction);
-    pmenu->addAction(openGraphAction);
-    pmenu->addAction(openPeersAction);
+    QAction* options_action = pmenu->addAction(optionsAction->text(), optionsAction, &QAction::trigger);
+    options_action->setMenuRole(QAction::PreferencesRole);
+    QAction* info_action = pmenu->addAction(openInfoAction->text(), openInfoAction, &QAction::trigger);
+    QAction* node_window_action = pmenu->addAction(openRPCConsoleAction->text(), openRPCConsoleAction, &QAction::trigger);
+    QAction* graph_action = pmenu->addAction(openGraphAction->text(), openGraphAction, &QAction::trigger);
+    QAction* peer_action = pmenu->addAction(openPeersAction->text(), openPeersAction, &QAction::trigger);
+    QAction* repair_action{nullptr};
     if (enableWallet) {
-        pmenu->addAction(openRepairAction);
+        repair_action = pmenu->addAction(openRepairAction->text(), openRepairAction, &QAction::trigger);
     }
     pmenu->addSeparator();
-    pmenu->addAction(openConfEditorAction);
+    QAction* conf_action = pmenu->addAction(openConfEditorAction->text(), openConfEditorAction, &QAction::trigger);
+    QAction* backups_action{nullptr};
     if (enableWallet) {
-        pmenu->addAction(showBackupsAction);
+        backups_action = pmenu->addAction(showBackupsAction->text(), showBackupsAction, &QAction::trigger);
     }
+    QAction* quit_action{nullptr};
 #ifndef Q_OS_MAC
     // Note: On macOS, the Dock icon's menu already has Quit action.
     pmenu->addSeparator();
-    pmenu->addAction(quitAction);
+    quit_action = pmenu->addAction(quitAction->text(), quitAction, &QAction::trigger);
 #endif // Q_OS_MAC
 
     connect(
         // Using QSystemTrayIcon::Context is not reliable.
         // See https://bugreports.qt.io/browse/QTBUG-91697
         pmenu, &QMenu::aboutToShow,
-        [this, show_hide_action, send_action, cj_send_action, receive_action] {
+        [this, show_hide_action, send_action, cj_send_action, receive_action, sign_action, verify_action, repair_action, backups_action] {
             if (show_hide_action) show_hide_action->setText(
                 (!isHidden() && !isMinimized() && !GUIUtil::isObscured(this)) ?
                     tr("&Hide") :
@@ -1084,6 +1090,10 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
                 send_action->setEnabled(sendCoinsAction->isEnabled());
                 cj_send_action->setEnabled(coinJoinCoinsAction->isEnabled());
                 receive_action->setEnabled(receiveCoinsAction->isEnabled());
+                sign_action->setEnabled(signMessageAction->isEnabled());
+                verify_action->setEnabled(verifyMessageAction->isEnabled());
+                repair_action->setEnabled(openRepairAction->isEnabled());
+                backups_action->setEnabled(showBackupsAction->isEnabled());
             }
         });
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1038,7 +1038,7 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
     QAction* show_hide_action{nullptr};
 #ifndef Q_OS_MAC
     // Note: On macOS, the Dock icon is used to provide the tray's functionality.
-    show_hide_action = pmenu->addAction(tr("Show / &Hide"), this, &BitcoinGUI::toggleHidden);
+    show_hide_action = pmenu->addAction(QString(), this, &BitcoinGUI::toggleHidden);
     pmenu->addSeparator();
 #endif // Q_OS_MAC
 
@@ -1069,6 +1069,17 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
     pmenu->addSeparator();
     pmenu->addAction(quitAction);
 #endif // Q_OS_MAC
+
+    connect(
+        // Using QSystemTrayIcon::Context is not reliable.
+        // See https://bugreports.qt.io/browse/QTBUG-91697
+        pmenu, &QMenu::aboutToShow,
+        [this, show_hide_action] {
+            if (show_hide_action) show_hide_action->setText(
+                (!isHidden() && !isMinimized() && !GUIUtil::isObscured(this)) ?
+                    tr("&Hide") :
+                    tr("S&how"));
+        });
 }
 
 void BitcoinGUI::optionsClicked()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -154,7 +154,6 @@ private:
     QAction* aboutAction = nullptr;
     QAction* receiveCoinsMenuAction = nullptr;
     QAction* optionsAction = nullptr;
-    QAction* toggleHideAction = nullptr;
     QAction* encryptWalletAction = nullptr;
     QAction* backupWalletAction = nullptr;
     QAction* changePassphraseAction = nullptr;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -374,9 +374,6 @@ public Q_SLOTS:
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
-#else
-    /** Handle macOS Dock icon clicked */
-    void macosDockIconActivated();
 #endif
 
     /** Show window if hidden, unminimize when minimized, rise when obscured or show if hidden and fToggleHidden is true */

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -143,8 +143,8 @@ private:
     QToolButton* governanceButton = nullptr;
     QAction* appToolBarLogoAction = nullptr;
     QAction* quitAction = nullptr;
-    QAction* sendCoinsMenuAction = nullptr;
-    QAction* coinJoinCoinsMenuAction = nullptr;
+    QAction* sendCoinsAction = nullptr;
+    QAction* coinJoinCoinsAction = nullptr;
     QAction* usedSendingAddressesAction = nullptr;
     QAction* usedReceivingAddressesAction = nullptr;
     QAction* signMessageAction = nullptr;
@@ -152,7 +152,7 @@ private:
     QAction* m_load_psbt_action = nullptr;
     QAction* m_load_psbt_clipboard_action = nullptr;
     QAction* aboutAction = nullptr;
-    QAction* receiveCoinsMenuAction = nullptr;
+    QAction* receiveCoinsAction = nullptr;
     QAction* optionsAction = nullptr;
     QAction* encryptWalletAction = nullptr;
     QAction* backupWalletAction = nullptr;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -371,10 +371,6 @@ public Q_SLOTS:
     void showHelpMessageClicked();
     /** Show CoinJoin help message dialog */
     void showCoinJoinHelpClicked();
-#ifndef Q_OS_MAC
-    /** Handle tray icon clicked */
-    void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
-#endif
 
     /** Show window if hidden, unminimize when minimized, rise when obscured or show if hidden and fToggleHidden is true */
     void showNormalIfMinimized() { showNormalIfMinimized(false); }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1950,7 +1950,7 @@ void PrintSlotException(
     PrintExceptionContinue(std::make_exception_ptr(exception), description.c_str());
 }
 
-void ShowModalDialogAndDeleteOnClose(QDialog* dialog)
+void ShowModalDialogAsynchronously(QDialog* dialog)
 {
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowModality(Qt::ApplicationModal);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -613,7 +613,7 @@ namespace GUIUtil
     /**
      * Shows a QDialog instance asynchronously, and deletes it on close.
      */
-    void ShowModalDialogAndDeleteOnClose(QDialog* dialog);
+    void ShowModalDialogAsynchronously(QDialog* dialog);
 
 } // namespace GUIUtil
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -940,7 +940,7 @@ void SendCoinsDialog::coinControlButtonClicked()
 {
     auto dlg = new CoinControlDialog(*m_coin_control, model);
     connect(dlg, &QDialog::finished, this, &SendCoinsDialog::coinControlUpdateLabels);
-    GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 
 // Coin Control: checkbox custom change address

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -516,7 +516,7 @@ void TransactionView::editLabel()
                 : EditAddressDialog::EditSendingAddress, this);
             dlg->setModel(addressBook);
             dlg->loadRow(idx);
-            GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+            GUIUtil::ShowModalDialogAsynchronously(dlg);
         }
         else
         {
@@ -525,7 +525,7 @@ void TransactionView::editLabel()
                 this);
             dlg->setModel(addressBook);
             dlg->setAddress(address);
-            GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+            GUIUtil::ShowModalDialogAsynchronously(dlg);
         }
     }
 }

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -288,7 +288,7 @@ void WalletFrame::gotoLoadPSBT(bool from_clipboard)
 
     auto dlg = new PSBTOperationsDialog(this, currentWalletModel(), clientModel);
     dlg->openWithPSBT(psbtx);
-    GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 
 void WalletFrame::encryptWallet()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -333,7 +333,7 @@ void WalletView::unlockWallet(bool fForMixingOnly)
 {
     // Unlock wallet when requested by wallet model
     if (walletModel->getEncryptionStatus() == WalletModel::Locked || walletModel->getEncryptionStatus() == WalletModel::UnlockedForMixingOnly) {
-        AskPassphraseDialog dlg(AskPassphraseDialog::Unlock, this);
+        AskPassphraseDialog dlg(fForMixingOnly ? AskPassphraseDialog::UnlockMixing : AskPassphraseDialog::Unlock, this);
         dlg.setModel(walletModel);
         // A modal dialog must be synchronous here as expected
         // in the WalletModel::requestUnlock() function.

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -299,7 +299,7 @@ void WalletView::encryptWallet()
     auto dlg = new AskPassphraseDialog(AskPassphraseDialog::Encrypt, this);
     dlg->setModel(walletModel);
     connect(dlg, &QDialog::finished, this, &WalletView::encryptionStatusChanged);
-    GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 
 void WalletView::backupWallet()
@@ -326,7 +326,7 @@ void WalletView::changePassphrase()
 {
     auto dlg = new AskPassphraseDialog(AskPassphraseDialog::ChangePass, this);
     dlg->setModel(walletModel);
-    GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+    GUIUtil::ShowModalDialogAsynchronously(dlg);
 }
 
 void WalletView::unlockWallet(bool fForMixingOnly)

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -333,9 +333,11 @@ void WalletView::unlockWallet(bool fForMixingOnly)
 {
     // Unlock wallet when requested by wallet model
     if (walletModel->getEncryptionStatus() == WalletModel::Locked || walletModel->getEncryptionStatus() == WalletModel::UnlockedForMixingOnly) {
-        auto dlg = new AskPassphraseDialog(AskPassphraseDialog::Unlock, this);
-        dlg->setModel(walletModel);
-        GUIUtil::ShowModalDialogAndDeleteOnClose(dlg);
+        AskPassphraseDialog dlg(AskPassphraseDialog::Unlock, this);
+        dlg.setModel(walletModel);
+        // A modal dialog must be synchronous here as expected
+        // in the WalletModel::requestUnlock() function.
+        dlg.exec();
     }
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
bitcoin-core/gui#336 backported in #6569 broke unlock dialog

## What was done?
backport bitcoin-core/gui#509 to fix this

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

