### PR TITLE
perf: optimize sizeof CBLSLazyWrapper

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -391,12 +391,13 @@ private:
     mutable std::mutex mutex;
 
     mutable std::array<uint8_t, BLSObject::SerSize> vecBytes;
-    // Indicates if the value contained in vecBytes is valid
-    mutable bool bufValid{false};
-    mutable bool bufLegacyScheme{true};
 
     mutable BLSObject obj;
     mutable bool objInitialized{false};
+
+    // Indicates if the value contained in vecBytes is valid
+    mutable bool bufValid{false};
+    mutable bool bufLegacyScheme{true};
 
     mutable uint256 hash;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

members of `CBLSLazyWrapper` has bad padding

## What was done?
This PR reduces memory consumption for classes CBLSLazySignature and CBLSLazyPublicKey on x86_64

    sizeof(CBLSLazyPublicKey)=344 down to 336
    sizeof(CBLSLazySignature)=536 down to 528

During full index close to ~1Bln of CBLSLazyPublicKey objects are created and destroyed as members of CDeterministicMNState and CSimplifiedMNListEntry with peak in memory close to ~1Mln

It gave a bit of RAM saving (roughly 8Mb in peak) and a bit of CPU saving by being more cache friendly.

CBLSLazySignature is not used as widely as CBLSLazyPublicKey


## How Has This Been Tested?
Performance improvement is unmeasurable small (expected improvement is seconds for full re-index and μseconds per a block)

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone