### PR TITLE
test: functional tests for invalid QuorumCommitment

### DIFF
--- a/test/functional/feature_llmq_dkgerrors.py
+++ b/test/functional/feature_llmq_dkgerrors.py
@@ -6,12 +6,13 @@
 import copy
 from io import BytesIO
 
-from test_framework.test_framework import DashTestFramework
 from test_framework.messages import (
-        CBlock,
-        CFinalCommitmentPayload,
-        from_hex,
+    CBlock,
+    CFinalCommitmentPayload,
+    from_hex,
 )
+
+from test_framework.test_framework import DashTestFramework
 from test_framework.util import assert_equal
 '''
 feature_llmq_dkgerrors.py

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1407,6 +1407,34 @@ class CFinalCommitment:
             .format(self.nVersion, self.llmqType, self.quorumHash, self.quorumIndex, repr(self.signers),
                     repr(self.validMembers), self.quorumPublicKey.hex(), self.quorumVvecHash, self.quorumSig.hex(), self.membersSig.hex())
 
+
+class CFinalCommitmentPayload:
+    __slots__ = ("nVersion", "nHeight", "commitment")
+
+    def __init__(self):
+        self.set_null()
+
+    def set_null(self):
+        self.nVersion = 0
+        self.nHeight = 0
+        self.commitment = CFinalCommitment()
+
+    def deserialize(self, f):
+        self.nVersion = struct.unpack("<H", f.read(2))[0]
+        self.nHeight = struct.unpack("<I", f.read(4))[0]
+        self.commitment = CFinalCommitment()
+        self.commitment.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<H", self.nVersion)
+        r += struct.pack("<I", self.nHeight)
+        r += self.commitment.serialize()
+        return r
+
+    def __repr__(self):
+        return f"CFinalCommitmentPayload(nVersion={self.nVersion} nHeight={self.nHeight} commitment={self.commitment})"
+
 class CGovernanceObject:
     __slots__ = ("nHashParent", "nRevision", "nTime", "nCollateralHash", "vchData", "nObjectType",
                  "masternodeOutpoint", "vchSig")

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2189,7 +2189,7 @@ class DashTestFramework(BitcoinTestFramework):
             # Mine 8 (SIGN_HEIGHT_OFFSET) more blocks to make sure that the new quorum gets eligible for signing sessions
             self.generate(self.nodes[0], 8, sync_fun=lambda: self.sync_blocks(nodes))
 
-        self.log.info("New quorum: height=%d, quorumHash=%s, quorumIndex=%d, minedBlock=%s" % (quorum_info["height"], new_quorum, quorum_info["quorumIndex"], quorum_info["minedBlock"]))
+        self.log.info(f"New quorum: height={quorum_info['height']}, quorumHash={new_quorum}, is_mature={not skip_maturity} quorumIndex={quorum_info['quorumIndex']}, minedBlock={quorum_info['minedBlock']}")
 
         for mn in mninfos_valid:
             assert not check_punished(self.nodes[0], mn)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2108,7 +2108,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.bump_mocktime(1, nodes=nodes)
         self.generate(self.nodes[0], num_blocks, sync_fun=lambda: self.sync_blocks(nodes))
 
-    def mine_quorum(self, llmq_type_name="llmq_test", llmq_type=100, expected_connections=None, expected_members=None, expected_contributions=None, expected_complaints=0, expected_justifications=0, expected_commitments=None, mninfos_online=None, mninfos_valid=None):
+    def mine_quorum(self, llmq_type_name="llmq_test", llmq_type=100, expected_connections=None, expected_members=None, expected_contributions=None, expected_complaints=0, expected_justifications=0, expected_commitments=None, mninfos_online=None, mninfos_valid=None, skip_maturity=False):
         spork21_active = self.nodes[0].spork('show')['SPORK_21_QUORUM_ALL_CONNECTED'] <= 1
         spork23_active = self.nodes[0].spork('show')['SPORK_23_QUORUM_POSE'] <= 1
 
@@ -2185,8 +2185,9 @@ class DashTestFramework(BitcoinTestFramework):
         assert_equal(q, new_quorum)
         quorum_info = self.nodes[0].quorum("info", llmq_type, new_quorum)
 
-        # Mine 8 (SIGN_HEIGHT_OFFSET) more blocks to make sure that the new quorum gets eligible for signing sessions
-        self.generate(self.nodes[0], 8, sync_fun=lambda: self.sync_blocks(nodes))
+        if not skip_maturity:
+            # Mine 8 (SIGN_HEIGHT_OFFSET) more blocks to make sure that the new quorum gets eligible for signing sessions
+            self.generate(self.nodes[0], 8, sync_fun=lambda: self.sync_blocks(nodes))
 
         self.log.info("New quorum: height=%d, quorumHash=%s, quorumIndex=%d, minedBlock=%s" % (quorum_info["height"], new_quorum, quorum_info["quorumIndex"], quorum_info["minedBlock"]))
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
As I noticed implementing https://github.com/dashpay/dash/pull/6692 if BlsChecker works incorrectly it won't be caught by unit or functional tests. See also https://github.com/dashpay/dash/pull/6692#issuecomment-2916034041 how 6692 has been tested without this PR.

## What was done?
This PR introduces new functional tests to validated that `llmqType`, `membersSig`, `quorumSig` and `quorumPublicKey` are indeed validated by Dash Core as part of consensus.


## How Has This Been Tested?
See changes in `feature_llmq_dkgerrors.py`

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone