### PR TITLE
refactor: reduce ostringstream usage, set UniValue variable to object during construction, reduce `GetHash()` usage

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -44,9 +44,7 @@ std::string CDeterministicMN::ToString() const
 
 UniValue CDeterministicMN::ToJson() const
 {
-    UniValue obj;
-    obj.setObject();
-
+    UniValue obj(UniValue::VOBJ);
     obj.pushKV("type", std::string(GetMnType(nType).description));
     obj.pushKV("proTxHash", proTxHash.ToString());
     obj.pushKV("collateralHash", collateralOutpoint.hash.ToString());

--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -37,8 +37,7 @@ std::string CDeterministicMNState::ToString() const
 
 UniValue CDeterministicMNState::ToJson(MnType nType) const
 {
-    UniValue obj;
-    obj.setObject();
+    UniValue obj(UniValue::VOBJ);
     obj.pushKV("version", nVersion);
     obj.pushKV("service", addr.ToStringAddrPort());
     obj.pushKV("registeredHeight", nRegisteredHeight);
@@ -69,8 +68,7 @@ UniValue CDeterministicMNState::ToJson(MnType nType) const
 
 UniValue CDeterministicMNStateDiff::ToJson(MnType nType) const
 {
-    UniValue obj;
-    obj.setObject();
+    UniValue obj(UniValue::VOBJ);
     if (fields & Field_nVersion) {
         obj.pushKV("version", state.nVersion);
     }

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -49,9 +49,7 @@ public:
 
     [[nodiscard]] UniValue ToJson() const
     {
-        UniValue obj;
-        obj.clear();
-        obj.setObject();
+        UniValue obj(UniValue::VOBJ);
         obj.pushKV("versionBit", (int)versionBit);
         obj.pushKV("quorumHash", quorumHash.ToString());
         obj.pushKV("sig", sig.ToString());

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -72,8 +72,7 @@ std::string CSimplifiedMNListEntry::ToString() const
 
 UniValue CSimplifiedMNListEntry::ToJson(bool extended) const
 {
-    UniValue obj;
-    obj.setObject();
+    UniValue obj(UniValue::VOBJ);
     obj.pushKV("nVersion", nVersion);
     obj.pushKV("nType", ToUnderlying(nType));
     obj.pushKV("proRegTxHash", proRegTxHash.ToString());
@@ -239,8 +238,7 @@ bool CSimplifiedMNListDiff::BuildQuorumChainlockInfo(const llmq::CQuorumManager&
 
 UniValue CSimplifiedMNListDiff::ToJson(bool extended) const
 {
-    UniValue obj;
-    obj.setObject();
+    UniValue obj(UniValue::VOBJ);
 
     obj.pushKV("nVersion", nVersion);
     obj.pushKV("baseBlockHash", baseBlockHash.ToString());

--- a/src/governance/exceptions.cpp
+++ b/src/governance/exceptions.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <governance/exceptions.h>
+#include <tinyformat.h>
 
 #include <iostream>
 #include <sstream>
@@ -32,11 +33,8 @@ std::ostream& operator<<(std::ostream& os, governance_exception_type_enum_t eTyp
 CGovernanceException::CGovernanceException(const std::string& strMessageIn,
                                            governance_exception_type_enum_t eTypeIn,
                                            int nNodePenaltyIn) :
-    strMessage(),
-    eType(eTypeIn),
-    nNodePenalty(nNodePenaltyIn)
+    strMessage{strprintf("%s:%s", eTypeIn, strMessageIn)},
+    eType{eTypeIn},
+    nNodePenalty{nNodePenaltyIn}
 {
-    std::ostringstream ostr;
-    ostr << eType << ":" << strMessageIn;
-    strMessage = ostr.str();
 }

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -99,13 +99,10 @@ std::string CGovernanceVote::ToString(const CDeterministicMNList& tip_mn_list) c
 {
     auto dmn = tip_mn_list.GetMNByCollateral(masternodeOutpoint);
     int voteWeight = dmn != nullptr ? GetMnType(dmn->nType).voting_weight : 0;
-    std::ostringstream ostr;
-    ostr << masternodeOutpoint.ToStringShort() << ":"
-         << nTime << ":"
-         << CGovernanceVoting::ConvertOutcomeToString(GetOutcome()) << ":"
-         << CGovernanceVoting::ConvertSignalToString(GetSignal()) << ":"
-         << voteWeight;
-    return ostr.str();
+    return strprintf("%s:%d:%s:%s:%d",
+        masternodeOutpoint.ToStringShort(), nTime,
+        CGovernanceVoting::ConvertOutcomeToString(GetOutcome()), CGovernanceVoting::ConvertSignalToString(GetSignal()),
+        voteWeight);
 }
 
 void CGovernanceVote::Relay(PeerManager& peerman, const CMasternodeSync& mn_sync, const CDeterministicMNList& tip_mn_list) const

--- a/src/llmq/commitment.h
+++ b/src/llmq/commitment.h
@@ -121,8 +121,7 @@ public:
 
     [[nodiscard]] UniValue ToJson() const
     {
-        UniValue obj;
-        obj.setObject();
+        UniValue obj(UniValue::VOBJ);
         obj.pushKV("version", int{nVersion});
         obj.pushKV("llmqType", ToUnderlying(llmqType));
         obj.pushKV("quorumHash", quorumHash.ToString());

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -23,8 +23,7 @@ static const std::string DB_QUORUM_SNAPSHOT = "llmq_S";
 
 UniValue CQuorumSnapshot::ToJson() const
 {
-    UniValue obj;
-    obj.setObject();
+    UniValue obj(UniValue::VOBJ);
     UniValue activeQ(UniValue::VARR);
     for (const bool h : activeQuorumMembers) {
         // cppcheck-suppress useStlAlgorithm
@@ -43,8 +42,7 @@ UniValue CQuorumSnapshot::ToJson() const
 
 UniValue CQuorumRotationInfo::ToJson() const
 {
-    UniValue obj;
-    obj.setObject();
+    UniValue obj(UniValue::VOBJ);
     obj.pushKV("extraShare", extraShare);
 
     obj.pushKV("quorumSnapshotAtHMinusC", quorumSnapshotAtHMinusC.ToJson());

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -129,9 +129,6 @@ std::vector<uint256> CMasternodeMetaMan::GetAndClearDirtyGovernanceObjectHashes(
 
 std::string MasternodeMetaStore::ToString() const
 {
-    std::ostringstream info;
     LOCK(cs);
-    info << "Masternodes: meta infos object count: " << (int)metaInfos.size() <<
-         ", nDsqCount: " << (int)nDsqCount;
-    return info.str();
+    return strprintf("Masternodes: meta infos object count: %d, nDsqCount: %d", metaInfos.size(), nDsqCount);
 }

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -87,9 +87,7 @@ void NetFulfilledRequestStore::Clear()
 
 std::string NetFulfilledRequestStore::ToString() const
 {
-    std::ostringstream info;
-    info << "Nodes with fulfilled requests: " << (int)mapFulfilledRequests.size();
-    return info.str();
+    return strprintf("Nodes with fulfilled requests: %d", mapFulfilledRequests.size());
 }
 
 void CNetFulfilledRequestManager::DoMaintenance()

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -680,7 +680,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
         paramIdx += 2;
     }
 
-    if (request.params[paramIdx].get_str() != "") {
+    if (!request.params[paramIdx].get_str().empty()) {
         if (auto addr = Lookup(request.params[paramIdx].get_str(), Params().GetDefaultPort(), false); addr.has_value()) {
             ptx.addr = addr.value();
         } else {
@@ -694,7 +694,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
 
     CKeyID keyIDVoting = ptx.keyIDOwner;
 
-    if (request.params[paramIdx + 3].get_str() != "") {
+    if (!request.params[paramIdx + 3].get_str().empty()) {
         keyIDVoting = ParsePubKeyIDFromAddress(request.params[paramIdx + 3].get_str(), "voting address");
     }
 
@@ -1106,7 +1106,7 @@ static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_
     ptx.keyIDVoting = dmn->pdmnState->keyIDVoting;
     ptx.scriptPayout = dmn->pdmnState->scriptPayout;
 
-    if (request.params[1].get_str() != "") {
+    if (!request.params[1].get_str().empty()) {
         // new pubkey
         ptx.pubKeyOperator.Set(ParseBLSPubKey(request.params[1].get_str(), "operator BLS address", use_legacy), use_legacy);
     } else {
@@ -1116,13 +1116,13 @@ static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_
 
     CHECK_NONFATAL(ptx.pubKeyOperator.IsLegacy() == (ptx.nVersion == ProTxVersion::LegacyBLS));
 
-    if (request.params[2].get_str() != "") {
+    if (!request.params[2].get_str().empty()) {
         ptx.keyIDVoting = ParsePubKeyIDFromAddress(request.params[2].get_str(), "voting address");
     }
 
     CTxDestination payoutDest;
     ExtractDestination(ptx.scriptPayout, payoutDest);
-    if (request.params[3].get_str() != "") {
+    if (!request.params[3].get_str().empty()) {
         payoutDest = DecodeDestination(request.params[3].get_str());
         if (!IsValidDestination(payoutDest)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("invalid payout address: %s", request.params[3].get_str()));

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -570,43 +570,38 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, strAddress);
         } else if (strMode == "full") {
-            std::ostringstream streamFull;
-            streamFull << std::setw(18) <<
-                           dmnToStatus(dmn) << " " <<
-                           dmn.pdmnState->nPoSePenalty << " " <<
-                           payeeStr << " " << std::setw(10) <<
-                           dmnToLastPaidTime(dmn) << " "  << std::setw(6) <<
-                           dmn.pdmnState->nLastPaidHeight << " " <<
-                           dmn.pdmnState->addr.ToStringAddrPort();
-            std::string strFull = streamFull.str();
+            std::string strFull = strprintf("%s %d %s %s %s %s",
+                                    PadString(dmnToStatus(dmn), 18),
+                                    dmn.pdmnState->nPoSePenalty,
+                                    payeeStr,
+                                    PadString(ToString(dmnToLastPaidTime(dmn)), 10),
+                                    PadString(ToString(dmn.pdmnState->nLastPaidHeight), 6),
+                                    dmn.pdmnState->addr.ToStringAddrPort());
             if (strFilter !="" && strFull.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, strFull);
         } else if (strMode == "info") {
-            std::ostringstream streamInfo;
-            streamInfo << std::setw(18) <<
-                           dmnToStatus(dmn) << " " <<
-                           dmn.pdmnState->nPoSePenalty << " " <<
-                           payeeStr << " " <<
-                           dmn.pdmnState->addr.ToStringAddrPort();
-            std::string strInfo = streamInfo.str();
+            std::string strInfo = strprintf("%s %d %s %s",
+                                    PadString(dmnToStatus(dmn), 18),
+                                    dmn.pdmnState->nPoSePenalty,
+                                    payeeStr,
+                                    dmn.pdmnState->addr.ToStringAddrPort());
             if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, strInfo);
         } else if (strMode == "json" || strMode == "recent" || strMode == "evo") {
-            std::ostringstream streamInfo;
-            streamInfo <<  dmn.proTxHash.ToString() << " " <<
-                           dmn.pdmnState->addr.ToStringAddrPort() << " " <<
-                           payeeStr << " " <<
-                           dmnToStatus(dmn) << " " <<
-                           dmn.pdmnState->nPoSePenalty << " " <<
-                           dmnToLastPaidTime(dmn) << " " <<
-                           dmn.pdmnState->nLastPaidHeight << " " <<
-                           EncodeDestination(PKHash(dmn.pdmnState->keyIDOwner)) << " " <<
-                           EncodeDestination(PKHash(dmn.pdmnState->keyIDVoting)) << " " <<
-                           collateralAddressStr << " " <<
-                           dmn.pdmnState->pubKeyOperator.ToString();
-            std::string strInfo = streamInfo.str();
+            std::string strInfo = strprintf("%s %s %s %s %d %d %d %s %s %s %s",
+                                    dmn.proTxHash.ToString(),
+                                    dmn.pdmnState->addr.ToStringAddrPort(),
+                                    payeeStr,
+                                    dmnToStatus(dmn),
+                                    dmn.pdmnState->nPoSePenalty,
+                                    dmnToLastPaidTime(dmn),
+                                    dmn.pdmnState->nLastPaidHeight,
+                                    EncodeDestination(PKHash(dmn.pdmnState->keyIDOwner)),
+                                    EncodeDestination(PKHash(dmn.pdmnState->keyIDVoting)),
+                                    collateralAddressStr,
+                                    dmn.pdmnState->pubKeyOperator.ToString());
             if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             UniValue objMN(UniValue::VOBJ);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -263,7 +263,7 @@ static RPCHelpMan masternode_winners()
         auto payee = node.dmnman->GetListForBlock(pIndex).GetMNPayee(pIndex);
         if (payee) {
             std::string strPayments = GetRequiredPaymentsString(*CHECK_NONFATAL(node.govman), tip_mn_list, h, payee);
-            if (strFilter != "" && strPayments.find(strFilter) == std::string::npos) continue;
+            if (!strFilter.empty() && strPayments.find(strFilter) == std::string::npos) continue;
             obj.pushKV(strprintf("%d", h), strPayments);
         }
     }
@@ -272,7 +272,7 @@ static RPCHelpMan masternode_winners()
     for (size_t i = 0; i < projection.size(); i++) {
         int h = nChainTipHeight + 1 + i;
         std::string strPayments = GetRequiredPaymentsString(*node.govman, tip_mn_list, h, projection[i]);
-        if (strFilter != "" && strPayments.find(strFilter) == std::string::npos) continue;
+        if (!strFilter.empty() && strPayments.find(strFilter) == std::string::npos) continue;
         obj.pushKV(strprintf("%d", h), strPayments);
     }
 
@@ -566,7 +566,7 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
 
         if (strMode == "addr") {
             std::string strAddress = dmn.pdmnState->addr.ToStringAddrPort();
-            if (strFilter !="" && strAddress.find(strFilter) == std::string::npos &&
+            if (!strFilter.empty() && strAddress.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, strAddress);
         } else if (strMode == "full") {
@@ -577,7 +577,7 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
                                     PadString(ToString(dmnToLastPaidTime(dmn)), 10),
                                     PadString(ToString(dmn.pdmnState->nLastPaidHeight), 6),
                                     dmn.pdmnState->addr.ToStringAddrPort());
-            if (strFilter !="" && strFull.find(strFilter) == std::string::npos &&
+            if (!strFilter.empty() && strFull.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, strFull);
         } else if (strMode == "info") {
@@ -586,7 +586,7 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
                                     dmn.pdmnState->nPoSePenalty,
                                     payeeStr,
                                     dmn.pdmnState->addr.ToStringAddrPort());
-            if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
+            if (!strFilter.empty() && strInfo.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, strInfo);
         } else if (strMode == "json" || strMode == "recent" || strMode == "evo") {
@@ -602,7 +602,7 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
                                     EncodeDestination(PKHash(dmn.pdmnState->keyIDVoting)),
                                     collateralAddressStr,
                                     dmn.pdmnState->pubKeyOperator.ToString());
-            if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
+            if (!strFilter.empty() && strInfo.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             UniValue objMN(UniValue::VOBJ);
             objMN.pushKV("proTxHash", dmn.proTxHash.ToString());
@@ -625,28 +625,28 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
             objMN.pushKV("pubkeyoperator", dmn.pdmnState->pubKeyOperator.ToString());
             obj.pushKV(strOutpoint, objMN);
         } else if (strMode == "lastpaidblock") {
-            if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
+            if (!strFilter.empty() && strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, dmn.pdmnState->nLastPaidHeight);
         } else if (strMode == "lastpaidtime") {
-            if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
+            if (!strFilter.empty() && strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, dmnToLastPaidTime(dmn));
         } else if (strMode == "payee") {
-            if (strFilter !="" && payeeStr.find(strFilter) == std::string::npos &&
+            if (!strFilter.empty() && payeeStr.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, payeeStr);
         } else if (strMode == "owneraddress") {
-            if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
+            if (!strFilter.empty() && strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, EncodeDestination(PKHash(dmn.pdmnState->keyIDOwner)));
         } else if (strMode == "pubkeyoperator") {
-            if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
+            if (!strFilter.empty() && strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, dmn.pdmnState->pubKeyOperator.ToString());
         } else if (strMode == "status") {
             std::string strStatus = dmnToStatus(dmn);
-            if (strFilter !="" && strStatus.find(strFilter) == std::string::npos &&
+            if (!strFilter.empty() && strStatus.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, strStatus);
         } else if (strMode == "votingaddress") {
-            if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
+            if (!strFilter.empty() && strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, EncodeDestination(PKHash(dmn.pdmnState->keyIDVoting)));
         }
     });

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1828,4 +1828,26 @@ BOOST_AUTO_TEST_CASE(clearshrink_test)
     }
 }
 
+BOOST_AUTO_TEST_CASE(padding_test)
+{
+    /* By default strings will be padded to the left */
+    BOOST_CHECK_EQUAL(PadString("example", 8), " example");
+
+    /* Check padding works on the correct side */
+    BOOST_CHECK_EQUAL(PadString("example", 8, /*left=*/true),  " example");
+    BOOST_CHECK_EQUAL(PadString("example", 8, /*left=*/false), "example ");
+
+    /* Padding lesser than the string size should return the string */
+    BOOST_CHECK_EQUAL(PadString("example", 6), "example");
+
+    /* Padding equal to the string size should return the string */
+    BOOST_CHECK_EQUAL(PadString("example", 7), "example");
+
+    /* Padding an empty string with zero length should return an empty string */
+    BOOST_CHECK(PadString("", 0).empty());
+
+    /* An empty string should be padded if non-zero length specified */
+    BOOST_CHECK_EQUAL(PadString("", 1), " ");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -57,6 +57,12 @@ void ReplaceAll(std::string& in_out, const std::string& search, const std::strin
     return std::string(RemovePrefixView(str, prefix));
 }
 
+[[nodiscard]] inline std::string PadString(std::string str, std::string::size_type size, bool left = true)
+{
+    if (size <= str.size()) return str;
+    return left ? std::string(size - str.size(), ' ').append(str) : str.append(std::string(size - str.size(), ' '));
+}
+
 /**
  * Join all container items. Typically used to concatenate strings but accepts
  * containers with elements of any type.


### PR DESCRIPTION
## Additional Information

* Dependency for https://github.com/dashpay/dash/pull/6627

* We use `std::ostringstream` in `masternodelist` to pad values using `std::setw` ([source](https://github.com/dashpay/dash/blob/bcd14b05cec7d94986f114ca17bbdadbee701d9b/src/rpc/masternode.cpp#L574-L575)) for consistency, this was fine because we didn't plan on removing anything from the stream after it was added.

  But in [dash#6627](https://github.com/dashpay/dash/pull/6627), we intend to print multiple addresses and need to remove excess padding after the last entry, which can be trivially done with a `pop_back()` ([source](https://github.com/dashpay/dash/blob/bba9c6dd8e2edbbb83a26763a1d64209409b5b82/src/rpc/masternode.cpp#L569-L572)) but that cannot be done with a `std::ostringstream`. The best that can be done is rewinding the cursor but that doesn't change its contents and at most lets you overwrite it ([source](https://stackoverflow.com/a/26492431)), which is fine when you do have something to overwrite it with but this isn't always the case.

  To get around this, `PadString()` has been implemented and `std::ostringstream` usage has been replaced with constructing a string with `strprintf`.



## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

