### PR TITLE
fix: `cycleHash` should represent a cycle starting block of the signing quorum

### DIFF
--- a/doc/release-notes-6608.md
+++ b/doc/release-notes-6608.md
@@ -1,0 +1,4 @@
+P2P Changes
+-----------
+
+* `cycleHash` field in `isdlock` message will now represent a DKG cycle starting block of the signing quorum instead of a DKG cycle starting block corresponding to the current chain height. While this is fully backwards compatible with older versions of Dash Core, other implementations might not be expecting this, so the P2P protocol version was bumped to 70237.

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70236;
+static const int PROTOCOL_VERSION = 70237;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -20,7 +20,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION = 70216;
 
 //! minimum proto version of masternode to accept in DKGs
-static const int MIN_MASTERNODE_PROTO_VERSION = 70235;
+static const int MIN_MASTERNODE_PROTO_VERSION = 70237;
 
 //! protocol version is included in MNAUTH starting with this version
 static const int MNAUTH_NODE_VER_VERSION = 70218;
@@ -63,6 +63,9 @@ static const int INCREASE_MAX_HEADERS2_VERSION = 70235;
 
 //! Behavior of QRINFO is changed in this protocol version
 static const int EFFICIENT_QRINFO_VERSION = 70236;
+
+//! cycleHash in isdlock message switched to using quorum's base block in this version
+static const int ISDLOCK_CYCLEHASH_UPDATE_VERSION = 70237;
 
 // Make sure that none of the values above collide with `ADDRV2_FORMAT`.
 

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -99,8 +99,8 @@ logger = logging.getLogger("TestFramework.p2p")
 # The minimum P2P version that this test framework supports
 MIN_P2P_VERSION_SUPPORTED = 60001
 # The P2P version that this test framework implements and sends in its `version` message
-# Version 70235 increased max header count for HEADERS2 message from 2000 to 8000
-P2P_VERSION = 70236
+# Version 70237 switched cycleHash in isdlock message to using quorum's base block
+P2P_VERSION = 70237
 # The services that this test framework offers in its `version` message
 P2P_SERVICES = NODE_NETWORK | NODE_HEADERS_COMPRESSED
 # The P2P user agent string that this test framework sends in its `version` message


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently `cycleHash` is calculated based on the current chain height we are signing `isdlock` at. This however can result in `cycleHash` to be a block hash of a new cycle where DKG is still in progress which can be confusing to verifiers.

## What was done?
Select a signing quorum first and then calculate `cycleHash` based on the quorum's base block index instead of using the current chain height.

## How Has This Been Tested?
Running a testnet MN for some time. It's creating new `isdlock`s and processing `isdlock`s from other nodes with no issues.

## Breaking Changes
None, `cycleHash` is simply going to be more accurate now.

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

