### PR TITLE
test: intermittent error due to missing _other_ quorums

### DIFF
--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -320,8 +320,17 @@ class AssetLocksTest(DashTestFramework):
         extra_lock_tx = self.create_assetlock(coin, COIN, pubkey)
         self.create_and_check_block([extra_lock_tx], expected_error = 'bad-cbtx-assetlocked-amount')
 
-        self.log.info("Mine a quorum...")
-        self.mine_quorum_2_nodes()
+        self.log.info("Mine IS quorum")
+        if len(self.nodes[0].quorum('list')['llmq_test_instantsend']) == 0:
+            self.mine_quorum(llmq_type_name='llmq_test_instantsend', expected_members=2, expected_connections=1, expected_contributions=2, expected_commitments=2, llmq_type=104)
+        else:
+            self.log.info("IS quorum exist")
+
+        self.log.info("Mine a platform quorum")
+        if len(self.nodes[0].quorum('list')['llmq_test_platform']) == 0:
+            self.mine_quorum_2_nodes()
+        else:
+            self.log.info("Platform quorum exist")
 
         self.validate_credit_pool_balance(locked_1)
 

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -103,7 +103,13 @@ class NotificationsTest(DashTestFramework):
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", 4070908800)
         self.wait_for_sporks_same()
+        self.log.info("Mine quorum for InstantSend")
         (quorum_info_i_0, quorum_info_i_1) = self.mine_cycle_quorum()
+        self.log.info("Mine quorum for ChainLocks")
+        if len(self.nodes[0].quorum('list')['llmq_test']) == 0:
+            self.mine_quorum(llmq_type_name='llmq_test', llmq_type=104)
+        else:
+            self.log.info("Quorum `llmq_test` already exist")
         self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", 0)
         self.wait_for_sporks_same()
 

--- a/test/functional/p2p_instantsend.py
+++ b/test/functional/p2p_instantsend.py
@@ -23,7 +23,13 @@ class InstantSendTest(DashTestFramework):
     def run_test(self):
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.wait_for_sporks_same()
+        self.log.info("Mine quorum for InstantSend")
         (quorum_info_i_0, quorum_info_i_1) = self.mine_cycle_quorum()
+        self.log.info("Mine quorum for ChainLocks")
+        if len(self.nodes[0].quorum('list')['llmq_test']) == 0:
+            self.mine_quorum(llmq_type_name='llmq_test', llmq_type=104)
+        else:
+            self.log.info("Quorum `llmq_test` already exist")
 
         self.test_mempool_doublespend()
         self.test_block_doublespend()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1652,6 +1652,7 @@ class DashTestFramework(BitcoinTestFramework):
                 return node.getrawtransaction(txid, True)["instantlock"]
             except:
                 return False
+        self.log.info(f"Expecting InstantLock for {txid}")
         if self.wait_until(check_instantlock, timeout=timeout, sleep=1, do_assert=expected) and not expected:
             raise AssertionError("waiting unexpectedly succeeded")
 
@@ -1662,6 +1663,7 @@ class DashTestFramework(BitcoinTestFramework):
                 return block["confirmations"] > 0 and block["chainlock"]
             except:
                 return False
+        self.log.info(f"Expecting ChainLock for {block_hash}")
         if self.wait_until(check_chainlocked_block, timeout=timeout, sleep=0.1, do_assert=expected) and not expected:
             raise AssertionError("waiting unexpectedly succeeded")
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
In functional test `feature_asset_locks.py` a quorum for InstantSend is not generated intentionally but usually it is enough time to be formed while other quorums are generated.
Similar situation for `p2p_instantsend.py` and `feature_notifications.py`.

This fix is one of the blockers for https://github.com/dashpay/dash/pull/6631 because with smaller delays extra quorums (beyond expected) almost never formed.

Example of logs:

    2025-05-15T19:50:51.884000Z TestFramework (INFO): Test no IS for asset unlock...
    2025-05-15T19:50:52.892000Z TestFramework (INFO): Send tx with expected_error:'None'...
    2025-05-15T19:51:54.214000Z TestFramework.utils (ERROR): wait_until() failed. Predicate: ''''
            def check_instantlock():
                self.bump_mocktime(1)
                try:
                    return node.getrawtransaction(txid, True)["instantlock"]
                except:
                    return False
        ....
        not true after 60.0 seconds

Meanwhile, there's just no quorum for signing InstantSend, logs from nodes:

    node3 2025-05-15T19:50:54.054321Z (mocktime: 2014-12-04T18:19:47Z) [ scheduler] [llmq/signing.cpp:712] [AsyncSignIfMember] [llmq] CSigningManager::AsyncSignIfMember -- failed to select quorum. id=ce79d1f19020ec65caa8a81306362ddad6ffd0e6fc45e18c83630f401b38d54c, msgHash=83b6e8b1549ad9f2750e13e61aabdf08fd31eb1e80cbbd3729920c4c840318ae
 


## What was done?



## How Has This Been Tested?
Run functional tests

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

