### PR TITLE
test: fix feature_llmq_evo.py flakiness

### DIFF
--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -84,7 +84,7 @@ class LLMQEvoNodesTest(DashTestFramework):
 
         self.log.info("Test llmq_platform are formed only with EvoNodes")
         for _ in range(3):
-            quorum_i_hash = self.mine_quorum(llmq_type_name='llmq_test_platform', llmq_type=106, expected_connections=2, expected_members=3, expected_contributions=3, expected_complaints=0, expected_justifications=0, expected_commitments=3 )
+            quorum_i_hash = self.mine_quorum(llmq_type_name='llmq_test_platform', llmq_type=106)
             self.test_quorum_members_are_evo_nodes(quorum_i_hash, llmq_type=106)
 
         self.log.info("Test that EvoNodes are present in MN list")


### PR DESCRIPTION
## Issue being fixed or feature implemented
#6533 changed `set_dash_llmq_test_params` to adjust `llmq_test_platform` quorum params. We use this quorum type in `feature_llmq_evo.py` but we forgot to update arguments we pass into `mine_quorum()` accordingly and `mine_quorum()` switches dkg phases too fast now.

## What was done?
Drop incorrect params.

## How Has This Been Tested?
Run multiple `feature_llmq_evo.py` in parallel. Before this patch it would fail 50/50 for me.

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

