### PR TITLE
fix: intermittent error in feature_notification due to extra CL

### DIFF
--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -109,10 +109,15 @@ class NotificationsTest(DashTestFramework):
 
         self.log.info("Mine single block, wait for chainlock")
         self.bump_mocktime(1)
+        pre_tip = self.nodes[0].getbestblockhash()
         tip = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[-1]
         self.wait_for_chainlocked_block_all_nodes(tip)
         # directory content should equal the chainlocked block hash
-        assert_equal([tip], sorted(os.listdir(self.chainlocknotify_dir)))
+        cl_hashes = sorted(os.listdir(self.chainlocknotify_dir))
+        if len(cl_hashes) <= 1:
+            assert_equal([tip], cl_hashes)
+        else:
+            assert_equal(sorted([tip, pre_tip]), cl_hashes)
 
         if self.is_wallet_compiled():
             self.log.info("test -instantsendnotify")


### PR DESCRIPTION
## Issue being fixed or feature implemented

It can happen if the best block get CL too fast. Locally it fails 1 time out of 10 with error:

    2025-05-16T07:09:24.060000Z TestFramework (INFO): Mine single block, wait for chainlock
    2025-05-16T07:09:24.275000Z TestFramework (ERROR): Assertion failed
    Traceback (most recent call last):
      File "DASH/test/functional/test_framework/test_framework.py", line 162, in main
        self.run_test()
      File "DASH/test/functional/feature_notifications.py", line 121, in run_test
        assert_equal([tip], sorted(os.listdir(self.chainlocknotify_dir)))
      File "DASH/test/functional/test_framework/util.py", line 69, in assert_equal
        raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
    AssertionError: not(['21b88334ae6fc29ee3bb7c89dd760dad5dc8ce1064db370dc697b3da4c4315e0'] == ['21b88334ae6fc29ee3bb7c89dd760dad5dc8ce1064db370dc697b3da4c4315e0', '4fe83a613290bd755fba25da02f493376a96971b119884831a75cea33032718d'])
    2025-05-16T07:09:24.326000Z TestFramework (INFO): Stopping nodes

## What was done?
We should expect CL not only for tip but for block before tip, if CL has been formed really fast.

## How Has This Been Tested?
Run feature_notifications.py multiple times with these extra changes https://github.com/dashpay/dash/pull/6671/

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone