### PR TITLE
perf: use vector instead CDeterministicMNList for computing rotating quorums

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -333,12 +333,6 @@ public:
     [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(gsl::not_null<const CBlockIndex* const> pindexPrev, int nCount = std::numeric_limits<int>::max()) const;
 
     /**
-     * Calculate a quorum based on the modifier. The resulting list is deterministically sorted by score
-     */
-    [[nodiscard]] std::vector<CDeterministicMNCPtr> CalculateQuorum(size_t maxSize, const uint256& modifier, const bool onlyEvoNodes = false) const;
-    [[nodiscard]] std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CalculateScores(const uint256& modifier, const bool onlyEvoNodes) const;
-
-    /**
      * Calculates the maximum penalty which is allowed at the height of this MN list. It is dynamic and might change
      * for every block.
      */

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -503,8 +503,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(
     });
 
     auto sortedMnsUsedAtHM = CalculateQuorum(MnsUsedAtH, MnsUsedAtH.GetAllMNsCount(), modifier, false);
-    auto sortedMnsNotUsedAtH = CalculateQuorum(MnsNotUsedAtH, MnsNotUsedAtH.size(), modifier, false);
-    auto sortedCombinedMnsList = std::move(sortedMnsNotUsedAtH);
+    auto sortedCombinedMnsList = CalculateQuorum(MnsNotUsedAtH, MnsNotUsedAtH.size(), modifier, false);
     for (auto& m : sortedMnsUsedAtHM) {
         sortedCombinedMnsList.push_back(std::move(m));
     }
@@ -621,8 +620,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> GetQuorumQuarterMembersBySnapshot
         const auto modifier = GetHashModifier(llmqParams, pCycleQuorumBaseBlockIndex);
         const auto [MnsUsedAtH, MnsNotUsedAtH] = GetMNUsageBySnapshot(llmqParams, dmnman, pCycleQuorumBaseBlockIndex, snapshot, nHeight);
         // the list begins with all the unused MNs
-        auto sortedMnsNotUsedAtH = CalculateQuorum(MnsNotUsedAtH, MnsNotUsedAtH.size(), modifier, false);
-        sortedCombinedMns = std::move(sortedMnsNotUsedAtH);
+        sortedCombinedMns = CalculateQuorum(MnsNotUsedAtH, MnsNotUsedAtH.size(), modifier, false);
         // Now add the already used MNs to the end of the list
         auto sortedMnsUsedAtH = CalculateQuorum(MnsUsedAtH, MnsUsedAtH.size(), modifier, false);
         std::move(sortedMnsUsedAtH.begin(), sortedMnsUsedAtH.end(), std::back_inserter(sortedCombinedMns));

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -171,12 +171,13 @@ std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqTy
         }
 
         auto q = ComputeQuorumMembersByQuarterRotation(llmq_params, dmnman, qsnapman, pCycleQuorumBaseBlockIndex);
+        quorumMembers = q[quorumIndex];
+
         LOCK(cs_indexed_members);
         for (const size_t i : irange::range(q.size())) {
-            mapIndexedQuorumMembers[llmqType].insert(std::make_pair(pCycleQuorumBaseBlockIndex->GetBlockHash(), i), q[i]);
+            mapIndexedQuorumMembers[llmqType].emplace(std::make_pair(pCycleQuorumBaseBlockIndex->GetBlockHash(), i),
+                                                      std::move(q[i]));
         }
-
-        quorumMembers = q[quorumIndex];
     } else {
         quorumMembers = ComputeQuorumMembers(llmqType, dmnman, pQuorumBaseBlockIndex);
     }

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -730,7 +730,7 @@ static std::pair<std::vector<CDeterministicMNCPtr>, std::vector<CDeterministicMN
         i++;
     }
 
-    return std::make_pair(std::move(usedMNs), std::move(nonUsedMNs));
+    return {usedMNs, nonUsedMNs};
 }
 
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Helper to get quorum members uses CDeterministicMNList as a source of data.
It makes temporary calculation slower, because temporary lists of masternodes should not construct heavy objects CDeterministicMNList just to keep a list of them.


## What was done?
 - helpers `CalculateQuorum`, `CalculateScores` are moved from class `CDeterministicMNList` to `llmq::utils` so far as they don't actually use any private data of `CDeterministicMNList`
 - helper `CalculateQuorum` can accept as source of data not only CDeterministicMNList but std::vector with shared ptrs.
 - helper `BuildNewQuorumQuarterMembers` does not use CDeterministicMNList for `MnsNotUsedAtH`
 - `GetMNUsageBySnapshot` does not use CDeterministicMNList anymore

Also, `BuildNewQuorumQuarterMembers` uses `std::move` when possible.


## How Has This Been Tested?
invalidate + reconsider 15000 blocks; check logs and `perf`.

By perf `PreComputeQuorumMembers` got almost double faster; most improvements came from `GetQuorumQuarterMembersBySnapshot` as expected.
It should give roughly 2% overall improvement for block validation speed and reindex.

PR:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/d27778fa-cc09-4bd7-bccd-601fa6df75f3" />
```
2025-05-20T15:46:53Z [bench]         - m_qblockman: 0.05ms [87.08s]
2025-05-20T15:46:53Z [bench] - Connect block: 21.17ms [249.92s (17.38ms/blk)]
```

Develop:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/aff54059-703d-4c76-967a-15279b1b420c" />
```
2025-05-20T16:11:33Z [bench]         - m_qblockman: 0.05ms [93.42s]
2025-05-20T16:11:33Z [bench] - Connect block: 19.06ms [256.95s (17.13ms/blk)]
```

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

