### PR TITLE
chore: deprecate `protx register{,_fund,_prepare}_legacy` and `protx update_registrar_legacy`, specifying scheme in `bls generate`

### DIFF
--- a/doc/release-notes-6723.md
+++ b/doc/release-notes-6723.md
@@ -1,0 +1,6 @@
+Updated RPCs
+------------
+
+* The RPCs `protx register_legacy`, `protx register_fund_legacy`, `protx register_prepare_legacy` and
+  `protx update_registrar_legacy` have been deprecated in Dash Core v23 and may be removed in a future version
+  They can be re-enabled with the runtime argument `-deprecatedrpc=legacy_mn`.

--- a/doc/release-notes-6723.md
+++ b/doc/release-notes-6723.md
@@ -4,3 +4,6 @@ Updated RPCs
 * The RPCs `protx register_legacy`, `protx register_fund_legacy`, `protx register_prepare_legacy` and
   `protx update_registrar_legacy` have been deprecated in Dash Core v23 and may be removed in a future version
   They can be re-enabled with the runtime argument `-deprecatedrpc=legacy_mn`.
+
+* The argument `legacy` in `bls generate` has been deprecated in Dash Core v23 and may be ignored in a future version.
+  It can be re-enabled with the runtime argument `deprecatedrpc=legacy_mn`.

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -379,6 +379,7 @@ static RPCHelpMan protx_register_fund_wrapper(const bool legacy)
         "masternode.\n"
         "A few of the limitations you see in the arguments are temporary and might be lifted after DIP3\n"
         "is fully deployed.\n"
+        + std::string(legacy ? "\nDEPRECATED: May be removed in a future version, pass config option -deprecatedrpc=legacy_mn to use RPC\n" : "")
         + HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("collateralAddress"),
@@ -402,6 +403,9 @@ static RPCHelpMan protx_register_fund_wrapper(const bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (legacy && !IsDeprecatedRPCEnabled("legacy_mn")) {
+        throw std::runtime_error("DEPRECATED: Pass config option -deprecatedrpc=legacy_mn to enable this RPC");
+    }
     return protx_register_common_wrapper(request, self.m_name == "protx register_fund_legacy", ProTxRegisterAction::Fund, MnType::Regular);
 },
     };
@@ -425,6 +429,7 @@ static RPCHelpMan protx_register_wrapper(bool legacy)
         "\nSame as \"protx register_fund\", but with an externally referenced collateral.\n"
         "The collateral is specified through \"collateralHash\" and \"collateralIndex\" and must be an unspent\n"
         "transaction output spendable by this wallet. It must also not be used by any other masternode.\n"
+        + std::string(legacy ? "\nDEPRECATED: May be removed in a future version, pass config option -deprecatedrpc=legacy_mn to use RPC\n" : "")
         + HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("collateralHash"),
@@ -449,6 +454,9 @@ static RPCHelpMan protx_register_wrapper(bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (legacy && !IsDeprecatedRPCEnabled("legacy_mn")) {
+        throw std::runtime_error("DEPRECATED: Pass config option -deprecatedrpc=legacy_mn to enable this RPC");
+    }
     return protx_register_common_wrapper(request, self.m_name == "protx register_legacy", ProTxRegisterAction::External, MnType::Regular);
 },
     };
@@ -473,7 +481,8 @@ static RPCHelpMan protx_register_prepare_wrapper(const bool legacy)
     return RPCHelpMan{rpc_full_name,
         "\nCreates an unsigned ProTx and a message that must be signed externally\n"
         "with the private key that corresponds to collateralAddress to prove collateral ownership.\n"
-        "The prepared transaction will also contain inputs and outputs to cover fees.\n",
+        "The prepared transaction will also contain inputs and outputs to cover fees.\n"
+        + std::string(legacy ? "\nDEPRECATED: May be removed in a future version, pass config option -deprecatedrpc=legacy_mn to use RPC\n" : ""),
         {
             GetRpcArg("collateralHash"),
             GetRpcArg("collateralIndex"),
@@ -497,6 +506,9 @@ static RPCHelpMan protx_register_prepare_wrapper(const bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (legacy && !IsDeprecatedRPCEnabled("legacy_mn")) {
+        throw std::runtime_error("DEPRECATED: Pass config option -deprecatedrpc=legacy_mn to enable this RPC");
+    }
     return protx_register_common_wrapper(request, self.m_name == "protx register_prepare_legacy", ProTxRegisterAction::Prepare, MnType::Regular);
 },
     };
@@ -1063,6 +1075,7 @@ static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_
         "\nCreates and sends a ProUpRegTx to the network. This will update the operator key, voting key and payout\n"
         "address of the masternode specified by \"proTxHash\".\n"
         "The owner key of the masternode must be known to your wallet.\n"
+        + std::string(specific_legacy_bls_scheme ? "\nDEPRECATED: May be removed in a future version, pass config option -deprecatedrpc=legacy_mn to use RPC\n" : "")
         + HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("proTxHash"),
@@ -1080,6 +1093,10 @@ static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     const bool use_legacy{self.m_name == "protx update_registrar_legacy"};
+    if (use_legacy && !IsDeprecatedRPCEnabled("legacy_mn")) {
+        throw std::runtime_error("DEPRECATED: Pass config option -deprecatedrpc=legacy_mn to enable this RPC");
+    }
+
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const ChainstateManager& chainman = EnsureChainman(node);
 
@@ -1662,9 +1679,9 @@ static RPCHelpMan protx_help()
         "  register_evo             - Create and send ProTx to network for an EvoNode\n"
         "  register_fund_evo        - Fund, create and send ProTx to network for an EvoNode\n"
         "  register_prepare_evo     - Create an unsigned ProTx for an EvoNode\n"
-        "  register_legacy          - Create a ProTx by parsing BLS using the legacy scheme and send it to network\n"
-        "  register_fund_legacy     - Fund and create a ProTx by parsing BLS using the legacy scheme, then send it to network\n"
-        "  register_prepare_legacy  - Create an unsigned ProTx by parsing BLS using the legacy scheme\n"
+        "  register_legacy          - (DEPRECATED) Create a ProTx by parsing BLS using the legacy scheme and send it to network\n"
+        "  register_fund_legacy     - (DEPRECATED) Fund and create a ProTx by parsing BLS using the legacy scheme, then send it to network\n"
+        "  register_prepare_legacy  - (DEPRECATED) Create an unsigned ProTx by parsing BLS using the legacy scheme\n"
         "  register_submit          - Sign and submit a ProTx\n"
 #endif
         "  list                     - List ProTxs\n"
@@ -1673,7 +1690,7 @@ static RPCHelpMan protx_help()
         "  update_service           - Create and send ProUpServTx to network\n"
         "  update_service_evo       - Create and send ProUpServTx to network for an EvoNode\n"
         "  update_registrar         - Create and send ProUpRegTx to network\n"
-        "  update_registrar_legacy  - Create ProUpRegTx by parsing BLS using the legacy scheme, then send it to network\n"
+        "  update_registrar_legacy  - (DEPRECATED) Create ProUpRegTx by parsing BLS using the legacy scheme, then send it to network\n"
         "  revoke                   - Create and send ProUpRevTx to network\n"
 #endif
         "  diff                     - Calculate a diff and a proof between two masternode lists\n"
@@ -1788,19 +1805,19 @@ static const CRPCCommand commands[] =
     { "evo",                &protx_info,                       },
     { "evo",                &protx_register,                   },
     { "evo",                &protx_register_evo,               },
-    { "evo",                &protx_register_legacy,            },
     { "evo",                &protx_register_fund,              },
-    { "evo",                &protx_register_fund_legacy,       },
     { "evo",                &protx_register_fund_evo,          },
     { "evo",                &protx_register_prepare,           },
     { "evo",                &protx_register_prepare_evo,       },
-    { "evo",                &protx_register_prepare_legacy,    },
     { "evo",                &protx_update_service,             },
     { "evo",                &protx_update_service_evo,         },
     { "evo",                &protx_register_submit,            },
     { "evo",                &protx_update_registrar,           },
-    { "evo",                &protx_update_registrar_legacy,    },
     { "evo",                &protx_revoke,                     },
+    { "hidden",             &protx_register_legacy,            },
+    { "hidden",             &protx_register_fund_legacy,       },
+    { "hidden",             &protx_register_prepare_legacy,    },
+    { "hidden",             &protx_update_registrar_legacy,    },
 };
 // clang-format on
     return commands;

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1713,7 +1713,7 @@ static RPCHelpMan bls_generate()
         "bls generate",
         "\nReturns a BLS secret/public key pair.\n",
         {
-            {"legacy", RPCArg::Type::BOOL, RPCArg::Default{false}, "Set it true if need in legacy BLS scheme"},
+            {"legacy", RPCArg::Type::BOOL, RPCArg::Default{false}, "(DEPRECATED, can be set if -deprecatedrpc=legacy_mn is passed) Set true to use legacy BLS scheme"},
         },
         RPCResult{RPCResult::Type::OBJ,
                   "",
@@ -1727,6 +1727,9 @@ static RPCHelpMan bls_generate()
             sk.MakeNewKey();
             bool bls_legacy_scheme{false};
             if (!request.params[0].isNull()) {
+                if (!IsDeprecatedRPCEnabled("legacy_mn")) {
+                    throw std::runtime_error("DEPRECATED: Pass config option -deprecatedrpc=legacy_mn to set this argument");
+                }
                 bls_legacy_scheme = ParseBoolV(request.params[0], "bls_legacy_scheme");
             }
             UniValue ret(UniValue::VOBJ);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -41,6 +41,9 @@ private:
 class RPCTestingSetup : public TestingSetup
 {
 public:
+    RPCTestingSetup()
+        : TestingSetup(CBaseChainParams::MAIN, {"-deprecatedrpc=legacy_mn"}) {}
+
     UniValue TransformParams(const UniValue& params, std::vector<std::string> arg_names);
     UniValue CallRPC(std::string args);
 };

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -47,6 +47,7 @@ class TestP2PConn(P2PInterface):
 class DIP3V19Test(DashTestFramework):
     def set_test_params(self):
         self.extra_args = [[
+            '-deprecatedrpc=legacy_mn',
             '-testactivationheight=v19@200',
         ]] * 6
         self.set_dash_test_params(6, 5, evo_count=2, extra_args=self.extra_args)


### PR DESCRIPTION
## Breaking Changes

* The RPCs `protx register_legacy`, `protx register_fund_legacy`, `protx register_prepare_legacy` and
  `protx update_registrar_legacy` have been deprecated in Dash Core v23 and may be removed in a future version
  They can be re-enabled with the runtime argument `-deprecatedrpc=legacy_mn`.

* The argument `legacy` in `bls generate` has been deprecated in Dash Core v23 and may be ignored in a future version.
  It can be re-enabled with the runtime argument `deprecatedrpc=legacy_mn`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
