### PR TITLE
refactor: drop static IsMNPoSeBanned and IsMNValid which are confusing

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -69,7 +69,7 @@ bool CDeterministicMNList::IsMNValid(const uint256& proTxHash) const
     if (p == nullptr) {
         return false;
     }
-    return IsMNValid(**p);
+    return !(*p)->pdmnState->IsBanned();
 }
 
 bool CDeterministicMNList::IsMNPoSeBanned(const uint256& proTxHash) const
@@ -78,17 +78,7 @@ bool CDeterministicMNList::IsMNPoSeBanned(const uint256& proTxHash) const
     if (p == nullptr) {
         return false;
     }
-    return IsMNPoSeBanned(**p);
-}
-
-bool CDeterministicMNList::IsMNValid(const CDeterministicMN& dmn)
-{
-    return !IsMNPoSeBanned(dmn);
-}
-
-bool CDeterministicMNList::IsMNPoSeBanned(const CDeterministicMN& dmn)
-{
-    return dmn.pdmnState->IsBanned();
+    return (*p)->pdmnState->IsBanned();
 }
 
 CDeterministicMNCPtr CDeterministicMNList::GetMN(const uint256& proTxHash) const
@@ -103,7 +93,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMN(const uint256& proTxHash) const
 CDeterministicMNCPtr CDeterministicMNList::GetValidMN(const uint256& proTxHash) const
 {
     auto dmn = GetMN(proTxHash);
-    if (dmn && !IsMNValid(*dmn)) {
+    if (dmn && dmn->pdmnState->IsBanned()) {
         return nullptr;
     }
     return dmn;
@@ -127,7 +117,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNByCollateral(const COutPoint& co
 CDeterministicMNCPtr CDeterministicMNList::GetValidMNByCollateral(const COutPoint& collateralOutpoint) const
 {
     auto dmn = GetMNByCollateral(collateralOutpoint);
-    if (dmn && !IsMNValid(*dmn)) {
+    if (dmn && dmn->pdmnState->IsBanned()) {
         return nullptr;
     }
     return dmn;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -221,7 +221,7 @@ public:
 
     [[nodiscard]] size_t GetValidMNsCount() const
     {
-        return ranges::count_if(mnMap, [](const auto& p) { return IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [](const auto& p) { return !p.second->pdmnState->IsBanned(); });
     }
 
     [[nodiscard]] size_t GetAllEvoCount() const
@@ -231,14 +231,15 @@ public:
 
     [[nodiscard]] size_t GetValidEvoCount() const
     {
-        return ranges::count_if(mnMap,
-                                [](const auto& p) { return p.second->nType == MnType::Evo && IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [](const auto& p) {
+            return p.second->nType == MnType::Evo && !p.second->pdmnState->IsBanned();
+        });
     }
 
     [[nodiscard]] size_t GetValidWeightedMNsCount() const
     {
         return std::accumulate(mnMap.begin(), mnMap.end(), 0, [](auto res, const auto& p) {
-            if (!IsMNValid(*p.second)) return res;
+            if (p.second->pdmnState->IsBanned()) return res;
             return res + GetMnType(p.second->nType).voting_weight;
         });
     }
@@ -253,7 +254,7 @@ public:
     void ForEachMN(bool onlyValid, Callback&& cb) const
     {
         for (const auto& p : mnMap) {
-            if (!onlyValid || IsMNValid(*p.second)) {
+            if (!onlyValid || !p.second->pdmnState->IsBanned()) {
                 cb(*p.second);
             }
         }
@@ -270,7 +271,7 @@ public:
     void ForEachMNShared(bool onlyValid, Callback&& cb) const
     {
         for (const auto& p : mnMap) {
-            if (!onlyValid || IsMNValid(*p.second)) {
+            if (!onlyValid || !p.second->pdmnState->IsBanned()) {
                 cb(p.second);
             }
         }
@@ -301,8 +302,6 @@ public:
 
     [[nodiscard]] bool IsMNValid(const uint256& proTxHash) const;
     [[nodiscard]] bool IsMNPoSeBanned(const uint256& proTxHash) const;
-    static bool IsMNValid(const CDeterministicMN& dmn);
-    static bool IsMNPoSeBanned(const CDeterministicMN& dmn);
 
     [[nodiscard]] bool HasMN(const uint256& proTxHash) const
     {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -517,13 +517,10 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
 
     const auto mnList = CHECK_NONFATAL(node.dmnman)->GetListAtChainTip();
     const auto dmnToStatus = [&](const auto& dmn) {
-        if (mnList.IsMNValid(dmn)) {
-            return "ENABLED";
-        }
-        if (mnList.IsMNPoSeBanned(dmn)) {
+        if (dmn.pdmnState->IsBanned()) {
             return "POSE_BANNED";
         }
-        return "UNKNOWN";
+        return "ENABLED";
     };
     const auto dmnToLastPaidTime = [&](const auto& dmn) {
         if (dmn.pdmnState->nLastPaidHeight == 0) {
@@ -539,7 +536,7 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
     const bool showEvoOnly = strMode == "evo";
     const int tipHeight = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip()->nHeight);
     mnList.ForEachMN(false, [&](auto& dmn) {
-        if (showRecentMnsOnly && mnList.IsMNPoSeBanned(dmn)) {
+        if (showRecentMnsOnly && dmn.pdmnState->IsBanned()) {
             if (tipHeight - dmn.pdmnState->GetBannedHeight() > Params().GetConsensus().nSuperblockCycle) {
                 return;
             }


### PR DESCRIPTION
## Issue being fixed or feature implemented
This methods are static, but they are confusing, because their usage such as `IsMNValid(*p.second);` or `mnList.IsMNValid(dmn)` looks like it does something with CDeterministicMNList; but all data contained inside CDeterministicMNState (dmn) object.

## What was done?
Dropped static methods `IsMNValid` and `IsMNPoSeBanned` from CDeterministicMNList. Non-static methods with same name that uses proTx still exist and are not changed.


## How Has This Been Tested?
Run unit / functional tests


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone