### PR TITLE
perf: using asynchronous worker to validate BLS signatures in quorum commitments

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -529,6 +529,8 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-parbls=<n>", strprintf("Set the number of bls verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
+        -GetNumCores(), llmq::MAX_BLSCHECK_THREADS, llmq::DEFAULT_BLSCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-pid=<file>", strprintf("Specify pid file. Relative paths will be prefixed by a net-specific datadir location. (default: %s)", BITCOIN_PID_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-prune=<n>", strprintf("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex, -rescan and -disablegovernance=false. "

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -529,7 +529,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-parbls=<n>", strprintf("Set the number of bls verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
+    argsman.AddArg("-parbls=<n>", strprintf("Set the number of BLS verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
         -GetNumCores(), llmq::MAX_BLSCHECK_THREADS, llmq::DEFAULT_BLSCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-pid=<file>", strprintf("Specify pid file. Relative paths will be prefixed by a net-specific datadir location. (default: %s)", BITCOIN_PID_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -66,7 +66,7 @@ CQuorumBlockProcessor::CQuorumBlockProcessor(CChainState& chainstate, CDetermini
     // Number of script-checking threads <= MAX_BLSCHECK_THREADS
     bls_threads = std::min(bls_threads, MAX_BLSCHECK_THREADS);
 
-    LogPrintf("Bls verification uses %d additional threads\n", bls_threads);
+    LogPrintf("BLS verification uses %d additional threads\n", bls_threads);
     m_bls_queue.StartWorkerThreads(bls_threads);
 }
 

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -224,7 +224,7 @@ bool CQuorumBlockProcessor::ProcessBlock(const CBlock& block, gsl::not_null<cons
 
         if (!queue_control.Wait()) {
             // at least one check failed
-            return false;
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-invalid");
         }
     }
     for (const auto& [_, qc] : qcs) {

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -7,7 +7,10 @@
 
 #include <unordered_lru_cache.h>
 
+#include <bls/bls.h>
+#include <checkqueue.h>
 #include <llmq/params.h>
+#include <llmq/utils.h>
 #include <protocol.h>
 #include <saltedhasher.h>
 #include <sync.h>
@@ -19,6 +22,7 @@
 class BlockValidationState;
 class CBlock;
 class CBlockIndex;
+class CBLSSignature;
 class CChain;
 class CChainState;
 class CDataStream;
@@ -41,6 +45,8 @@ private:
     CEvoDB& m_evoDb;
     CQuorumSnapshotManager& m_qsnapman;
 
+    CCheckQueue<utils::BlsCheck> m_bls_queue{4};
+
     mutable Mutex minableCommitmentsCs;
     std::map<std::pair<Consensus::LLMQType, uint256>, uint256> minableCommitmentsByQuorum GUARDED_BY(minableCommitmentsCs);
     std::map<uint256, CFinalCommitment> minableCommitments GUARDED_BY(minableCommitmentsCs);
@@ -50,6 +56,7 @@ private:
 public:
     explicit CQuorumBlockProcessor(CChainState& chainstate, CDeterministicMNManager& dmnman, CEvoDB& evoDb,
                                    CQuorumSnapshotManager& qsnapman);
+    ~CQuorumBlockProcessor();
 
     [[nodiscard]] MessageProcessingResult ProcessMessage(const CNode& peer, std::string_view msg_type, CDataStream& vRecv);
 

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -82,7 +82,8 @@ public:
     std::optional<const CBlockIndex*> GetLastMinedCommitmentsByQuorumIndexUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, int quorumIndex, size_t cycle) const;
 private:
     static bool GetCommitmentsFromBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, std::multimap<Consensus::LLMQType, CFinalCommitment>& ret, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, BlockValidationState& state, bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc,
+                           BlockValidationState& state, bool fJustCheck) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     size_t GetNumCommitmentsRequired(const Consensus::LLMQParams& llmqParams, int nHeight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     static uint256 GetQuorumBlockHash(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight, int quorumIndex) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };

--- a/src/llmq/commitment.h
+++ b/src/llmq/commitment.h
@@ -25,11 +25,16 @@ class CBlockIndex;
 class CDeterministicMNManager;
 class ChainstateManager;
 class TxValidationState;
+template <typename T>
+class CCheckQueueControl;
 
 namespace llmq
 {
 class CQuorumSnapshotManager;
 
+namespace utils {
+struct BlsCheck;
+} // namespace utils
 // This message is an aggregation of all received premature commitments and only valid if
 // enough (>=threshold) premature commitments were aggregated
 // This is mined on-chain as part of TRANSACTION_QUORUM_COMMITMENT
@@ -67,8 +72,9 @@ public:
         return int(std::count(validMembers.begin(), validMembers.end(), true));
     }
 
-    bool VerifySignature(CDeterministicMNManager& dmnman, CQuorumSnapshotManager& qsnapman,
-                         gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex) const;
+    bool VerifySignatureAsync(CDeterministicMNManager& dmnman, CQuorumSnapshotManager& qsnapman,
+                              gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
+                              CCheckQueueControl<utils::BlsCheck>* queue_control) const;
     bool Verify(CDeterministicMNManager& dmnman, CQuorumSnapshotManager& qsnapman,
                 gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, bool checkSigs) const;
     bool VerifyNull() const;

--- a/src/llmq/commitment.h
+++ b/src/llmq/commitment.h
@@ -67,6 +67,8 @@ public:
         return int(std::count(validMembers.begin(), validMembers.end(), true));
     }
 
+    bool VerifySignature(CDeterministicMNManager& dmnman, CQuorumSnapshotManager& qsnapman,
+                         gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex) const;
     bool Verify(CDeterministicMNManager& dmnman, CQuorumSnapshotManager& qsnapman,
                 gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, bool checkSigs) const;
     bool VerifyNull() const;

--- a/src/llmq/options.h
+++ b/src/llmq/options.h
@@ -24,6 +24,11 @@ enum class QvvecSyncMode {
     OnlyIfTypeMember = 1,
 };
 
+/** Maximum number of dedicated script-checking threads allowed */
+static const int MAX_BLSCHECK_THREADS = 31;
+/** -parbls default (number of bls-checking threads, 0 = auto) */
+static const int DEFAULT_BLSCHECK_THREADS = 0;
+
 static constexpr bool DEFAULT_ENABLE_QUORUM_DATA_RECOVERY{true};
 
 // If true, we will connect to all new quorums and watch their communication

--- a/src/llmq/options.h
+++ b/src/llmq/options.h
@@ -25,7 +25,7 @@ enum class QvvecSyncMode {
 };
 
 /** Maximum number of dedicated script-checking threads allowed */
-static const int MAX_BLSCHECK_THREADS = 31;
+static const int MAX_BLSCHECK_THREADS = 33;
 /** -parbls default (number of bls-checking threads, 0 = auto) */
 static const int DEFAULT_BLSCHECK_THREADS = 0;
 

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -953,7 +953,8 @@ bool BlsCheck::operator()()
             return false;
         }
     } else {
-        // It is supposed to be at least one public key!
+        // we should not get there ever
+        LogPrint(BCLog::LLMQ, "%s - no public keys are provided\n", m_id_string);
         return false;
     }
     return true;

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -940,6 +940,25 @@ void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman
     }
 }
 
+bool BlsCheck::operator()()
+{
+    if (m_pubkeys.size() > 1) {
+        if (!m_sig.VerifySecureAggregated(m_pubkeys, m_msg_hash)) {
+            LogPrint(BCLog::LLMQ, "%s\n", m_id_string);
+            return false;
+        }
+    } else if (m_pubkeys.size() == 1) {
+        if (!m_sig.VerifyInsecure(m_pubkeys.back(), m_msg_hash)) {
+            LogPrint(BCLog::LLMQ, "%s\n", m_id_string);
+            return false;
+        }
+    } else {
+        // It is supposed to be at least one public key!
+        return false;
+    }
+    return true;
+}
+
 template <typename CacheType>
 void InitQuorumsCache(CacheType& cache, bool limit_by_connections)
 {

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_LLMQ_UTILS_H
 #define BITCOIN_LLMQ_UTILS_H
 
+#include <bls/bls.h>
 #include <gsl/pointers.h>
 #include <llmq/params.h>
 #include <saltedhasher.h>
@@ -56,8 +57,36 @@ void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman
                                const CSporkManager& sporkman, const CDeterministicMNList& tip_mn_list,
                                gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& myProTxHash);
 
+struct BlsCheck {
+    CBLSSignature m_sig;
+    std::vector<CBLSPublicKey> m_pubkeys;
+    uint256 m_msg_hash;
+    std::string m_id_string;
+
+    BlsCheck() = default;
+
+    BlsCheck(CBLSSignature sig, std::vector<CBLSPublicKey> pubkeys, uint256 msg_hash, std::string id_string) :
+        m_sig(sig),
+        m_pubkeys(pubkeys),
+        m_msg_hash(msg_hash),
+        m_id_string(id_string)
+    {
+    }
+
+    void swap(BlsCheck& obj)
+    {
+        std::swap(m_sig, obj.m_sig);
+        std::swap(m_pubkeys, obj.m_pubkeys);
+        std::swap(m_msg_hash, obj.m_msg_hash);
+        std::swap(m_id_string, obj.m_id_string);
+    }
+
+    bool operator()();
+};
+
 template <typename CacheType>
 void InitQuorumsCache(CacheType& cache, bool limit_by_connections = true);
+
 } // namespace utils
 } // namespace llmq
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
During blocks validation, quorum commitments are processed in single thread.
While some blocks have up to 32 commitments (blocks which have rotation quorums commitment), each quorum commitment have hundreds public keys to validate and 2 signature (quorum signature and public key signature). It takes up to 30% in total indexing time and up to 1 second for heavy blocks.


## What was done?
`CCheckQueue` which is used for validation ECDSA signatures is used now for validation of BLS signatures in quorum commitments.
Quorum signature and members signatures are validated simultaneously now which makes performance improvement even for blocks which has only 1 commitment.

## How Has This Been Tested?
Invalidated + reconsidered 15k blocks (~1 months worth)
This PR makes validation of Quorum Commitment 3.5x times faster; overall indexing 25% faster on my 12 cores environment.

PR:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/6f1d9815-e8f1-4294-a376-ebbfd7a312c9" />
```
2025-05-28T10:17:56Z [bench]         - m_qblockman: 0.03ms [28.90s]
2025-05-28T10:17:56Z [bench]   - Connect total: 9.01ms [184.16s (11.86ms/blk)]
2025-05-28T10:17:56Z [bench] - Connect block: 9.21ms [190.33s (12.25ms/blk)]
```

develop:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/af7e5379-b3ce-4df0-ab90-f34649011f46" />
```
2025-05-22T18:39:44Z [bench]         - m_qblockman: 0.03ms [96.90s]
2025-05-22T18:39:44Z [bench]   - Connect total: 9.31ms [252.80s (16.28ms/blk)]
2025-05-22T18:39:44Z [bench] - Connect block: 9.50ms [258.90s (16.67ms/blk)]
```



## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone