### PR TITLE
feat: fire up 🏃 test chains by first block (v20, mn_rr) - 9/9

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -795,7 +795,7 @@ public:
         consensus.DIP0024Height = 1; // Always have dip0024 quorums unless overridden
         consensus.DIP0024QuorumsHeight = 1; // Always have dip0024 quorums unless overridden
         consensus.V19Height = 1; // Always active unless overriden
-        consensus.V20Height = 900;
+        consensus.V20Height = consensus.DIP0003Height; // Active not earlier than dip0003. Functional tests (DashTestFramework) uses height 100 (same as coinbase maturity)
         consensus.MN_RRHeight = 900;
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -796,7 +796,7 @@ public:
         consensus.DIP0024QuorumsHeight = 1; // Always have dip0024 quorums unless overridden
         consensus.V19Height = 1; // Always active unless overriden
         consensus.V20Height = consensus.DIP0003Height; // Active not earlier than dip0003. Functional tests (DashTestFramework) uses height 100 (same as coinbase maturity)
-        consensus.MN_RRHeight = 1;
+        consensus.MN_RRHeight = consensus.V20Height; // MN_RR does not really have effect before v20 activation
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
@@ -922,6 +922,7 @@ public:
         UpdateLLMQTestParametersFromArgs(args, Consensus::LLMQType::LLMQ_TEST_PLATFORM);
         UpdateLLMQInstantSendDIP0024FromArgs(args);
         assert(consensus.V20Height >= consensus.DIP0003Height);
+        assert(consensus.MN_RRHeight >= consensus.V20Height);
     }
 
     /**

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -796,7 +796,7 @@ public:
         consensus.DIP0024QuorumsHeight = 1; // Always have dip0024 quorums unless overridden
         consensus.V19Height = 1; // Always active unless overriden
         consensus.V20Height = consensus.DIP0003Height; // Active not earlier than dip0003. Functional tests (DashTestFramework) uses height 100 (same as coinbase maturity)
-        consensus.MN_RRHeight = 900;
+        consensus.MN_RRHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -243,7 +243,7 @@ CCreditPoolDiff::CCreditPoolDiff(CCreditPool starter, const CBlockIndex* pindexP
     assert(pindexPrev);
 
     if (DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_MN_RR)) {
-        // We consider V20 active if mn_rr is active
+        // No credit pool exists before V20.
         platformReward = PlatformShare(GetMasternodePayment(pindexPrev->nHeight + 1, blockSubsidy, /*fV20Active=*/ true));
     }
 }

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -243,7 +243,7 @@ CCreditPoolDiff::CCreditPoolDiff(CCreditPool starter, const CBlockIndex* pindexP
     assert(pindexPrev);
 
     if (DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_MN_RR)) {
-        // No credit pool exists before V20.
+        // If credit pool exists, it means v20 is activated
         platformReward = PlatformShare(GetMasternodePayment(pindexPrev->nHeight + 1, blockSubsidy, /*fV20Active=*/ true));
     }
 }

--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -41,7 +41,9 @@ CAmount PlatformShare(const CAmount reward)
     bool fV20Active = DeploymentActiveAfter(pindexPrev, m_consensus_params, Consensus::DEPLOYMENT_V20);
     CAmount masternodeReward = GetMasternodePayment(nBlockHeight, blockSubsidy + feeReward, fV20Active);
 
-    if (DeploymentActiveAfter(pindexPrev, m_consensus_params, Consensus::DEPLOYMENT_MN_RR)) {
+    // Credit Pool doesn't exist before V20. If any part of reward will re-allocated to credit pool before v20
+    // activation these fund will be just permanently lost. Applyable for devnets, regtest, testnet
+    if (fV20Active && DeploymentActiveAfter(pindexPrev, m_consensus_params, Consensus::DEPLOYMENT_MN_RR)) {
         CAmount masternodeSubsidyReward = GetMasternodePayment(nBlockHeight, blockSubsidy, fV20Active);
         const CAmount platformReward = PlatformShare(masternodeSubsidyReward);
         masternodeReward -= platformReward;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -399,7 +399,7 @@ TestChainSetup::TestChainSetup(int num_blocks, const std::vector<const char*>& e
             /*TestChainBRRBeforeActivationSetup=*/
             {  497, uint256S("0x0857a9b5db51835b1c828f019f4c664b5fe6c28ac44a6d868436930f832d31e5") },
             /*TestChainV19BeforeActivationSetup=*/
-            {  494, uint256S("72c5b8760d9070ca3b6402094dcea76cd25806bc20d1bf3777a7be712e17bbd2") },
+            {  494, uint256S("0x06ec12cb5419daf83e04455a24ff8f27fef76cfdbd3e8723ca4946fab91a2f11") },
         }
     };
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -399,7 +399,7 @@ TestChainSetup::TestChainSetup(int num_blocks, const std::vector<const char*>& e
             /*TestChainBRRBeforeActivationSetup=*/
             {  497, uint256S("0x0857a9b5db51835b1c828f019f4c664b5fe6c28ac44a6d868436930f832d31e5") },
             /*TestChainV19BeforeActivationSetup=*/
-            {  494, uint256S("0x44ee5c8a5e5cbd4437d63c54ddc1d40329be811b25c492fa901e11cdf408f905") },
+            {  494, uint256S("72c5b8760d9070ca3b6402094dcea76cd25806bc20d1bf3777a7be712e17bbd2") },
         }
     };
 

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -54,8 +54,8 @@ class AssetLocksTest(DashTestFramework):
         self.set_dash_test_params(2, 0, [[
                 "-whitelist=127.0.0.1",
                 "-llmqtestinstantsenddip0024=llmq_test_instantsend",
-                "-testactivationheight=mn_rr@620",
         ]] * 2, evo_count=2)
+        self.mn_rr_height = 620
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -54,7 +54,7 @@ class AssetLocksTest(DashTestFramework):
         self.set_dash_test_params(2, 0, [[
                 "-whitelist=127.0.0.1",
                 "-llmqtestinstantsenddip0024=llmq_test_instantsend",
-                "-testactivationheight=mn_rr@1400",
+                "-testactivationheight=mn_rr@620",
         ]] * 2, evo_count=2)
 
     def skip_test_if_missing_module(self):
@@ -620,10 +620,9 @@ class AssetLocksTest(DashTestFramework):
 
 
     def test_mn_rr(self, node_wallet, node, pubkey):
-        self.log.info(node_wallet.getblockcount())
         self.log.info("Activate mn_rr...")
         locked = self.get_credit_pool_balance()
-        self.activate_mn_rr(expected_activation_height=1400)
+        self.activate_mn_rr(expected_activation_height=620)
         self.log.info(f'mn-rr height: {node.getblockcount()} credit: {self.get_credit_pool_balance()}')
         assert_equal(locked, self.get_credit_pool_balance())
 
@@ -635,7 +634,7 @@ class AssetLocksTest(DashTestFramework):
         all_mn_rewards = platform_reward + owner_reward + operator_reward
         assert_equal(all_mn_rewards, bt['coinbasevalue'] * 3 // 4)  # 75/25 mn/miner reward split
         assert_equal(platform_reward, all_mn_rewards * 375 // 1000)  # 0.375 platform share
-        assert_equal(platform_reward, 57741807)
+        assert_equal(platform_reward, 104549943)
         assert_equal(locked, self.get_credit_pool_balance())
         self.generate(node, 1)
         locked += platform_reward

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -62,7 +62,12 @@ class AssumeValidTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
-        self.extra_args = ["-dip3params=9000:9000", '-testactivationheight=v20@9000', "-checkblockindex=0"]
+        self.extra_args = [
+            "-dip3params=9000:9000",
+            '-testactivationheight=v20@9000',
+            '-testactivationheight=mn_rr@9000',
+            "-checkblockindex=0",
+        ]
         self.rpc_timeout = 120
 
     def setup_network(self):

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -90,11 +90,12 @@ class FullBlockTest(BitcoinTestFramework):
         # which causes RPC to hang, so we need to increase RPC timeouts
         self.rpc_timeout = 180
         self.extra_args = [[
-            '-dip3params=2000:2000', # Must set '-dip3params=2000:2000' to create pre-dip3 blocks only
             '-acceptnonstdtxn=1',  # This is a consensus block test, we don't care about tx policy
             '-testactivationheight=bip34@2',
+            '-dip3params=2000:2000', # Must set '-dip3params=2000:2000' to create pre-dip3 blocks only
             '-testactivationheight=dip0001@2000',
             '-testactivationheight=v20@2000',
+            '-testactivationheight=mn_rr@2000',
         ]]
 
     def setup_nodes(self):

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -88,10 +88,11 @@ class BIP65Test(BitcoinTestFramework):
         self.extra_args = [[
             f'-testactivationheight=cltv@{CLTV_HEIGHT}',
             '-whitelist=noban@127.0.0.1',
-            '-dip3params=9000:9000',
-            '-testactivationheight=v20@9000', # disabled for this test
             '-par=1',  # Use only one script thread to get the exact reject reason for testing
             '-acceptnonstdtxn=1',  # cltv_invalidate is nonstandard
+            '-dip3params=9000:9000',
+            '-testactivationheight=v20@9000', # disabled for this test
+            '-testactivationheight=mn_rr@9000', # disabled for this test
         ]]
         self.setup_clean_chain = True
         self.rpc_timeout = 480

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -99,10 +99,11 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.extra_args = [[
             '-peertimeout=999999',  # bump because mocktime might cause a disconnect otherwise
             '-whitelist=noban@127.0.0.1',
-            '-dip3params=2000:2000',
-            '-testactivationheight=v20@2000',
             f'-testactivationheight=csv@{CSV_ACTIVATION_HEIGHT}',
             '-par=1',  # Use only one script thread to get the exact reject reason for testing
+            '-dip3params=2000:2000',
+            '-testactivationheight=v20@2000',
+            '-testactivationheight=mn_rr@2000',
         ]]
         self.supports_cli = False
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -50,10 +50,11 @@ class BIP66Test(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             f'-testactivationheight=dersig@{DERSIG_HEIGHT}',
-            '-testactivationheight=v20@9000', # due to changes in CbTx
             '-whitelist=noban@127.0.0.1',
-            '-dip3params=9000:9000',
             '-par=1',  # Use only one script thread to get the exact log msg for testing
+            '-dip3params=9000:9000',
+            '-testactivationheight=v20@9000', # due to changes in CbTx
+            '-testactivationheight=mn_rr@9000', # due to changes in CbTx
         ]]
         self.setup_clean_chain = True
         self.rpc_timeout = 240

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -47,7 +47,7 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
     def set_test_params(self):
         self.extra_args = [[ f'-testactivationheight=dip0008@{DIP0008_HEIGHT}', f'-testactivationheight=dip0024@{DIP0024_HEIGHT}', "-vbparams=testdummy:999999999999:999999999999" ]] * 4
         self.set_dash_test_params(4, 3, extra_args = self.extra_args)
-        self.delay_v20(height=V20_HEIGHT)
+        self.delay_v20_and_mn_rr(height=V20_HEIGHT)
 
     def remove_masternode(self, idx):
         mn = self.mninfo[idx]

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -19,6 +19,7 @@ from test_framework.util import assert_equal
 
 DIP0008_HEIGHT = 432
 DIP0024_HEIGHT = 900
+V20_HEIGHT = 900
 
 # TODO: this helper used in many tests, find a new home for it
 class TestP2PConn(P2PInterface):
@@ -46,6 +47,7 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
     def set_test_params(self):
         self.extra_args = [[ f'-testactivationheight=dip0008@{DIP0008_HEIGHT}', f'-testactivationheight=dip0024@{DIP0024_HEIGHT}', "-vbparams=testdummy:999999999999:999999999999" ]] * 4
         self.set_dash_test_params(4, 3, extra_args = self.extra_args)
+        self.delay_v20(height=V20_HEIGHT)
 
     def remove_masternode(self, idx):
         mn = self.mninfo[idx]

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -17,8 +17,8 @@ class DashGovernanceTest (DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(6, 5, [[
             "-budgetparams=10:10:10",
-            '-testactivationheight=v20@160',
         ]] * 6)
+        self.delay_v20(height=160)
 
     def check_superblockbudget(self, v20_active):
         v20_state = self.nodes[0].getblockchaininfo()["softforks"]["v20"]

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -18,7 +18,7 @@ class DashGovernanceTest (DashTestFramework):
         self.set_dash_test_params(6, 5, [[
             "-budgetparams=10:10:10",
         ]] * 6)
-        self.delay_v20(height=160)
+        self.delay_v20_and_mn_rr(height=160)
 
     def check_superblockbudget(self, v20_active):
         v20_state = self.nodes[0].getblockchaininfo()["softforks"]["v20"]

--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -11,7 +11,6 @@ from test_framework.util import (
 )
 from test_framework.governance import EXPECTED_STDERR_NO_GOV_PRUNE
 
-# TODO: remove testactivationheight=v20@3000 when it will be activated from block 1
 DEPLOYMENT_ARGS = ["-testactivationheight=v20@3000", "-dip3params=3000:3000"]
 
 class FeatureIndexPruneTest(BitcoinTestFramework):
@@ -145,7 +144,7 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         for node in self.nodes[:2]:
             with node.assert_debug_log(['limited pruning to height 2489']):
                 pruneheight_new = node.pruneblockchain(2500)
-                assert_equal(pruneheight_new, 2125)
+                assert_equal(pruneheight_new, 2196)
 
         self.log.info("ensure that prune locks don't prevent indices from failing in a reorg scenario")
         with self.nodes[0].assert_debug_log(['basic block filter index prune lock moved back to 2480']):

--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -11,7 +11,11 @@ from test_framework.util import (
 )
 from test_framework.governance import EXPECTED_STDERR_NO_GOV_PRUNE
 
-DEPLOYMENT_ARGS = ["-testactivationheight=v20@3000", "-dip3params=3000:3000"]
+DEPLOYMENT_ARGS = [
+    "-dip3params=3000:3000",
+    "-testactivationheight=v20@3000",
+    "-testactivationheight=mn_rr@3000",
+]
 
 class FeatureIndexPruneTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -20,6 +20,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error, force_fin
 class LLMQChainLocksTest(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(5, 4)
+        self.delay_v20(height=200)
 
     def run_test(self):
         # Connect all nodes to node1 so that we always have the whole network connected
@@ -30,8 +31,8 @@ class LLMQChainLocksTest(DashTestFramework):
 
         self.test_coinbase_best_cl(self.nodes[0], expected_cl_in_cb=False)
 
-        self.activate_mn_rr(expected_activation_height=900)
-        self.log.info("Activated MN_RR at height:" + str(self.nodes[0].getblockcount()))
+        self.activate_v20(expected_activation_height=200)
+        self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
 
         # v20 is active for the next block, not for the tip
         self.test_coinbase_best_cl(self.nodes[0], expected_cl_in_cb=False)

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -20,7 +20,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error, force_fin
 class LLMQChainLocksTest(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(5, 4)
-        self.delay_v20(height=200)
+        self.delay_v20_and_mn_rr(height=200)
 
     def run_test(self):
         # Connect all nodes to node1 so that we always have the whole network connected

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -45,8 +45,9 @@ class TestP2PConn(P2PInterface):
 
 class LLMQEvoNodesTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(5, 4, [["-testactivationheight=mn_rr@400"]] * 5, evo_count=5)
+        self.set_dash_test_params(5, 4, evo_count=5)
         self.set_dash_llmq_test_params(4, 4)
+        self.mn_rr_height = 400
 
     def run_test(self):
         # Connect all nodes to node1 so that we always have the whole network connected

--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -49,8 +49,9 @@ class TestP2PConn(P2PInterface):
 
 class LLMQ_IS_CL_Conflicts(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(5, 4, [["-testactivationheight=mn_rr@2000"]] * 5)
+        self.set_dash_test_params(5, 4)
         self.set_dash_llmq_test_params(4, 4)
+        self.delay_v20_and_mn_rr(2000)
         self.supports_cli = False
 
     def run_test(self):

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -53,6 +53,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(9, 8)
         self.set_dash_llmq_test_params(4, 4)
+        self.delay_v20(height=900)
 
     def run_test(self):
         llmq_type=103

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -53,7 +53,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(9, 8)
         self.set_dash_llmq_test_params(4, 4)
-        self.delay_v20(height=900)
+        self.delay_v20_and_mn_rr(height=900)
 
     def run_test(self):
         llmq_type=103

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -22,7 +22,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         self.extra_args = [[ '-testactivationheight=dip0024@9999' ]] * 6
         self.set_dash_test_params(6, 5)
         self.set_dash_llmq_test_params(5, 3)
-        self.delay_v20(height=9999)
+        self.delay_v20_and_mn_rr(height=9999)
 
     def add_options(self, parser):
         parser.add_argument("--disable-spork23", dest="disable_spork23", default=False, action="store_true",

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -22,6 +22,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         self.extra_args = [[ '-testactivationheight=dip0024@9999' ]] * 6
         self.set_dash_test_params(6, 5)
         self.set_dash_llmq_test_params(5, 3)
+        self.delay_v20(height=9999)
 
     def add_options(self, parser):
         parser.add_argument("--disable-spork23", dest="disable_spork23", default=False, action="store_true",

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -121,9 +121,6 @@ class MnehfTest(DashTestFramework):
         node = self.nodes[0]
 
         self.set_sporks()
-        self.log.info("Consensus rules assume there're no EHF signal before V20")
-        self.activate_v20()
-
         self.log.info("Mine a quorum...")
         self.mine_quorum()
         self.check_fork('defined')

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -38,6 +38,7 @@ DEPLOYMENT_ARGS = [
     "-testactivationheight=dip0001@2000",
     "-testactivationheight=dip0008@2000",
     "-testactivationheight=v20@2000",
+    "-testactivationheight=mn_rr@2000",
 ]
 
 def mine_large_blocks(node, n):

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -48,7 +48,11 @@ class P2PStaller(P2PDataStore):
 class P2PIBDStallingTest(BitcoinTestFramework):
     def set_test_params(self):
         self.disable_mocktime = True
-        self.extra_args = [["-dip3params=2000:2000", "-testactivationheight=v20@2000"]]
+        self.extra_args = [[
+            "-dip3params=2000:2000",
+            "-testactivationheight=v20@2000",
+            "-testactivationheight=mn_rr@2000",
+        ]]
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -185,8 +185,8 @@ class BlockchainTest(BitcoinTestFramework):
             '-testactivationheight=dip0024@13',
             '-testactivationheight=brr@14',
             '-testactivationheight=v19@15',
-            '-testactivationheight=v20@901',
-            '-testactivationheight=mn_rr@902',
+            '-testactivationheight=v20@412', # no earlier than DIP0003
+            '-testactivationheight=mn_rr@16',
         ])
 
         res = self.nodes[0].getblockchaininfo()
@@ -212,8 +212,8 @@ class BlockchainTest(BitcoinTestFramework):
             'dip0024': { 'type': 'buried', 'active': True, 'height': 13},
             'realloc': { 'type': 'buried', 'active': True, 'height': 14},
             'v19': { 'type': 'buried', 'active': True, 'height': 15},
-            'v20': { 'type': 'buried', 'active': False, 'height': 901},
-            'mn_rr': { 'type': 'buried', 'active': False, 'height': 902},
+            'v20': { 'type': 'buried', 'active': False, 'height': 412},
+            'mn_rr': { 'type': 'buried', 'active': True, 'height': 16},
             'withdrawals': {
                 'type': 'bip9',
                 'bip9': {

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -186,7 +186,7 @@ class BlockchainTest(BitcoinTestFramework):
             '-testactivationheight=brr@14',
             '-testactivationheight=v19@15',
             '-testactivationheight=v20@412', # no earlier than DIP0003
-            '-testactivationheight=mn_rr@16',
+            '-testactivationheight=mn_rr@413',
         ])
 
         res = self.nodes[0].getblockchaininfo()
@@ -213,7 +213,7 @@ class BlockchainTest(BitcoinTestFramework):
             'realloc': { 'type': 'buried', 'active': True, 'height': 14},
             'v19': { 'type': 'buried', 'active': True, 'height': 15},
             'v20': { 'type': 'buried', 'active': False, 'height': 412},
-            'mn_rr': { 'type': 'buried', 'active': True, 'height': 16},
+            'mn_rr': { 'type': 'buried', 'active': False, 'height': 413},
             'withdrawals': {
                 'type': 'bip9',
                 'bip9': {

--- a/test/functional/rpc_masternode.py
+++ b/test/functional/rpc_masternode.py
@@ -32,17 +32,24 @@ class RPCMasternodeTest(DashTestFramework):
             assert_equal(len(payments), 1)
             payments_block = payments[0]
             payments_block_payees = payments_block["masternodes"][0]["payees"]
+
+            num_payees = 0
             payments_payee = ""
             for i in range(0, len(payments_block_payees)):
+                if i == 0:
+                    assert_equal(payments_block_payees[i]['script'], '6a')
+                    continue
+
                 payments_payee += payments_block_payees[i]["address"]
                 if i < len(payments_block_payees) - 1:
                     payments_payee += ", "
+                num_payees += 1
             assert_equal(payments_block["height"], height)
             assert_equal(payments_block["blockhash"], blockhash)
             assert_equal(winners_payee, payments_payee)
-            if len(payments_block_payees) == 1:
+            if num_payees == 1:
                 checked_0_operator_reward = True
-            if len(payments_block_payees) > 1:
+            if num_payees > 1:
                 checked_non_0_operator_reward = True
 
         self.log.info("test various `payments` RPC options")
@@ -73,15 +80,15 @@ class RPCMasternodeTest(DashTestFramework):
         while not checked_0_operator_reward or not checked_non_0_operator_reward:
             payments_masternode = self.nodes[0].masternode("payments")[0]["masternodes"][0]
             protx_info = self.nodes[0].protx("info", payments_masternode["proTxHash"])
-            if len(payments_masternode["payees"]) == 1:
-                assert_equal(protx_info["state"]["payoutAddress"], payments_masternode["payees"][0]["address"])
+            if len(payments_masternode["payees"]) == 2:
+                assert_equal(protx_info["state"]["payoutAddress"], payments_masternode["payees"][1]["address"])
                 checked_0_operator_reward = True
             else:
-                assert_equal(len(payments_masternode["payees"]), 2)
-                option1 = protx_info["state"]["payoutAddress"] == payments_masternode["payees"][0]["address"] and \
+                assert_equal(len(payments_masternode["payees"]), 3)
+                option1 = protx_info["state"]["payoutAddress"] == payments_masternode["payees"][1]["address"] and \
+                    protx_info["state"]["operatorPayoutAddress"] == payments_masternode["payees"][2]["address"]
+                option2 = protx_info["state"]["payoutAddress"] == payments_masternode["payees"][2]["address"] and \
                     protx_info["state"]["operatorPayoutAddress"] == payments_masternode["payees"][1]["address"]
-                option2 = protx_info["state"]["payoutAddress"] == payments_masternode["payees"][1]["address"] and \
-                    protx_info["state"]["operatorPayoutAddress"] == payments_masternode["payees"][0]["address"]
                 assert option1 or option2
                 checked_non_0_operator_reward = True
             self.generate(self.nodes[0], 1, sync_fun=self.no_op)

--- a/test/functional/rpc_masternode.py
+++ b/test/functional/rpc_masternode.py
@@ -33,7 +33,6 @@ class RPCMasternodeTest(DashTestFramework):
             payments_block = payments[0]
             payments_block_payees = payments_block["masternodes"][0]["payees"]
 
-            num_payees = 0
             payments_payee = ""
             for i in range(0, len(payments_block_payees)):
                 if i == 0:
@@ -43,10 +42,10 @@ class RPCMasternodeTest(DashTestFramework):
                 payments_payee += payments_block_payees[i]["address"]
                 if i < len(payments_block_payees) - 1:
                     payments_payee += ", "
-                num_payees += 1
             assert_equal(payments_block["height"], height)
             assert_equal(payments_block["blockhash"], blockhash)
             assert_equal(winners_payee, payments_payee)
+            num_payees = len(payments_block_payees) - 1
             if num_payees == 1:
                 checked_0_operator_reward = True
             if num_payees > 1:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -635,6 +635,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             f.write("shrinkdebugfile=0\n")
             f.write("dip3params=2:2\n")
             f.write(f"testactivationheight=v20@{self.v20_height}\n")
+            f.write(f"testactivationheight=mn_rr@{self.mn_rr_height}\n")
             os.makedirs(os.path.join(new_data_dir, 'stderr'), exist_ok=True)
             os.makedirs(os.path.join(new_data_dir, 'stdout'), exist_ok=True)
 
@@ -1172,7 +1173,11 @@ class DashTestFramework(BitcoinTestFramework):
         old_num_nodes = len(self.nodes)
         super().add_nodes(num_nodes, extra_args, rpchost=rpchost, binary=binary, binary_cli=binary_cli, versions=versions)
         for i in range(old_num_nodes, old_num_nodes + num_nodes):
-            append_config(self.nodes[i].datadir, ["dip3params=2:2", f"testactivationheight=v20@{self.v20_height}"])
+            append_config(self.nodes[i].datadir, [
+                "dip3params=2:2",
+                f"testactivationheight=v20@{self.v20_height}",
+                f"testactivationheight=mn_rr@{self.mn_rr_height}",
+            ])
         if old_num_nodes == 0:
             # controller node is the only node that has an extra option allowing it to submit sporks
             append_config(self.nodes[0].datadir, ["sporkkey=cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"])
@@ -1193,6 +1198,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.mninfo = []
         self.setup_clean_chain = True
         self.v20_height = 100
+        self.mn_rr_height = 100
         # additional args
         if extra_args is None:
             extra_args = [[]] * num_nodes
@@ -1210,8 +1216,9 @@ class DashTestFramework(BitcoinTestFramework):
         self.quorum_data_request_expiration_timeout = 360
 
 
-    def delay_v20(self, height=None):
+    def delay_v20_and_mn_rr(self, height=None):
         self.v20_height = height
+        self.mn_rr_height = height
 
     def activate_by_name(self, name, expected_activation_height=None, slow_mode=True):
         assert not softfork_active(self.nodes[0], name)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -599,6 +599,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         self.nodes.append(t_node)
         return t_node
 
+    # TODO: move it to DashTestFramework where it belongs
     def dynamically_initialize_datadir(self, node_p2p_port, node_rpc_port):
         source_data_dir = get_datadir_path(self.options.tmpdir, 0)  # use node0 as a source
         new_data_dir = get_datadir_path(self.options.tmpdir, len(self.nodes))
@@ -633,6 +634,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             f.write("natpmp=0\n")
             f.write("shrinkdebugfile=0\n")
             f.write("dip3params=2:2\n")
+            f.write(f"testactivationheight=v20@{self.v20_height}\n")
             os.makedirs(os.path.join(new_data_dir, 'stderr'), exist_ok=True)
             os.makedirs(os.path.join(new_data_dir, 'stdout'), exist_ok=True)
 
@@ -1170,7 +1172,7 @@ class DashTestFramework(BitcoinTestFramework):
         old_num_nodes = len(self.nodes)
         super().add_nodes(num_nodes, extra_args, rpchost=rpchost, binary=binary, binary_cli=binary_cli, versions=versions)
         for i in range(old_num_nodes, old_num_nodes + num_nodes):
-            append_config(self.nodes[i].datadir, ["dip3params=2:2"])
+            append_config(self.nodes[i].datadir, ["dip3params=2:2", f"testactivationheight=v20@{self.v20_height}"])
         if old_num_nodes == 0:
             # controller node is the only node that has an extra option allowing it to submit sporks
             append_config(self.nodes[0].datadir, ["sporkkey=cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"])
@@ -1190,6 +1192,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.num_nodes = num_nodes
         self.mninfo = []
         self.setup_clean_chain = True
+        self.v20_height = 100
         # additional args
         if extra_args is None:
             extra_args = [[]] * num_nodes
@@ -1206,6 +1209,9 @@ class DashTestFramework(BitcoinTestFramework):
         # This is EXPIRATION_TIMEOUT + EXPIRATION_BIAS in CQuorumDataRequest
         self.quorum_data_request_expiration_timeout = 360
 
+
+    def delay_v20(self, height=None):
+        self.v20_height = height
 
     def activate_by_name(self, name, expected_activation_height=None, slow_mode=True):
         assert not softfork_active(self.nodes[0], name)


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR is the final PR that activates all currently buried soft-forks on earlier block as possible.
This series of PR chased 3 ultimate goals:
 - improve performance of functional tests: no need to generate many blocks just waiting until some feature is activated
 - it helps for unit & functional tests to test actual code that works on mainnet currently with all features enabled. Not some pre-feature status
 - it helps platform's dev environment to start faster (some final integration is expected after this PR).

Prior work: https://github.com/dashpay/dash/pull/6511 and other PRs

## What was done?
Changes are related to 2 forks that has been activated on high height on regtest:
 - v20 which set subsidy of each block to fixed value 5, increases governance share of reward (10% to 20%), introduces EHF forks and add to coinbase transaction ChainLocks and Credit Pool, also changes behavior in build SML lists.
 - mn_rr: part of reward of each block is actually goes to credit pool, triggers platform chain genesis blocks

Functional test `rpc_masternode.py` is compatible now with MN_RR fork (expected 3 or 4 outputs of coinbase tx: miner, credit pool, masternode reward, optional operator reward) 

### V20
V20 must not be active before fork dip0003 so far as all features depends on DIP0003.

For BitcoinTestFramework v20's activation is delayed to block 500 same as DIP0003 because unit tests and functional tests that are backported from bitcoin expects certains behaviour: manually constructed blocks do not have CbTx transaction of version 2 (dip003) or version 3 (v20 with CL) and may not be accepted after DIP3 or v20 activation.

For DashTestFramework v20's activation is delayed to block 100 because wallet should have enough coins to create masternodes / evonodes; but with fixed subsidy equaled to 2 it takes thousands of blocks before masternodes can be created. 100 blocks is chosen to match with coinbase maturity. Higher height may cause v20 to be activated too late for some functional tests. Height can be lower than 100 blocks, maybe low as just 50 blocks, but 50 * 500 = 25000 tDash which is not enough to create more than 8 evo nodes. 

### MN_RR
Part of block reward is not coming to credit pool before it is actually exist (v20 activated).

## How Has This Been Tested?
Run unit / functional tests that possible affected by this PR.
Time is slightly reduced for `feature_asset_locks.py`, `feature_mnehf.py`, `feature_llmq_chainlocks.py` as expected.
Time is unexpectedly increased for `feature_llmq_rotation.py` (should not be changed).
Disk usage is significantly reduced as expected (less blocks means less storage for blocks; less logs for each node).

PR:
```
feature_asset_locks.py                | ✓ Passed  | 110 s
feature_dip4_coinbasemerkleroots.py   | ✓ Passed  | 97 s
feature_governance.py --descriptors   | ✓ Passed  | 186 s
feature_governance.py --legacy-wallet | ✓ Passed  | 184 s
feature_llmq_chainlocks.py            | ✓ Passed  | 105 s
feature_llmq_rotation.py              | ✓ Passed  | 133 s
feature_mnehf.py                      | ✓ Passed  | 71 s
rpc_blockchain.py --v1transport       | ✓ Passed  | 13 s
rpc_blockchain.py --v2transport       | ✓ Passed  | 12 s
rpc_masternode.py                     | ✓ Passed  | 8 s

ALL                                   | ✓ Passed  | 919 s (accumulated) 
Runtime: 186 s
```
Disk usage:
```
1396020 /tmp/test_runner_∋_🏃_20250512_115202
```

develop:
```
feature_asset_locks.py                | ✓ Passed  | 131 s
feature_dip4_coinbasemerkleroots.py   | ✓ Passed  | 90 s
feature_governance.py --descriptors   | ✓ Passed  | 181 s
feature_governance.py --legacy-wallet | ✓ Passed  | 186 s
feature_llmq_chainlocks.py            | ✓ Passed  | 120 s
feature_llmq_rotation.py              | ✓ Passed  | 92 s
feature_mnehf.py                      | ✓ Passed  | 92 s
rpc_blockchain.py --v1transport       | ✓ Passed  | 12 s
rpc_blockchain.py --v2transport       | ✓ Passed  | 12 s
rpc_masternode.py                     | ✓ Passed  | 8 s
ALL                                   | ✓ Passed  | 924 s (accumulated) 
```
Disk usage:
```
1633584 /tmp/test_runner_∋_🏃_20250512_121826/
```

## Breaking Changes
On Regtest fork `v20` is activated on block 1 if not specified otherwise.
Use `-testactivationheight=v20@100` to activate v20 from block 100 and increase subsidy of first blocks, if you want to register any masternode.

On Regtest fork `MN_RR` is activated on block 1 if not speicifed otherwise.
Use `-testactivationheight=mn_rr@{HEIGHT}` to activate mn_rr from block `{HEIGHT}` to trigger platform activation. `{HEIGHT}` may be less than v20, but actual reward reallocation will happens only since v20 (credit pool in CbTx) is activated.

No changes for devnets, testnet3, mainnet.\

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone