### PR TITLE
fix: MN port validation is broken after 6627

### DIFF
--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -37,9 +37,11 @@ NetInfoStatus MnNetInfo::ValidateService(const CService& service)
     }
 
     const auto default_port_main = MainParams().GetDefaultPort();
-    if (IsNodeOnMainnet() && service.GetPort() != default_port_main) {
-        // Must use mainnet port on mainnet
-        return NetInfoStatus::BadPort;
+    if (IsNodeOnMainnet()) {
+        if (service.GetPort() != default_port_main) {
+            // Must use mainnet port on mainnet
+            return NetInfoStatus::BadPort;
+        }
     } else if (service.GetPort() == default_port_main) {
         // Using mainnet port prohibited outside of mainnet
         return NetInfoStatus::BadPort;


### PR DESCRIPTION
## Issue being fixed or feature implemented
#6627 broke MN port validation

## What was done?
Implement it the way it was before https://github.com/dashpay/dash/pull/6627/files#diff-0998f8dfc4c1089e90cbaafe9607b361035b904cd103df31e3c2339a3cbf790dL1189-L1195

## How Has This Been Tested?
sync on mainnet

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

