### PR TITLE
test: speed-up feature_llmq_simplepose.py for 33%

### DIFF
--- a/test/functional/feature_llmq_dkgerrors.py
+++ b/test/functional/feature_llmq_dkgerrors.py
@@ -24,20 +24,22 @@ class LLMQDKGErrors(DashTestFramework):
         qh = self.mine_quorum()
         self.assert_member_valid(qh, self.mninfo[0].proTxHash, True)
 
+        mninfos_valid = self.mninfo.copy()[1:]
+
         self.log.info("Lets omit the contribution")
         self.mninfo[0].node.quorum('dkgsimerror', 'contribution-omit', '100')
-        qh = self.mine_quorum(expected_contributions=2)
+        qh = self.mine_quorum(expected_contributions=2, mninfos_valid=mninfos_valid)
         self.assert_member_valid(qh, self.mninfo[0].proTxHash, False)
 
         self.log.info("Lets lie in the contribution but provide a correct justification")
         self.mninfo[0].node.quorum('dkgsimerror', 'contribution-omit', '0')
         self.mninfo[0].node.quorum('dkgsimerror', 'contribution-lie', '100')
-        qh = self.mine_quorum(expected_contributions=3, expected_complaints=2, expected_justifications=1)
+        qh = self.mine_quorum(expected_contributions=3, expected_complaints=2, expected_justifications=1, mninfos_valid=mninfos_valid)
         self.assert_member_valid(qh, self.mninfo[0].proTxHash, True)
 
         self.log.info("Lets lie in the contribution and then omit the justification")
         self.mninfo[0].node.quorum('dkgsimerror', 'justify-omit', '100')
-        qh = self.mine_quorum(expected_contributions=3, expected_complaints=2)
+        qh = self.mine_quorum(expected_contributions=3, expected_complaints=2, mninfos_valid=mninfos_valid)
         self.assert_member_valid(qh, self.mninfo[0].proTxHash, False)
 
         self.log.info("Heal some damage (don't get PoSe banned)")
@@ -46,26 +48,26 @@ class LLMQDKGErrors(DashTestFramework):
         self.log.info("Lets lie in the contribution and then also lie in the justification")
         self.mninfo[0].node.quorum('dkgsimerror', 'justify-omit', '0')
         self.mninfo[0].node.quorum('dkgsimerror', 'justify-lie', '100')
-        qh = self.mine_quorum(expected_contributions=3, expected_complaints=2, expected_justifications=1)
+        qh = self.mine_quorum(expected_contributions=3, expected_complaints=2, expected_justifications=1, mninfos_valid=mninfos_valid)
         self.assert_member_valid(qh, self.mninfo[0].proTxHash, False)
 
         self.log.info("Lets lie about another MN")
         self.mninfo[0].node.quorum('dkgsimerror', 'contribution-lie', '0')
         self.mninfo[0].node.quorum('dkgsimerror', 'justify-lie', '0')
         self.mninfo[0].node.quorum('dkgsimerror', 'complain-lie', '100')
-        qh = self.mine_quorum(expected_contributions=3, expected_complaints=1, expected_justifications=2)
+        qh = self.mine_quorum(expected_contributions=3, expected_complaints=1, expected_justifications=2, mninfos_valid=mninfos_valid)
         self.assert_member_valid(qh, self.mninfo[0].proTxHash, True)
 
         self.log.info("Lets omit 1 premature commitments")
         self.mninfo[0].node.quorum('dkgsimerror', 'complain-lie', '0')
         self.mninfo[0].node.quorum('dkgsimerror', 'commit-omit', '100')
-        qh = self.mine_quorum(expected_contributions=3, expected_complaints=0, expected_justifications=0, expected_commitments=2)
+        qh = self.mine_quorum(expected_contributions=3, expected_complaints=0, expected_justifications=0, expected_commitments=2, mninfos_valid=mninfos_valid)
         self.assert_member_valid(qh, self.mninfo[0].proTxHash, True)
 
         self.log.info("Lets lie in 1 premature commitments")
         self.mninfo[0].node.quorum('dkgsimerror', 'commit-omit', '0')
         self.mninfo[0].node.quorum('dkgsimerror', 'commit-lie', '100')
-        qh = self.mine_quorum(expected_contributions=3, expected_complaints=0, expected_justifications=0, expected_commitments=2)
+        qh = self.mine_quorum(expected_contributions=3, expected_complaints=0, expected_justifications=0, expected_commitments=2, mninfos_valid=mninfos_valid)
         self.assert_member_valid(qh, self.mninfo[0].proTxHash, True)
 
     def assert_member_valid(self, quorumHash, proTxHash, expectedValid):

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -29,10 +29,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.wait_for_sporks_same()
 
-        # check if mining quorums with all nodes being online succeeds without punishment/banning
-        self.test_no_banning()
-
-        # Now lets isolate MNs one by one and verify that punishment/banning happens
+        # Lets isolate MNs one by one and verify that punishment/banning happens
         self.test_banning(self.isolate_mn, 2)
 
         self.repair_masternodes(False)
@@ -42,9 +39,6 @@ class LLMQSimplePoSeTest(DashTestFramework):
         self.wait_for_sporks_same()
 
         self.reset_probe_timeouts()
-
-        # Make sure no banning happens with spork21 enabled
-        self.test_no_banning()
 
         # Lets restart masternodes with closed ports and verify that they get banned even though they are connected to other MNs (via outbound connections)
         self.test_banning(self.close_mn_port)
@@ -96,8 +90,6 @@ class LLMQSimplePoSeTest(DashTestFramework):
         for i in range(3):
             self.log.info(f"Testing no PoSe banning in normal conditions {i + 1}/3")
             self.mine_quorum(expected_connections=expected_connections)
-            for mn in self.mninfo:
-                assert not check_punished(self.nodes[0], mn) and not check_banned(self.nodes[0], mn)
 
     def mine_quorum_less_checks(self, expected_good_nodes, mninfos_online):
         # Unlike in mine_quorum we skip most of the checks and only care about
@@ -161,6 +153,11 @@ class LLMQSimplePoSeTest(DashTestFramework):
     def test_banning(self, invalidate_proc, expected_connections=None):
         mninfos_online = self.mninfo.copy()
         mninfos_valid = self.mninfo.copy()
+
+        for mn in mninfos_valid:
+            assert not check_punished(self.nodes[0], mn)
+            assert not check_banned(self.nodes[0], mn)
+
         expected_contributors = len(mninfos_online)
         for i in range(2):
             self.log.info(f"Testing PoSe banning due to {invalidate_proc.__name__} {i + 1}/2")

--- a/test/functional/test_framework/masternodes.py
+++ b/test/functional/test_framework/masternodes.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Helpful routines for masternode regression testing."""
+
+def check_punished(node, mn):
+    info = node.protx('info', mn.proTxHash)
+    if info['state']['PoSePenalty'] > 0:
+        return True
+    return False
+
+def check_banned(node, mn):
+    info = node.protx('info', mn.proTxHash)
+    if info['state']['PoSeBanHeight'] != -1:
+        return True
+    return False

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -26,6 +26,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import List
 from .address import ADDRESS_BCRT1_P2SH_OP_TRUE
 from .authproxy import JSONRPCException
+from test_framework.masternodes import check_banned, check_punished
 from test_framework.blocktools import TIME_GENESIS_BLOCK
 from . import coverage
 from .messages import (
@@ -1904,6 +1905,10 @@ class DashTestFramework(BitcoinTestFramework):
         self.generate(self.nodes[0], 8, sync_fun=lambda: self.sync_blocks(nodes))
 
         self.log.info("New quorum: height=%d, quorumHash=%s, quorumIndex=%d, minedBlock=%s" % (quorum_info["height"], new_quorum, quorum_info["quorumIndex"], quorum_info["minedBlock"]))
+
+        for mn in mninfos_valid:
+            assert not check_punished(self.nodes[0], mn)
+            assert not check_banned(self.nodes[0], mn)
 
         return new_quorum
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -126,6 +126,7 @@ BASE_SCRIPTS = [
     'feature_llmq_is_retroactive.py', # NOTE: needs dash_hash to pass
     'feature_llmq_chainlocks.py', # NOTE: needs dash_hash to pass
     'feature_llmq_simplepose.py', # NOTE: needs dash_hash to pass
+    'feature_llmq_simplepose.py --disable-spork23', # NOTE: needs dash_hash to pass
     'feature_dip3_deterministicmns.py --legacy-wallet', # NOTE: needs dash_hash to pass
     'feature_dip3_deterministicmns.py --descriptors', # NOTE: needs dash_hash to pass
     'feature_llmq_signing.py', # NOTE: needs dash_hash to pass


### PR DESCRIPTION
## Issue being fixed or feature implemented
The functional test `feature_llmq_simplepose.py` is the slowest one and its run alone taking longer time than all functional tests together in 30threads.
```
Remaining jobs: [feature_llmq_simplepose.py]
285/285 - feature_llmq_simplepose.py passed, Duration: 294 s

...
feature_llmq_simplepose.py                         | ✓ Passed  | 294 s
...
    
ALL                                                | ✓ Passed  | 6078 s (accumulated)

Runtime: 294 s
```

## What was done?
Done 2 major refactorings that improved performance:
1. split functional test to 2 version: with spork23 activated and spork23 disabled
2. checks "there's no pose ban or no puse punishement" are done now for each successfully generated quorum in `mine_quorum` helper.

It should also increase reliability of feature_llmq_simplepose.py because it generate less quorums in each run and in total.

## How Has This Been Tested?
Total time of test-suite is dropped from 294seconds to just 249seconds (while running in 30 threads, built with -O3):
```
267/286 - rpc_help.py passed, Duration: 2 s
Remaining jobs: [feature_llmq_data_recovery.py, feature_block.py, p2p_quorum_data.py, feature_llmq_simplepose.py, feature_governance.py --legacy-wallet, feature_governance.py --descriptors, feature_csv_activation.py, p2p_addr_relay.py, p2p_compactblocks.py, p2p_add_connections.py, p2p_blockfilters.py, p2p_sendtxrcncl.py, feature_anchors.py, p2p_node_network_limited.py --v1transport, p2p_node_network_limited.py --v2transport, p2p_permissions.py, feature_config_args.py, feature_settings.py, feature_dirsymlinks.py]
268/286 - feature_llmq_simplepose.py passed, Duration: 195 s

... 
feature_llmq_simplepose.py                         | ✓ Passed  | 195 s
feature_llmq_simplepose.py --disable-spork23       | ✓ Passed  | 105 s
... 
ALL                                                | ✓ Passed  | 5998 s (accumulated)
Runtime: 249 s
```

There's no more outsiders, the slowest functional tests are even slow now:
```
feature_llmq_simplepose.py --disable-spork23       | ✓ Passed  | 105 s
feature_llmq_connections.py                        | ✓ Passed  | 106 s
p2p_sendheaders_compressed.py                      | ✓ Passed  | 114 s
p2p_sendheaders.py                                 | ✓ Passed  | 117 s
feature_llmq_chainlocks.py                         | ✓ Passed  | 122 s
p2p_addr_relay.py                                  | ✓ Passed  | 128 s
feature_csv_activation.py                          | ✓ Passed  | 130 s
p2p_tx_download.py                                 | ✓ Passed  | 137 s
feature_llmq_is_retroactive.py                     | ✓ Passed  | 139 s
feature_asset_locks.py                             | ✓ Passed  | 142 s
feature_governance.py --descriptors                | ✓ Passed  | 180 s
feature_governance.py --legacy-wallet              | ✓ Passed  | 181 s
feature_maxuploadtarget.py                         | ✓ Passed  | 190 s
feature_llmq_simplepose.py                         | ✓ Passed  | 195 s
feature_block.py                                   | ✓ Passed  | 196 s
feature_llmq_data_recovery.py                      | ✓ Passed  | 199 s
p2p_quorum_data.py                                 | ✓ Passed  | 209 s
```

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone