### PR TITLE
refactor: remove return value from InitAutoBackup follow-up #3426

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -31,7 +31,7 @@ public:
     // Dash Specific WalletInitInterface InitCoinJoinSettings
     void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const override {}
     void InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const override {}
-    bool InitAutoBackup() const override {return true;}
+    void InitAutoBackup() const override {}
 };
 
 void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1551,7 +1551,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 5: verify wallet database integrity
 
-    if (!g_wallet_init_interface.InitAutoBackup()) return false;
+    g_wallet_init_interface.InitAutoBackup();
     for (const auto& client : node.chain_clients) {
         if (!client->verify()) {
             return false;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -49,7 +49,7 @@ public:
     // Dash Specific Wallet Init
     void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const override;
     void InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const override;
-    bool InitAutoBackup() const override;
+    void InitAutoBackup() const override;
 };
 
 const WalletInitInterface& g_wallet_init_interface = WalletInit();
@@ -231,7 +231,7 @@ void WalletInit::InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loa
               CCoinJoinClientOptions::GetDenomsHardCap());
 }
 
-bool WalletInit::InitAutoBackup() const
+void WalletInit::InitAutoBackup() const
 {
-    return CWallet::InitAutoBackup();
+    CWallet::InitAutoBackup();
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3742,15 +3742,13 @@ void CWallet::postInitProcess()
     chain().requestMempoolTransactions(*this);
 }
 
-bool CWallet::InitAutoBackup()
+void CWallet::InitAutoBackup()
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
-        return true;
+        return;
 
     nWalletBackups = gArgs.GetIntArg("-createwalletbackups", 10);
     nWalletBackups = std::max(0, std::min(10, nWalletBackups));
-
-    return true;
 }
 
 bool CWallet::BackupWallet(const std::string& strDest) const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -925,7 +925,7 @@ public:
     void postInitProcess();
 
     /* AutoBackup functionality */
-    static bool InitAutoBackup();
+    static void InitAutoBackup();
     bool AutoBackupWallet(const fs::path& wallet_path, bilingual_str& error_string, std::vector<bilingual_str>& warnings);
 
     bool BackupWallet(const std::string& strDest) const;

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -28,7 +28,7 @@ public:
     // Dash Specific WalletInitInterface
     virtual void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const = 0;
     virtual void InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const = 0;
-    virtual bool InitAutoBackup() const = 0;
+    virtual void InitAutoBackup() const = 0;
 
     virtual ~WalletInitInterface() {}
 };


### PR DESCRIPTION
## Issue being fixed or feature implemented
`InitAutoBackup` always return true since #3426.

## What was done?
Refactored to return no value

## How Has This Been Tested?
Build and run

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone