### PR TITLE
fix(rpc)!: the third param in `quorum rotationinfo` RPC should be a JSON array

### DIFF
--- a/doc/release-notes-6628.md
+++ b/doc/release-notes-6628.md
@@ -1,0 +1,4 @@
+Updated RPCs
+------------
+
+* `quorum rotationinfo` will now expect the third param to be a JSON array

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -236,7 +236,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         block_count = self.nodes[0].getblockcount()
         hmc_base_blockhash = self.nodes[0].getblockhash(block_count - (block_count % 24) - 24 - 8)
         best_block_hash = self.nodes[0].getbestblockhash()
-        rpc_qr_info = self.nodes[0].quorum("rotationinfo", best_block_hash, False, hmc_base_blockhash)
+        rpc_qr_info = self.nodes[0].quorum("rotationinfo", best_block_hash, False, [hmc_base_blockhash])
         assert_equal(rpc_qr_info["mnListDiffTip"]["blockHash"], best_block_hash)
         assert_equal(rpc_qr_info["mnListDiffTip"]["baseBlockHash"], rpc_qr_info["mnListDiffH"]["blockHash"])
         assert_equal(rpc_qr_info["mnListDiffH"]["baseBlockHash"], rpc_qr_info["mnListDiffAtHMinusC"]["blockHash"])


### PR DESCRIPTION
## Issue being fixed or feature implemented
Parsing unlimited params doesn't work with recent `RPCHelpMan` changes, can't pass multiple base block hashes to `quorum rotationinfo` anymore.

## What was done?
`quorum rotationinfo` will now expect the third param to be a JSON array

## How Has This Been Tested?
Run tests, run `quorum rotationinfo` in Qt console

Qt RPC example call:
`quorum rotationinfo 0000000000000016840c57624eb003477b2bd47954224bae4b05ad90c7896e8f true '["000000000000000da09ab7540aebde86f2864234f4cbffffd38afb10fc910dc2", "00000000000000032b5285954202a0bb41eebf642193da7d1387ca1dacf87313"]'`

## Breaking Changes
Apps/scripts which used `basesBlockHash` param in `quorum rotationinfo` RPC should be adjusted accordingly.

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

