### PR TITLE
test: functional tests for RPC debug

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -55,7 +55,7 @@ static RPCHelpMan debug()
         "Note: Consider using 'logging' RPC which has more features.\n"
         " - For 'debug all': logging [\\\"all\\\"]\n"
         " - For 'debug none': logging []\n"
-        " - For 'debug X+Y': logging \"[\\\"X\\\", \\\"Y\\\"]\"",
+        " - For 'debug X+Y': logging '[\"X\", \"Y\"]'",
         {
             {"category", RPCArg::Type::STR, RPCArg::Optional::NO, "The name of the debug category to turn on."},
         },
@@ -1242,6 +1242,7 @@ static RPCHelpMan logging()
         },
         RPCExamples{
             HelpExampleCli("logging", "\"[\\\"all\\\"]\" \"[\\\"http\\\"]\"")
+          + HelpExampleCli("logging", "'[\"dash\"]' '[\"llmq\",\"zmq\"]'")
     + HelpExampleRpc("logging", "[\"all\"], \"[libevent]\"")
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -51,7 +51,11 @@ static RPCHelpMan debug()
         " - \"all\", \"1\" and \"\" activate all categories at once;\n"
         " - \"dash\" activates all Dash-specific categories at once;\n"
         " - \"none\" (or \"0\") deactivates all categories at once.\n"
-        "Note: If specified category doesn't match any of the above, no error is thrown.\n",
+        "Note: If specified category doesn't match any of the above, no error is thrown.\n"
+        "Note: Consider using 'logging' RPC which has more features.\n"
+        " - For 'debug all': logging [\\\"all\\\"]\n"
+        " - For 'debug none': logging []\n"
+        " - For 'debug X+Y': logging \"[\\\"X\\\", \\\"Y\\\"]\"",
         {
             {"category", RPCArg::Type::STR, RPCArg::Optional::NO, "The name of the debug category to turn on."},
         },

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -62,6 +62,10 @@ class RpcMiscTest(BitcoinTestFramework):
         assert_equal(node.logging()['qt'], False)
         node.logging(include=['qt'])
         assert_equal(node.logging()['qt'], True)
+        node.debug('none')
+        assert_equal(node.logging()['qt'], False)
+        node.debug('qt')
+        assert_equal(node.logging()['qt'], True)
 
         # Test logging RPC returns the logging categories in alphabetical order.
         sorted_logging_categories = sorted(node.logging())
@@ -71,6 +75,7 @@ class RpcMiscTest(BitcoinTestFramework):
         categories = ', '.join(sorted_logging_categories)
         logging_help = self.nodes[0].help('logging')
         assert f"valid logging categories are: {categories}" in logging_help
+        assert f"valid logging categories are: {categories}" in self.nodes[0].help('debug')
 
         self.log.info("test echoipc (testing spawned process in multiprocess build)")
         assert_equal(node.echoipc("hello"), "hello")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -898,8 +898,6 @@ class RPCCoverage():
         covered_cmds.add('voteraw')
         # TODO: implement functional tests for getmerkleblocks
         covered_cmds.add('getmerkleblocks')
-        # TODO: drop it with v23+: remove `debug` in favour of `logging`
-        covered_cmds.add('debug')
 
         if not os.path.isfile(coverage_ref_filename):
             raise RuntimeError("No coverage reference found")


### PR DESCRIPTION
## Issue being fixed or feature implemented
See https://github.com/dashpay/dash-issues/issues/63

## What was done?
Functional tests for RPC `debug`. Extended help for this RPC (mentioning of RPC `logging`)

This PR replaces https://github.com/dashpay/dash/pull/6480
Lately I noticed that it's not trivial to use `logging` with more than 1 category such as `logging [a, b]` due to requirement to escape quotes, inside quotes while `debug a+b` doesn't require any escaping and easier to type.


## How Has This Been Tested?
Run unit / functional tests (by CI)
```
test/functional/test_runner.py -j20 --previous-releases --coverage --extended
```

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

