### PR TITLE
docs: add build badge from GitHub Actions runs on `master` and `develop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 Dash Core staging tree
 ===========================
 
-|CI|master|develop|
-|-|-|-|
-|Gitlab|[![Build Status](https://gitlab.com/dashpay/dash/badges/master/pipeline.svg)](https://gitlab.com/dashpay/dash/-/tree/master)|[![Build Status](https://gitlab.com/dashpay/dash/badges/develop/pipeline.svg)](https://gitlab.com/dashpay/dash/-/tree/develop)|
+| Source         | `master` | `develop` |
+| -------------- | -------- | --------- |
+| GitHub Actions | [![Build Status](https://github.com/dashpay/dash/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/dashpay/dash/tree/master) | [![Build Status](https://github.com/dashpay/dash/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/dashpay/dash/tree/develop) |
+| GitLab CI      | [![Build Status](https://gitlab.com/dashpay/dash/badges/master/pipeline.svg?key_text=CI&key_width=40)](https://gitlab.com/dashpay/dash/-/tree/master) | [![Build Status](https://gitlab.com/dashpay/dash/badges/develop/pipeline.svg?key_text=CI&key_width=40)](https://gitlab.com/dashpay/dash/-/tree/develop) |
 
 https://www.dash.org
 


### PR DESCRIPTION
## Motivation

Since [dash#6604](https://github.com/dashpay/dash/pull/6604), we haven't seen GitHub Actions runners experience sporadic failures that aren't the result of test failures. In comparison, GitLab CI has been showing greater instability with its runners ([build](https://gitlab.com/dashpay/dash/-/jobs/9960288430), [build](https://gitlab.com/dashpay/dash/-/jobs/9922122668)).

As GitHub Actions runners are now at coverage parity with GitLab CI, this pull request adds status badges for it in the same vein as [dash#3915](https://github.com/dashpay/dash/pull/3915).

## How Has This Been Tested?

![Build Status](https://github.com/user-attachments/assets/a46647dd-57ba-4da1-a74e-739b80c78c82)

## Checklist

- [x] I have performed a self-review of my own code **(note: N/A)**
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
