### PR TITLE
perf: avoid heavy object copy during ApplyDiff for CDeterministicMNList

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -367,7 +367,12 @@ public:
     void PoSeDecrease(const CDeterministicMN& dmn);
 
     [[nodiscard]] CDeterministicMNListDiff BuildDiff(const CDeterministicMNList& to) const;
-    [[nodiscard]] CDeterministicMNList ApplyDiff(gsl::not_null<const CBlockIndex*> pindex, const CDeterministicMNListDiff& diff) const;
+    /**
+     * Apply Diff modifies current object.
+     * It is more efficient than creating a copy due to heavy copy constructor.
+     * Calculating for old block may require up to {DISK_SNAPSHOT_PERIOD} object copy & destroy.
+     */
+    void ApplyDiff(gsl::not_null<const CBlockIndex*> pindex, const CDeterministicMNListDiff& diff);
 
     void AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTotalCount = true);
     void UpdateMN(const CDeterministicMN& oldDmn, const std::shared_ptr<const CDeterministicMNState>& pdmnState);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -369,9 +369,10 @@ void FuncV19Activation(TestChainSetup& setup)
 
     // check mn list/diff
     CDeterministicMNListDiff dummy_diff = base_list.BuildDiff(tip_list);
-    CDeterministicMNList dummmy_list = base_list.ApplyDiff(chainman.ActiveChain().Tip(), dummy_diff);
+    CDeterministicMNList dummy_list{base_list};
+    dummy_list.ApplyDiff(chainman.ActiveChain().Tip(), dummy_diff);
     // Lists should match
-    BOOST_REQUIRE(dummmy_list == tip_list);
+    BOOST_REQUIRE(dummy_list == tip_list);
 
     // mine 10 more blocks
     for (int i = 0; i < 10; ++i)
@@ -392,20 +393,22 @@ void FuncV19Activation(TestChainSetup& setup)
     const CBlockIndex* v19_index = chainman.ActiveChain().Tip()->GetAncestor(Params().GetConsensus().V19Height);
     auto v19_list = dmnman.GetListForBlock(v19_index);
     dummy_diff = v19_list.BuildDiff(tip_list);
-    dummmy_list = v19_list.ApplyDiff(chainman.ActiveChain().Tip(), dummy_diff);
-    BOOST_REQUIRE(dummmy_list == tip_list);
+    dummy_list = v19_list;
+    dummy_list.ApplyDiff(chainman.ActiveChain().Tip(), dummy_diff);
+    BOOST_REQUIRE(dummy_list == tip_list);
 
     // NOTE: this fails on v19/v19.1 with errors like:
     // "RemoveMN: Can't delete a masternode ... with a pubKeyOperator=..."
     dummy_diff = base_list.BuildDiff(tip_list);
-    dummmy_list = base_list.ApplyDiff(chainman.ActiveChain().Tip(), dummy_diff);
-    BOOST_REQUIRE(dummmy_list == tip_list);
+    dummy_list = base_list;
+    dummy_list.ApplyDiff(chainman.ActiveChain().Tip(), dummy_diff);
+    BOOST_REQUIRE(dummy_list == tip_list);
 
-    dummmy_list = base_list;
+    dummy_list = base_list;
     for (const auto& diff : diffs) {
-        dummmy_list = dummmy_list.ApplyDiff(chainman.ActiveChain().Tip(), diff);
+        dummy_list.ApplyDiff(chainman.ActiveChain().Tip(), diff);
     }
-    BOOST_REQUIRE(dummmy_list == tip_list);
+    BOOST_REQUIRE(dummy_list == tip_list);
 };
 
 void FuncDIP3Protx(TestChainSetup& setup)


### PR DESCRIPTION
## Issue being fixed or feature implemented
The function `ApplyDiff` for CDeterministicMNList creates copy of current object and return it.
It is not efficient in case of applying several diffs one after one.
In case if `UndoBlock` and in case of calculating Quorum Members for old blocks (without caches) up to 576 temporary copies of CDeterministicMNList may be created and destroyed.

## What was done?
`ApplyDiff` now changes current object, not returning a copy.

It speed ups calculation of GetDeterministicMNListInternal for ~10%; this helper is most hot function during:
 - block undo
 - RPC `quorum info` for distant quorums (when it's not in cache).
 - RPC `quorum verify` for distant quorums (when it's not in cache)


## How Has This Been Tested?
Run unit / functional tests

Collected `perf` stats for block-undo.

develop:
<img width="772" alt="image" src="https://github.com/user-attachments/assets/a74e5dbb-314e-4067-b0dc-372235d37fb5" />

PR:
<img width="772" alt="image" src="https://github.com/user-attachments/assets/a587cb6d-96f1-4932-9143-90b7a08b2751" />



## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone