### PR TITLE
fix: resolve or sidestep compiler warnings, re-enable `-Werror` for Clang, merge bitcoin#13633

### DIFF
--- a/ci/test/00_setup_env_mac.sh
+++ b/ci/test/00_setup_env_mac.sh
@@ -15,4 +15,3 @@ export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export GOAL="all deploy"
 export BITCOIN_CONFIG="--with-gui --enable-reduce-exports --disable-miner --with-boost-process"
-export NO_WERROR=1

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -16,4 +16,3 @@ export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --disable-ccache --enable-fuzz --with-sanitizers=fuzzer,address,undefined,integer CC='clang-18 -ftrivial-auto-var-init=pattern' CXX='clang++-18 -ftrivial-auto-var-init=pattern' --with-boost-process"
-export NO_WERROR=1

--- a/ci/test/00_setup_env_native_multiprocess.sh
+++ b/ci/test/00_setup_env_native_multiprocess.sh
@@ -17,4 +17,3 @@ export BITCOIN_CONFIG="--with-boost-process --enable-debug CC=clang-18 CXX=clang
 # Additional flags for RUN_TIDY
 export BITCOIN_CONFIG="${BITCOIN_CONFIG} --disable-hardening CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0 -Wno-error=documentation'"
 export BITCOIND=dash-node  # Used in functional tests
-export NO_WERROR=1

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -15,4 +15,3 @@ export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-sanitizers=thread CC=clang-18 CXX=clang++-18 CXXFLAGS='-g' --with-boost-process"
 export CPPFLAGS="-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION"
 export PYZMQ=true
-export NO_WERROR=1

--- a/ci/test/00_setup_env_native_ubsan.sh
+++ b/ci/test/00_setup_env_native_ubsan.sh
@@ -13,4 +13,3 @@ export DEP_OPTS="NO_UPNP=1 DEBUG=1"
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --with-sanitizers=undefined CC=clang-18 CXX=clang++-18"
 export PYZMQ=true
-export NO_WERROR=1

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -12,4 +12,3 @@ export NO_DEPENDS=1
 export TEST_RUNNER_EXTRA="--exclude rpc_bind,feature_bind_extra --timeout-factor=4"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang-18 CXX=clang++-18"  # TODO enable GUI
-export NO_WERROR=1

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -139,7 +139,6 @@ class CCoinJoinClientSession : public CCoinJoinBaseSession
 {
 private:
     const std::shared_ptr<CWallet> m_wallet;
-    CoinJoinWalletManager& m_walletman;
     CCoinJoinClientManager& m_clientman;
     CDeterministicMNManager& m_dmnman;
     CMasternodeMetaMan& m_mn_metaman;
@@ -201,10 +200,9 @@ private:
     void SetNull() override EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
 public:
-    explicit CCoinJoinClientSession(const std::shared_ptr<CWallet>& wallet, CoinJoinWalletManager& walletman,
-                                    CCoinJoinClientManager& clientman, CDeterministicMNManager& dmnman,
-                                    CMasternodeMetaMan& mn_metaman, const CMasternodeSync& mn_sync,
-                                    const llmq::CInstantSendManager& isman,
+    explicit CCoinJoinClientSession(const std::shared_ptr<CWallet>& wallet, CCoinJoinClientManager& clientman,
+                                    CDeterministicMNManager& dmnman, CMasternodeMetaMan& mn_metaman,
+                                    const CMasternodeSync& mn_sync, const llmq::CInstantSendManager& isman,
                                     const std::unique_ptr<CCoinJoinClientQueueManager>& queueman, bool is_masternode);
 
     void ProcessMessage(CNode& peer, CChainState& active_chainstate, CConnman& connman, const CTxMemPool& mempool, std::string_view msg_type, CDataStream& vRecv);
@@ -266,7 +264,6 @@ class CCoinJoinClientManager
 {
 private:
     const std::shared_ptr<CWallet> m_wallet;
-    CoinJoinWalletManager& m_walletman;
     CDeterministicMNManager& m_dmnman;
     CMasternodeMetaMan& m_mn_metaman;
     const CMasternodeSync& m_mn_sync;
@@ -305,12 +302,11 @@ public:
     CCoinJoinClientManager(CCoinJoinClientManager const&) = delete;
     CCoinJoinClientManager& operator=(CCoinJoinClientManager const&) = delete;
 
-    explicit CCoinJoinClientManager(const std::shared_ptr<CWallet>& wallet, CoinJoinWalletManager& walletman,
-                                    CDeterministicMNManager& dmnman, CMasternodeMetaMan& mn_metaman,
-                                    const CMasternodeSync& mn_sync, const llmq::CInstantSendManager& isman,
+    explicit CCoinJoinClientManager(const std::shared_ptr<CWallet>& wallet, CDeterministicMNManager& dmnman,
+                                    CMasternodeMetaMan& mn_metaman, const CMasternodeSync& mn_sync,
+                                    const llmq::CInstantSendManager& isman,
                                     const std::unique_ptr<CCoinJoinClientQueueManager>& queueman, bool is_masternode) :
         m_wallet(wallet),
-        m_walletman(walletman),
         m_dmnman(dmnman),
         m_mn_metaman(mn_metaman),
         m_mn_sync(mn_sync),

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -317,6 +317,7 @@ public:
     int nSessionDenom{0}; // Users must submit a denom matching this
 
     CCoinJoinBaseSession() = default;
+    virtual ~CCoinJoinBaseSession() = default;
 
     int GetState() const { return nState; }
     std::string GetStateString() const;

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -235,10 +235,10 @@ CCreditPoolManager::CCreditPoolManager(CEvoDB& _evoDb)
 {
 }
 
-CCreditPoolDiff::CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindexPrev, const Consensus::Params& consensusParams, const CAmount blockSubsidy) :
+CCreditPoolDiff::CCreditPoolDiff(CCreditPool starter, const CBlockIndex* pindexPrev,
+                                 const Consensus::Params& consensusParams, const CAmount blockSubsidy) :
     pool(std::move(starter)),
-    pindexPrev(pindexPrev),
-    params(consensusParams)
+    pindexPrev(pindexPrev)
 {
     assert(pindexPrev);
 

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -75,7 +75,7 @@ private:
     CAmount platformReward{0};
 
     const CBlockIndex *pindexPrev{nullptr};
-    const Consensus::Params& params;
+
 public:
     explicit CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindexPrev,
                              const Consensus::Params& consensusParams,

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1187,32 +1187,6 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
 
 }
 
-[[nodiscard]] static bool EraseOldDBData(CDBWrapper& db, const std::vector<std::string>& db_key_prefixes)
-{
-    bool erased{false};
-    for(const auto& db_key_prefix : db_key_prefixes) {
-        CDBBatch batch{db};
-        std::unique_ptr<CDBIterator> it{db.NewIterator()};
-        std::pair firstKey{db_key_prefix, uint256()};
-        it->Seek(firstKey);
-        while (it->Valid()) {
-            decltype(firstKey) curKey;
-            if (!it->GetKey(curKey) || std::get<0>(curKey) != db_key_prefix) {
-                break;
-            }
-            batch.Erase(curKey);
-            erased = true;
-            it->Next();
-        }
-        if (erased) {
-            LogPrintf("CDeterministicMNManager::%s -- updating db...\n", __func__);
-            db.WriteBatch(batch);
-            LogPrintf("CDeterministicMNManager::%s -- done cleaning old data for %s\n", __func__, db_key_prefix);
-        }
-    }
-    return erased;
-}
-
 template <typename ProTx>
 static bool CheckService(const ProTx& proTx, TxValidationState& state)
 {

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -563,7 +563,6 @@ private:
     // Main thread has indicated we should perform cleanup up to this height
     std::atomic<int> to_cleanup {0};
 
-    CChainState& m_chainstate;
     CEvoDB& m_evoDb;
 
     std::unordered_map<uint256, CDeterministicMNList, StaticSaltedHasher> mnListsCache GUARDED_BY(cs);
@@ -572,8 +571,7 @@ private:
     const CBlockIndex* m_initial_snapshot_index GUARDED_BY(cs) {nullptr};
 
 public:
-    explicit CDeterministicMNManager(CChainState& chainstate, CEvoDB& evoDb) :
-        m_chainstate(chainstate),
+    explicit CDeterministicMNManager(CEvoDB& evoDb) :
         m_evoDb(evoDb)
     {
     }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -213,7 +213,7 @@ void DashChainstateSetup(ChainstateManager& chainman,
 {
     // Same logic as pblocktree
     dmnman.reset();
-    dmnman = std::make_unique<CDeterministicMNManager>(chainman.ActiveChainstate(), *evodb);
+    dmnman = std::make_unique<CDeterministicMNManager>(*evodb);
 
     cpoolman.reset();
     cpoolman = std::make_unique<CCreditPoolManager>(*evodb);

--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -91,19 +91,6 @@ static void ApplyStats(CCoinsStats& stats, const uint256& hash, const std::map<u
     }
 }
 
-static void ApplyStats(CCoinsStats& stats, std::nullptr_t, const uint256& hash, const std::map<uint32_t, Coin>& outputs)
-{
-    assert(!outputs.empty());
-    stats.nTransactions++;
-    for (const auto& output : outputs) {
-        stats.nTransactionOutputs++;
-        if (stats.total_amount.has_value()) {
-            stats.total_amount = CheckedAdd(*stats.total_amount, output.second.out.nValue);
-        }
-        stats.nBogoSize += GetBogoSize(output.second.out.scriptPubKey);
-    }
-}
-
 //! Calculate statistics about the unspent transaction output set
 template <typename T>
 static bool GetUTXOStats(CCoinsView* view, BlockManager& blockman, CCoinsStats& stats, T hash_obj, const std::function<void()>& interruption_point, const CBlockIndex* pindex)

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -24,9 +24,9 @@ static const struct {
     const std::string titleAddText;
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
-    {"test", QAPP_APP_NAME_TESTNET, 190, 20},
+    {"test", QAPP_APP_NAME_TESTNET, 190, 20, ""},
     {"devnet", QAPP_APP_NAME_DEVNET, 190, 20, "[devnet: %s]"},
-    {"regtest", QAPP_APP_NAME_REGTEST, 160, 30}
+    {"regtest", QAPP_APP_NAME_REGTEST, 160, 30, ""}
 };
 
 void NetworkStyle::rotateColor(QColor& col, const int iconColorHueShift, const int iconColorSaturationReduction)

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -180,6 +180,19 @@ static RPCArg GetRpcArg(const std::string& strParamName)
     return it->second;
 }
 
+static CBLSSecretKey ParseBLSSecretKey(const std::string& hexKey, const std::string& paramName)
+{
+    CBLSSecretKey secKey;
+
+    // Actually, bool flag for bls::PrivateKey has other meaning (modOrder)
+    if (!secKey.SetHexStr(hexKey, false)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s must be a valid BLS secret key", paramName));
+    }
+    return secKey;
+}
+
+#ifdef ENABLE_WALLET
+
 static CKeyID ParsePubKeyIDFromAddress(const std::string& strAddress, const std::string& paramName)
 {
     CTxDestination dest = DecodeDestination(strAddress);
@@ -199,23 +212,10 @@ static CBLSPublicKey ParseBLSPubKey(const std::string& hexKey, const std::string
     return pubKey;
 }
 
-static CBLSSecretKey ParseBLSSecretKey(const std::string& hexKey, const std::string& paramName)
-{
-    CBLSSecretKey secKey;
-
-    // Actually, bool flag for bls::PrivateKey has other meaning (modOrder)
-    if (!secKey.SetHexStr(hexKey, false)) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s must be a valid BLS secret key", paramName));
-    }
-    return secKey;
-}
-
 static bool ValidatePlatformPort(const int32_t port)
 {
     return port >= 1 && port <= std::numeric_limits<uint16_t>::max();
 }
-
-#ifdef ENABLE_WALLET
 
 template <typename SpecialTxPayload>
 static void FundSpecialTx(CWallet& wallet, CMutableTransaction& tx, const SpecialTxPayload& payload,

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -48,7 +48,7 @@ public:
         return *this;
     }
 
-    int GetVersion() const { return m_version; }
+    [[maybe_unused]] int GetVersion() const { return m_version; }
 private:
     const int m_version;
     const unsigned char* m_data;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1521,7 +1521,7 @@ template void PrecomputedTransactionData::Init(const CMutableTransaction& txTo, 
 template PrecomputedTransactionData::PrecomputedTransactionData(const CTransaction& txTo);
 template PrecomputedTransactionData::PrecomputedTransactionData(const CMutableTransaction& txTo);
 
-static bool HandleMissingData(MissingDataBehavior mdb)
+[[maybe_unused]] static bool HandleMissingData(MissingDataBehavior mdb)
 {
     switch (mdb) {
     case MissingDataBehavior::ASSERT_FAIL:

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -239,16 +239,10 @@ struct Stacks
 {
     std::vector<valtype> script;
 
-    Stacks() {}
-    explicit Stacks(const std::vector<valtype>& scriptSigStack_) : script(scriptSigStack_) {}
+    Stacks() = delete;
+    Stacks(const Stacks&) = delete;
     explicit Stacks(const SignatureData& data) {
         EvalScript(script, data.scriptSig, SCRIPT_VERIFY_STRICTENC, BaseSignatureChecker(), SigVersion::BASE);
-    }
-
-    SignatureData Output() const {
-        SignatureData result;
-        result.scriptSig = PushAll(script);
-        return result;
     }
 };
 }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -282,19 +282,19 @@ public:
         return *this;
     }
 
-    TestBuilder& Push(const std::string& hex)
+    [[maybe_unused]] TestBuilder& Push(const std::string& hex)
     {
         DoPush(ParseHex(hex));
         return *this;
     }
 
-    TestBuilder& Push(const uint256& hash)
+    [[maybe_unused]] TestBuilder& Push(const uint256& hash)
     {
         DoPush(ToByteVector(hash));
         return *this;
     }
 
-    TestBuilder& Push(const CScript& script)
+    [[maybe_unused]] TestBuilder& Push(const CScript& script)
     {
          DoPush(std::vector<unsigned char>(script.begin(), script.end()));
         return *this;

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -107,13 +107,16 @@ class AbstractEHFManager
 public:
     using Signals = std::unordered_map<uint8_t, int>;
 
+public:
+    AbstractEHFManager() = default;
+    virtual ~AbstractEHFManager() = default;
+
     /**
      * getInstance() is used in versionbit because it is non-trivial
      * to get access to NodeContext from all usages of VersionBits* methods
      * For simplification of interface this methods static/global variable is used
      * to get access to EHF data
      */
-public:
     [[nodiscard]] static gsl::not_null<AbstractEHFManager*> getInstance() {
         return globalInstance;
     };
@@ -126,7 +129,6 @@ public:
      * This member function is not const because it calls non-const GetFromCache()
      */
     virtual Signals GetSignalsStage(const CBlockIndex* const pindexPrev) = 0;
-
 
 protected:
     static AbstractEHFManager* globalInstance;

--- a/src/wallet/hdchain.h
+++ b/src/wallet/hdchain.h
@@ -122,7 +122,7 @@ class CHDPubKey
 {
 private:
     static const int CURRENT_VERSION = 1;
-    int nVersion{CHDPubKey::CURRENT_VERSION};
+    [[maybe_unused]] int nVersion{CHDPubKey::CURRENT_VERSION};
 
 public:
     CExtPubKey extPubKey{};

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -952,6 +952,8 @@ struct tallyitem
 
 static UniValue ListReceived(const CWallet& wallet, const UniValue& params, const bool by_label, const bool include_immature_coinbase) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
+    AssertLockHeld(wallet.cs_wallet);
+
     // Minimum confirmations
     int nMinDepth = 1;
     if (!params[0].isNull())
@@ -1029,7 +1031,11 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
     UniValue ret(UniValue::VARR);
     std::map<std::string, tallyitem> label_tally;
 
-    const auto& func = [&](const CTxDestination& address, const std::string& label, const std::string& purpose, bool is_change) {
+    const auto& func = [&](const CTxDestination& address, const std::string& label, const std::string& purpose, bool is_change)
+        EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+    {
+        AssertLockHeld(wallet.cs_wallet);
+
         if (is_change) return; // no change addresses
         auto it = mapTally.find(address);
         if (it == mapTally.end() && !fIncludeEmpty)

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -219,7 +219,7 @@ bool LegacyScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key
         if (keyFail) {
             return false;
         }
-        if (!keyPass && !accept_no_keys && (m_hd_chain.IsNull() || !m_hd_chain.IsNull() && !m_hd_chain.IsCrypted())) {
+        if (!keyPass && !accept_no_keys && (m_hd_chain.IsNull() || (!m_hd_chain.IsNull() && !m_hd_chain.IsCrypted()))) {
             return false;
         }
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -373,7 +373,8 @@ bool CWallet::AttemptSelection(const CAmount& nTargetValue, const CoinEligibilit
     std::vector<OutputGroup> positive_groups = GroupOutputs(coins, coin_selection_params, eligibility_filter, true /* positive_only */);
     std::set<CInputCoin> bnb_coins;
     CAmount bnb_value;
-    if (false && SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change, bnb_coins, bnb_value)) {
+    // Note: BnB is disabled because it is unaware of mixed coins
+    if (/* DISABLES CODE */ (false) && SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change, bnb_coins, bnb_value)) {
         const auto waste = GetSelectionWaste(bnb_coins, /* cost of change */ CAmount(0), nTargetValue, !coin_selection_params.m_subtract_fee_outputs);
         results.emplace_back(std::make_tuple(waste, std::move(bnb_coins), bnb_value));
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3702,7 +3702,7 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
     }
 
     // TODO: consider discourage users to skip passphrase for HD wallets for v21
-    if (false && nMaxVersion >= FEATURE_HD && !IsHDEnabled()) {
+    if (/* DISABLES CODE */ (false) && nMaxVersion >= FEATURE_HD && !IsHDEnabled()) {
         error = Untranslated("You should use upgradetohd RPC to upgrade non-HD wallet to HD");
         error = strprintf(_("Cannot upgrade a non HD wallet from version %i to version %i which is non-HD wallet. Use upgradetohd RPC"), prev_version, version);
         return false;


### PR DESCRIPTION
## Additional Information

* Depends on https://github.com/dashpay/dash/pull/6637

* Dependency for https://github.com/dashpay/dash/pull/6639

* While [bitcoin#13633](https://github.com/bitcoin/bitcoin/pull/13633) was originally marked as DNM in the backports spreadsheet for being SegWit-related, it's not SegWit-_dependent_ and is for dead code removal, which is necessary due to the enforcement of `-Wunused-function`. It has therefore been included.

* `EraseOldDBData()` fell into disuse after [dash#6579](https://github.com/dashpay/dash/pull/6579) but wasn't removed then. It has been removed now due to `-Wunused-function` enforcement.

* An extraneous `ApplyStats()` definition was left over when backporting [bitcoin#19145](https://github.com/bitcoin/bitcoin/pull/19145). It has been removed now due to `-Wunused-function` enforcement.

* [bitcoin#25337](https://github.com/bitcoin/bitcoin/pull/25337) ([commit](https://github.com/dashpay/dash/commit/a7d4127ea87c64d7015c7650c60025f4758fdbe4)) did not include a lock annotation for the lambda expression in `ListReceived()`. It has been added alongside `AssertLockHeld`s for both the lambda expression and the function. This was done to pass `-Wthread-safety` enforcement.

* `ParsePubKeyIDFromAddress()`, `ParseBLSPubKey()` and `ValidatePlatformPort()` have been moved inside the `ENABLE_WALLET` macro conditional to avoid `-Wunused-function` warnings if building with wallets disabled.

* Some dead code cannot be removed because they are either part of partial backports that may be completed in the future or complicate backports in the future that may expect their presence. To keep `-Wunused-function` happy, they have been marked with `[[maybe_unused]]` and this annotation should be removed when they are used.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
