### PR TITLE
feat: prohibit new legacy scheme masternodes, restrict ProTx version changes with `DEPLOYMENT_V23`

### DIFF
--- a/doc/release-notes-6729.md
+++ b/doc/release-notes-6729.md
@@ -1,0 +1,12 @@
+Notable Changes
+---------------
+
+* Dash Core will no longer permit the registration of new legacy scheme masternodes after the deployment of the v23
+  fork. Existing basic scheme masternodes will also be prohibited from downgrading to the legacy scheme after the
+  deployment is active.
+
+Updated RPCs
+----------------
+
+* `protx revoke` will now use the legacy scheme version for legacy masternodes instead of the defaulting to the
+   highest `ProUpRevTx` version.

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1434,8 +1434,8 @@ bool CheckProUpServTx(CDeterministicMNManager& dmnman, const CTransaction& tx, g
     }
 
     auto mnList = dmnman.GetListForBlock(pindexPrev);
-    auto mn = mnList.GetMN(opt_ptx->proTxHash);
-    if (!mn) {
+    auto dmn = mnList.GetMN(opt_ptx->proTxHash);
+    if (!dmn) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-hash");
     }
 
@@ -1459,7 +1459,7 @@ bool CheckProUpServTx(CDeterministicMNManager& dmnman, const CTransaction& tx, g
     }
 
     if (opt_ptx->scriptOperatorPayout != CScript()) {
-        if (mn->nOperatorReward == 0) {
+        if (dmn->nOperatorReward == 0) {
             // don't allow setting operator reward payee in case no operatorReward was set
             return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-operator-payee");
         }
@@ -1473,7 +1473,7 @@ bool CheckProUpServTx(CDeterministicMNManager& dmnman, const CTransaction& tx, g
         // pass the state returned by the function above
         return false;
     }
-    if (check_sigs && !CheckHashSig(*opt_ptx, mn->pdmnState->pubKeyOperator.Get(), state)) {
+    if (check_sigs && !CheckHashSig(*opt_ptx, dmn->pdmnState->pubKeyOperator.Get(), state)) {
         // pass the state returned by the function above
         return false;
     }
@@ -1556,8 +1556,9 @@ bool CheckProUpRevTx(CDeterministicMNManager& dmnman, const CTransaction& tx, gs
 
     auto mnList = dmnman.GetListForBlock(pindexPrev);
     auto dmn = mnList.GetMN(opt_ptx->proTxHash);
-    if (!dmn)
+    if (!dmn) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-hash");
+    }
 
     if (!CheckInputsHash(tx, *opt_ptx, state)) {
         // pass the state returned by the function above

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1313,6 +1313,11 @@ bool IsVersionChangeValid(gsl::not_null<const CBlockIndex*> pindexPrev, const ui
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-version-downgrade");
     }
 
+    if (state_version == ProTxVersion::LegacyBLS && tx_version > ProTxVersion::BasicBLS) {
+        // Nodes using the legacy scheme must first upgrade to the basic scheme before upgrading further
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-version-upgrade");
+    }
+
     return true;
 }
 

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1335,6 +1335,13 @@ bool CheckProRegTx(CDeterministicMNManager& dmnman, const CTransaction& tx, gsl:
         return false;
     }
 
+    const bool is_v23_active{DeploymentActiveAfter(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_V23)};
+
+    // No longer allow legacy scheme masternode registration
+    if (is_v23_active && opt_ptx->nVersion < ProTxVersion::BasicBLS) {
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-version-disallowed");
+    }
+
     // It's allowed to set addr to 0, which will put the MN into PoSe-banned state and require a ProUpServTx to be issues later
     // If any of both is set, it must be valid however
     if (!opt_ptx->netInfo->IsEmpty() && !CheckService(*opt_ptx, state)) {


### PR DESCRIPTION
## Additional Information

* Depends on https://github.com/dashpay/dash/pull/6665

* Depends on https://github.com/dashpay/dash/pull/6723

* Please refer to comments from [dash#6665](https://github.com/dashpay/dash/pull/6665) for prior discussion on the contents of the pull request ([comment](https://github.com/dashpay/dash/pull/6665#discussion_r2151713253), [comment](https://github.com/dashpay/dash/pull/6665#discussion_r2153021564), [comment](https://github.com/dashpay/dash/pull/6665#discussion_r2153031520))

* Complementing the deprecation in [dash#6723](https://github.com/dashpay/dash/pull/6723), after `DEPLOYMENT_V23` is activated
  * Registration of **new** masternodes  (i.e. `ProRegTx`) with the legacy scheme (`LegacyBLS`) will no longer be allowed. Existing masternodes are not affected and can continue to operate and participate.

  * Masternodes that are already using the basic scheme (`BasicBLS`) or higher may no longer **downgrade** to the legacy scheme.

* Additional guardrails have been introduced to complement [dash#6665](https://github.com/dashpay/dash/pull/6665), which reserves a new version for extended addresses (`ExtAddr`), affecting `ProRegTx` and `ProUpServTx`, applicable after `DEPLOYMENT_V23` is activated
  * Masternodes **must** migrate to the basic scheme (`BasicBLS`) _before_ attempting to utilize extended addresses (`ExtAddr`), legacy scheme nodes may not attempt a direct upgrade.

  * Special transactions other than `ProRegTx` or `ProUpServTx` may not bear the version reserved for extended addresses (`ExtAddr`). Note that `IsVersionChangeValid()` does not extend to `ProRegTx` as it _creates_ a new entry and therefore doesn't have a masternode state version to compare against (i.e. there's no version to _change_), so the restriction in `IsVersionChangeValid()` only _de facto_ applies to `ProUpServTx`.

* Future version updates must be conscious of updates to the masternode state ([source](https://github.com/dashpay/dash/blob/d9f52acecb94d57be91b5e17d478d5c909df3633/src/evo/deterministicmns.cpp#L887-L888)), example code for what changes may be required are available [here](https://github.com/dashpay/dash/pull/6665#discussion_r2180793275).

## Breaking Changes

* `protx revoke` will no longer default to using the highest possible version of `ProUpRevTx` and will now _clamp_ the version to `LegacyBLS` if the masternode uses the legacy scheme.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
