### PR TITLE
fix: use correct hash of quorum as cycle hash for regtest

### DIFF
--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -932,8 +932,11 @@ std::unordered_set<uint256, StaticSaltedHasher> CInstantSendManager::ProcessPend
         if (blockIndex->nHeight + dkgInterval < m_chainstate.m_chain.Height()) {
             nSignHeight = blockIndex->nHeight + dkgInterval - 1;
         }
+        // For RegTest non-rotating quorum cycleHash has directly quorum hash
+        auto quorum = llmq_params.useRotation ? llmq::SelectQuorumForSigning(llmq_params, m_chainstate.m_chain, qman,
+                                                                             id, nSignHeight, signOffset)
+                                              : qman.GetQuorum(llmq_params.type, islock->cycleHash);
 
-        auto quorum = llmq::SelectQuorumForSigning(llmq_params, m_chainstate.m_chain, qman, id, nSignHeight, signOffset);
         if (!quorum) {
             // should not happen, but if one fails to select, all others will also fail to select
             return {};


### PR DESCRIPTION
## Issue being fixed or feature implemented
feature_llmq_singlenode.py works unstable, roughly 10% failure rate. It fails with this error:

    2025-05-17T15:03:08.586000Z TestFramework (INFO): InstantSend lock on tx: 202b6698cf0da8adfeff8430daff3d1cfe767d1120751bb7765f6df15d09a3ee is expecting
    2025-05-17T15:04:09.033000Z TestFramework.utils (ERROR): wait_until() failed. Predicate: ''''
            def check_instantlock():
                self.bump_mocktime(1)
                try:
                    return node.getrawtransaction(txid, True)["instantlock"]
                except:
                    return False
    '''
    2025-05-17T15:04:09.033000Z TestFramework (ERROR): Assertion failed


Deep in logs the failure look like this:
```
 node0 2025-05-17T14:40:45.628148Z (mocktime: 2014-12-12T05:56:24Z) [     isman] [llmq/instantsend.cpp:985] [ProcessPendingInstantSendLocks] [instantsend] CInstantSendManager::ProcessPendingInstantSendLocks -- txid=202b6698cf0da8adfeff8430daff3d1cfe767d1120751bb7765f6df15d09a3ee, islock=89b6a8bb50c2a6b07ebd2bbde0727a72ed4fbe4f78247aab509189b50fc7293f: invalid sig in islock, peer=1
```

Further debug shown that somehow sign-hash sometimes is different; while msgHash is same; signature is valid and bytes-per-bytes matched; just validation code does not work as expected.

## What was done?
For non-rotating quorums on RegTest should be used directly quorum hash instead `cycleQuorum`; no quorum choosing procedure is needed.

## How Has This Been Tested?
Run multiple times functional tests.


## Breaking Changes
N/A; affect only RegTests for special case of non-rotating quorum used for InstantSend.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone