### PR TITLE
perf: build diff for DeterministicMNList more efficient for removed mns

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -403,12 +403,14 @@ CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNL
             }
         }
     });
-    ForEachMN(false, [&](auto& fromPtr) {
-        auto toPtr = to.GetMN(fromPtr.proTxHash);
-        if (toPtr == nullptr) {
-            diffRet.removedMns.emplace(fromPtr.GetInternalId());
-        }
-    });
+    if (mnMap.size() + diffRet.addedMNs.size() != to.mnMap.size()) {
+        ForEachMN(false, [&](auto& fromPtr) {
+            auto toPtr = to.GetMN(fromPtr.proTxHash);
+            if (toPtr == nullptr) {
+                diffRet.removedMns.emplace(fromPtr.GetInternalId());
+            }
+        });
+    }
 
     // added MNs need to be sorted by internalId so that these are added in correct order when the diff is applied later
     // otherwise internalIds will not match with the original list

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -392,7 +392,8 @@ CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNL
 {
     CDeterministicMNListDiff diffRet;
 
-    to.ForEachMNShared(false, [this, &diffRet](const CDeterministicMNCPtr& toPtr) {
+    for (const auto& p : to.mnMap) {
+        const auto& toPtr = p.second;
         auto fromPtr = GetMN(toPtr->proTxHash);
         if (fromPtr == nullptr) {
             diffRet.addedMNs.emplace_back(toPtr);
@@ -402,14 +403,15 @@ CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNL
                 diffRet.updatedMNs.emplace(toPtr->GetInternalId(), std::move(stateDiff));
             }
         }
-    });
+    }
     if (mnMap.size() + diffRet.addedMNs.size() != to.mnMap.size()) {
-        ForEachMN(false, [&](auto& fromPtr) {
-            auto toPtr = to.GetMN(fromPtr.proTxHash);
+        for (auto& fromPtr : mnMap) {
+            const auto toPtr = to.GetMN(fromPtr.second->proTxHash);
             if (toPtr == nullptr) {
-                diffRet.removedMns.emplace(fromPtr.GetInternalId());
+                diffRet.removedMns.emplace(fromPtr.second->GetInternalId());
+                if (mnMap.size() + diffRet.addedMNs.size() - diffRet.removedMns.size() == to.mnMap.size()) break;
             }
-        });
+        };
     }
 
     // added MNs need to be sorted by internalId so that these are added in correct order when the diff is applied later


### PR DESCRIPTION
## Issue being fixed or feature implemented
2nd loop through all masternodes may be useless, but it requires O(N) look-ups in the map with all masternodes for each block.

## What was done?
2nd loop is ignored completely if there's no masternodes to remove on this block. In case if there's any masternodes to remove, loop is interrupted immidiately as all of them found.

## How Has This Been Tested?
undo ~5k blocks + reconsider them; compare perf output.

develop: 
<img width="754" alt="image" src="https://github.com/user-attachments/assets/6b2bbdd0-0771-4fa3-b714-c57e223d1e73" />
```
2025-05-04T18:36:29Z [bench]         - m_dmnman: 2.74ms [5.98s]
2025-05-04T18:36:29Z [bench]   - Connect total: 54.40ms [94.48s (16.14ms/blk)]
```

PR:
<img width="754" alt="image" src="https://github.com/user-attachments/assets/f3116032-7857-4b0f-9c3d-20c7aa3b43da" />
```
2025-05-04T18:44:35Z [bench]         - m_dmnman: 2.03ms [4.98s]
2025-05-04T18:44:35Z [bench]   - Connect total: 54.40ms [91.68s (15.66ms/blk)]
```

This optimization improves index time and validating new blocks noticeable.

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone