### PR TITLE
ci: consolidate 2 jobs to 1, add arm64 image

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,5 +1,4 @@
 name: Build container
-
 on:
   workflow_call:
     inputs:
@@ -15,6 +14,11 @@ on:
         description: "Container name"
         required: true
         type: string
+      runs-on:
+        description: "Runner to use"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
     outputs:
       path:
         description: "Path to built container"
@@ -23,7 +27,7 @@ on:
 jobs:
   build:
     name: Build container
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runs-on }}
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
       repo: ${{ steps.prepare.outputs.repo }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -7,11 +7,19 @@ on:
         required: true
         type: string
       file:
-        description: "Path to Dockerfile"
+        description: "Path to main Dockerfile"
         required: true
         type: string
       name:
-        description: "Container name"
+        description: "Main container name"
+        required: true
+        type: string
+      slim-file:
+        description: "Path to slim Dockerfile"
+        required: true
+        type: string
+      slim-name:
+        description: "Slim container name"
         required: true
         type: string
       runs-on:
@@ -21,8 +29,11 @@ on:
         default: "ubuntu-24.04"
     outputs:
       path:
-        description: "Path to built container"
+        description: "Path to built main container"
         value: ghcr.io/${{ jobs.build.outputs.repo }}/${{ inputs.name }}:${{ jobs.build.outputs.tag }}
+      slim-path:
+        description: "Path to built slim container"
+        value: ghcr.io/${{ jobs.build.outputs.repo }}/${{ inputs.slim-name }}:${{ jobs.build.outputs.tag }}
 
 jobs:
   build:
@@ -55,7 +66,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push SLIM Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.slim-file }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.slim-name }}:${{ hashFiles(inputs.slim-file) }}
+            ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.slim-name }}:${{ steps.prepare.outputs.tag }}
+            ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.slim-name }}:latest
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.slim-name }}:${{ hashFiles(inputs.slim-file) }}
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.slim-name }}:${{ steps.prepare.outputs.tag }}
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.slim-name }}:latest
+          cache-to: type=inline
+
+      - name: Build and push MAIN Docker image
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.context }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,24 @@ jobs:
       file: ./contrib/containers/ci/ci-slim.Dockerfile
       name: dashcore-ci-slim
 
+  container-arm64:
+    name: Build container (ARM64)
+    uses: ./.github/workflows/build-container.yml
+    with:
+      context: ./contrib/containers/ci
+      file: ./contrib/containers/ci/ci.Dockerfile
+      name: dashcore-ci-runner
+      runs-on: ubuntu-24.04-arm
+
+  container-slim-arm64:
+    name: Build slim container (ARM64)
+    uses: ./.github/workflows/build-container.yml
+    with:
+      context: ./contrib/containers/ci
+      file: ./contrib/containers/ci/ci-slim.Dockerfile
+      name: dashcore-ci-slim
+      runs-on: ubuntu-24.04-arm
+
   depends-arm-linux:
     name: arm-linux-gnueabihf
     uses: ./.github/workflows/build-depends.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,37 +19,24 @@ concurrency:
 
 jobs:
   container:
-    name: Build container
+    name: Build containers (amd64)
     uses: ./.github/workflows/build-container.yml
     with:
       context: ./contrib/containers/ci
       file: ./contrib/containers/ci/ci.Dockerfile
       name: dashcore-ci-runner
-
-  container-slim:
-    name: Build slim container
-    uses: ./.github/workflows/build-container.yml
-    with:
-      context: ./contrib/containers/ci
-      file: ./contrib/containers/ci/ci-slim.Dockerfile
-      name: dashcore-ci-slim
+      slim-file: ./contrib/containers/ci/ci-slim.Dockerfile
+      slim-name: dashcore-ci-slim
 
   container-arm64:
-    name: Build container (ARM64)
+    name: Build containers (ARM64)
     uses: ./.github/workflows/build-container.yml
     with:
       context: ./contrib/containers/ci
       file: ./contrib/containers/ci/ci.Dockerfile
       name: dashcore-ci-runner
-      runs-on: ubuntu-24.04-arm
-
-  container-slim-arm64:
-    name: Build slim container (ARM64)
-    uses: ./.github/workflows/build-container.yml
-    with:
-      context: ./contrib/containers/ci
-      file: ./contrib/containers/ci/ci-slim.Dockerfile
-      name: dashcore-ci-slim
+      slim-file: ./contrib/containers/ci/ci-slim.Dockerfile
+      slim-name: dashcore-ci-slim
       runs-on: ubuntu-24.04-arm
 
   depends-arm-linux:
@@ -211,53 +198,62 @@ jobs:
   test-linux64:
     name: linux64-test
     uses: ./.github/workflows/test-src.yml
-    needs: [container-slim, src-linux64]
+    needs: [container, src-linux64]
     with:
       bundle-key: ${{ needs.src-linux64.outputs.key }}
       build-target: linux64
-      container-path: ${{ needs.container-slim.outputs.path }}
+      container-path: ${{ needs.container.outputs.slim-path }}
 
   test-linux64_multiprocess:
     name: linux64_multiprocess-test
     uses: ./.github/workflows/test-src.yml
-    needs: [container-slim, src-linux64_multiprocess]
+    needs: [container, src-linux64_multiprocess]
     with:
       bundle-key: ${{ needs.src-linux64_multiprocess.outputs.key }}
       build-target: linux64_multiprocess
-      container-path: ${{ needs.container-slim.outputs.path }}
+      container-path: ${{ needs.container.outputs.slim-path }}
 
   test-linux64_nowallet:
     name: linux64_nowallet-test
     uses: ./.github/workflows/test-src.yml
-    needs: [container-slim, src-linux64_nowallet]
+    needs: [container, src-linux64_nowallet]
     with:
       bundle-key: ${{ needs.src-linux64_nowallet.outputs.key }}
       build-target: linux64_nowallet
-      container-path: ${{ needs.container-slim.outputs.path }}
+      container-path: ${{ needs.container.outputs.slim-path }}
 
   test-linux64_sqlite:
     name: linux64_sqlite-test
     uses: ./.github/workflows/test-src.yml
-    needs: [container-slim, src-linux64_sqlite]
+    needs: [container, src-linux64_sqlite]
     with:
       bundle-key: ${{ needs.src-linux64_sqlite.outputs.key }}
       build-target: linux64_sqlite
-      container-path: ${{ needs.container-slim.outputs.path }}
+      container-path: ${{ needs.container.outputs.slim-path }}
 
   test-linux64_tsan:
     name: linux64_tsan-test
     uses: ./.github/workflows/test-src.yml
-    needs: [container-slim, src-linux64_tsan]
+    needs: [container, src-linux64_tsan]
     with:
       bundle-key: ${{ needs.src-linux64_tsan.outputs.key }}
       build-target: linux64_tsan
-      container-path: ${{ needs.container-slim.outputs.path }}
+      container-path: ${{ needs.container.outputs.slim-path }}
 
   test-linux64_ubsan:
     name: linux64_ubsan-test
     uses: ./.github/workflows/test-src.yml
-    needs: [container-slim, src-linux64_ubsan]
+    needs: [container, src-linux64_ubsan]
     with:
       bundle-key: ${{ needs.src-linux64_ubsan.outputs.key }}
       build-target: linux64_ubsan
-      container-path: ${{ needs.container-slim.outputs.path }}
+      container-path: ${{ needs.container.outputs.slim-path }}
+
+  test-arm-linux:
+    name: arm-linux-test
+    uses: ./.github/workflows/test-src.yml
+    needs: [container-arm64, src-arm-linux]
+    with:
+      bundle-key: ${{ needs.src-arm-linux.outputs.key }}
+      build-target: arm-linux
+      container-path: ${{ needs.container-arm64.outputs.slim-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,8 +252,8 @@ jobs:
   test-arm-linux:
     name: arm-linux-test
     uses: ./.github/workflows/test-src.yml
-    needs: [container-arm64, src-arm-linux]
+    needs: [container, src-arm-linux]
     with:
       bundle-key: ${{ needs.src-arm-linux.outputs.key }}
       build-target: arm-linux
-      container-path: ${{ needs.container-arm64.outputs.slim-path }}
+      container-path: ${{ needs.container.outputs.slim-path }}

--- a/contrib/containers/ci/ci-slim.Dockerfile
+++ b/contrib/containers/ci/ci-slim.Dockerfile
@@ -88,7 +88,9 @@ RUN set -ex; \
 
 ARG SHELLCHECK_VERSION=v0.7.1
 RUN set -ex; \
-    curl -fL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" -o /tmp/shellcheck.tar.xz; \
+    ARCH=$(uname -m); \
+    if [ "$ARCH" = "aarch64" ]; then SHELLCHECK_ARCH="aarch64"; else SHELLCHECK_ARCH="x86_64"; fi; \
+    curl -fL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" -o /tmp/shellcheck.tar.xz; \
     mkdir -p /opt/shellcheck && tar -xf /tmp/shellcheck.tar.xz -C /opt/shellcheck --strip-components=1 && rm /tmp/shellcheck.tar.xz
 ENV PATH="/opt/shellcheck:${PATH}"
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
1. We only build arm64 docker dev images
2. We spawn 2 separate jobs for slim and main image, when they share the vast majority of steps.

## What was done?
1. Add step to ship arm64 docker dev images too, currently this isn't used in CI, though it may be later. These are built on arm.
2. Consolidate the 2 steps into a single step, that pushes both images. This way, when there are no changes, we don't have the overhead of spinning up 2 jobs, and when there is a change, we aren't wasting compute by performing the same operations in both jobs.

## How Has This Been Tested?
CI in my fork: https://github.com/PastaPastaPasta/dash/actions/runs/15408489687

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

