### PR TITLE
fix: adjust quorum rotation data results in some edge cases, add tests

### DIFF
--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -399,8 +399,7 @@ uint256 GetLastBaseBlockHash(Span<const CBlockIndex*> baseBlockIndexes, const CB
     // default to genesis block
     uint256 hash{Params().GenesisBlock().GetHash()};
     for (const auto baseBlock : baseBlockIndexes) {
-        if (baseBlock->nHeight > blockIndex->nHeight)
-            break;
+        if (baseBlock->nHeight > blockIndex->nHeight) break;
         hash = baseBlock->GetBlockHash();
     }
     return hash;

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -392,11 +392,12 @@ bool BuildQuorumRotationInfo(CDeterministicMNManager& dmnman, CQuorumSnapshotMan
 uint256 GetLastBaseBlockHash(Span<const CBlockIndex*> baseBlockIndexes, const CBlockIndex* blockIndex,
                              bool use_legacy_construction)
 {
-    uint256 hash;
     if (!use_legacy_construction) {
         std::sort(baseBlockIndexes.begin(), baseBlockIndexes.end(),
                   [](const CBlockIndex* a, const CBlockIndex* b) { return a->nHeight < b->nHeight; });
     }
+    // default to genesis block
+    uint256 hash{Params().GenesisBlock().GetHash()};
     for (const auto baseBlock : baseBlockIndexes) {
         if (baseBlock->nHeight >= blockIndex->nHeight)
             break;

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -399,7 +399,7 @@ uint256 GetLastBaseBlockHash(Span<const CBlockIndex*> baseBlockIndexes, const CB
     // default to genesis block
     uint256 hash{Params().GenesisBlock().GetHash()};
     for (const auto baseBlock : baseBlockIndexes) {
-        if (baseBlock->nHeight >= blockIndex->nHeight)
+        if (baseBlock->nHeight > blockIndex->nHeight)
             break;
         hash = baseBlock->GetBlockHash();
     }

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -237,7 +237,6 @@ class LLMQQuorumRotationTest(DashTestFramework):
         hmc_base_blockhash = self.nodes[0].getblockhash(block_count - (block_count % 24) - 24 - 8)
         best_block_hash = self.nodes[0].getbestblockhash()
         rpc_qr_info = self.nodes[0].quorum("rotationinfo", best_block_hash, False, hmc_base_blockhash)
-        self.log.info(rpc_qr_info)
         assert_equal(rpc_qr_info["mnListDiffTip"]["blockHash"], best_block_hash)
         assert_equal(rpc_qr_info["mnListDiffTip"]["baseBlockHash"], rpc_qr_info["mnListDiffH"]["blockHash"])
         assert_equal(rpc_qr_info["mnListDiffH"]["baseBlockHash"], rpc_qr_info["mnListDiffAtHMinusC"]["blockHash"])

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -231,6 +231,23 @@ class LLMQQuorumRotationTest(DashTestFramework):
         self.wait_until(lambda: self.nodes[0].getbestblockhash() == new_quorum_blockhash)
         assert_equal(self.nodes[0].quorum("list", llmq_type), new_quorum_list)
 
+        self.log.info("Test 'quorum rotationinfo' RPC")
+        genesis_blockhash = self.nodes[0].getblockhash(0)
+        block_count = self.nodes[0].getblockcount()
+        hmc_base_blockhash = self.nodes[0].getblockhash(block_count - (block_count % 24) - 24 - 8)
+        best_block_hash = self.nodes[0].getbestblockhash()
+        rpc_qr_info = self.nodes[0].quorum("rotationinfo", best_block_hash, False, hmc_base_blockhash)
+        self.log.info(rpc_qr_info)
+        assert_equal(rpc_qr_info["mnListDiffTip"]["blockHash"], best_block_hash)
+        assert_equal(rpc_qr_info["mnListDiffTip"]["baseBlockHash"], rpc_qr_info["mnListDiffH"]["blockHash"])
+        assert_equal(rpc_qr_info["mnListDiffH"]["baseBlockHash"], rpc_qr_info["mnListDiffAtHMinusC"]["blockHash"])
+        assert_equal(rpc_qr_info["mnListDiffAtHMinusC"]["blockHash"], hmc_base_blockhash)
+        assert_equal(rpc_qr_info["mnListDiffAtHMinusC"]["baseBlockHash"], hmc_base_blockhash)
+        assert_equal(rpc_qr_info["mnListDiffAtHMinusC"]["newQuorums"], [])
+        assert_equal(rpc_qr_info["mnListDiffAtHMinusC"]["deletedQuorums"], [])
+        assert_equal(rpc_qr_info["mnListDiffAtHMinus2C"]["baseBlockHash"], rpc_qr_info["mnListDiffAtHMinus3C"]["blockHash"])
+        assert_equal(rpc_qr_info["mnListDiffAtHMinus3C"]["baseBlockHash"], genesis_blockhash)
+
     def test_getmnlistdiff_quorums(self, baseBlockHash, blockHash, baseQuorumList, expectedDeleted, expectedNew, testQuorumsCLSigs = True):
         d = self.test_getmnlistdiff_base(baseBlockHash, blockHash, testQuorumsCLSigs)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Before this PR you could get `baseBlockHash` as all 0s for some cases. Also, a known `baseBlockHash` that matched the `cycleHash` was ignored which means that results included quorum changes from an older known `baseBlockHash` till the `cycleHash`(which is the same as the `baseBlockHash` in question) i.e. these changes were already known to the requester.

## What was done?
Pls see individual commits

## How Has This Been Tested?
Run tests

## Breaking Changes
n/a, results should simply be a bit more meaningful and compact

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

