### PR TITLE
fix: missing mutex for bls::operator==

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -509,19 +509,23 @@ public:
 
     bool operator==(const CBLSLazyWrapper& r) const
     {
-        // If neither bufValid or objInitialized are set, then the object is the default object.
-        const bool is_default{!bufValid && !objInitialized};
-        const bool r_is_default{!r.bufValid && !r.objInitialized};
-        // If both are default; they are equal.
-        if (is_default && r_is_default) return true;
-        // If one is default and the other isn't, we are not equal
-        if (is_default != r_is_default) return false;
+        if (&r == this) return true;
+        {
+            std::scoped_lock lock(mutex, r.mutex);
+            // If neither bufValid or objInitialized are set, then the object is the default object.
+            const bool is_default{!bufValid && !objInitialized};
+            const bool r_is_default{!r.bufValid && !r.objInitialized};
+            // If both are default; they are equal.
+            if (is_default && r_is_default) return true;
+            // If one is default and the other isn't, we are not equal
+            if (is_default != r_is_default) return false;
 
-        if (bufValid && r.bufValid && bufLegacyScheme == r.bufLegacyScheme) {
-            return vecBytes == r.vecBytes;
-        }
-        if (objInitialized && r.objInitialized) {
-            return obj == r.obj;
+            if (bufValid && r.bufValid && bufLegacyScheme == r.bufLegacyScheme) {
+                return vecBytes == r.vecBytes;
+            }
+            if (objInitialized && r.objInitialized) {
+                return obj == r.obj;
+            }
         }
         return Get() == r.Get();
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Somehow, CBLSLazyWrapper works correctly till now and does not cause any failures even `CBLSLazyWrapper::operator==()` doesn't have mutex inside. Let's fix it!

## What was done?
Added mutex to operator== for CBLSWrapper; added ptrs comparision to operator== in case of compare `A==A` to avoid deadlock.


## How Has This Been Tested?
Run unit / functional tests.



## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
