### PR TITLE
feat: add `id` to `getislocks` rpc output

### DIFF
--- a/doc/release-notes-6607.md
+++ b/doc/release-notes-6607.md
@@ -1,0 +1,4 @@
+Updated RPCs
+------------
+
+* `getislocks` will now return request `id` for each InstantSend Lock in results

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -387,6 +387,7 @@ static RPCHelpMan getislocks()
                             },
                         },
                     }},
+                    {RPCResult::Type::STR_HEX, "id", "Request ID"},
                     {RPCResult::Type::STR_HEX, "cycleHash", "The Cycle Hash"},
                     {RPCResult::Type::STR_HEX, "signature", "The InstantSend's BLS signature"},
                     {RPCResult::Type::STR_HEX, "hex", "The serialized, hex-encoded data for 'txid'"},
@@ -424,6 +425,7 @@ static RPCHelpMan getislocks()
                 inputs.push_back(outpoint);
             }
             objIS.pushKV("inputs", inputs);
+            objIS.pushKV("id", islock->GetRequestId().ToString());
             objIS.pushKV("cycleHash", islock->cycleHash.ToString());
             objIS.pushKV("signature", islock->sig.ToString());
             {

--- a/test/functional/rpc_verifyislock.py
+++ b/test/functional/rpc_verifyislock.py
@@ -5,7 +5,7 @@
 
 from test_framework.messages import CTransaction, from_hex, hash256, ser_compact_size, ser_string
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import assert_raises_rpc_error, satoshi_round
+from test_framework.util import assert_equal, assert_raises_rpc_error, satoshi_round
 
 '''
 rpc_verifyislock.py
@@ -41,6 +41,8 @@ class RPCVerifyISLockTest(DashTestFramework):
         self.wait_for_instantlock(txid, node)
 
         request_id = self.get_request_id(self.nodes[0].getrawtransaction(txid))
+        request_id_rpc = self.nodes[0].getislocks([txid])[0]["id"]
+        assert_equal(request_id, request_id_rpc)
         self.wait_until(lambda: node.quorum("hasrecsig", 103, request_id, txid))
 
         rec_sig = node.quorum("getrecsig", 103, request_id, txid)['sig']


### PR DESCRIPTION
## Issue being fixed or feature implemented
`verifyislock` rpc needs request `id` as a param but `getislocks` (or any other rpc) doesn't provide one so it's hard to use

## What was done?

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

