### PR TITLE
perf: versionbits avoid calculation which is not used

### DIFF
--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -73,6 +73,9 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
     assert(cache.count(pindexPrev));
     ThresholdState state = cache[pindexPrev];
 
+    // we should avoid heavy calculation of nStartHeight below if there's nothing to compute
+    if (vToCompute.empty()) return state;
+
     int nStartHeight = calculateStartHeight(pindexPrev, state, nPeriod, cache);
 
     // Now walk forward and compute the state of descendants of pindexPrev


### PR DESCRIPTION
## Issue being fixed or feature implemented
It seems as there's O(N^2) for some certain situations when calling `invalidateblock`.

See perf result during adding / removing blocks to chain:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/472e019e-905b-49b6-9786-aa7343eb5724" />



## What was done?
Call `calculateStartHeight` only if its result is going to be used.


## How Has This Been Tested?
```
$ getblockcount
2255311
$ getblockhash 2250000
00000000000000062539a6cd3adece4a10598e729ef571bfded9d4b704af69f0
$ invalidateblock 00000000000000062539a6cd3adece4a10598e729ef571bfded9d4b704af69f0
null
```
With changes in PR it takes 1minute, without them - 3 minutes.
<img width="687" alt="image" src="https://github.com/user-attachments/assets/967cb943-429d-405d-8aa2-cb192e0d8317" />

Mainnet re-indexed with no issues.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

