### PR TITLE
feat: remove useless debug logs and improve mocktime logging

### DIFF
--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -457,14 +457,6 @@ bool CSpecialTxProcessor::BuildNewListFromBlock(const CBlock& block, gsl::not_nu
             }
         }
         newList.UpdateMN(payee->proTxHash, newState);
-        if (debugLogs) {
-            dmn = newList.GetMN(payee->proTxHash);
-            // Since the previous GetMN query returned a value, after an update, querying the same
-            // hash *must* give us a result. If it doesn't, that would be a potential logic bug.
-            assert(dmn);
-            LogPrint(BCLog::MNPAYMENTS, "%s -- MN %s, nConsecutivePayments=%d\n", __func__, dmn->proTxHash.ToString(),
-                     dmn->pdmnState->nConsecutivePayments);
-        }
     }
 
     // reset nConsecutivePayments on non-paid EvoNodes

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -220,7 +220,8 @@ static std::tuple<std::string, Consensus::LLMQType, int, uint32_t> BuildInversed
     return std::make_tuple(DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT_Q_INDEXED, llmqType, quorumIndex, htobe32_internal(std::numeric_limits<uint32_t>::max() - nMinedHeight));
 }
 
-static bool IsMiningPhase(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+static bool IsMiningPhase(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -247,8 +248,12 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
 
     uint256 quorumHash = GetQuorumBlockHash(llmq_params, m_chainstate.m_chain, nHeight, qc.quorumIndex);
 
-    LogPrint(BCLog::LLMQ, "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, signers=%s, validMembers=%d, quorumPublicKey=%s fJustCheck[%d] processing commitment from block.\n", __func__,
-             nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), qc.quorumPublicKey.ToString(), fJustCheck);
+    LogPrint(BCLog::LLMQ, /* Continued */
+             "%s -- processing commitment for block height=%d, type=%d, quorumIndex=%d, quorumHash=%s, signers=%s, "
+             "validMembers=%d, quorumPublicKey=%s "
+             "fJustCheck[%d] processing commitment from block.\n",
+             __func__, nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(), qc.CountSigners(),
+             qc.CountValidMembers(), qc.quorumPublicKey.ToString(), fJustCheck);
 
     // skip `bad-qc-block` checks below when replaying blocks after the crash
     if (m_chainstate.m_chain.Tip() == nullptr) {
@@ -256,20 +261,29 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
     }
 
     if (quorumHash.IsNull()) {
-        LogPrint(BCLog::LLMQ, "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, signers=%s, validMembers=%d, quorumPublicKey=%s quorumHash is null.\n", __func__,
-                 nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), qc.quorumPublicKey.ToString());
+        LogPrint(BCLog::LLMQ, /* Continued */
+                 "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, signers=%s, validMembers=%d, "
+                 "quorumPublicKey=%s quorumHash is null.\n",
+                 __func__, nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(), qc.CountSigners(),
+                 qc.CountValidMembers(), qc.quorumPublicKey.ToString());
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-block");
     }
     if (quorumHash != qc.quorumHash) {
-        LogPrint(BCLog::LLMQ, "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, qc.quorumHash=%s signers=%s, validMembers=%d, quorumPublicKey=%s non equal quorumHash.\n", __func__,
-                 nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(), qc.quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), qc.quorumPublicKey.ToString());
+        LogPrint(BCLog::LLMQ, /* Continued */
+                 "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, qc.quorumHash=%s signers=%s, "
+                 "validMembers=%d, quorumPublicKey=%s non equal quorumHash.\n",
+                 __func__, nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(),
+                 qc.quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), qc.quorumPublicKey.ToString());
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-block");
     }
 
     if (qc.IsNull()) {
         if (!qc.VerifyNull()) {
-            LogPrint(BCLog::LLMQ, "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, signers=%s, validMembers=%dqc verifynull failed.\n", __func__,
-                     nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers());
+            LogPrint(BCLog::LLMQ, /* Continued */
+                     "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, signers=%s, validMembers=%dqc "
+                     "verifynull failed.\n",
+                     __func__, nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(),
+                     qc.CountSigners(), qc.CountValidMembers());
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-invalid-null");
         }
         return true;
@@ -288,8 +302,11 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
     const auto* pQuorumBaseBlockIndex = m_chainstate.m_blockman.LookupBlockIndex(qc.quorumHash);
 
     if (!qc.Verify(m_dmnman, m_qsnapman, pQuorumBaseBlockIndex, /*checkSigs=*/fBLSChecks)) {
-        LogPrint(BCLog::LLMQ, "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, signers=%s, validMembers=%d, quorumPublicKey=%s qc verify failed.\n", __func__,
-                 nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), qc.quorumPublicKey.ToString());
+        LogPrint(BCLog::LLMQ, /* Continued */
+                 "%s -- height=%d, type=%d, quorumIndex=%d, quorumHash=%s, signers=%s, validMembers=%d, "
+                 "quorumPublicKey=%s qc verify failed.\n",
+                 __func__, nHeight, ToUnderlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString(), qc.CountSigners(),
+                 qc.CountValidMembers(), qc.quorumPublicKey.ToString());
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-qc-invalid");
     }
 
@@ -300,8 +317,8 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
     bool rotation_enabled = IsQuorumRotationEnabled(llmq_params, pQuorumBaseBlockIndex);
 
     if (rotation_enabled) {
-        LogPrint(BCLog::LLMQ, "%s -- height[%d] pQuorumBaseBlockIndex[%d] quorumIndex[%d] qversion[%d] Built\n", __func__,
-                 nHeight, pQuorumBaseBlockIndex->nHeight, qc.quorumIndex, qc.nVersion);
+        LogPrint(BCLog::LLMQ, "%s -- height[%d] pQuorumBaseBlockIndex[%d] quorumIndex[%d] qversion[%d] Built\n",
+                 __func__, nHeight, pQuorumBaseBlockIndex->nHeight, qc.quorumIndex, qc.nVersion);
     }
 
     // Store commitment in DB

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -76,7 +76,6 @@ public:
 private:
     static bool GetCommitmentsFromBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, std::multimap<Consensus::LLMQType, CFinalCommitment>& ret, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, BlockValidationState& state, bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    static bool IsMiningPhase(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     size_t GetNumCommitmentsRequired(const Consensus::LLMQParams& llmqParams, int nHeight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     static uint256 GetQuorumBlockHash(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight, int quorumIndex) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -401,7 +401,7 @@ std::string BCLog::Logger::LogTimestampStr(const std::string& str)
         }
         std::chrono::seconds mocktime = GetMockTime();
         if (mocktime > 0s) {
-            strStamped += " (mocktime: " + FormatISO8601DateTime(count_seconds(mocktime)) + ")";
+            strStamped += strprintf(" (mocktime: %d)", count_seconds(mocktime));
         }
         strStamped += ' ' + str;
     } else

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2539,7 +2539,6 @@ void CConnman::SocketHandlerConnected(const Sock::EventsPerSock& events_per_sock
         // (even if there are pending messages to be sent)
         for (auto it = mapSendableNodes.begin(); it != mapSendableNodes.end(); ) {
             if (!it->second->fCanSendData) {
-                LogPrint(BCLog::NET, "%s -- remove mapSendableNodes, peer=%d\n", __func__, it->second->GetId());
                 it = mapSendableNodes.erase(it);
             } else {
                 ++it;
@@ -2548,7 +2547,6 @@ void CConnman::SocketHandlerConnected(const Sock::EventsPerSock& events_per_sock
         // clean up mapReceivableNodes from nodes that were receivable in the last iteration but aren't anymore
         for (auto it = mapReceivableNodes.begin(); it != mapReceivableNodes.end(); ) {
             if (!it->second->fHasRecvData) {
-                LogPrint(BCLog::NET, "%s -- remove mapReceivableNodes, peer=%d\n", __func__, it->second->GetId());
                 it = mapReceivableNodes.erase(it);
             } else {
                 ++it;


### PR DESCRIPTION
## Issue being fixed or feature implemented
I have been lately watching to debug logs really a lot while investigating various flackiness in functional tests, and there are some adjustment that I found as useful.

## What was done?
 - removed `remove mapSendableNodes` an `remove mapReceivableNodes` lines that are triggered for almost each received network package

There's still plenty logs about network connection, but that particular line is useless.
```
 node0 2025-06-03T06:50:11.185505Z (mocktime: 2014-12-04T17:15:48Z) [       net] [net.cpp:2029] [CreateNodeFromAcceptedSocket] [net|netconn] connection accepted, sock=46, peer=0 
[REMOVED] node0 2025-06-03T06:50:11.185760Z (mocktime: 2014-12-04T17:15:48Z) [       net] [net.cpp:2798] [SocketHandlerConnected] [net] SocketHandlerConnected -- remove mapReceivableNodes, peer=0 
 node0 2025-06-03T06:50:11.185877Z (mocktime: 2014-12-04T17:15:48Z) [   msghand] [net_processing.cpp:3518] [ProcessMessage] [net] received: version (148 bytes) peer=0 
 node0 2025-06-03T06:50:11.185927Z (mocktime: 2014-12-04T17:15:48Z) [   msghand] [net.cpp:4967] [PushMessage] [net] sending version (148 bytes) peer=0 
 node0 2025-06-03T06:50:11.185959Z (mocktime: 2014-12-04T17:15:48Z) [   msghand] [net_processing.cpp:1468] [PushNodeVersion] [net] send version message: version 70237, blocks=113, txrelay=1, peer=0 
 node0 2025-06-03T06:50:11.185977Z (mocktime: 2014-12-04T17:15:48Z) [   msghand] [net.cpp:4967] [PushMessage] [net] sending sendaddrv2 (0 bytes) peer=0 
 node0 2025-06-03T06:50:11.186004Z (mocktime: 2014-12-04T17:15:48Z) [   msghand] [net.cpp:4967] [PushMessage] [net] sending verack (0 bytes) peer=0 
```

 - removed multiple lines from CQuorumBlockProcessor which are logged for each block but doesn't really help to understand why any quorum is failed to form, not bringing any useful input. Also 
`CQuorumBlockProcessor::ProcessCommitment` is simplified to just ProcessCommitment
```
[REMOVED] node0 2025-06-03T06:50:08.720090Z (mocktime: 2014-12-04T17:15:38Z) [httpworker.1] [llmq/blockprocessor.cpp:412] [IsMiningPhase] [llmq] [IsMiningPhase] nHeight[2] llmqType[100] quorumCycleStartHeight[0] -- NOT mining[10-18] 
[REMOVED] node0 2025-06-03T06:50:08.720101Z (mocktime: 2014-12-04T17:15:38Z) [httpworker.1] [llmq/blockprocessor.cpp:412] [IsMiningPhase] [llmq] [IsMiningPhase] nHeight[2] llmqType[103] quorumCycleStartHeight[0] -- NOT mining[12-20] 
[REMOVED] node0 2025-06-03T06:50:08.720112Z (mocktime: 2014-12-04T17:15:38Z) [httpworker.1] [llmq/blockprocessor.cpp:412] [IsMiningPhase] [llmq] [IsMiningPhase] nHeight[2] llmqType[106] quorumCycleStartHeight[0] -- NOT mining[10-18] 

[OLD] node0 2025-06-03T06:50:13.768237Z (mocktime: 2014-12-04T17:15:56Z) [httpworker.1] [llmq/blockprocessor.cpp:236] [ProcessCommitment] [llmq] CQuorumBlockProcessor::ProcessCommitment height=114, type=100, quorumIndex=0, quorumHash=224adea5fe8b95219555319e09cc4509ff550343b306a74fcf57dac9c380c6f2, signers=0, validMembers=0, quorumPublicKey=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 fJustCheck[1] processing commitment from block. 
[NEW]  node0 2025-06-03T06:51:07.902742Z (mocktime: 1417713341) [httpworker.1] [llmq/blockprocessor.cpp:250] [ProcessCommitment] [llmq] ProcessCommitment -- height=34, type=100, quorumIndex=0, quorumHash=793bfcce397cc0ab4a685f4fe2d2a4b71ce06402813ea1f55e626ad2f1acbe9b, signers=0, validMembers=0, quorumPublicKey=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 fJustCheck[1] processing commitment from block. 
```

 - removed logs for consequent masternode payments (which is always 0 since mn_rr activated)

```
[REMOVED] node0 2025-06-03T06:50:20.938625Z (mocktime: 2014-12-04T17:16:09Z) [httpworker.0] [evo/deterministicmns.cpp:977] [BuildNewListFromBlock] [mnpayments] CDeterministicMNManager::BuildNewListFromBlock -- MN 8e26622b3336527f126324c71fb169b9be741ed5351832c28007571cbe864b28, nConsecutivePayments=0
```

 - mocktime is shown now in seconds since 1970. Comparing strings `2014-12-04T17:15:37Z` and `2014-12-04T17:15:38Z` I find difficult to do, especially if mocktime bumped for more than 1 second or multiple times; it requires to do some math also over module 60 (60 seconds in minute).

```
[OLD] node0 2025-06-03T06:47:49.402583Z (mocktime: 2014-12-04T17:15:37Z) [httpworker.3] [rpc/request.cpp:180] [parse] [rpc] ThreadRPCServer method=setmocktime user=__cookie__
[OLD] node0 2025-06-03T06:47:49.402632Z (mocktime: 2014-12-04T17:15:38Z) [httpworker.3] [httprpc.cpp:93] [~RpcHttpRequest] [bench] HTTP RPC request handled: user=__cookie__ command=setmocktime external=false status=200 elapsed_time_ms=0 
[NEW] node0 2025-06-03T06:46:35.684642Z (mocktime: 1417713337) [httpworker.2] [rpc/request.cpp:180] [parse] [rpc] ThreadRPCServer method=setmocktime user=__cookie__ 
[NEW] node0 2025-06-03T06:46:35.684674Z (mocktime: 1417713338) [httpworker.2] [httprpc.cpp:93] [~RpcHttpRequest] [bench] HTTP RPC request handled: user=__cookie__ command=setmocktime external=false status=200 elapsed_time_ms=0 
```

## How Has This Been Tested?
It makes reading by eyes much more friendly because less items to read and lines a bit shorter, and less matches by block hash / protx hashes when you are looking for some particular records.
 
As positive side effect, total size of all logs of all functional tests is decreased for ~200Mb (1.7Gb -> 1.5Gb).

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone