### PR TITLE
test: fix intermittent failure in feature_governance.py waiting votes to be propagated

### DIFF
--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -279,6 +279,8 @@ class DashGovernanceTest (DashTestFramework):
         self.log.info("Should see NO votes on both triggers now")
         self.wait_until(lambda: self.nodes[0].gobject("list", "valid", "triggers")[winning_trigger_hash]['NoCount'] == 1, timeout=5)
         self.wait_until(lambda: self.nodes[0].gobject("list", "valid", "triggers")[isolated_trigger_hash]['NoCount'] == self.mn_count - 1, timeout=5)
+        self.log.info("Should wait until all 24 votes are counted for success on next stages")
+        self.wait_until(lambda: self.nodes[1].gobject("count")["votes"] == 24, timeout=5)
 
         self.log.info("Remember vote count")
         before = self.nodes[1].gobject("count")["votes"]


### PR DESCRIPTION
## Issue being fixed or feature implemented
While implementing https://github.com/dashpay/dash/pull/6631 found instability in feature_governance.py

## What was done?
Governance votes are not delivered instantly between notes. If any vote is delayed a bit the wrong amount of votes will be remembered and test will fail further when comparing its count.


## How Has This Been Tested?
Tested locally with changes from https://github.com/dashpay/dash/pull/6631
without them - 90+% probability feature_governance.py to fail, with them - no failure happens locally.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone