### PR TITLE
perf: parse CbTx only once perf block

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -59,31 +59,15 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidati
 }
 
 // This can only be done after the block has been fully processed, as otherwise we won't have the finished MN list
-bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex,
+bool CheckCbTxMerkleRoots(const CBlock& block, const CCbTx& cbTx, const CBlockIndex* pindex,
                           const llmq::CQuorumBlockProcessor& quorum_block_processor, CSimplifiedMNList&& sml,
                           BlockValidationState& state)
 {
-    if (block.vtx[0]->nType != TRANSACTION_COINBASE) {
-        return true;
-    }
-
-    static int64_t nTimePayload = 0;
-
-    int64_t nTime1 = GetTimeMicros();
-
-    const auto opt_cbTx = GetTxPayload<CCbTx>(*block.vtx[0]);
-    if (!opt_cbTx) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-payload");
-    }
-    auto cbTx = *opt_cbTx;
-
-    int64_t nTime2 = GetTimeMicros(); nTimePayload += nTime2 - nTime1;
-    LogPrint(BCLog::BENCHMARK, "          - GetTxPayload: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimePayload * 0.000001);
-
     if (pindex) {
         static int64_t nTimeMerkleMNL = 0;
         static int64_t nTimeMerkleQuorum = 0;
 
+        int64_t nTime1 = GetTimeMicros();
         uint256 calculatedMerkleRoot;
         if (!CalcCbTxMerkleRootMNList(calculatedMerkleRoot, std::move(sml), state)) {
             // pass the state returned by the function above
@@ -93,8 +77,10 @@ bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex,
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-mnmerkleroot");
         }
 
-        int64_t nTime3 = GetTimeMicros(); nTimeMerkleMNL += nTime3 - nTime2;
-        LogPrint(BCLog::BENCHMARK, "          - CalcCbTxMerkleRootMNList: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeMerkleMNL * 0.000001);
+        int64_t nTime2 = GetTimeMicros();
+        nTimeMerkleMNL += nTime2 - nTime1;
+        LogPrint(BCLog::BENCHMARK, "          - CalcCbTxMerkleRootMNList: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1),
+                 nTimeMerkleMNL * 0.000001);
 
         if (cbTx.nVersion >= CCbTx::Version::MERKLE_ROOT_QUORUMS) {
             if (!CalcCbTxMerkleRootQuorums(block, pindex->pprev, quorum_block_processor, calculatedMerkleRoot, state)) {
@@ -106,9 +92,10 @@ bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex,
             }
         }
 
-        int64_t nTime4 = GetTimeMicros(); nTimeMerkleQuorum += nTime4 - nTime3;
-        LogPrint(BCLog::BENCHMARK, "          - CalcCbTxMerkleRootQuorums: %.2fms [%.2fs]\n", 0.001 * (nTime4 - nTime3), nTimeMerkleQuorum * 0.000001);
-
+        int64_t nTime3 = GetTimeMicros();
+        nTimeMerkleQuorum += nTime3 - nTime2;
+        LogPrint(BCLog::BENCHMARK, "          - CalcCbTxMerkleRootQuorums: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2),
+                 nTimeMerkleQuorum * 0.000001);
     }
 
     return true;
@@ -314,19 +301,9 @@ bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPre
     return true;
 }
 
-bool CheckCbTxBestChainlock(const CBlock& block, const CBlockIndex* pindex,
+bool CheckCbTxBestChainlock(const CCbTx& cbTx, const CBlockIndex* pindex,
                             const llmq::CChainLocksHandler& chainlock_handler, BlockValidationState& state)
 {
-    if (block.vtx[0]->nType != TRANSACTION_COINBASE) {
-        return true;
-    }
-
-    const auto opt_cbTx = GetTxPayload<CCbTx>(*block.vtx[0]);
-    if (!opt_cbTx) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-payload");
-    }
-    const auto& cbTx = *opt_cbTx;
-
     if (cbTx.nVersion < CCbTx::Version::CLSIG_AND_BALANCE) {
         return true;
     }

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -19,22 +19,8 @@
 #include <deploymentstatus.h>
 
 
-bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state)
+bool CheckCbTx(const CCbTx& cbTx, const CBlockIndex* pindexPrev, TxValidationState& state)
 {
-    if (tx.nType != TRANSACTION_COINBASE) {
-        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-type");
-    }
-
-    if (!tx.IsCoinBase()) {
-        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-invalid");
-    }
-
-    const auto opt_cbTx = GetTxPayload<CCbTx>(tx);
-    if (!opt_cbTx) {
-        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-payload");
-    }
-    const auto& cbTx = *opt_cbTx;
-
     if (cbTx.nVersion == CCbTx::Version::INVALID || cbTx.nVersion >= CCbTx::Version::UNKNOWN) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
     }

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -64,7 +64,7 @@ public:
 };
 template<> struct is_serializable_enum<CCbTx::Version> : std::true_type {};
 
-bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state);
+bool CheckCbTx(const CCbTx& cbTx, const CBlockIndex* pindexPrev, TxValidationState& state);
 
 bool CheckCbTxMerkleRoots(const CBlock& block, const CCbTx& cbTx, const CBlockIndex* pindex,
                           const llmq::CQuorumBlockProcessor& quorum_block_processor, CSimplifiedMNList&& sml,

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -66,7 +66,7 @@ template<> struct is_serializable_enum<CCbTx::Version> : std::true_type {};
 
 bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state);
 
-bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex,
+bool CheckCbTxMerkleRoots(const CBlock& block, const CCbTx& cbTx, const CBlockIndex* pindex,
                           const llmq::CQuorumBlockProcessor& quorum_block_processor, CSimplifiedMNList&& sml,
                           BlockValidationState& state);
 bool CalcCbTxMerkleRootMNList(uint256& merkleRootRet, CSimplifiedMNList&& sml, BlockValidationState& state);
@@ -74,7 +74,7 @@ bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPre
                                const llmq::CQuorumBlockProcessor& quorum_block_processor, uint256& merkleRootRet,
                                BlockValidationState& state);
 
-bool CheckCbTxBestChainlock(const CBlock& block, const CBlockIndex* pindexPrev,
+bool CheckCbTxBestChainlock(const CCbTx& cbTx, const CBlockIndex* pindexPrev,
                             const llmq::CChainLocksHandler& chainlock_handler, BlockValidationState& state);
 bool CalcCbTxBestChainlock(const llmq::CChainLocksHandler& chainlock_handler, const CBlockIndex* pindexPrev,
                            uint32_t& bestCLHeightDiff, CBLSSignature& bestCLSignature);

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -149,7 +149,7 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(const CBlock& block, const CB
         int64_t nTime0 = GetTimeMicros();
 
         std::optional<CCbTx> opt_cbTx{std::nullopt};
-        if (block.vtx.size() > 0 && block.vtx[0]->nType == TRANSACTION_COINBASE) {
+        if (fCheckCbTxMerkleRoots && block.vtx.size() > 0 && block.vtx[0]->nType == TRANSACTION_COINBASE) {
             const auto& tx = block.vtx[0];
             if (!tx->IsCoinBase()) {
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-invalid");

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -46,10 +46,6 @@ private:
     const llmq::CChainLocksHandler& m_clhandler;
     const llmq::CQuorumManager& m_qman;
 
-private:
-    [[nodiscard]] bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, TxValidationState& state);
-    [[nodiscard]] bool UndoSpecialTx(const CTransaction& tx, const CBlockIndex* pindex);
-
 public:
     explicit CSpecialTxProcessor(CCreditPoolManager& cpoolman, CDeterministicMNManager& dmnman, CMNHFManager& mnhfman,
                                  llmq::CQuorumBlockProcessor& qblockman, llmq::CQuorumSnapshotManager& qsnapman,

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -14,6 +14,7 @@
 class BlockValidationState;
 class CBlock;
 class CBlockIndex;
+class CCbTx;
 class CCoinsViewCache;
 class CCreditPoolManager;
 class CDeterministicMNManager;
@@ -70,7 +71,9 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, std::optional<MNListUpdates>& updatesRet)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    bool CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex, const CAmount blockSubsidy, BlockValidationState& state)
+    // TODO: make it private and remove forward declaration CCbTx
+    bool CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex, const CCbTx& cbTx,
+                                     const CAmount blockSubsidy, BlockValidationState& state)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_EVO_SPECIALTXMAN_H
 #define BITCOIN_EVO_SPECIALTXMAN_H
 
-#include <consensus/amount.h>
 #include <sync.h>
 #include <threadsafety.h>
 
@@ -71,10 +70,10 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, std::optional<MNListUpdates>& updatesRet)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    // TODO: make it private and remove forward declaration CCbTx
+
+private:
     bool CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex, const CCbTx& cbTx,
-                                     const CAmount blockSubsidy, BlockValidationState& state)
-        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                                     BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 #endif // BITCOIN_EVO_SPECIALTXMAN_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2113,7 +2113,6 @@ static int64_t nTimeForks = 0;
 static int64_t nTimeVerify = 0;
 static int64_t nTimeISFilter = 0;
 static int64_t nTimeSubsidy = 0;
-static int64_t nTimeCreditPool = 0;
 static int64_t nTimeValueValid = 0;
 static int64_t nTimePayeeValid = 0;
 static int64_t nTimeProcessSpecial = 0;
@@ -2495,13 +2494,6 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     int64_t nTime5_2 = GetTimeMicros(); nTimeSubsidy += nTime5_2 - nTime5_1;
     LogPrint(BCLog::BENCHMARK, "      - GetBlockSubsidy: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_2 - nTime5_1), nTimeSubsidy * MICRO, nTimeSubsidy * MILLI / nBlocksTotal);
 
-    if (!m_chain_helper->special_tx->CheckCreditPoolDiffForBlock(block, pindex, blockSubsidy, state)) {
-        return error("ConnectBlock(DASH): CheckCreditPoolDiffForBlock for block %s failed with %s",
-                     pindex->GetBlockHash().ToString(), state.ToString());
-    }
-
-    int64_t nTime5_3 = GetTimeMicros(); nTimeCreditPool += nTime5_3 - nTime5_2;
-    LogPrint(BCLog::BENCHMARK, "      - CheckCreditPoolDiffForBlock: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_3 - nTime5_2), nTimeCreditPool * MICRO, nTimeCreditPool * MILLI / nBlocksTotal);
 
     const bool check_superblock = m_chain_helper->GetBestChainLockHeight() < pindex->nHeight;
 
@@ -2511,8 +2503,8 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
         return state.Invalid(BlockValidationResult::BLOCK_RESULT_UNSET, "bad-cb-amount");
     }
 
-    int64_t nTime5_4 = GetTimeMicros(); nTimeValueValid += nTime5_4 - nTime5_3;
-    LogPrint(BCLog::BENCHMARK, "      - IsBlockValueValid: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_4 - nTime5_3), nTimeValueValid * MICRO, nTimeValueValid * MILLI / nBlocksTotal);
+    int64_t nTime5_3 = GetTimeMicros(); nTimeValueValid += nTime5_3 - nTime5_2;
+    LogPrint(BCLog::BENCHMARK, "      - IsBlockValueValid: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_3 - nTime5_2), nTimeValueValid * MICRO, nTimeValueValid * MILLI / nBlocksTotal);
 
     if (!m_chain_helper->mn_payments->IsBlockPayeeValid(*block.vtx[0], pindex->pprev, blockSubsidy, feeReward, check_superblock)) {
         // NOTE: Do not punish, the node might be missing governance data
@@ -2520,8 +2512,8 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
         return state.Invalid(BlockValidationResult::BLOCK_RESULT_UNSET, "bad-cb-payee");
     }
 
-    int64_t nTime5_5 = GetTimeMicros(); nTimePayeeValid += nTime5_5 - nTime5_4;
-    LogPrint(BCLog::BENCHMARK, "      - IsBlockPayeeValid: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_5 - nTime5_4), nTimePayeeValid * MICRO, nTimePayeeValid * MILLI / nBlocksTotal);
+    int64_t nTime5_4 = GetTimeMicros(); nTimePayeeValid += nTime5_4 - nTime5_3;
+    LogPrint(BCLog::BENCHMARK, "      - IsBlockPayeeValid: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_4 - nTime5_3), nTimePayeeValid * MICRO, nTimePayeeValid * MILLI / nBlocksTotal);
 
     int64_t nTime5 = GetTimeMicros(); nTimeDashSpecific += nTime5 - nTime4;
     LogPrint(BCLog::BENCHMARK, "    - Dash specific: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5 - nTime4), nTimeDashSpecific * MICRO, nTimeDashSpecific * MILLI / nBlocksTotal);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Coinbase Transaction (CCbTx) is parsed several times:
 - itself validation (during CheckCbTx)
 - for merkle roots (during CheckCbTxMerkleRoots)
 - for CL validation (during CheckCbTxBestChainlock)
 - for Credit Pool (during CheckCreditPoolDiffForBlock)

For pre-v20 blocks this parsing has been relatively cheap, but once V20 has been activated, each CbTx has CL signature and its deserialization become expensive due to heavy call of `CBLSWrapper<bls::G2Element, 96ul, CBLSSignature>::Unserialize<CDataStream>(CDataStream&, bool)`.

## What was done?
CCbTx is parsed only once and reused for all related checks.

This PR makes validation of blocks after v20 activation for ~6% faster.
Validation of pre-v20 block is expected to be improved insignificantly (<1% of total time).

## How Has This Been Tested?
Invalidated + reconsidered ~8.5k blocks (~2 weeks) after v20 activation.

Develop:
<img width="704" alt="image" src="https://github.com/user-attachments/assets/08b63507-4cbf-4e2c-917e-1287ff17210d" />
```
[bench]         - Loop: 0.22ms [10.01s]
[bench]           - GetTxPayload: 0.21ms [2.16s]
[bench]         - CheckCbTxMerkleRoots: 3.23ms [28.46s]
[bench]         - CheckCbTxBestChainlock: 3.16ms [24.65s]
[bench]       - ProcessSpecialTxsInBlock: 8.15ms [101.19s (11.66ms/blk)]
[bench]       - CheckCreditPoolDiffForBlock: 0.22ms [2.98s (0.34ms/blk)]
[bench]     - Dash specific: 0.42ms [4.98s (0.57ms/blk)]
[bench]   - Connect total: 8.87ms [113.20s (13.04ms/blk)]
[bench] - Connect block: 9.26ms [116.51s (13.42ms/blk)]
```

PR:
<img width="704" alt="image" src="https://github.com/user-attachments/assets/697d9b73-83f4-419e-9ecc-fa9c24e1eafc" />
```
[bench]       - GetTxPayload: 0.24ms [2.34s]
[bench]       - Loop: 0.02ms [7.89s]
[bench]       - CheckCreditPoolDiffForBlock: 0.01ms [0.76s]
[bench]       - CheckCbTxMerkleRoots: 3.17ms [26.50s]
[bench]       - CheckCbTxBestChainlock: 3.08ms [22.77s]
[bench]       - ProcessSpecialTxsInBlock: 8.02ms [98.70s (11.37ms/blk)]
[bench]     - Dash specific: 0.27ms [1.97s (0.23ms/blk)]
[bench]   - Connect total: 8.58ms [107.65s (12.40ms/blk)]
[bench] - Connect block: 8.92ms [110.97s (12.78ms/blk)]
```

Some insignificant lines (not relevant to PR) are removed from both screenshots and bench logs, only affected functions are shown.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone