### PR TITLE
ci: cancel prior runs by defining concurrency groups in GitHub Actions, remove unused `DOCKER_DRIVER` var

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,9 +20,6 @@ on:
         description: "Path to built container"
         value: ghcr.io/${{ jobs.build.outputs.repo }}/${{ inputs.name }}:${{ jobs.build.outputs.tag }}
 
-env:
-  DOCKER_DRIVER: overlay2
-
 jobs:
   build:
     name: Build container

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,6 @@ permissions:
   contents: read
   packages: write
 
-env:
-  DOCKER_DRIVER: overlay2
-
 jobs:
   container:
     name: Build container

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ permissions:
 concurrency:
   group: |
     ${{ github.workflow }}-${{
+      (vars.ALLOW_CONCURRENCY != '' && github.sha) ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.number) ||
       (github.event_name == 'push' && github.ref)
     }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
       (github.event_name == 'pull_request_target' && github.event.pull_request.number) ||
       (github.event_name == 'push' && github.ref)
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
   container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: |
+    ${{ github.workflow }}-${{
+      (github.event_name == 'pull_request_target' && github.event.pull_request.number) ||
+      (github.event_name == 'push' && github.ref)
+    }}
+  cancel-in-progress: true
+
 jobs:
   container:
     name: Build container


### PR DESCRIPTION
## Additional Information

* This pull request utilizes [concurrency groups](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) to cancel previous jobs in the event of a newer job being spawned (e.g. due to (force) push or merge).

  This should alleviate the need to manually cancel jobs due to force-pushes or a spike in merged pull request to free up runners to test latest changes. 

  * Tags have been excluded from auto-cancellation.

* The `DOCKER_DRIVER` environment variable has been dropped as we do not rely on DinD on GitHub Actions like we do on GitLab CI.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
