### PR TITLE
feat: introduce type-flexible `NetInfoEntry` to allow non-`CService` entries, use in `MnNetInfo`

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1213,6 +1213,8 @@ static bool CheckService(const ProTx& proTx, TxValidationState& state)
         return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-addr-type");
     case NetInfoStatus::NotRoutable:
         return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-addr-unroutable");
+    case NetInfoStatus::Malformed:
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-bad");
     case NetInfoStatus::Success:
         return true;
     // Shouldn't be possible during self-checks

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1255,6 +1255,7 @@ static bool CheckService(const ProTx& proTx, TxValidationState& state)
         return true;
     // Shouldn't be possible during self-checks
     case NetInfoStatus::BadInput:
+    case NetInfoStatus::MaxLimit:
         assert(false);
     } // no default case, so the compiler can warn about missing cases
     assert(false);

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1205,12 +1205,19 @@ template <typename ProTx>
 static bool CheckService(const ProTx& proTx, TxValidationState& state)
 {
     switch (proTx.netInfo.Validate()) {
-    case NetInfoStatus::BadInput:
-        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo");
+    case NetInfoStatus::BadAddress:
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-addr");
     case NetInfoStatus::BadPort:
         return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-port");
+    case NetInfoStatus::BadType:
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-addr-type");
+    case NetInfoStatus::NotRoutable:
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-addr-unroutable");
     case NetInfoStatus::Success:
         return true;
+    // Shouldn't be possible during self-checks
+    case NetInfoStatus::BadInput:
+        assert(false);
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -470,11 +470,18 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTota
         throw(std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate collateralOutpoint=%s", __func__,
                 dmn->proTxHash.ToString(), dmn->collateralOutpoint.ToStringShort())));
     }
-    for (const CService& entry : dmn->pdmnState->netInfo.GetEntries()) {
-        if (!AddUniqueProperty(*dmn, entry)) {
+    for (const NetInfoEntry& entry : dmn->pdmnState->netInfo.GetEntries()) {
+        if (const auto& service_opt{entry.GetAddrPort()}; service_opt.has_value()) {
+            const CService& service{service_opt.value()};
+            if (!AddUniqueProperty(*dmn, service)) {
+                mnUniquePropertyMap = mnUniquePropertyMapSaved;
+                throw std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate address=%s",
+                                                   __func__, dmn->proTxHash.ToString(), service.ToStringAddrPort()));
+            }
+        } else {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
-            throw(std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate address=%s", __func__,
-                                               dmn->proTxHash.ToString(), entry.ToStringAddrPort())));
+            throw std::runtime_error(
+                strprintf("%s: Can't add a masternode %s with invalid address", __func__, dmn->proTxHash.ToString()));
         }
     }
     if (!AddUniqueProperty(*dmn, dmn->pdmnState->keyIDOwner)) {
@@ -513,28 +520,40 @@ void CDeterministicMNList::UpdateMN(const CDeterministicMN& oldDmn, const std::s
     // Using this temporary map as a checkpoint to roll back to in case of any issues.
     decltype(mnUniquePropertyMap) mnUniquePropertyMapSaved = mnUniquePropertyMap;
 
-    const auto updateNetInfo = [&]() {
-        if (oldState->netInfo != pdmnState->netInfo) {
+    auto updateNetInfo = [this](const CDeterministicMN& dmn, const MnNetInfo& oldInfo,
+                                const MnNetInfo& newInfo) -> std::string {
+        if (oldInfo != newInfo) {
             // We track each individual entry in netInfo as opposed to netInfo itself (preventing us from
             // using UpdateUniqueProperty()), so we need to successfully purge all old entries and insert
             // new entries to successfully update.
-            for (const CService& old_entry : oldState->netInfo.GetEntries()) {
-                if (!DeleteUniqueProperty(*dmn, old_entry)) {
-                    return strprintf("internal error"); // This shouldn't be possible
+            for (const NetInfoEntry& old_entry : oldInfo.GetEntries()) {
+                if (const auto& service_opt{old_entry.GetAddrPort()}) {
+                    const CService& service{service_opt.value()};
+                    if (!DeleteUniqueProperty(dmn, service)) {
+                        return "internal error"; // This shouldn't be possible
+                    }
+                } else {
+                    return "invalid address";
                 }
             }
-            for (const CService& new_entry : pdmnState->netInfo.GetEntries()) {
-                if (!AddUniqueProperty(*dmn, new_entry)) {
-                    return strprintf("duplicate (%s)", new_entry.ToStringAddrPort());
+            for (const NetInfoEntry& new_entry : newInfo.GetEntries()) {
+                if (const auto& service_opt{new_entry.GetAddrPort()}) {
+                    const CService& service{service_opt.value()};
+                    if (!AddUniqueProperty(dmn, service)) {
+                        return strprintf("duplicate (%s)", service.ToStringAddrPort());
+                    }
+                } else {
+                    return "invalid address";
                 }
             }
         }
-        return strprintf("");
-    }();
-    if (!updateNetInfo.empty()) {
+        return "";
+    };
+
+    if (auto err = updateNetInfo(*dmn, oldState->netInfo, pdmnState->netInfo); !err.empty()) {
         mnUniquePropertyMap = mnUniquePropertyMapSaved;
         throw(std::runtime_error(strprintf("%s: Can't update masternode %s with addresses, reason=%s", __func__,
-                                           oldDmn.proTxHash.ToString(), updateNetInfo)));
+                                           oldDmn.proTxHash.ToString(), err)));
     }
     if (!UpdateUniqueProperty(*dmn, oldState->keyIDOwner, pdmnState->keyIDOwner)) {
         mnUniquePropertyMap = mnUniquePropertyMapSaved;
@@ -591,11 +610,18 @@ void CDeterministicMNList::RemoveMN(const uint256& proTxHash)
         throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with a collateralOutpoint=%s", __func__,
                 proTxHash.ToString(), dmn->collateralOutpoint.ToStringShort())));
     }
-    for (const CService& entry : dmn->pdmnState->netInfo.GetEntries()) {
-        if (!DeleteUniqueProperty(*dmn, entry)) {
+    for (const NetInfoEntry& entry : dmn->pdmnState->netInfo.GetEntries()) {
+        if (const auto& service_opt{entry.GetAddrPort()}; service_opt.has_value()) {
+            const CService& service{service_opt.value()};
+            if (!DeleteUniqueProperty(*dmn, service)) {
+                mnUniquePropertyMap = mnUniquePropertyMapSaved;
+                throw std::runtime_error(strprintf("%s: Can't delete a masternode %s with an address=%s", __func__,
+                                                   proTxHash.ToString(), service.ToStringAddrPort()));
+            }
+        } else {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
-            throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with an address=%s", __func__,
-                                               proTxHash.ToString(), entry.ToStringAddrPort())));
+            throw std::runtime_error(strprintf("%s: Can't delete a masternode %s with invalid address", __func__,
+                                               dmn->proTxHash.ToString()));
         }
     }
     if (!DeleteUniqueProperty(*dmn, dmn->pdmnState->keyIDOwner)) {
@@ -811,9 +837,14 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, gsl::no
                 }
             }
 
-            for (const CService& entry : proTx.netInfo.GetEntries()) {
-                if (newList.HasUniqueProperty(entry)) {
-                    return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-netinfo-entry");
+            for (const NetInfoEntry& entry : proTx.netInfo.GetEntries()) {
+                if (const auto& service_opt{entry.GetAddrPort()}; service_opt.has_value()) {
+                    const CService& service{service_opt.value()};
+                    if (newList.HasUniqueProperty(service)) {
+                        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-netinfo-entry");
+                    }
+                } else {
+                    return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-netinfo-entry");
                 }
             }
             if (newList.HasUniqueProperty(proTx.keyIDOwner) || newList.HasUniqueProperty(proTx.pubKeyOperator)) {
@@ -842,10 +873,15 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, gsl::no
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-payload");
             }
 
-            for (const CService& entry : opt_proTx->netInfo.GetEntries()) {
-                if (newList.HasUniqueProperty(entry) &&
-                    newList.GetUniquePropertyMN(entry)->proTxHash != opt_proTx->proTxHash) {
-                    return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-netinfo-entry");
+            for (const NetInfoEntry& entry : opt_proTx->netInfo.GetEntries()) {
+                if (const auto& service_opt{entry.GetAddrPort()}; service_opt.has_value()) {
+                    const CService& service{service_opt.value()};
+                    if (newList.HasUniqueProperty(service) &&
+                        newList.GetUniquePropertyMN(service)->proTxHash != opt_proTx->proTxHash) {
+                        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-netinfo-entry");
+                    }
+                } else {
+                    return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-netinfo-entry");
                 }
             }
 
@@ -1382,10 +1418,15 @@ bool CheckProRegTx(CDeterministicMNManager& dmnman, const CTransaction& tx, gsl:
         auto mnList = dmnman.GetListForBlock(pindexPrev);
 
         // only allow reusing of addresses when it's for the same collateral (which replaces the old MN)
-        for (const CService& entry : opt_ptx->netInfo.GetEntries()) {
-            if (mnList.HasUniqueProperty(entry) &&
-                mnList.GetUniquePropertyMN(entry)->collateralOutpoint != collateralOutpoint) {
-                return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-netinfo-entry");
+        for (const NetInfoEntry& entry : opt_ptx->netInfo.GetEntries()) {
+            if (const auto& service_opt{entry.GetAddrPort()}; service_opt.has_value()) {
+                const CService& service{service_opt.value()};
+                if (mnList.HasUniqueProperty(service) &&
+                    mnList.GetUniquePropertyMN(service)->collateralOutpoint != collateralOutpoint) {
+                    return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-netinfo-entry");
+                }
+            } else {
+                return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-entry");
             }
         }
 
@@ -1455,9 +1496,14 @@ bool CheckProUpServTx(CDeterministicMNManager& dmnman, const CTransaction& tx, g
     }
 
     // don't allow updating to addresses already used by other MNs
-    for (const CService& entry : opt_ptx->netInfo.GetEntries()) {
-        if (mnList.HasUniqueProperty(entry) && mnList.GetUniquePropertyMN(entry)->proTxHash != opt_ptx->proTxHash) {
-            return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-netinfo-entry");
+    for (const NetInfoEntry& entry : opt_ptx->netInfo.GetEntries()) {
+        if (const auto& service_opt{entry.GetAddrPort()}; service_opt.has_value()) {
+            const CService& service{service_opt.value()};
+            if (mnList.HasUniqueProperty(service) && mnList.GetUniquePropertyMN(service)->proTxHash != opt_ptx->proTxHash) {
+                return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-netinfo-entry");
+            }
+        } else {
+            return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-entry");
         }
     }
 

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -398,6 +398,7 @@ private:
     static_assert(!std::is_same_v<std::decay_t<T>, name>, "GetUniquePropertyHash cannot be templated against " #name)
         DMNL_NO_TEMPLATE(CBLSPublicKey);
         DMNL_NO_TEMPLATE(MnNetInfo);
+        DMNL_NO_TEMPLATE(NetInfoEntry);
 #undef DMNL_NO_TEMPLATE
         return ::SerializeHash(v);
     }

--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -27,13 +27,13 @@ const CChainParams& MainParams()
 NetInfoStatus MnNetInfo::ValidateService(const CService& service)
 {
     if (!service.IsValid()) {
-        return NetInfoStatus::BadInput;
+        return NetInfoStatus::BadAddress;
     }
     if (!service.IsIPv4()) {
-        return NetInfoStatus::BadInput;
+        return NetInfoStatus::BadType;
     }
     if (Params().RequireRoutableExternalIP() && !service.IsRoutable()) {
-        return NetInfoStatus::BadInput;
+        return NetInfoStatus::NotRoutable;
     }
 
     if (IsNodeOnMainnet() != (service.GetPort() == MainParams().GetDefaultPort())) {

--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -167,23 +167,22 @@ NetInfoStatus MnNetInfo::AddEntry(const std::string& input)
         const auto ret{ValidateService(*service_opt)};
         if (ret == NetInfoStatus::Success) {
             m_addr = NetInfoEntry{*service_opt};
-            ASSERT_IF_DEBUG(GetPrimary() != empty_service);
+            ASSERT_IF_DEBUG(m_addr.GetAddrPort().has_value());
         }
         return ret;
     }
     return NetInfoStatus::BadInput;
 }
 
-CServiceList MnNetInfo::GetEntries() const
+NetInfoList MnNetInfo::GetEntries() const
 {
-    CServiceList ret;
     if (!IsEmpty()) {
-        ASSERT_IF_DEBUG(GetPrimary() != empty_service);
-        ret.push_back(GetPrimary());
+        ASSERT_IF_DEBUG(m_addr.GetAddrPort().has_value());
+        return {m_addr};
     }
     // If MnNetInfo is empty, we probably don't expect any entries to show up, so
     // we return a blank set instead.
-    return ret;
+    return {};
 }
 
 const CService& MnNetInfo::GetPrimary() const

--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -163,6 +163,9 @@ NetInfoStatus MnNetInfo::ValidateService(const CService& service)
 
 NetInfoStatus MnNetInfo::AddEntry(const std::string& input)
 {
+    if (!IsEmpty()) {
+        return NetInfoStatus::MaxLimit;
+    }
     if (auto service_opt{Lookup(input, /*portDefault=*/Params().GetDefaultPort(), /*fAllowLookup=*/false)}) {
         const auto ret{ValidateService(*service_opt)};
         if (ret == NetInfoStatus::Success) {

--- a/src/evo/netinfo.h
+++ b/src/evo/netinfo.h
@@ -11,18 +11,31 @@
 class CService;
 
 enum class NetInfoStatus : uint8_t {
+    // Managing entries
     BadInput,
+
+    // Validation
+    BadAddress,
     BadPort,
+    BadType,
+    NotRoutable,
+
     Success
 };
 
 constexpr std::string_view NISToString(const NetInfoStatus code)
 {
     switch (code) {
-    case NetInfoStatus::BadInput:
+    case NetInfoStatus::BadAddress:
         return "invalid address";
+    case NetInfoStatus::BadInput:
+        return "invalid input";
     case NetInfoStatus::BadPort:
         return "invalid port";
+    case NetInfoStatus::BadType:
+        return "invalid address type";
+    case NetInfoStatus::NotRoutable:
+        return "unroutable address";
     case NetInfoStatus::Success:
         return "success";
     } // no default case, so the compiler can warn about missing cases

--- a/src/evo/netinfo.h
+++ b/src/evo/netinfo.h
@@ -16,6 +16,7 @@ class CService;
 enum class NetInfoStatus : uint8_t {
     // Managing entries
     BadInput,
+    MaxLimit,
 
     // Validation
     BadAddress,
@@ -42,6 +43,8 @@ constexpr std::string_view NISToString(const NetInfoStatus code)
         return "unroutable address";
     case NetInfoStatus::Malformed:
         return "malformed";
+    case NetInfoStatus::MaxLimit:
+        return "too many entries";
     case NetInfoStatus::Success:
         return "success";
     } // no default case, so the compiler can warn about missing cases

--- a/src/evo/netinfo.h
+++ b/src/evo/netinfo.h
@@ -119,7 +119,7 @@ public:
 
 template<> struct is_serializable_enum<NetInfoEntry::NetInfoType> : std::true_type {};
 
-using CServiceList = std::vector<std::reference_wrapper<const CService>>;
+using NetInfoList = std::vector<std::reference_wrapper<const NetInfoEntry>>;
 
 class MnNetInfo
 {
@@ -160,7 +160,7 @@ public:
     }
 
     NetInfoStatus AddEntry(const std::string& service);
-    CServiceList GetEntries() const;
+    NetInfoList GetEntries() const;
 
     const CService& GetPrimary() const;
     bool IsEmpty() const { return *this == MnNetInfo(); }

--- a/src/evo/netinfo.h
+++ b/src/evo/netinfo.h
@@ -7,6 +7,7 @@
 
 #include <netaddress.h>
 #include <serialize.h>
+#include <streams.h>
 
 #include <variant>
 
@@ -72,8 +73,9 @@ public:
     bool operator!=(const NetInfoEntry& rhs) const { return !(*this == rhs); }
 
     template <typename Stream>
-    void Serialize(Stream& s) const
+    void Serialize(Stream& s_) const
     {
+        OverrideStream<Stream> s(&s_, /*nType=*/0, s_.GetVersion() | ADDRV2_FORMAT);
         if (const auto* data_ptr{std::get_if<CService>(&m_data)};
             m_type == NetInfoType::Service && data_ptr && data_ptr->IsValid()) {
             s << m_type << *data_ptr;
@@ -83,8 +85,9 @@ public:
     }
 
     template <typename Stream>
-    void Unserialize(Stream& s)
+    void Unserialize(Stream& s_)
     {
+        OverrideStream<Stream> s(&s_, /*nType=*/0, s_.GetVersion() | ADDRV2_FORMAT);
         s >> m_type;
         if (m_type == NetInfoType::Service) {
             m_data = CService{};

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -36,6 +36,11 @@ bool CProRegTx::IsTriviallyValid(bool is_basic_scheme_active, TxValidationState&
     if (!scriptPayout.IsPayToPublicKeyHash() && !scriptPayout.IsPayToScriptHash()) {
         return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-payee");
     }
+    for (const NetInfoEntry& entry : netInfo.GetEntries()) {
+        if (!entry.IsTriviallyValid()) {
+            return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-bad");
+        }
+    }
 
     CTxDestination payoutDest;
     if (!ExtractDestination(scriptPayout, payoutDest)) {
@@ -104,6 +109,14 @@ bool CProUpServTx::IsTriviallyValid(bool is_basic_scheme_active, TxValidationSta
     }
     if (nVersion < ProTxVersion::BasicBLS && nType == MnType::Evo) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-evo-version");
+    }
+    if (netInfo.IsEmpty()) {
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-empty");
+    }
+    for (const NetInfoEntry& entry : netInfo.GetEntries()) {
+        if (!entry.IsTriviallyValid()) {
+            return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-netinfo-bad");
+        }
     }
 
     return true;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -568,7 +568,7 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
         std::string strAddress{};
         if (strMode == "addr" || strMode == "full" || strMode == "info" || strMode == "json" || strMode == "recent" ||
             strMode == "evo") {
-            for (const CService& entry : dmn.pdmnState->netInfo.GetEntries()) {
+            for (const NetInfoEntry& entry : dmn.pdmnState->netInfo.GetEntries()) {
                 strAddress += entry.ToStringAddrPort() + " ";
             }
             if (!strAddress.empty()) strAddress.pop_back(); // Remove trailing space

--- a/src/test/evo_netinfo_tests.cpp
+++ b/src/test/evo_netinfo_tests.cpp
@@ -21,13 +21,13 @@ const std::vector<std::pair</*input=*/std::string, /*expected_ret=*/NetInfoStatu
     // Non-mainnet port on mainnet
     {"1.1.1.1:9998", NetInfoStatus::BadPort},
     // Internal addresses not allowed on mainnet
-    {"127.0.0.1:9999", NetInfoStatus::BadInput},
+    {"127.0.0.1:9999", NetInfoStatus::NotRoutable},
     // Valid IPv4 formatting but invalid IPv4 address
-    {"0.0.0.0:9999", NetInfoStatus::BadInput},
+    {"0.0.0.0:9999", NetInfoStatus::BadAddress},
     // Port greater than uint16_t max
     {"1.1.1.1:99999", NetInfoStatus::BadInput},
     // Only IPv4 allowed
-    {"[2606:4700:4700::1111]:9999", NetInfoStatus::BadInput},
+    {"[2606:4700:4700::1111]:9999", NetInfoStatus::BadType},
     // Domains are not allowed
     {"example.com:9999", NetInfoStatus::BadInput},
     // Incorrect IPv4 address

--- a/src/test/evo_netinfo_tests.cpp
+++ b/src/test/evo_netinfo_tests.cpp
@@ -60,6 +60,14 @@ BOOST_AUTO_TEST_CASE(mnnetinfo_rules)
             ValidateGetEntries(netInfo.GetEntries(), /*expected_size=*/1);
         }
     }
+
+    {
+        // MnNetInfo only stores one value, overwriting prohibited
+        MnNetInfo netInfo;
+        BOOST_CHECK_EQUAL(netInfo.AddEntry("1.1.1.1:9999"), NetInfoStatus::Success);
+        BOOST_CHECK_EQUAL(netInfo.AddEntry("1.1.1.2:9999"), NetInfoStatus::MaxLimit);
+        ValidateGetEntries(netInfo.GetEntries(), /*expected_size=*/1);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(netinfo_ser)

--- a/src/test/evo_netinfo_tests.cpp
+++ b/src/test/evo_netinfo_tests.cpp
@@ -37,9 +37,12 @@ const std::vector<std::pair</*input=*/std::string, /*expected_ret=*/NetInfoStatu
     {":9999", NetInfoStatus::BadInput},
 };
 
-void ValidateGetEntries(const CServiceList& entries, const size_t expected_size)
+void ValidateGetEntries(const NetInfoList& entries, const size_t expected_size)
 {
     BOOST_CHECK_EQUAL(entries.size(), expected_size);
+    for (const NetInfoEntry& entry : entries) {
+        BOOST_CHECK(entry.IsTriviallyValid());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(mnnetinfo_rules)

--- a/src/test/evo_netinfo_tests.cpp
+++ b/src/test/evo_netinfo_tests.cpp
@@ -28,7 +28,7 @@ const std::vector<std::pair</*input=*/std::string, /*expected_ret=*/NetInfoStatu
     // Port greater than uint16_t max
     {"1.1.1.1:99999", NetInfoStatus::BadInput},
     // Only IPv4 allowed
-    {"[2606:4700:4700::1111]:9999", NetInfoStatus::BadType},
+    {"[2606:4700:4700::1111]:9999", NetInfoStatus::BadInput},
     // Domains are not allowed
     {"example.com:9999", NetInfoStatus::BadInput},
     // Incorrect IPv4 address
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(cservice_compatible)
     // Validation failure (non-IPv4 not allowed), MnNetInfo should remain empty if ValidateService() failed
     service = CService();
     netInfo.Clear();
-    BOOST_CHECK_EQUAL(netInfo.AddEntry("[2606:4700:4700::1111]:9999"), NetInfoStatus::BadType);
+    BOOST_CHECK_EQUAL(netInfo.AddEntry("[2606:4700:4700::1111]:9999"), NetInfoStatus::BadInput);
     BOOST_CHECK(CheckIfSerSame(service, netInfo));
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -691,7 +691,7 @@ void CTxMemPool::addUncheckedProTx(indexed_transaction_set::iterator& newit, con
         if (!proTx.collateralOutpoint.hash.IsNull()) {
             mapProTxRefs.emplace(tx_hash, proTx.collateralOutpoint.hash);
         }
-        for (const CService& entry : proTx.netInfo.GetEntries()) {
+        for (const NetInfoEntry& entry : proTx.netInfo.GetEntries()) {
             mapProTxAddresses.emplace(entry, tx_hash);
         }
         mapProTxPubKeyIDs.emplace(proTx.keyIDOwner, tx_hash);
@@ -704,7 +704,7 @@ void CTxMemPool::addUncheckedProTx(indexed_transaction_set::iterator& newit, con
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         auto proTx = *Assert(GetTxPayload<CProUpServTx>(tx));
         mapProTxRefs.emplace(proTx.proTxHash, tx_hash);
-        for (const CService& entry : proTx.netInfo.GetEntries()) {
+        for (const NetInfoEntry& entry : proTx.netInfo.GetEntries()) {
             mapProTxAddresses.emplace(entry, tx_hash);
         }
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_REGISTRAR) {
@@ -795,7 +795,7 @@ void CTxMemPool::removeUncheckedProTx(const CTransaction& tx)
         if (!proTx.collateralOutpoint.IsNull()) {
             eraseProTxRef(tx_hash, proTx.collateralOutpoint.hash);
         }
-        for (const CService& entry : proTx.netInfo.GetEntries()) {
+        for (const NetInfoEntry& entry : proTx.netInfo.GetEntries()) {
             mapProTxAddresses.erase(entry);
         }
         mapProTxPubKeyIDs.erase(proTx.keyIDOwner);
@@ -805,7 +805,7 @@ void CTxMemPool::removeUncheckedProTx(const CTransaction& tx)
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         auto proTx = *Assert(GetTxPayload<CProUpServTx>(tx));
         eraseProTxRef(proTx.proTxHash, tx_hash);
-        for (const CService& entry : proTx.netInfo.GetEntries()) {
+        for (const NetInfoEntry& entry : proTx.netInfo.GetEntries()) {
             mapProTxAddresses.erase(entry);
         }
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_REGISTRAR) {
@@ -1034,7 +1034,7 @@ void CTxMemPool::removeProTxConflicts(const CTransaction &tx)
         }
         auto& proTx = *opt_proTx;
 
-        for (const CService& entry : proTx.netInfo.GetEntries()) {
+        for (const NetInfoEntry& entry : proTx.netInfo.GetEntries()) {
             if (mapProTxAddresses.count(entry)) {
                 uint256 conflictHash = mapProTxAddresses[entry];
                 if (conflictHash != tx_hash && mapTx.count(conflictHash)) {
@@ -1056,7 +1056,7 @@ void CTxMemPool::removeProTxConflicts(const CTransaction &tx)
             return;
         }
 
-        for (const CService& entry : opt_proTx->netInfo.GetEntries()) {
+        for (const NetInfoEntry& entry : opt_proTx->netInfo.GetEntries()) {
             if (mapProTxAddresses.count(entry)) {
                 uint256 conflictHash = mapProTxAddresses[entry];
                 if (conflictHash != tx_hash && mapTx.count(conflictHash)) {
@@ -1394,7 +1394,7 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
             return true; // i.e. can't decode payload == conflict
         }
         auto& proTx = *opt_proTx;
-        for (const CService& entry : proTx.netInfo.GetEntries()) {
+        for (const NetInfoEntry& entry : proTx.netInfo.GetEntries()) {
             if (mapProTxAddresses.count(entry)) {
                 return true;
             }
@@ -1419,7 +1419,7 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
             LogPrint(BCLog::MEMPOOL, "%s: ERROR: Invalid transaction payload, tx: %s\n", __func__, tx_hash.ToString());
             return true; // i.e. can't decode payload == conflict
         }
-        for (const CService& entry : opt_proTx->netInfo.GetEntries()) {
+        for (const NetInfoEntry& entry : opt_proTx->netInfo.GetEntries()) {
             auto it = mapProTxAddresses.find(entry);
             if (it != mapProTxAddresses.end() && it->second != opt_proTx->proTxHash) {
                 return true;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -17,6 +17,7 @@
 #include <addressindex.h>
 #include <coins.h>
 #include <consensus/amount.h>
+#include <evo/netinfo.h>
 #include <gsl/pointers.h>
 #include <indirectmap.h>
 #include <netaddress.h>
@@ -525,7 +526,7 @@ private:
     std::map<uint256, std::vector<CSpentIndexKey>> mapSpentInserted;
 
     std::multimap<uint256, uint256> mapProTxRefs; // proTxHash -> transaction (all TXs that refer to an existing proTx)
-    std::map<CService, uint256> mapProTxAddresses;
+    std::map<NetInfoEntry, uint256> mapProTxAddresses;
     std::map<CKeyID, uint256> mapProTxPubKeyIDs;
     std::map<uint256, uint256> mapProTxBlsPubKeyHashes;
     std::map<COutPoint, uint256> mapProTxCollaterals;


### PR DESCRIPTION
## Motivation

The upcoming extended addresses specification envisions the ability to store address information _beyond_ the set of addresses that can be represented by BIP-155 (i.e. `CService`). To enable this, we need to devise a backwards-compatible way to allow storing and manipulating address information with differing serialization formats and validation rules.

Backwards compatibility is a priority as the unique properties set (used to detect attempts at storing already-registered values) only stores a hashed representation of the value and therefore, in-place migration is not a viable option.

With this in mind, this pull request introduces `NetInfoEntry`, which is wrapper around an `std::variant` that provides dispatching for common endpoints with `std::visit`, serialization and trivial validity enforcement between potential implementations and the ability to access the underlying type if necessary (for code that relies on backwards-compatibility, like hashing). It doesn't implement any network rules itself but requires that it must hold a valid instance of any underlying type that it supports.

While `MnNetInfo` (the current implementation) has and always will store a `CService`, to ensure a conformity between it and `ExtNetInfo` (the upcoming extended implementation), its public functions will return a `NetInfoEntry` when applicable so that both can be abstracted by a common interface to aid with the transition.

## Additional Information

* Depends on https://github.com/dashpay/dash/pull/6627

* Depends on https://github.com/dashpay/dash/pull/6664

* Dependency for https://github.com/dashpay/dash/pull/6665

* ~~2e9bde0519b242d1d7aaf49344a357b90121689e in [dash#6627](https://github.com/dashpay/dash/pull/6627) incorrectly migrated validation conditions such that attempting to set a valid `addr:port` combination on mainnet would result in a `BadPort` error because the non-mainnet rules were applied _regardless_ of network.~~

  ~~This evaded testing as our unit and functional tests do not run on mainnet. To prevent this from occurring again, the whole `evo_netinfo_tests` suite now uses `BasicTestingSetup` (which advertises itself as mainnet), which comes with the added benefit of greater coverage as mainnet rules are _stricter_.~~

  ~~The port validation check for non-mainnet networks are tested _indirectly_ through tests like `evo_simplifiedmns_merkleroots`'s usage of `NetInfoInterface::*` methods ([source](https://github.com/dashpay/dash/blob/0f94e3e3e793925caa24a73ad54d843770b1a8c5/src/test/evo_simplifiedmns_tests.cpp#L25)).~~ Superseded by [dash#6664](https://github.com/dashpay/dash/pull/6664).

* Per replies to review comments ([comment](https://github.com/dashpay/dash/pull/6627#discussion_r2078152332), [comment](https://github.com/dashpay/dash/pull/6627#discussion_r2078155944)) from [dash#6627](https://github.com/dashpay/dash/pull/6627), reported error codes from `netInfo` interactions have been expanded to be more specific.

* `CService` by default is serialized using ADDRV1 and utilizing ADDRV2 serialization is either explicitly opted into ([source](https://github.com/dashpay/dash/blob/0f94e3e3e793925caa24a73ad54d843770b1a8c5/src/addrman.cpp#L173-L175)) or determined on-the-fly ([source](https://github.com/dashpay/dash/blob/0f94e3e3e793925caa24a73ad54d843770b1a8c5/src/net_processing.cpp#L3960-L3965)). As we envision the ability to store Tor and I2P addresses, using ADDRV2 is mandatory.

  Though this affects (de)serialization of `NetInfoEntry`, it does not affect `MnNetInfo` as `NetInfoEntry` is only used for the sake of a consistent interface _but_ internally still (de)serializes to an ADDRV1 `CService`.

* The introduction of fast-failing based on permitted characters is meant to mirror the upcoming extended addresses implementation where permitted characters are used as a quick way to classify the intended underlying type before running more expensive checks.

  As a side effect, this may cause inconsistency where attempting to use `MnNetInfo::AddEntry()` with, for example, an IPv6 address will result in `BadInput` as the delimiter used in IPv6 addresses are not part of the permitted characters filter _but_ validating a `MnNetInfo` with an IPv6 address _already stored_ will return a `BadType`. 

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
