### PR TITLE
chore: drop deprecated RPC `instantsendtoaddress`

### DIFF
--- a/doc/release-notes-6686.md
+++ b/doc/release-notes-6686.md
@@ -1,0 +1,4 @@
+Updated RPCs
+------------
+
+* The `instantsendtoaddress` RPC was deprecated in Dash Core v0.15 and is now removed.

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -422,24 +422,6 @@ static RPCHelpMan sendtoaddress()
     };
 }
 
-// DEPRECATED
-static RPCHelpMan instantsendtoaddress()
-{
-    return RPCHelpMan{"instantsendtoaddress",
-        "instantsendtoaddress is deprecated and sendtoaddress should be used instead",
-        {},
-        RPCResult{
-            RPCResult::Type::STR_HEX, "txid", "The transaction id."
-        },
-        RPCExamples{""},
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    LogPrintf("WARNING: Used deprecated RPC method 'instantsendtoaddress'! Please use 'sendtoaddress' instead\n");
-    return sendtoaddress().HandleRequest(request);
-},
-    };
-}
-
 static RPCHelpMan listaddressgroupings()
 {
     return RPCHelpMan{"listaddressgroupings",
@@ -4639,7 +4621,6 @@ Span<const CRPCCommand> GetWalletRPCCommands()
 static const CRPCCommand commands[] =
 { //  category              actor (function)
   //  ------------------    ------------------------
-    { "hidden",             &instantsendtoaddress,           },
     { "rawtransactions",    &fundrawtransaction,             },
     { "wallet",             &abandontransaction,             },
     { "wallet",             &abortrescan,                    },


### PR DESCRIPTION
## Additional Information

* `instantsendtoaddress` was deprecated in [dash#3020](https://github.com/dashpay/dash/pull/3020), which was included in Dash Core v0.15.

## Breaking Changes

Deprecated RPCs will no longer be available.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas  **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests  **(note: N/A)**
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
