### PR TITLE
fix: use `GetTxDepthInMainChain` for CoinJoin depth checks

### DIFF
--- a/src/wallet/coinjoin.cpp
+++ b/src/wallet/coinjoin.cpp
@@ -497,7 +497,7 @@ CAmount CachedTxGetAnonymizedCredit(const CWallet& wallet, const CWalletTx& wtx,
     AssertLockHeld(wallet.cs_wallet);
 
     // Exclude coinbase and conflicted txes
-    if (wtx.IsCoinBase() || wallet.GetTxBlocksToMaturity(wtx) < 0)
+    if (wtx.IsCoinBase() || wallet.GetTxDepthInMainChain(wtx) < 0)
         return 0;
 
     CAmount nCredit = 0;
@@ -533,7 +533,7 @@ CoinJoinCredits CachedTxGetAvailableCoinJoinCredits(const CWallet& wallet, const
     if (wtx.IsCoinBase() && wallet.GetTxBlocksToMaturity(wtx) > 0)
         return ret;
 
-    int nDepth = wallet.GetTxBlocksToMaturity(wtx);
+    int nDepth = wallet.GetTxDepthInMainChain(wtx);
     if (nDepth < 0) return ret;
 
     ret.is_unconfirmed = CachedTxIsTrusted(wallet, wtx) && nDepth == 0;


### PR DESCRIPTION
## Motivation

When testing CoinJoin on [dash#6654](https://github.com/dashpay/dash/pull/6654), it was found that CoinJoin on `develop` (fc96190b4b5a9f10c8986562141471b1078e4b4b) had stopped working as expected. The regression was traced back to 9a5dc6241018bc32f135869b30db0e9c3e80fb7b in [dash#6633](https://github.com/dashpay/dash/pull/6633).

Specifically, erroneous substitution of `GetDepthInMainChain()` calls with `GetTxBlocksToMaturity()`. This has been resolved by changing them to the intended substitution, `GetTxDepthInMainChain()` and now CoinJoin should work as intended.

## How Has This Been Tested?

A full CoinJoin session run on 2b3d4a574bbcc4af89f1d21ee3bdd92b2a69424b

![CoinJoin session run on build 2b3d4a57](https://github.com/user-attachments/assets/69e5950f-3ff4-46b6-bb84-ab10410c7f93)

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
