### PR TITLE
perf: optimize GetQuorumQuarterMembersBySnapshot calculation

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -64,7 +64,7 @@ static std::vector<std::vector<CDeterministicMNCPtr>> ComputeQuorumMembersByQuar
     const CBlockIndex* pCycleQuorumBaseBlockIndex);
 
 static std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(
-    const Consensus::LLMQParams& llmqParams, const CDeterministicMNList& dmnman, CQuorumSnapshotManager& qsnapman,
+    const Consensus::LLMQParams& llmqParams, const CDeterministicMNList& allMns, CQuorumSnapshotManager& qsnapman,
     const CBlockIndex* pCycleQuorumBaseBlockIndex, const PreviousQuorumQuarters& previousQuarters);
 
 static PreviousQuorumQuarters GetPreviousQuorumQuarterMembers(const Consensus::LLMQParams& llmqParams,


### PR DESCRIPTION
## Issue being fixed or feature implemented
Masternodes already sorted with the same modifier inside `GetMNUsageBySnapshot`, no need to re-sort them inside `GetQuorumQuarterMembersBySnapshot`.


## What was done?
Removed extra sort of already sorted vectors; removed duplicated calculation of modifier, simplified `GetMNUsageBySnapshot` by inlining it. 
Also several methods are changed to accept CDeterministicMNList instead of CDeterministicMNManager.

## How Has This Been Tested?
It improves significantly performance of `llmq::utils::GetAllQuorumMembers` which is widely used during block validation; for many RPC calls, for processing some network messages, for masternodes participating in quorums.
Despite 25% improvement for performance of `llmq::utils::GetAllQuorumMembers` overall improvement for indexing is less than 1% of total CPU time (thanks to caches).

`perf` for PR:
<img width="838" alt="image" src="https://github.com/user-attachments/assets/cb98a0ef-3a4b-4d21-a674-80c300764712" />

`perf` for develop:
<img width="838" alt="image" src="https://github.com/user-attachments/assets/879acdac-facd-4a11-b37a-607f4cb31e48" />


## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
