### PR TITLE
backport: bitcoin-core/gui#605: Delete splash screen widget early

### DIFF
--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -86,7 +86,6 @@ Q_SIGNALS:
     void requestedInitialize();
     void requestedRestart(QStringList args);
     void requestedShutdown();
-    void splashFinished();
     void windowShown(BitcoinGUI* window);
 
 protected:

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -166,16 +166,6 @@ bool SplashScreen::eventFilter(QObject * obj, QEvent * ev) {
     return QObject::eventFilter(obj, ev);
 }
 
-void SplashScreen::finish()
-{
-    /* If the window is minimized, hide() will be ignored. */
-    /* Make sure we de-minimize the splashscreen window before hiding */
-    if (isMinimized())
-        showNormal();
-    hide();
-    deleteLater(); // No more need for this
-}
-
 static void InitMessage(SplashScreen *splash, const std::string &message)
 {
     bool invoked = QMetaObject::invokeMethod(splash, "showMessage",

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -37,9 +37,6 @@ protected:
     void closeEvent(QCloseEvent *event) override;
 
 public Q_SLOTS:
-    /** Hide the splash screen window and schedule the splash screen object for deletion */
-    void finish();
-
     /** Show message and progress */
     void showMessage(const QString &message, int alignment, const QColor &color);
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Original PR description:

>  `SplashScreen::deleteLater()` [does not guarantee](https://doc.qt.io/qt-5/qobject.html#deleteLater) deletion of the `m_splash` object prior to the wallet context deletion. If the latter happens first, the [segfault](https://github.com/bitcoin-core/gui/issues/604#issuecomment-1133907013) follows.

Crash:
```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
...
6   libc++abi.dylib               	       0x19012d6b4 std::terminate() + 108
7   dash-qt                       	       0x1027e5744 SplashScreen::~SplashScreen() + 504 (splashscreen.cpp:142)
8   dash-qt                       	       0x1027e5974 SplashScreen::~SplashScreen() + 4 (splashscreen.cpp:141) [inlined]
9   dash-qt                       	       0x1027e5974 SplashScreen::~SplashScreen() + 36 (splashscreen.cpp:141)
...
```

The issue was introduced via https://github.com/bitcoin/bitcoin/pull/19101 backport (14aa05dfa7) in #6529.

## What was done?
Backport bitcoin-core/gui#605

## How Has This Been Tested?
Run `./src/qt/dash-qt --regtest` and press `q` while on splash screen to shutdown asap

develop: crash
this PR: no crash

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

