### PR TITLE
backport: merge bitcoin#23497 (Add `src/node/` and `src/wallet/` code to `node::` and `wallet::` namespaces)

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -12,6 +12,15 @@
 #include <set>
 
 using node::NodeContext;
+using wallet::CHANGE_LOWER;
+using wallet::CoinEligibilityFilter;
+using wallet::CoinSelectionParams;
+using wallet::COutput;
+using wallet::CreateDummyWalletDatabase;
+using wallet::CWallet;
+using wallet::CWalletTx;
+using wallet::OutputGroup;
+using wallet::TxStateInactive;
 
 static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<std::unique_ptr<CWalletTx>>& wtxs)
 {

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -11,6 +11,8 @@
 
 #include <set>
 
+using node::NodeContext;
+
 static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<std::unique_ptr<CWalletTx>>& wtxs)
 {
     static int nextLockTime = 0;

--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -40,7 +40,7 @@ static void LoadExternalBlockFile(benchmark::Bench& bench)
         // "wb+" is "binary, O_RDWR | O_CREAT | O_TRUNC".
         FILE* file{fsbridge::fopen(blkfile, "wb+")};
         // Make the test block file about 128 MB in length.
-        for (size_t i = 0; i < MAX_BLOCKFILE_SIZE / ss.size(); ++i) {
+        for (size_t i = 0; i < node::MAX_BLOCKFILE_SIZE / ss.size(); ++i) {
             if (fwrite(ss.data(), 1, ss.size(), file) != ss.size()) {
                 throw std::runtime_error("write to test file failed\n");
             }

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -14,6 +14,11 @@
 
 #include <optional>
 
+using wallet::CreateMockWalletDatabase;
+using wallet::CWallet;
+using wallet::DBErrors;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+
 static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const bool add_mine, const uint32_t epoch_iters)
 {
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -112,7 +112,7 @@ MAIN_FUNCTION
     }
 
     ECC_Start();
-    if (!WalletTool::ExecuteWalletToolFunc(args, command->command)) {
+    if (!wallet::WalletTool::ExecuteWalletToolFunc(args, command->command)) {
         return EXIT_FAILURE;
     }
     ECC_Stop();

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -31,6 +31,8 @@
 #include <cstdio>
 #include <functional>
 
+using node::NodeContext;
+
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = urlDecode;
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -4,8 +4,14 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
+#include <util/time.h>
 
 #include <tinyformat.h>
+
+std::string CBlockFileInfo::ToString() const
+{
+    return strprintf("CBlockFileInfo(blocks=%u, size=%u, heights=%u...%u, time=%s...%s)", nBlocks, nSize, nHeightFirst, nHeightLast, FormatISO8601Date(nTimeFirst), FormatISO8601Date(nTimeLast));
+}
 
 std::string CBlockIndex::ToString() const
 {

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -54,7 +54,7 @@ PeerMsgRet CCoinJoinClientQueueManager::ProcessDSQueue(const CNode& peer, CConnm
     vRecv >> dsq;
 
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         peerman.EraseObjectRequest(peer.GetId(), CInv(MSG_DSQ, dsq.GetHash()));
     }
 

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -33,6 +33,13 @@
 #include <memory>
 #include <univalue.h>
 
+using wallet::CCoinControl;
+using wallet::CompactTallyItem;
+using wallet::COutput;
+using wallet::CoinType;
+using wallet::CWallet;
+using wallet::ReserveDestination;
+
 PeerMsgRet CCoinJoinClientQueueManager::ProcessMessage(const CNode& peer, CConnman& connman, PeerManager& peerman,
                                                        std::string_view msg_type, CDataStream& vRecv)
 {

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -96,7 +96,7 @@ public:
         }
     }
 
-    void Add(const std::shared_ptr<CWallet>& wallet);
+    void Add(const std::shared_ptr<wallet::CWallet>& wallet);
     void DoMaintenance(CConnman& connman);
 
     void Remove(const std::string& name);
@@ -138,7 +138,7 @@ private:
 class CCoinJoinClientSession : public CCoinJoinBaseSession
 {
 private:
-    const std::shared_ptr<CWallet> m_wallet;
+    const std::shared_ptr<wallet::CWallet> m_wallet;
     CCoinJoinClientManager& m_clientman;
     CDeterministicMNManager& m_dmnman;
     CMasternodeMetaMan& m_mn_metaman;
@@ -162,12 +162,12 @@ private:
 
     /// Create denominations
     bool CreateDenominated(CAmount nBalanceToDenominate);
-    bool CreateDenominated(CAmount nBalanceToDenominate, const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals)
+    bool CreateDenominated(CAmount nBalanceToDenominate, const wallet::CompactTallyItem& tallyItem, bool fCreateMixingCollaterals)
         EXCLUSIVE_LOCKS_REQUIRED(m_wallet->cs_wallet);
 
     /// Split up large inputs or make fee sized inputs
     bool MakeCollateralAmounts();
-    bool MakeCollateralAmounts(const CompactTallyItem& tallyItem, bool fTryDenominated)
+    bool MakeCollateralAmounts(const wallet::CompactTallyItem& tallyItem, bool fTryDenominated)
         EXCLUSIVE_LOCKS_REQUIRED(m_wallet->cs_wallet);
 
     bool CreateCollateralTransaction(CMutableTransaction& txCollateral, std::string& strReason)
@@ -200,7 +200,7 @@ private:
     void SetNull() override EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
 public:
-    explicit CCoinJoinClientSession(const std::shared_ptr<CWallet>& wallet, CCoinJoinClientManager& clientman,
+    explicit CCoinJoinClientSession(const std::shared_ptr<wallet::CWallet>& wallet, CCoinJoinClientManager& clientman,
                                     CDeterministicMNManager& dmnman, CMasternodeMetaMan& mn_metaman,
                                     const CMasternodeSync& mn_sync, const llmq::CInstantSendManager& isman,
                                     const std::unique_ptr<CCoinJoinClientQueueManager>& queueman, bool is_masternode);
@@ -263,7 +263,7 @@ public:
 class CCoinJoinClientManager
 {
 private:
-    const std::shared_ptr<CWallet> m_wallet;
+    const std::shared_ptr<wallet::CWallet> m_wallet;
     CDeterministicMNManager& m_dmnman;
     CMasternodeMetaMan& m_mn_metaman;
     const CMasternodeSync& m_mn_sync;
@@ -302,7 +302,7 @@ public:
     CCoinJoinClientManager(CCoinJoinClientManager const&) = delete;
     CCoinJoinClientManager& operator=(CCoinJoinClientManager const&) = delete;
 
-    explicit CCoinJoinClientManager(const std::shared_ptr<CWallet>& wallet, CDeterministicMNManager& dmnman,
+    explicit CCoinJoinClientManager(const std::shared_ptr<wallet::CWallet>& wallet, CDeterministicMNManager& dmnman,
                                     CMasternodeMetaMan& mn_metaman, const CMasternodeSync& mn_sync,
                                     const llmq::CInstantSendManager& isman,
                                     const std::unique_ptr<CCoinJoinClientQueueManager>& queueman, bool is_masternode) :

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -257,7 +257,7 @@ bool CCoinJoinBaseSession::IsValidInOuts(CChainState& active_chainstate, const l
         nFees -= txout.nValue;
     }
 
-    CCoinsViewMemPool viewMemPool(WITH_LOCK(cs_main, return &active_chainstate.CoinsTip()), mempool);
+    CCoinsViewMemPool viewMemPool(WITH_LOCK(::cs_main, return &active_chainstate.CoinsTip()), mempool);
 
     for (const auto& txin : vin) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinBaseSession::%s -- txin=%s\n", __func__, txin.ToString());
@@ -299,7 +299,7 @@ bool CCoinJoinBaseSession::IsValidInOuts(CChainState& active_chainstate, const l
 // but CoinJoin still requires ATMP with fee sanity checks so we need to implement them separately
 bool ATMPIfSaneFee(ChainstateManager& chainman, const CTransactionRef& tx, bool test_accept)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     const MempoolAcceptResult result = chainman.ProcessTransaction(tx, /*test_accept=*/true);
     if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
@@ -360,7 +360,7 @@ bool CoinJoin::IsCollateralValid(ChainstateManager& chainman, const llmq::CInsta
     LogPrint(BCLog::COINJOIN, "CoinJoin::IsCollateralValid -- %s", txCollateral.ToString()); /* Continued */
 
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         if (!ATMPIfSaneFee(chainman, MakeTransactionRef(txCollateral), /*test_accept=*/true)) {
             LogPrint(BCLog::COINJOIN, "CoinJoin::IsCollateralValid -- didn't pass ATMPIfSaneFee()\n");
             return false;

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -404,6 +404,6 @@ private:
 };
 
 bool ATMPIfSaneFee(ChainstateManager& chainman, const CTransactionRef& tx, bool test_accept = false)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 #endif // BITCOIN_COINJOIN_COINJOIN_H

--- a/src/coinjoin/interfaces.cpp
+++ b/src/coinjoin/interfaces.cpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+using node::NodeContext;
+
 namespace coinjoin {
 namespace {
 

--- a/src/coinjoin/interfaces.cpp
+++ b/src/coinjoin/interfaces.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 using node::NodeContext;
+using wallet::CWallet;
 
 namespace coinjoin {
 namespace {

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -119,7 +119,7 @@ PeerMsgRet CCoinJoinServer::ProcessDSQUEUE(const CNode& peer, CDataStream& vRecv
     vRecv >> dsq;
 
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         Assert(m_peerman)->EraseObjectRequest(peer.GetId(), CInv(MSG_DSQ, dsq.GetHash()));
     }
 
@@ -327,7 +327,7 @@ void CCoinJoinServer::CommitFinalTransaction()
 
     {
         // See if the transaction is valid
-        TRY_LOCK(cs_main, lockMain);
+        TRY_LOCK(::cs_main, lockMain);
         mempool.PrioritiseTransaction(hashTx, 0.1 * COIN);
         if (!lockMain || !ATMPIfSaneFee(m_chainman, finalTransaction)) {
             LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- ATMPIfSaneFee() error: Transaction not valid\n");
@@ -460,7 +460,7 @@ void CCoinJoinServer::ChargeRandomFees() const
 
 void CCoinJoinServer::ConsumeCollateral(const CTransactionRef& txref) const
 {
-    LOCK(cs_main);
+    LOCK(::cs_main);
     if (!ATMPIfSaneFee(m_chainman, txref)) {
         LogPrint(BCLog::COINJOIN, "%s -- ATMPIfSaneFee failed\n", __func__);
     } else {

--- a/src/coinjoin/util.cpp
+++ b/src/coinjoin/util.cpp
@@ -273,7 +273,7 @@ bool CTransactionBuilder::Commit(bilingual_str& strResult)
 
     CTransactionRef tx;
     {
-        LOCK2(m_wallet.cs_wallet, cs_main);
+        LOCK2(m_wallet.cs_wallet, ::cs_main);
         FeeCalculation fee_calc_out;
         if (!CreateTransaction(m_wallet, vecSend, tx, nFeeRet, nChangePosRet, strResult, coinControl, fee_calc_out)) {
             return false;
@@ -312,7 +312,7 @@ bool CTransactionBuilder::Commit(bilingual_str& strResult)
     }
 
     {
-        LOCK2(m_wallet.cs_wallet, cs_main);
+        LOCK2(m_wallet.cs_wallet, ::cs_main);
         m_wallet.CommitTransaction(tx, {}, {});
     }
 

--- a/src/coinjoin/util.cpp
+++ b/src/coinjoin/util.cpp
@@ -14,6 +14,13 @@
 
 #include <numeric>
 
+using wallet::CompactTallyItem;
+using wallet::CRecipient;
+using wallet::CWallet;
+using wallet::FEATURE_COMPRPUBKEY;
+using wallet::GetDiscardRate;
+using wallet::WalletBatch;
+
 inline unsigned int GetSizeOfCompactSizeDiff(uint64_t nSizePrev, uint64_t nSizeNew)
 {
     assert(nSizePrev <= nSizeNew);

--- a/src/coinjoin/util.h
+++ b/src/coinjoin/util.h
@@ -13,11 +13,11 @@ struct bilingual_str;
 class CKeyHolder
 {
 private:
-    ReserveDestination reserveDestination;
+    wallet::ReserveDestination reserveDestination;
     CTxDestination dest;
 
 public:
-    explicit CKeyHolder(CWallet* pwalletIn);
+    explicit CKeyHolder(wallet::CWallet* pwalletIn);
     CKeyHolder(CKeyHolder&&) = delete;
     CKeyHolder& operator=(CKeyHolder&&) = delete;
     void KeepKey();
@@ -33,7 +33,7 @@ private:
     std::vector<std::unique_ptr<CKeyHolder> > storage GUARDED_BY(cs_storage);
 
 public:
-    CScript AddKey(CWallet* pwalletIn) EXCLUSIVE_LOCKS_REQUIRED(!cs_storage);
+    CScript AddKey(wallet::CWallet* pwalletIn) EXCLUSIVE_LOCKS_REQUIRED(!cs_storage);
     void KeepAll() EXCLUSIVE_LOCKS_REQUIRED(!cs_storage);
     void ReturnAll() EXCLUSIVE_LOCKS_REQUIRED(!cs_storage);
 };
@@ -47,14 +47,14 @@ class CTransactionBuilderOutput
     /// Used for amount updates
     CTransactionBuilder* pTxBuilder{nullptr};
     /// Reserve key where the amount of this output will end up
-    ReserveDestination dest;
+    wallet::ReserveDestination dest;
     /// Amount this output will receive
     CAmount nAmount{0};
     /// ScriptPubKey of this output
     CScript script;
 
 public:
-    CTransactionBuilderOutput(CTransactionBuilder* pTxBuilderIn, CWallet& wallet, CAmount nAmountIn);
+    CTransactionBuilderOutput(CTransactionBuilder* pTxBuilderIn, wallet::CWallet& wallet, CAmount nAmountIn);
     CTransactionBuilderOutput(CTransactionBuilderOutput&&) = delete;
     CTransactionBuilderOutput& operator=(CTransactionBuilderOutput&&) = delete;
     /// Get the scriptPubKey of this output
@@ -77,15 +77,15 @@ public:
 class CTransactionBuilder
 {
     /// Wallet the transaction will be build for
-    CWallet& m_wallet;
+    wallet::CWallet& m_wallet;
     /// See CTransactionBuilder() for initialization
-    CCoinControl coinControl;
+    wallet::CCoinControl coinControl;
     /// Dummy since we anyway use tallyItem's destination as change destination in coincontrol.
     /// Its a member just to make sure ReturnKey can be called in destructor just in case it gets generated/kept
     /// somewhere in CWallet code.
-    ReserveDestination dummyReserveDestination;
+    wallet::ReserveDestination dummyReserveDestination;
     /// Contains all utxos available to generate this transactions. They are all from the same address.
-    CompactTallyItem tallyItem;
+    wallet::CompactTallyItem tallyItem;
     /// Contains the number of bytes required for a transaction with only the inputs of tallyItems, no outputs
     int nBytesBase{0};
     /// Contains the number of bytes required to add one output
@@ -100,7 +100,7 @@ class CTransactionBuilder
     friend class CTransactionBuilderOutput;
 
 public:
-    CTransactionBuilder(CWallet& wallet, const CompactTallyItem& tallyItemIn);
+    CTransactionBuilder(wallet::CWallet& wallet, const wallet::CompactTallyItem& tallyItemIn);
     ~CTransactionBuilder();
     /// Check it would be possible to add a single output with the amount nAmount. Returns true if its possible and false if not.
     bool CouldAddOutput(CAmount nAmountOutput) const EXCLUSIVE_LOCKS_REQUIRED(!cs_outputs);

--- a/src/context.h
+++ b/src/context.h
@@ -13,12 +13,14 @@ class ChainstateManager;
 class CTxMemPool;
 class CBlockPolicyEstimator;
 struct LLMQContext;
-struct NodeContext;
 struct WalletContext;
+namespace node {
+struct NodeContext;
+} // namespace node
 
 using CoreContext = std::variant<std::monostate,
                                  std::reference_wrapper<ArgsManager>,
-                                 std::reference_wrapper<NodeContext>,
+                                 std::reference_wrapper<node::NodeContext>,
                                  std::reference_wrapper<WalletContext>,
                                  std::reference_wrapper<CTxMemPool>,
                                  std::reference_wrapper<ChainstateManager>,

--- a/src/context.h
+++ b/src/context.h
@@ -13,15 +13,17 @@ class ChainstateManager;
 class CTxMemPool;
 class CBlockPolicyEstimator;
 struct LLMQContext;
-struct WalletContext;
 namespace node {
 struct NodeContext;
 } // namespace node
+namespace wallet {
+struct WalletContext;
+} // namespace wallet
 
 using CoreContext = std::variant<std::monostate,
                                  std::reference_wrapper<ArgsManager>,
                                  std::reference_wrapper<node::NodeContext>,
-                                 std::reference_wrapper<WalletContext>,
+                                 std::reference_wrapper<wallet::WalletContext>,
                                  std::reference_wrapper<CTxMemPool>,
                                  std::reference_wrapper<ChainstateManager>,
                                  std::reference_wrapper<CBlockPolicyEstimator>,

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -7,8 +7,6 @@
 #include <walletinitinterface.h>
 
 class ArgsManager;
-class CWallet;
-
 namespace interfaces {
 class Chain;
 class Handler;
@@ -22,6 +20,9 @@ class Loader;
 namespace node {
 class NodeContext;
 } // namespace node
+namespace wallet {
+class CWallet;
+} // namespace wallet
 
 class DummyWalletInit : public WalletInitInterface {
 public:
@@ -90,7 +91,7 @@ std::unique_ptr<CoinJoin::Loader> MakeCoinJoinLoader(node::NodeContext& node)
     throw std::logic_error("Wallet function called in non-wallet build.");
 }
 
-std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet)
+std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<wallet::CWallet>& wallet)
 {
     throw std::logic_error("Wallet function called in non-wallet build.");
 }

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -17,8 +17,11 @@ class WalletClient;
 class WalletLoader;
 namespace CoinJoin {
 class Loader;
-} // namespcae CoinJoin
-}
+} // namespace CoinJoin
+} // namespace interfaces
+namespace node {
+class NodeContext;
+} // namespace node
 
 class DummyWalletInit : public WalletInitInterface {
 public:
@@ -26,7 +29,7 @@ public:
     bool HasWalletSupport() const override {return false;}
     void AddWalletOptions(ArgsManager& argsman) const override;
     bool ParameterInteraction() const override {return true;}
-    void Construct(NodeContext& node) const override {LogPrintf("No wallet support compiled in!\n");}
+    void Construct(node::NodeContext& node) const override {LogPrintf("No wallet support compiled in!\n");}
 
     // Dash Specific WalletInitInterface InitCoinJoinSettings
     void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const override {}
@@ -82,7 +85,7 @@ const WalletInitInterface& g_wallet_init_interface = DummyWalletInit();
 
 namespace interfaces {
 
-std::unique_ptr<CoinJoin::Loader> MakeCoinJoinLoader(NodeContext& node)
+std::unique_ptr<CoinJoin::Loader> MakeCoinJoinLoader(node::NodeContext& node)
 {
     throw std::logic_error("Wallet function called in non-wallet build.");
 }
@@ -92,7 +95,7 @@ std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet)
     throw std::logic_error("Wallet function called in non-wallet build.");
 }
 
-std::unique_ptr<WalletClient> MakeWalletLoader(Chain& chain, ArgsManager& args, NodeContext& node_context,
+std::unique_ptr<WalletClient> MakeWalletLoader(Chain& chain, ArgsManager& args, node::NodeContext& node_context,
                                                interfaces::CoinJoin::Loader& coinjoin_loader)
 {
     throw std::logic_error("Wallet function called in non-wallet build.");

--- a/src/evo/assetlocktx.cpp
+++ b/src/evo/assetlocktx.cpp
@@ -184,7 +184,7 @@ bool CheckAssetUnlockTx(const BlockManager& blockman, const llmq::CQuorumManager
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-assetunlock-duplicated-index");
     }
 
-    if (LOCK(cs_main); blockman.LookupBlockIndex(assetUnlockTx.getQuorumHash()) == nullptr) {
+    if (LOCK(::cs_main); blockman.LookupBlockIndex(assetUnlockTx.getQuorumHash()) == nullptr) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-assetunlock-quorum-hash");
     }
 

--- a/src/evo/assetlocktx.cpp
+++ b/src/evo/assetlocktx.cpp
@@ -20,6 +20,8 @@
 
 #include <algorithm>
 
+using node::BlockManager;
+
 /**
  *  Common code for Asset Lock and Asset Unlock
  */

--- a/src/evo/assetlocktx.h
+++ b/src/evo/assetlocktx.h
@@ -14,13 +14,15 @@
 
 #include <optional>
 
-class BlockManager;
 class CBlockIndex;
 class CRangesSet;
 class TxValidationState;
 namespace llmq {
 class CQuorumManager;
 } // namespace llmq
+namespace node {
+class BlockManager;
+} // namespace node
 
 class CAssetLockPayload
 {
@@ -150,8 +152,8 @@ public:
 };
 
 bool CheckAssetLockTx(const CTransaction& tx, TxValidationState& state);
-bool CheckAssetUnlockTx(const BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state);
-bool CheckAssetLockUnlockTx(const BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state);
+bool CheckAssetUnlockTx(const node::BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state);
+bool CheckAssetLockUnlockTx(const node::BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state);
 bool GetAssetUnlockFee(const CTransaction& tx, CAmount& txfee, TxValidationState& state);
 
 #endif // BITCOIN_EVO_ASSETLOCKTX_H

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -18,6 +18,7 @@
 #include <consensus/merkle.h>
 #include <deploymentstatus.h>
 
+using node::ReadBlockFromDisk;
 
 bool CheckCbTx(const CCbTx& cbTx, const CBlockIndex* pindexPrev, TxValidationState& state)
 {

--- a/src/evo/chainhelper.cpp
+++ b/src/evo/chainhelper.cpp
@@ -13,6 +13,8 @@
 #include <node/transaction.h>
 #include <txmempool.h>
 
+using node::GetTransaction;
+
 CChainstateHelper::CChainstateHelper(CCreditPoolManager& cpoolman, CDeterministicMNManager& dmnman,
                                      CMNHFManager& mnhfman, CGovernanceManager& govman, llmq::CInstantSendManager& isman,
                                      llmq::CQuorumBlockProcessor& qblockman, llmq::CQuorumSnapshotManager& qsnapman,

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -22,6 +22,9 @@
 #include <memory>
 #include <stack>
 
+using node::BlockManager;
+using node::ReadBlockFromDisk;
+
 // Forward declaration to prevent a new circular dependencies through masternode/payments.h
 CAmount PlatformShare(const CAmount masternodeReward);
 

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -20,7 +20,6 @@
 #include <optional>
 #include <unordered_set>
 
-class BlockManager;
 class CBlock;
 class CBlockIndex;
 class BlockValidationState;
@@ -32,6 +31,9 @@ struct Params;
 namespace llmq {
 class CQuorumManager;
 } // namespace llmq
+namespace node {
+class BlockManager;
+} // namespace node
 
 struct CCreditPool {
     CAmount locked{0};
@@ -86,7 +88,7 @@ public:
      * to change amount of credit pool
      * @return true if transaction can be included in this block
      */
-    bool ProcessLockUnlockTransaction(const BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, TxValidationState& state);
+    bool ProcessLockUnlockTransaction(const node::BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, TxValidationState& state);
 
     /**
      * this function returns total amount of credits for the next block
@@ -139,7 +141,7 @@ private:
                                     const Consensus::Params& consensusParams);
 };
 
-std::optional<CCreditPoolDiff> GetCreditPoolDiffForBlock(CCreditPoolManager& cpoolman, const BlockManager& blockman, const llmq::CQuorumManager& qman,
+std::optional<CCreditPoolDiff> GetCreditPoolDiffForBlock(CCreditPoolManager& cpoolman, const node::BlockManager& blockman, const llmq::CQuorumManager& qman,
                                                          const CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams,
                                                          const CAmount blockSubsidy, BlockValidationState& state);
 

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -588,7 +588,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, gsl::not_null<co
                                            llmq::CQuorumSnapshotManager& qsnapman, const CDeterministicMNList& newList,
                                            std::optional<MNListUpdates>& updatesRet)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     const auto& consensusParams = Params().GetConsensus();
     if (!DeploymentActiveAt(*pindex, consensusParams, Consensus::DEPLOYMENT_DIP0003)) {

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -582,7 +582,7 @@ public:
     bool ProcessBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, BlockValidationState& state,
                       const CCoinsViewCache& view, llmq::CQuorumSnapshotManager& qsnapman,
                       const CDeterministicMNList& newList, std::optional<MNListUpdates>& updatesRet)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs, cs_main);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs, ::cs_main);
     bool UndoBlock(gsl::not_null<const CBlockIndex*> pindex, std::optional<MNListUpdates>& updatesRet) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     void UpdatedBlockTip(gsl::not_null<const CBlockIndex*> pindex) EXCLUSIVE_LOCKS_REQUIRED(!cs);

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+using node::ReadBlockFromDisk;
+
 static const std::string MNEHF_REQUESTID_PREFIX = "mnhf";
 static const std::string DB_SIGNALS = "mnhf_s";
 static const std::string DB_SIGNALS_v2 = "mnhf_s2";

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -146,7 +146,7 @@ public:
      */
     void DisconnectManagers() { m_chainman = nullptr; m_qman = nullptr; };
 
-    bool ForceSignalDBUpdate() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool ForceSignalDBUpdate() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 private:
     void AddToCache(const Signals& signals, const CBlockIndex* const pindex);

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -335,7 +335,7 @@ bool BuildSimplifiedMNListDiff(CDeterministicMNManager& dmnman, const Chainstate
                                const llmq::CQuorumManager& qman, const uint256& baseBlockHash, const uint256& blockHash,
                                CSimplifiedMNListDiff& mnListDiffRet, std::string& errorRet, bool extended)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
     mnListDiffRet = CSimplifiedMNListDiff();
 
     const CBlockIndex* baseBlockIndex = chainman.ActiveChain().Genesis();

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -27,6 +27,8 @@
 #include <util/underlying.h>
 #include <util/enumerate.h>
 
+using node::ReadBlockFromDisk;
+
 CSimplifiedMNListEntry::CSimplifiedMNListEntry(const CDeterministicMN& dmn) :
     proRegTxHash(dmn.proTxHash),
     confirmedHash(dmn.pdmnState->confirmedHash),

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -27,7 +27,7 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, llmq::CQuorumSn
                                 const std::optional<CRangesSet>& indexes, bool check_sigs, TxValidationState& state)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     if (!tx.HasExtraPayloadField())
         return true;
@@ -76,7 +76,7 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, llmq::CQuorumSn
 
 bool CSpecialTxProcessor::CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs, TxValidationState& state)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
     return CheckSpecialTxInner(m_dmnman, m_qsnapman, m_chainman, m_qman, tx, pindexPrev, view, std::nullopt, check_sigs,
                                state);
 }
@@ -84,7 +84,7 @@ bool CSpecialTxProcessor::CheckSpecialTx(const CTransaction& tx, const CBlockInd
 bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, const CCoinsViewCache& view, bool fJustCheck,
                                                    bool fCheckCbTxMerkleRoots, BlockValidationState& state, std::optional<MNListUpdates>& updatesRet)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     try {
         static int64_t nTimeLoop = 0;
@@ -242,7 +242,7 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(const CBlock& block, const CB
 
 bool CSpecialTxProcessor::UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, std::optional<MNListUpdates>& updatesRet)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     auto bls_legacy_scheme = bls::bls_legacy_scheme.load();
 
@@ -277,7 +277,7 @@ bool CSpecialTxProcessor::UndoSpecialTxsInBlock(const CBlock& block, const CBloc
 bool CSpecialTxProcessor::CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex, const CCbTx& cbTx,
                                                       BlockValidationState& state)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     if (!DeploymentActiveAt(*pindex, m_consensus_params, Consensus::DEPLOYMENT_DIP0008)) return true;
     if (!DeploymentActiveAt(*pindex, m_consensus_params, Consensus::DEPLOYMENT_V20)) return true;

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -64,16 +64,16 @@ public:
     }
 
     bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs, TxValidationState& state)
-        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, const CCoinsViewCache& view, bool fJustCheck,
                                   bool fCheckCbTxMerkleRoots, BlockValidationState& state, std::optional<MNListUpdates>& updatesRet)
-        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, std::optional<MNListUpdates>& updatesRet)
-        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 private:
     bool CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex, const CCbTx& cbTx,
-                                     BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                                     BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };
 
 #endif // BITCOIN_EVO_SPECIALTXMAN_H

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -194,7 +194,7 @@ PeerMsgRet CGovernanceManager::ProcessMessage(CNode& peer, CConnman& connman, Pe
             return {};
         }
 
-        LOCK2(cs_main, cs);
+        LOCK2(::cs_main, cs);
 
         if (mapObjects.count(nHash) || mapPostponedObjects.count(nHash) || mapErasedGovernanceObjects.count(nHash)) {
             // TODO - print error code? what if it's GOVOBJ_ERROR_IMMATURE?
@@ -312,7 +312,7 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, PeerMana
 
     govobj.UpdateSentinelVariables(tip_mn_list); //this sets local vars in object
 
-    LOCK2(cs_main, cs);
+    LOCK2(::cs_main, cs);
     std::string strError;
 
     // MAKE SURE THIS OBJECT IS OK
@@ -374,7 +374,7 @@ void CGovernanceManager::CheckAndRemove()
 
     const auto tip_mn_list = Assert(m_dmnman)->GetListAtChainTip();
 
-    LOCK2(cs_main, cs);
+    LOCK2(::cs_main, cs);
 
     for (const uint256& nHash : vecDirtyHashes) {
         auto it = mapObjects.find(nHash);
@@ -701,7 +701,7 @@ std::optional<const CGovernanceObject> CGovernanceManager::CreateGovernanceTrigg
     if (!sb_opt.has_value()) return std::nullopt;
 
     //TODO: Check if nHashParentIn, nRevision and nCollateralHashIn are correct
-    LOCK2(cs_main, cs);
+    LOCK2(::cs_main, cs);
 
     // Check if identical trigger (equal DataHash()) is already created (signed by other masternode)
     CGovernanceObject gov_sb(uint256(), 1, GetAdjustedTime(), uint256(), sb_opt.value().GetHexStrData());
@@ -748,7 +748,7 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
     // only active masternodes can vote on triggers
     if (mn_activeman.GetProTxHash().IsNull()) return;
 
-    LOCK2(cs_main, cs);
+    LOCK2(::cs_main, cs);
 
     if (trigger_opt.has_value()) {
         // We should never vote "yes" on another trigger or the same trigger twice
@@ -1181,7 +1181,7 @@ void CGovernanceManager::CheckPostponedObjects(PeerManager& peerman)
 {
     if (!m_mn_sync.IsSynced()) return;
 
-    LOCK2(cs_main, cs);
+    LOCK2(::cs_main, cs);
 
     // Check postponed proposals
     for (auto it = mapPostponedObjects.begin(); it != mapPostponedObjects.end();) {
@@ -1355,7 +1355,7 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
             if (!pnode->CanRelay() || (fMasternodeMode && pnode->IsInboundConn())) continue;
             // stop early to prevent setAskFor overflow
             {
-                LOCK(cs_main);
+                LOCK(::cs_main);
                 size_t nProjectedSize = peerman.GetRequestedObjectCount(pnode->GetId()) + nProjectedVotes;
                 if (nProjectedSize > MAX_INV_SZ) continue;
                 // to early to ask the same node

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -361,7 +361,7 @@ UniValue CGovernanceObject::ToJson() const
 
 void CGovernanceObject::UpdateLocalValidity(const CDeterministicMNList& tip_mn_list, const ChainstateManager& chainman)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
     // THIS DOES NOT CHECK COLLATERAL, THIS IS CHECKED UPON ORIGINAL ARRIVAL
     fCachedLocalValidity = IsValidLocally(tip_mn_list, chainman, strLocalValidityError, false);
 }
@@ -376,7 +376,7 @@ bool CGovernanceObject::IsValidLocally(const CDeterministicMNList& tip_mn_list, 
 
 bool CGovernanceObject::IsValidLocally(const CDeterministicMNList& tip_mn_list, const ChainstateManager& chainman, std::string& strError, bool& fMissingConfirmations, bool fCheckCollateral) const
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     fMissingConfirmations = false;
 
@@ -447,7 +447,7 @@ CAmount CGovernanceObject::GetMinCollateralFee() const
 
 bool CGovernanceObject::IsCollateralValid(const ChainstateManager& chainman, std::string& strError, bool& fMissingConfirmations) const
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     strError = "";
     fMissingConfirmations = false;
@@ -505,7 +505,7 @@ bool CGovernanceObject::IsCollateralValid(const ChainstateManager& chainman, std
 
     // GET CONFIRMATIONS FOR TRANSACTION
 
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
     int nConfirmationsIn = 0;
     if (nBlockHash != uint256()) {
         const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(nBlockHash);

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -228,15 +228,15 @@ public:
 
     // CORE OBJECT FUNCTIONS
 
-    bool IsValidLocally(const CDeterministicMNList& tip_mn_list, const ChainstateManager& chainman, std::string& strError, bool fCheckCollateral) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool IsValidLocally(const CDeterministicMNList& tip_mn_list, const ChainstateManager& chainman, std::string& strError, bool fCheckCollateral) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    bool IsValidLocally(const CDeterministicMNList& tip_mn_list, const ChainstateManager& chainman, std::string& strError, bool& fMissingConfirmations, bool fCheckCollateral) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool IsValidLocally(const CDeterministicMNList& tip_mn_list, const ChainstateManager& chainman, std::string& strError, bool& fMissingConfirmations, bool fCheckCollateral) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /// Check the collateral transaction for the budget proposal/finalized budget
-    bool IsCollateralValid(const ChainstateManager& chainman, std::string& strError, bool& fMissingConfirmations) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool IsCollateralValid(const ChainstateManager& chainman, std::string& strError, bool& fMissingConfirmations) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     void UpdateLocalValidity(const CDeterministicMNList& tip_mn_list, const ChainstateManager& chainman)
-        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     void UpdateSentinelVariables(const CDeterministicMNList& tip_mn_list);
 

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -13,6 +13,10 @@
 #include <validation.h>
 #include <warnings.h>
 
+using node::PruneLockInfo;
+using node::ReadBlockFromDisk;
+using node::fPruneMode;
+
 constexpr uint8_t DB_BEST_BLOCK{'B'};
 
 constexpr auto SYNC_LOG_INTERVAL{30s};

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -10,6 +10,8 @@
 #include <node/blockstorage.h>
 #include <serialize.h>
 
+using node::UndoReadFromDisk;
+
 /* The index database stores three items for each block: the disk location of the encoded filter,
  * its dSHA256 hash, and the header. Those belonging to blocks on the active chain are indexed by
  * height, and those belonging to blocks that have been reorganized out of the active chain are

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -13,6 +13,12 @@
 #include <validation.h>
 #include <util/check.h>
 
+using node::CCoinsStats;
+using node::GetBogoSize;
+using node::ReadBlockFromDisk;
+using node::TxOutSer;
+using node::UndoReadFromDisk;
+
 static constexpr uint8_t DB_BLOCK_HASH{'s'};
 static constexpr uint8_t DB_BLOCK_HEIGHT{'t'};
 static constexpr uint8_t DB_MUHASH{'M'};

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -56,7 +56,7 @@ public:
     explicit CoinStatsIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Look up stats for a specific block using CBlockIndex
-    bool LookUpStats(const CBlockIndex* block_index, CCoinsStats& coins_stats) const;
+    bool LookUpStats(const CBlockIndex* block_index, node::CCoinsStats& coins_stats) const;
 };
 
 /// The global UTXO set hash object.

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -9,6 +9,8 @@
 #include <util/system.h>
 #include <validation.h>
 
+using node::OpenBlockFile;
+
 constexpr uint8_t DB_TXINDEX{'t'};
 
 std::unique_ptr<TxIndex> g_txindex;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -156,6 +156,9 @@ using node::fReindex;
 using node::fSpentIndex;
 using node::fTimestampIndex;
 using node::nPruneTarget;
+#ifdef ENABLE_WALLET
+using wallet::DEFAULT_DISABLE_WALLET;
+#endif // ENABLE_WALLET
 
 static constexpr bool DEFAULT_PROXYRANDOMIZE{true};
 static constexpr bool DEFAULT_REST_ENABLE{false};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -134,6 +134,8 @@
 #include <zmq/zmqrpc.h>
 #endif
 
+using node::NodeContext;
+
 static constexpr bool DEFAULT_PROXYRANDOMIZE{true};
 static constexpr bool DEFAULT_REST_ENABLE{false};
 static constexpr bool DEFAULT_I2P_ACCEPT_INCOMING{true};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -134,7 +134,28 @@
 #include <zmq/zmqrpc.h>
 #endif
 
+using node::CacheSizes;
+using node::CalculateCacheSizes;
+using node::CCoinsStats;
+using node::CoinStatsHashType;
+using node::ChainstateLoadingError;
+using node::ChainstateLoadVerifyError;
+using node::DashChainstateSetupClose;
+using node::DEFAULT_ADDRESSINDEX;
+using node::DEFAULT_PRINTPRIORITY;
+using node::DEFAULT_SPENTINDEX;
+using node::DEFAULT_STOPAFTERBLOCKIMPORT;
+using node::DEFAULT_TIMESTAMPINDEX;
+using node::LoadChainstate;
 using node::NodeContext;
+using node::ThreadImport;
+using node::VerifyLoadedChainstate;
+using node::fAddressIndex;
+using node::fPruneMode;
+using node::fReindex;
+using node::fSpentIndex;
+using node::fTimestampIndex;
+using node::nPruneTarget;
 
 static constexpr bool DEFAULT_PROXYRANDOMIZE{true};
 static constexpr bool DEFAULT_REST_ENABLE{false};

--- a/src/init.h
+++ b/src/init.h
@@ -17,14 +17,16 @@ static constexpr bool DEFAULT_DAEMON = false;
 static constexpr bool DEFAULT_DAEMONWAIT = false;
 
 class ArgsManager;
-struct NodeContext;
 namespace interfaces {
 struct BlockAndHeaderTipInfo;
 } // namespace interfaces
+namespace node {
+struct NodeContext;
+} // namespace node
 
 /** Interrupt threads */
-void Interrupt(NodeContext& node);
-void Shutdown(NodeContext& node);
+void Interrupt(node::NodeContext& node);
+void Shutdown(node::NodeContext& node);
 //!Initialize the logging infrastructure
 void InitLogging(const ArgsManager& args);
 //!Parameter interaction: change current parameters depending on various rules
@@ -56,14 +58,14 @@ bool AppInitLockDataDirectory();
 /**
  * Initialize node and wallet interface pointers. Has no prerequisites or side effects besides allocating memory.
  */
-bool AppInitInterfaces(NodeContext& node);
+bool AppInitInterfaces(node::NodeContext& node);
 /**
  * Dash Core main initialization.
  * @note This should only be done after daemonization. Call Shutdown() if this function fails.
  * @pre Parameters should be parsed and config file should be read, AppInitLockDataDirectory should have been called.
  */
-bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info = nullptr);
-void PrepareShutdown(NodeContext& node);
+bool AppInitMain(node::NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info = nullptr);
+void PrepareShutdown(node::NodeContext& node);
 
 /**
  * Register all arguments with the ArgsManager

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -22,7 +22,7 @@ const char* EXE_NAME = "dash-node";
 class BitcoinNodeInit : public interfaces::Init
 {
 public:
-    BitcoinNodeInit(NodeContext& node, const char* arg0)
+    BitcoinNodeInit(node::NodeContext& node, const char* arg0)
         : m_node(node),
           m_ipc(interfaces::MakeIpc(EXE_NAME, arg0, *this))
     {
@@ -41,14 +41,14 @@ public:
     }
     std::unique_ptr<interfaces::Echo> makeEcho() override { return interfaces::MakeEcho(); }
     interfaces::Ipc* ipc() override { return m_ipc.get(); }
-    NodeContext& m_node;
+    node::NodeContext& m_node;
     std::unique_ptr<interfaces::Ipc> m_ipc;
 };
 } // namespace
 } // namespace init
 
 namespace interfaces {
-std::unique_ptr<Init> MakeNodeInit(NodeContext& node, int argc, char* argv[], int& exit_status)
+std::unique_ptr<Init> MakeNodeInit(node::NodeContext& node, int argc, char* argv[], int& exit_status)
 {
     auto init = std::make_unique<init::BitcoinNodeInit>(node, argc > 0 ? argv[0] : "");
     // Check if bitcoin-node is being invoked as an IPC server. If so, then

--- a/src/init/bitcoind.cpp
+++ b/src/init/bitcoind.cpp
@@ -14,6 +14,8 @@
 
 #include <memory>
 
+using node::NodeContext;
+
 namespace init {
 namespace {
 class BitcoindInit : public interfaces::Init

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -31,9 +31,9 @@ enum class MemPoolRemovalReason;
 struct bilingual_str;
 struct CBlockLocator;
 struct FeeCalculation;
+namespace node {
 struct NodeContext;
-enum class MemPoolRemovalReason;
-
+} // namespace node
 namespace llmq {
 class CChainLockSig;
 struct CInstantSendLock;
@@ -339,7 +339,7 @@ public:
 };
 
 //! Return implementation of Chain interface.
-std::unique_ptr<Chain> MakeChain(NodeContext& node);
+std::unique_ptr<Chain> MakeChain(node::NodeContext& node);
 
 } // namespace interfaces
 

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -31,13 +31,13 @@ enum class MemPoolRemovalReason;
 struct bilingual_str;
 struct CBlockLocator;
 struct FeeCalculation;
-namespace node {
-struct NodeContext;
-} // namespace node
 namespace llmq {
 class CChainLockSig;
 struct CInstantSendLock;
 } // namespace llmq
+namespace node {
+struct NodeContext;
+} // namespace node
 
 typedef std::shared_ptr<const CTransaction> CTransactionRef;
 

--- a/src/interfaces/coinjoin.h
+++ b/src/interfaces/coinjoin.h
@@ -9,10 +9,12 @@
 #include <string>
 #include <vector>
 
-class CWallet;
 namespace node {
 struct NodeContext;
 } // namespace node
+namespace wallet {
+class CWallet;
+} // namespace wallet
 
 class UniValue;
 
@@ -40,7 +42,7 @@ class Loader
 public:
     virtual ~Loader() {}
     //! Add new wallet to CoinJoin client manager
-    virtual void AddWallet(const std::shared_ptr<CWallet>&) = 0;
+    virtual void AddWallet(const std::shared_ptr<wallet::CWallet>&) = 0;
     //! Remove wallet from CoinJoin client manager
     virtual void RemoveWallet(const std::string&) = 0;
     virtual void FlushWallet(const std::string&) = 0;

--- a/src/interfaces/coinjoin.h
+++ b/src/interfaces/coinjoin.h
@@ -10,7 +10,9 @@
 #include <vector>
 
 class CWallet;
+namespace node {
 struct NodeContext;
+} // namespace node
 
 class UniValue;
 
@@ -46,7 +48,7 @@ public:
 };
 } // namespace CoinJoin
 
-std::unique_ptr<CoinJoin::Loader> MakeCoinJoinLoader(NodeContext& node);
+std::unique_ptr<CoinJoin::Loader> MakeCoinJoinLoader(node::NodeContext& node);
 
 } // namespace interfaces
 

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -7,7 +7,9 @@
 
 #include <memory>
 
+namespace node {
 struct NodeContext;
+} // namespace node
 
 namespace interfaces {
 class Chain;
@@ -44,7 +46,7 @@ public:
 //! status code to exit with. If this returns non-null, the caller can start up
 //! normally and use the Init object to spawn and connect to other processes
 //! while it is running.
-std::unique_ptr<Init> MakeNodeInit(NodeContext& node, int argc, char* argv[], int& exit_status);
+std::unique_ptr<Init> MakeNodeInit(node::NodeContext& node, int argc, char* argv[], int& exit_status);
 
 //! Return implementation of Init interface for the wallet process.
 std::unique_ptr<Init> MakeWalletInit(int argc, char* argv[], int& exit_status);

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -24,7 +24,6 @@
 
 class BanMan;
 class CBlockIndex;
-class CCoinControl;
 class CDeterministicMNList;
 class CFeeRate;
 class CGovernanceObject;
@@ -41,6 +40,9 @@ struct CNodeStateStats;
 namespace node {
 struct NodeContext;
 } // namespace node
+namespace wallet {
+class CCoinControl;
+} // namespace wallet
 
 namespace interfaces {
 class Handler;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -33,20 +33,21 @@ class Coin;
 class RPCTimerInterface;
 class UniValue;
 class Proxy;
-struct bilingual_str;
 enum class SynchronizationState;
 enum class TransactionError;
-struct CNodeStateStats;
-struct NodeContext;
-
 enum vote_signal_enum_t : int;
+struct bilingual_str;
+struct CNodeStateStats;
+namespace node {
+struct NodeContext;
+} // namespace node
 
 namespace interfaces {
 class Handler;
 class WalletLoader;
 namespace CoinJoin {
 class Loader;
-} //namespsace CoinJoin
+} // namespace CoinJoin
 struct BlockTip;
 
 //! Interface for the src/evo part of a dash node (dashd process).
@@ -55,7 +56,7 @@ class EVO
 public:
     virtual ~EVO() {}
     virtual std::pair<CDeterministicMNList, const CBlockIndex*> getListAtChainTip() = 0;
-    virtual void setContext(NodeContext* context) {}
+    virtual void setContext(node::NodeContext* context) {}
 };
 
 //! Interface for the src/governance part of a dash node (dashd process).
@@ -67,7 +68,7 @@ public:
     virtual int32_t getObjAbsYesCount(const CGovernanceObject& obj, vote_signal_enum_t vote_signal) = 0;
     virtual bool getObjLocalValidity(const CGovernanceObject& obj, std::string& error, bool check_collateral) = 0;
     virtual bool isEnabled() = 0;
-    virtual void setContext(NodeContext* context) {}
+    virtual void setContext(node::NodeContext* context) {}
 };
 
 //! Interface for the src/llmq part of a dash node (dashd process).
@@ -76,7 +77,7 @@ class LLMQ
 public:
     virtual ~LLMQ() {}
     virtual size_t getInstantSentLockCount() = 0;
-    virtual void setContext(NodeContext* context) {}
+    virtual void setContext(node::NodeContext* context) {}
 };
 
 //! Interface for the src/masternode part of a dash node (dashd process).
@@ -89,7 +90,7 @@ public:
     virtual bool isBlockchainSynced() = 0;
     virtual bool isSynced() = 0;
     virtual std::string getSyncStatus() =  0;
-    virtual void setContext(NodeContext* context) {}
+    virtual void setContext(node::NodeContext* context) {}
 };
 }
 
@@ -354,12 +355,12 @@ public:
 
     //! Get and set internal node context. Useful for testing, but not
     //! accessible across processes.
-    virtual NodeContext* context() { return nullptr; }
-    virtual void setContext(NodeContext* context) { }
+    virtual node::NodeContext* context() { return nullptr; }
+    virtual void setContext(node::NodeContext* context) { }
 };
 
 //! Return implementation of Node interface.
-std::unique_ptr<Node> MakeNode(NodeContext& context);
+std::unique_ptr<Node> MakeNode(node::NodeContext& context);
 
 //! Block tip (could be a header or not, depends on the subscribed signal).
 struct BlockTip {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -35,10 +35,13 @@ enum class FeeReason;
 enum class TransactionError;
 enum isminetype : unsigned int;
 struct CRecipient;
-struct NodeContext;
 struct PartiallySignedTransaction;
 struct WalletContext;
 struct bilingual_str;
+namespace node {
+struct NodeContext;
+} // namespace node
+
 using isminefilter = std::underlying_type<isminetype>::type;
 
 template <typename T>
@@ -456,7 +459,7 @@ std::unique_ptr<Wallet> MakeWallet(WalletContext& context, const std::shared_ptr
 
 //! Return implementation of ChainClient interface for a wallet loader. This
 //! function will be undefined in builds where ENABLE_WALLET is false.
-std::unique_ptr<WalletLoader> MakeWalletLoader(Chain& chain, ArgsManager& args, NodeContext& node_context,
+std::unique_ptr<WalletLoader> MakeWalletLoader(Chain& chain, ArgsManager& args, node::NodeContext& node_context,
                                                CoinJoin::Loader& coinjoin_loader);
 
 } // namespace interfaces

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -25,24 +25,26 @@
 #include <utility>
 #include <vector>
 
-class CCoinControl;
 class CFeeRate;
 class CKey;
 class CRPCCommand;
-class CWallet;
-class UniValue;
 enum class FeeReason;
 enum class TransactionError;
-enum isminetype : unsigned int;
-struct CRecipient;
-struct PartiallySignedTransaction;
-struct WalletContext;
 struct bilingual_str;
+struct PartiallySignedTransaction;
 namespace node {
 struct NodeContext;
 } // namespace node
-
+namespace wallet {
+class CCoinControl;
+class CWallet;
+enum isminetype : unsigned int;
+struct CRecipient;
+struct WalletContext;
 using isminefilter = std::underlying_type<isminetype>::type;
+} // namespace wallet
+
+class UniValue;
 
 template <typename T>
 class Span;
@@ -133,7 +135,7 @@ public:
     //! Look up address in wallet, return whether exists.
     virtual bool getAddress(const CTxDestination& dest,
         std::string* name,
-        isminetype* is_mine,
+        wallet::isminetype* is_mine,
         std::string* purpose) = 0;
 
     //! Get wallet address list.
@@ -161,8 +163,8 @@ public:
     virtual std::vector<COutPoint> listProTxCoins() = 0;
 
     //! Create transaction.
-    virtual CTransactionRef createTransaction(const std::vector<CRecipient>& recipients,
-        const CCoinControl& coin_control,
+    virtual CTransactionRef createTransaction(const std::vector<wallet::CRecipient>& recipients,
+        const wallet::CCoinControl& coin_control,
         bool sign,
         int& change_pos,
         CAmount& fee,
@@ -240,19 +242,19 @@ public:
     virtual CAmount getAverageAnonymizedRounds() = 0;
 
     //! Get available balance.
-    virtual CAmount getAvailableBalance(const CCoinControl& coin_control) = 0;
+    virtual CAmount getAvailableBalance(const wallet::CCoinControl& coin_control) = 0;
 
     //! Return whether transaction input belongs to wallet.
-    virtual isminetype txinIsMine(const CTxIn& txin) = 0;
+    virtual wallet::isminetype txinIsMine(const CTxIn& txin) = 0;
 
     //! Return whether transaction output belongs to wallet.
-    virtual isminetype txoutIsMine(const CTxOut& txout) = 0;
+    virtual wallet::isminetype txoutIsMine(const CTxOut& txout) = 0;
 
     //! Return debit amount if transaction input belongs to wallet.
-    virtual CAmount getDebit(const CTxIn& txin, isminefilter filter) = 0;
+    virtual CAmount getDebit(const CTxIn& txin, wallet::isminefilter filter) = 0;
 
     //! Return credit amount if transaction input belongs to wallet.
-    virtual CAmount getCredit(const CTxOut& txout, isminefilter filter) = 0;
+    virtual CAmount getCredit(const CTxOut& txout, wallet::isminefilter filter) = 0;
 
     //! Return AvailableCoins + LockedCoins grouped by wallet address.
     //! (put change in one group with wallet address)
@@ -267,7 +269,7 @@ public:
 
     //! Get minimum fee.
     virtual CAmount getMinimumFee(unsigned int tx_bytes,
-        const CCoinControl& coin_control,
+        const wallet::CCoinControl& coin_control,
         int* returned_target,
         FeeReason* reason) = 0;
 
@@ -333,7 +335,7 @@ public:
     virtual std::unique_ptr<Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn fn) = 0;
 
     //! Return pointer to internal wallet class, useful for testing.
-    virtual CWallet* wallet() { return nullptr; }
+    virtual wallet::CWallet* wallet() { return nullptr; }
 };
 
 //! Wallet chain client that in addition to having chain client methods for
@@ -370,18 +372,18 @@ public:
    virtual std::unique_ptr<Handler> handleLoadWallet(LoadWalletFn fn) = 0;
 
    //! Return pointer to internal context, useful for testing.
-   virtual WalletContext* context() { return nullptr; }
+   virtual wallet::WalletContext* context() { return nullptr; }
 };
 
 //! Information about one wallet address.
 struct WalletAddress
 {
     CTxDestination dest;
-    isminetype is_mine;
+    wallet::isminetype is_mine;
     std::string name;
     std::string purpose;
 
-    WalletAddress(CTxDestination dest, isminetype is_mine, std::string name, std::string purpose)
+    WalletAddress(CTxDestination dest, wallet::isminetype is_mine, std::string name, std::string purpose)
         : dest(std::move(dest)), is_mine(is_mine), name(std::move(name)), purpose(std::move(purpose))
     {
     }
@@ -414,10 +416,10 @@ struct WalletBalances
 struct WalletTx
 {
     CTransactionRef tx;
-    std::vector<isminetype> txin_is_mine;
-    std::vector<isminetype> txout_is_mine;
+    std::vector<wallet::isminetype> txin_is_mine;
+    std::vector<wallet::isminetype> txout_is_mine;
     std::vector<CTxDestination> txout_address;
-    std::vector<isminetype> txout_address_is_mine;
+    std::vector<wallet::isminetype> txout_address_is_mine;
     CAmount credit;
     CAmount debit;
     CAmount change;
@@ -455,7 +457,7 @@ struct WalletTxOut
 
 //! Return implementation of Wallet interface. This function is defined in
 //! dummywallet.cpp and throws if the wallet component is not compiled.
-std::unique_ptr<Wallet> MakeWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
+std::unique_ptr<Wallet> MakeWallet(wallet::WalletContext& context, const std::shared_ptr<wallet::CWallet>& wallet);
 
 //! Return implementation of ChainClient interface for a wallet loader. This
 //! function will be undefined in builds where ENABLE_WALLET is false.

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -85,7 +85,7 @@ MessageProcessingResult CQuorumBlockProcessor::ProcessMessage(const CNode& peer,
     // Verify that quorumHash is part of the active chain and that it's the first block in the DKG interval
     const CBlockIndex* pQuorumBaseBlockIndex;
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         pQuorumBaseBlockIndex = m_chainstate.m_blockman.LookupBlockIndex(qc.quorumHash);
         if (pQuorumBaseBlockIndex == nullptr) {
             LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- unknown block %s in commitment, peer=%d\n", __func__,
@@ -153,7 +153,7 @@ MessageProcessingResult CQuorumBlockProcessor::ProcessMessage(const CNode& peer,
 
 bool CQuorumBlockProcessor::ProcessBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, BlockValidationState& state, bool fJustCheck, bool fBLSChecks)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     const auto blockHash = pindex->GetBlockHash();
 
@@ -222,7 +222,7 @@ static std::tuple<std::string, Consensus::LLMQType, int, uint32_t> BuildInversed
 
 bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, BlockValidationState& state, bool fJustCheck, bool fBLSChecks)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     const auto& llmq_params_opt = Params().GetLLMQ(qc.llmqType);
     if (!llmq_params_opt.has_value()) {
@@ -315,7 +315,7 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
 
 bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     PreComputeQuorumMembers(m_dmnman, m_qsnapman, pindex, /*reset_cache=*/true);
 
@@ -354,7 +354,7 @@ bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, gsl::not_null<const C
 
 bool CQuorumBlockProcessor::GetCommitmentsFromBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, std::multimap<Consensus::LLMQType, CFinalCommitment>& ret, BlockValidationState& state)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     const auto& consensus = Params().GetConsensus();
 
@@ -396,7 +396,7 @@ bool CQuorumBlockProcessor::GetCommitmentsFromBlock(const CBlock& block, gsl::no
 
 bool CQuorumBlockProcessor::IsMiningPhase(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     // Note: This function can be called for new blocks
     assert(nHeight <= active_chain.Height() + 1);
@@ -416,7 +416,7 @@ bool CQuorumBlockProcessor::IsMiningPhase(const Consensus::LLMQParams& llmqParam
 
 size_t CQuorumBlockProcessor::GetNumCommitmentsRequired(const Consensus::LLMQParams& llmqParams, int nHeight) const
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     if (!IsMiningPhase(llmqParams, m_chainstate.m_chain, nHeight)) return 0;
 
@@ -439,7 +439,7 @@ size_t CQuorumBlockProcessor::GetNumCommitmentsRequired(const Consensus::LLMQPar
 // WARNING: This method returns uint256() on the first block of the DKG interval (because the block hash is not known yet)
 uint256 CQuorumBlockProcessor::GetQuorumBlockHash(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight, int quorumIndex)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     int quorumStartHeight = nHeight - (nHeight % llmqParams.dkgInterval) + quorumIndex;
 
@@ -689,7 +689,7 @@ bool CQuorumBlockProcessor::GetMineableCommitmentByHash(const uint256& commitmen
 // Will return a null commitment if no mineable commitment is known and none was mined yet
 std::optional<std::vector<CFinalCommitment>> CQuorumBlockProcessor::GetMineableCommitments(const Consensus::LLMQParams& llmqParams, int nHeight) const
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     std::vector<CFinalCommitment> ret;
 
@@ -744,7 +744,7 @@ std::optional<std::vector<CFinalCommitment>> CQuorumBlockProcessor::GetMineableC
 
 bool CQuorumBlockProcessor::GetMineableCommitmentsTx(const Consensus::LLMQParams& llmqParams, int nHeight, std::vector<CTransactionRef>& ret) const
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
     std::optional<std::vector<CFinalCommitment>> qcs = GetMineableCommitments(llmqParams, nHeight);
     if (!qcs.has_value()) {
         return false;

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -55,15 +55,15 @@ public:
 
     MessageProcessingResult ProcessMessage(const CNode& peer, std::string_view msg_type, CDataStream& vRecv);
 
-    bool ProcessBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, BlockValidationState& state, bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    bool UndoBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool ProcessBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, BlockValidationState& state, bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool UndoBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! it returns hash of commitment if it should be relay, otherwise nullopt
     std::optional<CInv> AddMineableCommitment(const CFinalCommitment& fqc);
     bool HasMineableCommitment(const uint256& hash) const;
     bool GetMineableCommitmentByHash(const uint256& commitmentHash, CFinalCommitment& ret) const;
-    std::optional<std::vector<CFinalCommitment>> GetMineableCommitments(const Consensus::LLMQParams& llmqParams, int nHeight) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    bool GetMineableCommitmentsTx(const Consensus::LLMQParams& llmqParams, int nHeight, std::vector<CTransactionRef>& ret) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    std::optional<std::vector<CFinalCommitment>> GetMineableCommitments(const Consensus::LLMQParams& llmqParams, int nHeight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool GetMineableCommitmentsTx(const Consensus::LLMQParams& llmqParams, int nHeight, std::vector<CTransactionRef>& ret) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
     CFinalCommitmentPtr GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, uint256& retMinedBlockHash) const;
 
@@ -74,11 +74,11 @@ public:
     std::vector<std::pair<int, const CBlockIndex*>> GetLastMinedCommitmentsPerQuorumIndexUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t cycle) const;
     std::optional<const CBlockIndex*> GetLastMinedCommitmentsByQuorumIndexUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, int quorumIndex, size_t cycle) const;
 private:
-    static bool GetCommitmentsFromBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, std::multimap<Consensus::LLMQType, CFinalCommitment>& ret, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    bool ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, BlockValidationState& state, bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    static bool IsMiningPhase(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    size_t GetNumCommitmentsRequired(const Consensus::LLMQParams& llmqParams, int nHeight) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    static uint256 GetQuorumBlockHash(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight, int quorumIndex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    static bool GetCommitmentsFromBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, std::multimap<Consensus::LLMQType, CFinalCommitment>& ret, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, BlockValidationState& state, bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    static bool IsMiningPhase(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    size_t GetNumCommitmentsRequired(const Consensus::LLMQParams& llmqParams, int nHeight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    static uint256 GetQuorumBlockHash(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight, int quorumIndex) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };
 } // namespace llmq
 

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -24,6 +24,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+using node::ReadBlockFromDisk;
+
 static bool ChainLocksSigningEnabled(const CSporkManager& sporkman)
 {
     return sporkman.GetSporkValue(SPORK_19_CHAINLOCKS_ENABLED) == 0;

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -121,7 +121,7 @@ MessageProcessingResult CChainLocksHandler::ProcessNewChainLock(const NodeId fro
         return {};
     }
 
-    const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate.m_blockman.LookupBlockIndex(clsig.getBlockHash()));
+    const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(clsig.getBlockHash()));
 
     {
         LOCK(cs);
@@ -237,7 +237,7 @@ void CChainLocksHandler::TrySignChainTip(const llmq::CInstantSendManager& isman)
         return;
     }
 
-    const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate.m_chain.Tip());
+    const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
 
     if (pindex->pprev == nullptr) {
         return;
@@ -404,7 +404,7 @@ CChainLocksHandler::BlockTxs::mapped_type CChainLocksHandler::GetBlockTxs(const 
 
         uint32_t blockTime;
         {
-            LOCK(cs_main);
+            LOCK(::cs_main);
             const auto* pindex = m_chainstate.m_blockman.LookupBlockIndex(blockHash);
             CBlock block;
             if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
@@ -485,7 +485,7 @@ void CChainLocksHandler::EnforceBestChainLock()
             LogPrintf("CChainLocksHandler::%s -- ActivateBestChain failed: %s\n", __func__, dummy_state.ToString());
             return;
         }
-        LOCK(cs_main);
+        LOCK(::cs_main);
         if (m_chainstate.m_chain.Tip()->GetAncestor(currentBestChainLockBlockIndex->nHeight) != currentBestChainLockBlockIndex) {
             return;
         }
@@ -619,7 +619,7 @@ void CChainLocksHandler::Cleanup()
         }
     }
     // need mempool.cs due to GetTransaction calls
-    LOCK2(cs_main, mempool.cs);
+    LOCK2(::cs_main, mempool.cs);
     LOCK(cs);
 
     for (auto it = blockTxs.begin(); it != blockTxs.end(); ) {

--- a/src/llmq/commitment.cpp
+++ b/src/llmq/commitment.cpp
@@ -212,7 +212,7 @@ bool CheckLLMQCommitment(CDeterministicMNManager& dmnman, CQuorumSnapshotManager
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-height");
     }
 
-    const CBlockIndex* pQuorumBaseBlockIndex = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(qcTx.commitment.quorumHash));
+    const CBlockIndex* pQuorumBaseBlockIndex = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(qcTx.commitment.quorumHash));
     if (pQuorumBaseBlockIndex == nullptr) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-qc-quorum-hash");
     }

--- a/src/llmq/debug.cpp
+++ b/src/llmq/debug.cpp
@@ -26,7 +26,7 @@ UniValue CDKGDebugSessionStatus::ToJson(CDeterministicMNManager& dmnman, CQuorum
 
     std::vector<CDeterministicMNCPtr> dmnMembers;
     if (detailLevel == 2) {
-        const CBlockIndex* pindex = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(quorumHash));
+        const CBlockIndex* pindex = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(quorumHash));
         if (pindex != nullptr) {
             dmnMembers = utils::GetAllQuorumMembers(llmqType, dmnman, qsnapman, pindex);
         }

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -535,7 +535,7 @@ void CDKGSessionHandler::HandleDKGRound(CConnman& connman, PeerManager& peerman)
     pendingPrematureCommitments.Clear();
     uint256 curQuorumHash = WITH_LOCK(cs_phase_qhash, return quorumHash);
 
-    const CBlockIndex* pQuorumBaseBlockIndex = WITH_LOCK(cs_main, return m_chainstate.m_blockman.LookupBlockIndex(curQuorumHash));
+    const CBlockIndex* pQuorumBaseBlockIndex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(curQuorumHash));
 
     if (!InitNewQuorum(pQuorumBaseBlockIndex)) {
         // should actually never happen

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -155,7 +155,7 @@ PeerMsgRet CDKGSessionManager::ProcessMessage(CNode& pfrom, PeerManager& peerman
 
     // No luck, try to compute
     if (quorumIndex == -1) {
-        CBlockIndex* pQuorumBaseBlockIndex = WITH_LOCK(cs_main, return m_chainstate.m_blockman.LookupBlockIndex(quorumHash));
+        CBlockIndex* pQuorumBaseBlockIndex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(quorumHash));
         if (pQuorumBaseBlockIndex == nullptr) {
             LogPrintf("CDKGSessionManager -- unknown quorumHash %s\n", quorumHash.ToString());
             // NOTE: do not insta-ban for this, we might be lagging behind
@@ -408,7 +408,7 @@ void CDKGSessionManager::CleanupOldContributions() const
             decltype(start) k;
 
             pcursor->Seek(start);
-            LOCK(cs_main);
+            LOCK(::cs_main);
             while (pcursor->Valid()) {
                 if (!pcursor->GetKey(k) || std::get<0>(k) != prefix || std::get<1>(k) != params.type) {
                     break;

--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -101,7 +101,7 @@ MessageProcessingResult CEHFSignalsHandler::HandleNewRecoveredSig(const CRecover
     }
 
     MessageProcessingResult ret;
-    const auto ehfSignals = mnhfman.GetSignalsStage(WITH_LOCK(cs_main, return m_chainman.ActiveTip()));
+    const auto ehfSignals = mnhfman.GetSignalsStage(WITH_LOCK(::cs_main, return m_chainman.ActiveTip()));
     MNHFTxPayload mnhfPayload;
     for (const auto& deployment : Params().GetConsensus().vDeployments) {
         // skip deployments that do not use dip0023 or that have already been mined
@@ -123,7 +123,7 @@ MessageProcessingResult CEHFSignalsHandler::HandleNewRecoveredSig(const CRecover
         {
             CTransactionRef tx_to_sent = MakeTransactionRef(std::move(tx));
             LogPrintf("CEHFSignalsHandler::HandleNewRecoveredSig Special EHF TX is created hash=%s\n", tx_to_sent->GetHash().ToString());
-            LOCK(cs_main);
+            LOCK(::cs_main);
             const MempoolAcceptResult result = m_chainman.ProcessTransaction(tx_to_sent);
             if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                 ret.m_transactions.push_back(tx_to_sent->GetHash());

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -28,6 +28,9 @@
 
 #include <cxxtimer.hpp>
 
+using node::fImporting;
+using node::fReindex;
+
 namespace llmq
 {
 

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -87,7 +87,7 @@ bool BuildQuorumRotationInfo(CDeterministicMNManager& dmnman, CQuorumSnapshotMan
                              const CQuorumBlockProcessor& qblockman, const CGetQuorumRotationInfo& request,
                              bool use_legacy_construction, CQuorumRotationInfo& response, std::string& errorRet)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     std::vector<const CBlockIndex*> baseBlockIndexes;
     if (request.baseBlockHashes.size() == 0) {
@@ -426,7 +426,7 @@ void CQuorumSnapshotManager::StoreSnapshotForBlock(const Consensus::LLMQType llm
 {
     auto snapshotHash = ::SerializeHash(std::make_pair(llmqType, pindex->GetBlockHash()));
 
-    // LOCK(cs_main);
+    // LOCK(::cs_main);
     AssertLockNotHeld(m_evoDb.cs);
     LOCK2(snapshotCacheCs, m_evoDb.cs);
     m_evoDb.GetRawDB().Write(std::make_pair(DB_QUORUM_SNAPSHOT, snapshotHash), snapshot);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -77,6 +77,11 @@
 
 #include <stats/client.h>
 
+using node::ReadBlockFromDisk;
+using node::fImporting;
+using node::fPruneMode;
+using node::fReindex;
+
 /** Maximum number of in-flight objects from a peer */
 static constexpr int32_t MAX_PEER_OBJECT_IN_FLIGHT = 100;
 /** Maximum number of announced objects from a peer */

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -26,6 +26,7 @@
 #include <ranges>
 #include <unordered_map>
 
+namespace node {
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
 bool fPruneMode = false;
@@ -923,3 +924,4 @@ void ThreadImport(ChainstateManager& chainman, CDeterministicMNManager& dmnman, 
 
     chainman.ActiveChainstate().LoadMempool(args);
 }
+} // namespace node

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -479,11 +479,6 @@ void CleanupBlockRevFiles()
     }
 }
 
-std::string CBlockFileInfo::ToString() const
-{
-    return strprintf("CBlockFileInfo(blocks=%u, size=%u, heights=%u...%u, time=%s...%s)", nBlocks, nSize, nHeightFirst, nHeightLast, FormatISO8601Date(nTimeFirst), FormatISO8601Date(nTimeLast));
-}
-
 CBlockFileInfo* BlockManager::GetBlockFileInfo(size_t n)
 {
     LOCK(cs_LastBlockFile);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -35,6 +35,7 @@ namespace Consensus {
 struct Params;
 }
 
+namespace node {
 static constexpr bool DEFAULT_ADDRESSINDEX{false};
 static constexpr bool DEFAULT_SPENTINDEX{false};
 static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
@@ -230,5 +231,6 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 
 void ThreadImport(ChainstateManager& chainman, CDeterministicMNManager& dmnman, CDSNotificationInterface& dsnfi,
                   std::vector<fs::path> vImportFiles, CActiveMasternodeManager* const mn_activeman, const ArgsManager& args);
+} // namespace node
 
 #endif // BITCOIN_NODE_BLOCKSTORAGE_H

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -8,6 +8,7 @@
 #include <util/system.h>
 #include <validation.h>
 
+namespace node {
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
 {
     int64_t nTotalCache = (args.GetIntArg("-dbcache", nDefaultDbCache) << 20);
@@ -30,3 +31,4 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
     sizes.coins = nTotalCache; // the rest goes to in-memory cache
     return sizes;
 }
+} // namespace node

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -10,6 +10,7 @@
 
 class ArgsManager;
 
+namespace node {
 struct CacheSizes {
     int64_t block_tree_db;
     int64_t coins_db;
@@ -18,5 +19,6 @@ struct CacheSizes {
     int64_t filter_index;
 };
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);
+} // namespace node
 
 #endif // BITCOIN_NODE_CACHES_H

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -17,6 +17,7 @@
 #include <evo/mnhftx.h>
 #include <llmq/context.h>
 
+namespace node {
 std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      ChainstateManager& chainman,
                                                      CGovernanceManager& govman,
@@ -313,3 +314,4 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
 
     return std::nullopt;
 }
+} // namespace node

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -29,6 +29,7 @@ namespace Consensus {
 struct Params;
 }
 
+namespace node {
 enum class ChainstateLoadingError {
     ERROR_LOADING_BLOCK_DB,
     ERROR_BAD_GENESIS_BLOCK,
@@ -146,5 +147,6 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
                                                                 int check_level,
                                                                 std::function<int64_t()> get_unix_time_seconds,
                                                                 std::function<void(bool)> notify_bls_state = nullptr);
+} // namespace node
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -8,6 +8,8 @@
 #include <txmempool.h>
 #include <validation.h>
 
+using node::NodeContext;
+
 void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins)
 {
     assert(node.mempool);

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -8,8 +8,7 @@
 #include <txmempool.h>
 #include <validation.h>
 
-using node::NodeContext;
-
+namespace node {
 void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins)
 {
     assert(node.mempool);
@@ -24,3 +23,4 @@ void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins)
         }
     }
 }
+} // namespace node

--- a/src/node/coin.h
+++ b/src/node/coin.h
@@ -9,7 +9,9 @@
 
 class COutPoint;
 class Coin;
+namespace node {
 struct NodeContext;
+} // namespace node
 
 /**
  * Look up unspent output information. Returns coins in the mempool and in the
@@ -19,6 +21,6 @@ struct NodeContext;
  * @param[in] node The node context to use for lookup
  * @param[in,out] coins map to fill
  */
-void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins);
+void FindCoins(const node::NodeContext& node, std::map<COutPoint, Coin>& coins);
 
 #endif // BITCOIN_NODE_COIN_H

--- a/src/node/coin.h
+++ b/src/node/coin.h
@@ -9,9 +9,9 @@
 
 class COutPoint;
 class Coin;
+
 namespace node {
 struct NodeContext;
-} // namespace node
 
 /**
  * Look up unspent output information. Returns coins in the mempool and in the
@@ -22,5 +22,6 @@ struct NodeContext;
  * @param[in,out] coins map to fill
  */
 void FindCoins(const node::NodeContext& node, std::map<COutPoint, Coin>& coins);
+} // namespace node
 
 #endif // BITCOIN_NODE_COIN_H

--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -18,6 +18,7 @@
 
 #include <map>
 
+namespace node {
 // Database-independent metric indicating the UTXO set size
 uint64_t GetBogoSize(const CScript& script_pub_key)
 {
@@ -182,3 +183,4 @@ static void FinalizeHash(MuHash3072& muhash, CCoinsStats& stats)
     stats.hashSerialized = out;
 }
 static void FinalizeHash(std::nullptr_t, CCoinsStats& stats) {}
+} // namespace node

--- a/src/node/coinstats.h
+++ b/src/node/coinstats.h
@@ -16,9 +16,12 @@
 #include <functional>
 #include <optional>
 
-class BlockManager;
 class CCoinsView;
+namespace node {
+class BlockManager;
+} // namespace node
 
+namespace node {
 enum class CoinStatsHashType {
     HASH_SERIALIZED,
     MUHASH,
@@ -72,10 +75,11 @@ struct CCoinsStats {
 };
 
 //! Calculate statistics about the unspent transaction output set
-bool GetUTXOStats(CCoinsView* view, BlockManager& blockman, CCoinsStats& stats, const std::function<void()>& interruption_point = {}, const CBlockIndex* pindex = nullptr);
+bool GetUTXOStats(CCoinsView* view, node::BlockManager& blockman, CCoinsStats& stats, const std::function<void()>& interruption_point = {}, const CBlockIndex* pindex = nullptr);
 
 uint64_t GetBogoSize(const CScript& script_pub_key);
 
 CDataStream TxOutSer(const COutPoint& outpoint, const Coin& coin);
+} // namespace node
 
 #endif // BITCOIN_NODE_COINSTATS_H

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -29,5 +29,7 @@
 #include <txmempool.h>
 #include <validation.h>
 
+namespace node {
 NodeContext::NodeContext() {}
 NodeContext::~NodeContext() {}
+} // namespace node

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -44,6 +44,7 @@ class Loader;
 } // namspace CoinJoin
 } // namespace interfaces
 
+namespace node {
 //! NodeContext struct containing references to chain state and connection
 //! state.
 //!
@@ -96,5 +97,6 @@ struct NodeContext {
     NodeContext();
     ~NodeContext();
 };
+} // namespace node
 
 #endif // BITCOIN_NODE_CONTEXT_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -1020,6 +1020,6 @@ public:
 } // namespace node
 
 namespace interfaces {
-std::unique_ptr<Node> MakeNode(NodeContext& context) { return std::make_unique<node::NodeImpl>(context); }
-std::unique_ptr<Chain> MakeChain(NodeContext& node) { return std::make_unique<node::ChainImpl>(node); }
+std::unique_ptr<Node> MakeNode(node::NodeContext& context) { return std::make_unique<node::NodeImpl>(context); }
+std::unique_ptr<Chain> MakeChain(node::NodeContext& node) { return std::make_unique<node::ChainImpl>(node); }
 } // namespace interfaces

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -468,7 +468,7 @@ public:
     {
         return m_context->mn_activeman != nullptr;
     }
-    bool isLoadingBlocks() override { return ::fReindex || ::fImporting; }
+    bool isLoadingBlocks() override { return node::fReindex || node::fImporting; }
     void setNetworkActive(bool active) override
     {
         if (m_context->connman) {
@@ -938,7 +938,7 @@ public:
         LOCK(cs_main);
         return m_node.chainman->m_blockman.m_have_pruned;
     }
-    bool isReadyToBroadcast() override { return !::fImporting && !::fReindex && !isInitialBlockDownload(); }
+    bool isReadyToBroadcast() override { return !node::fImporting && !node::fReindex && !isInitialBlockDownload(); }
     bool isInitialBlockDownload() override {
         return chainman().ActiveChainstate().IsInitialBlockDownload();
     }

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -44,6 +44,8 @@
 #include <algorithm>
 #include <utility>
 
+using node::NodeContext;
+
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -44,8 +44,7 @@
 #include <algorithm>
 #include <utility>
 
-using node::NodeContext;
-
+namespace node {
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;
@@ -586,3 +585,4 @@ void BlockAssembler::addPackageTxs(const CTxMemPool& mempool, int& nPackagesSele
         nDescendantsUpdated += UpdatePackagesForAdded(mempool, ancestors, mapModifiedTx);
     }
 }
+} // namespace node

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -30,7 +30,6 @@ class CEvoDB;
 class CMNHFManager;
 class CScript;
 struct LLMQContext;
-struct NodeContext;
 
 namespace Consensus { struct Params; };
 namespace llmq {
@@ -40,6 +39,9 @@ class CQuorumBlockProcessor;
 class CQuorumManager;
 class CQuorumSnapshotManager;
 } // namespace llmq
+namespace node {
+struct NodeContext;
+} // namespace node
 
 static const bool DEFAULT_PRINTPRIORITY = false;
 
@@ -188,8 +190,8 @@ public:
         CFeeRate blockMinFeeRate;
     };
 
-    explicit BlockAssembler(CChainState& chainstate, const NodeContext& node, const CTxMemPool* mempool, const CChainParams& params);
-    explicit BlockAssembler(CChainState& chainstate, const NodeContext& node, const CTxMemPool* mempool, const CChainParams& params,
+    explicit BlockAssembler(CChainState& chainstate, const node::NodeContext& node, const CTxMemPool* mempool, const CChainParams& params);
+    explicit BlockAssembler(CChainState& chainstate, const node::NodeContext& node, const CTxMemPool* mempool, const CChainParams& params,
                             const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -19,7 +19,6 @@
 #include <boost/multi_index/tag.hpp>
 #include <boost/multi_index_container.hpp>
 
-class BlockManager;
 class CBlockIndex;
 class CChainParams;
 class CChainstateHelper;
@@ -39,9 +38,10 @@ class CQuorumBlockProcessor;
 class CQuorumManager;
 class CQuorumSnapshotManager;
 } // namespace llmq
+
 namespace node {
+class BlockManager;
 struct NodeContext;
-} // namespace node
 
 static const bool DEFAULT_PRINTPRIORITY = false;
 
@@ -229,5 +229,6 @@ private:
 };
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
+} // namespace node
 
 #endif // BITCOIN_NODE_MINER_H

--- a/src/node/minisketchwrapper.cpp
+++ b/src/node/minisketchwrapper.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+namespace node {
 namespace {
 
 static constexpr uint32_t BITS = 32;
@@ -75,3 +76,4 @@ Minisketch MakeMinisketch32FP(size_t max_elements, uint32_t fpbits)
 {
     return Minisketch::CreateFP(BITS, Minisketch32Implementation(), max_elements, fpbits);
 }
+} // namespace node

--- a/src/node/minisketchwrapper.h
+++ b/src/node/minisketchwrapper.h
@@ -9,9 +9,11 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace node {
 /** Wrapper around Minisketch::Minisketch(32, implementation, capacity). */
 Minisketch MakeMinisketch32(size_t capacity);
 /** Wrapper around Minisketch::CreateFP. */
 Minisketch MakeMinisketch32FP(size_t max_elements, uint32_t fpbits);
+} // namespace node
 
 #endif // BITCOIN_NODE_MINISKETCHWRAPPER_H

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -11,6 +11,7 @@
 
 #include <numeric>
 
+namespace node {
 PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
 {
     // Go through each input and build status
@@ -144,4 +145,4 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
 
     return result;
 }
-
+} // namespace node

--- a/src/node/psbt.h
+++ b/src/node/psbt.h
@@ -7,6 +7,7 @@
 
 #include <psbt.h>
 
+namespace node {
 /**
  * Holds an analysis of one input from a PSBT
  */
@@ -49,5 +50,6 @@ struct PSBTAnalysis {
  * @return A PSBTAnalysis with information about the provided PSBT.
  */
 PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx);
+} // namespace node
 
 #endif // BITCOIN_NODE_PSBT_H

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -17,8 +17,7 @@
 
 #include <future>
 
-using node::NodeContext;
-
+namespace node {
 static TransactionError HandleATMPError(const TxValidationState& state, std::string& err_string_out) {
     err_string_out = state.ToString();
     if (state.IsInvalid()) {
@@ -150,3 +149,4 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     }
     return nullptr;
 }
+} // namespace node

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -17,6 +17,8 @@
 
 #include <future>
 
+using node::NodeContext;
+
 static TransactionError HandleATMPError(const TxValidationState& state, std::string& err_string_out) {
     err_string_out = state.ToString();
     if (state.IsInvalid()) {

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -12,10 +12,12 @@
 
 class CBlockIndex;
 class CTxMemPool;
-struct NodeContext;
 namespace Consensus {
 struct Params;
 }
+namespace node {
+struct NodeContext;
+} // namespace node
 
 /** Maximum fee rate for sendrawtransaction and testmempoolaccept RPC calls.
  * Also used by the GUI when broadcasting a completed PSBT.
@@ -40,7 +42,7 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[in]  wait_callback wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
  * return error
  */
-[[nodiscard]] TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, bilingual_str& err_string, const CAmount& highfee, bool relay, bool wait_callback, bool bypass_limits = false);
+[[nodiscard]] TransactionError BroadcastTransaction(node::NodeContext& node, CTransactionRef tx, bilingual_str& err_string, const CAmount& highfee, bool relay, bool wait_callback, bool bypass_limits = false);
 
 /**
  * Return transaction with a given hash.

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -15,9 +15,9 @@ class CTxMemPool;
 namespace Consensus {
 struct Params;
 }
+
 namespace node {
 struct NodeContext;
-} // namespace node
 
 /** Maximum fee rate for sendrawtransaction and testmempoolaccept RPC calls.
  * Also used by the GUI when broadcasting a completed PSBT.
@@ -58,5 +58,6 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @returns                    The tx if found, otherwise nullptr
  */
 CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock);
+} // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -9,6 +9,7 @@
 #include <uint256.h>
 #include <serialize.h>
 
+namespace node {
 //! Metadata describing a serialized version of a UTXO set from which an
 //! assumeutxo CChainState can be constructed.
 class SnapshotMetadata
@@ -32,5 +33,6 @@ public:
 
     SERIALIZE_METHODS(SnapshotMetadata, obj) { READWRITE(obj.m_base_blockhash, obj.m_coins_count); }
 };
+} // namespace node
 
 #endif // BITCOIN_NODE_UTXO_SNAPSHOT_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -81,6 +81,8 @@ Q_DECLARE_METATYPE(CAmount)
 Q_DECLARE_METATYPE(SynchronizationState)
 Q_DECLARE_METATYPE(uint256)
 
+using node::NodeContext;
+
 static void RegisterMetaTypes()
 {
     // Register meta types used for QMetaObject::invokeMethod and Qt::QueuedConnection

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -31,6 +31,8 @@
 #include <QSettings>
 #include <QTreeWidget>
 
+using wallet::CCoinControl;
+
 QList<CAmount> CoinControlDialog::payAmounts;
 bool CoinControlDialog::fSubtractFeeFromAmount = false;
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -18,7 +18,9 @@
 
 class WalletModel;
 
+namespace wallet {
 class CCoinControl;
+} // namespace wallet
 
 namespace Ui {
     class CoinControlDialog;
@@ -41,18 +43,18 @@ class CoinControlDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit CoinControlDialog(CCoinControl& coin_control, WalletModel* model, QWidget *parent = nullptr);
+    explicit CoinControlDialog(wallet::CCoinControl& coin_control, WalletModel* model, QWidget *parent = nullptr);
     ~CoinControlDialog();
 
     // static because also called from sendcoinsdialog
-    static void updateLabels(CCoinControl& m_coin_control, WalletModel*, QDialog*);
+    static void updateLabels(wallet::CCoinControl& m_coin_control, WalletModel*, QDialog*);
 
     static QList<CAmount> payAmounts;
     static bool fSubtractFeeFromAmount;
 
 private:
     Ui::CoinControlDialog *ui;
-    CCoinControl& m_coin_control;
+    wallet::CCoinControl& m_coin_control;
     WalletModel *model;
     int sortColumn;
     Qt::SortOrder sortOrder;

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -20,6 +20,9 @@
 #include <iostream>
 #include <string>
 
+using node::AnalyzePSBT;
+using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
+using node::PSBTAnalysis;
 
 PSBTOperationsDialog::PSBTOperationsDialog(
     QWidget* parent, WalletModel* wallet_model, ClientModel* client_model) : QDialog(parent, GUIUtil::dialog_flags),

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -60,6 +60,10 @@
 #include <QTimer>
 #include <QVariant>
 
+#ifdef ENABLE_WALLET
+using wallet::GetWalletDir;
+#endif // ENABLE_WALLET
+
 const int CONSOLE_HISTORY = 50;
 const QSize FONT_RANGE(4, 40);
 const char fontSizeSettingsKey[] = "consoleFontSize";

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -30,6 +30,9 @@
 #include <wallet/wallet.h>
 #include <chrono>
 
+using wallet::CCoinControl;
+using wallet::DEFAULT_PAY_TX_FEE;
+
 #include <array>
 #include <fstream>
 #include <memory>

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -15,11 +15,13 @@
 
 static const int MAX_SEND_POPUP_ENTRIES = 10;
 
-class CCoinControl;
 class ClientModel;
 class SendCoinsEntry;
 class SendCoinsRecipient;
 enum class SynchronizationState;
+namespace wallet {
+class CCoinControl;
+} // namespace wallet
 
 namespace Ui {
     class SendCoinsDialog;
@@ -64,7 +66,7 @@ private:
     Ui::SendCoinsDialog *ui;
     ClientModel *clientModel;
     WalletModel *model;
-    std::unique_ptr<CCoinControl> m_coin_control;
+    std::unique_ptr<wallet::CCoinControl> m_coin_control;
     std::unique_ptr<WalletModelTransaction> m_current_transaction;
     bool fNewRecipientAllowed;
     bool send(const QList<SendCoinsRecipient>& recipients, QString& question_string, QString& informative_text, QString& detailed_text);

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -27,6 +27,13 @@
 #include <QTableView>
 #include <QTimer>
 
+using wallet::AddWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::CWallet;
+using wallet::RemoveWallet;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WalletContext;
+
 namespace
 {
 

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -45,6 +45,8 @@ Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
 #endif
 #endif
 
+using node::NodeContext;
+
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -40,6 +40,15 @@
 #include <QListView>
 #include <QDialogButtonBox>
 
+using wallet::AddWallet;
+using wallet::CWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::RemoveWallet;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WalletContext;
+using wallet::WalletDescriptor;
+using wallet::WalletRescanReserver;
+
 namespace
 {
 //! Press "Yes" or "Cancel" buttons in modal send confirmation dialog.

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -27,6 +27,11 @@
 
 #include <QLatin1String>
 
+using wallet::ISMINE_ALL;
+using wallet::ISMINE_SPENDABLE;
+using wallet::ISMINE_WATCH_ONLY;
+using wallet::isminetype;
+
 QString TransactionDesc::FormatTxStatus(const interfaces::WalletTxStatus& status, bool inMempool)
 {
     int depth = status.depth_in_main_chain;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -15,6 +15,11 @@
 
 #include <QDateTime>
 
+using wallet::ISMINE_ALL;
+using wallet::ISMINE_SPENDABLE;
+using wallet::ISMINE_WATCH_ONLY;
+using wallet::isminetype;
+
 /* Return positive answer if transaction should be shown in list.
  */
 bool TransactionRecord::showTransaction()

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -31,6 +31,10 @@
 #include <QTimer>
 #include <QWindow>
 
+using wallet::WALLET_FLAG_BLANK_WALLET;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WALLET_FLAG_DISABLE_PRIVATE_KEYS;
+
 WalletController::WalletController(ClientModel& client_model, QObject* parent)
     : QObject(parent)
     , m_activity_thread(new QThread(this))

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -38,6 +38,10 @@
 #include <QSet>
 #include <QTimer>
 
+using wallet::CCoinControl;
+using wallet::CRecipient;
+using wallet::DEFAULT_DISABLE_WALLET;
+using wallet::mapValue_t;
 
 WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel& client_model, QObject *parent) :
     QObject(parent),

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -29,7 +29,6 @@ class SendCoinsRecipient;
 class TransactionTableModel;
 class WalletModelTransaction;
 
-class CCoinControl;
 class CKeyID;
 class COutPoint;
 class COutput;
@@ -42,6 +41,9 @@ namespace CoinJoin {
 class Client;
 } // namespace CoinJoin
 } // namespace interfaces
+namespace wallet {
+class CCoinControl;
+} // namespace wallet
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -100,7 +102,7 @@ public:
     };
 
     // prepare transaction for getting txfee before sending coins
-    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl);
+    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const wallet::CCoinControl& coinControl);
 
     // Send coins to a list of recipients
     void sendCoins(WalletModelTransaction& transaction, bool fIsCoinJoin);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -32,7 +32,9 @@
 
 #include <univalue.h>
 
+using node::GetTransaction;
 using node::NodeContext;
+using node::ReadBlockFromDisk;
 
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
 static constexpr unsigned int MAX_REST_HEADERS_RESULTS = 2000;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -32,6 +32,8 @@
 
 #include <univalue.h>
 
+using node::NodeContext;
+
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
 static constexpr unsigned int MAX_REST_HEADERS_RESULTS = 2000;
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -64,7 +64,13 @@
 #include <condition_variable>
 #include <mutex>
 
+using node::BlockManager;
+using node::CCoinsStats;
+using node::CoinStatsHashType;
 using node::NodeContext;
+using node::ReadBlockFromDisk;
+using node::SnapshotMetadata;
+using node::UndoReadFromDisk;
 
 struct CUpdatedBlock
 {
@@ -1042,7 +1048,7 @@ static RPCHelpMan pruneblockchain()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!fPruneMode)
+    if (!node::fPruneMode)
         throw JSONRPCError(RPC_MISC_ERROR, "Cannot prune blocks because node is not in prune mode.");
 
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
@@ -1518,15 +1524,15 @@ RPCHelpMan getblockchaininfo()
     obj.pushKV("initialblockdownload", active_chainstate.IsInitialBlockDownload());
     obj.pushKV("chainwork", tip.nChainWork.GetHex());
     obj.pushKV("size_on_disk", chainman.m_blockman.CalculateCurrentUsage());
-    obj.pushKV("pruned", fPruneMode);
-    if (fPruneMode) {
+    obj.pushKV("pruned", node::fPruneMode);
+    if (node::fPruneMode) {
         obj.pushKV("pruneheight", chainman.m_blockman.GetFirstStoredBlock(tip)->nHeight);
 
         // if 0, execution bypasses the whole if block.
         bool automatic_pruning{args.GetIntArg("-prune", 0) != 1};
         obj.pushKV("automatic_pruning",  automatic_pruning);
         if (automatic_pruning) {
-            obj.pushKV("prune_target_size",  nPruneTarget);
+            obj.pushKV("prune_target_size",  node::nPruneTarget);
         }
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -64,6 +64,8 @@
 #include <condition_variable>
 #include <mutex>
 
+using node::NodeContext;
+
 struct CUpdatedBlock
 {
     uint256 hash;

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -16,7 +16,6 @@
 
 extern RecursiveMutex cs_main;
 
-class BlockManager;
 class CBlock;
 class CBlockIndex;
 class CChainState;
@@ -26,6 +25,7 @@ class CChainLocksHandler;
 class CInstantSendManager;
 } // namespace llmq
 namespace node {
+class BlockManager;
 struct NodeContext;
 } // namespace node
 
@@ -43,7 +43,7 @@ double GetDifficulty(const CBlockIndex* blockindex);
 void RPCNotifyBlockChange(const CBlockIndex*);
 
 /** Block description to JSON */
-UniValue blockToJSON(BlockManager& blockman, const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, const llmq::CChainLocksHandler& clhandler, const llmq::CInstantSendManager& isman, TxVerbosity verbosity) LOCKS_EXCLUDED(cs_main);
+UniValue blockToJSON(node::BlockManager& blockman, const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, const llmq::CChainLocksHandler& clhandler, const llmq::CInstantSendManager& isman, TxVerbosity verbosity) LOCKS_EXCLUDED(cs_main);
 
 /** Block header to JSON */
 UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex, const llmq::CChainLocksHandler& clhandler) LOCKS_EXCLUDED(cs_main);

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -21,11 +21,13 @@ class CBlock;
 class CBlockIndex;
 class CChainState;
 class UniValue;
-struct NodeContext;
 namespace llmq {
 class CChainLocksHandler;
 class CInstantSendManager;
 } // namespace llmq
+namespace node {
+struct NodeContext;
+} // namespace node
 
 static constexpr int NUM_GETBLOCKSTATS_PERCENTILES = 5;
 
@@ -54,7 +56,7 @@ void CalculatePercentilesBySize(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES], s
  * @return a UniValue map containing metadata about the snapshot.
  */
 UniValue CreateUTXOSnapshot(
-    NodeContext& node,
+    node::NodeContext& node,
     CChainState& chainstate,
     CAutoFile& afile,
     const fs::path& path,

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -24,6 +24,8 @@
 
 #include <univalue.h>
 
+using node::NodeContext;
+
 #ifdef ENABLE_WALLET
 namespace {
 void ValidateCoinJoinArguments()

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -25,6 +25,12 @@
 #include <univalue.h>
 
 using node::NodeContext;
+#ifdef ENABLE_WALLET
+using wallet::CWallet;
+using wallet::GetWalletForJSONRPCRequest;
+using wallet::DEFAULT_DISABLE_WALLET;
+using wallet::WALLET_FLAG_DISABLE_PRIVATE_KEYS;
+#endif // ENABLE_WALLET
 
 #ifdef ENABLE_WALLET
 namespace {

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -46,6 +46,7 @@ extern RPCHelpMan sendrawtransaction();
 class CWallet;
 #endif//ENABLE_WALLET
 
+using node::GetTransaction;
 using node::NodeContext;
 
 static RPCArg GetRpcArg(const std::string& strParamName)

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -37,17 +37,32 @@
 #include <wallet/coincontrol.h>
 #include <wallet/spend.h>
 #include <wallet/wallet.h>
-#endif//ENABLE_WALLET
+#endif // ENABLE_WALLET
 
 #ifdef ENABLE_WALLET
-extern RPCHelpMan signrawtransactionwithwallet();
 extern RPCHelpMan sendrawtransaction();
+namespace wallet {
+extern RPCHelpMan signrawtransactionwithwallet();
+} // namespace wallet
 #else
+namespace wallet {
 class CWallet;
-#endif//ENABLE_WALLET
+} // namespace wallet
+#endif // ENABLE_WALLET
 
 using node::GetTransaction;
 using node::NodeContext;
+using wallet::CWallet;
+#ifdef ENABLE_WALLET
+using wallet::CCoinControl;
+using wallet::CoinType;
+using wallet::COutput;
+using wallet::CRecipient;
+using wallet::DEFAULT_DISABLE_WALLET;
+using wallet::GetWalletForJSONRPCRequest;
+using wallet::HELP_REQUIRING_PASSPHRASE;
+using wallet::isminetype;
+#endif // ENABLE_WALLET
 
 static RPCArg GetRpcArg(const std::string& strParamName)
 {
@@ -340,7 +355,7 @@ static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, CChainsta
     JSONRPCRequest signRequest(request);
     signRequest.params.setArray();
     signRequest.params.push_back(HexStr(ds));
-    UniValue signResult = signrawtransactionwithwallet().HandleRequest(signRequest);
+    UniValue signResult = wallet::signrawtransactionwithwallet().HandleRequest(signRequest);
 
     if (!fSubmit) {
         return signResult["hex"].get_str();
@@ -349,7 +364,7 @@ static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, CChainsta
     JSONRPCRequest sendRequest(request);
     sendRequest.params.setArray();
     sendRequest.params.push_back(signResult["hex"].get_str());
-    return sendrawtransaction().HandleRequest(sendRequest).get_str();
+    return ::sendrawtransaction().HandleRequest(sendRequest).get_str();
 }
 
 // forward declaration

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -46,6 +46,8 @@ extern RPCHelpMan sendrawtransaction();
 class CWallet;
 #endif//ENABLE_WALLET
 
+using node::NodeContext;
+
 static RPCArg GetRpcArg(const std::string& strParamName)
 {
     static const std::map<std::string, RPCArg> mapParamHelp = {

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -323,7 +323,7 @@ static void SignSpecialTxPayloadByHash(const CMutableTransaction& tx, SpecialTxP
 static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, CChainstateHelper& chain_helper, const ChainstateManager& chainman, const CMutableTransaction& tx, bool fSubmit)
 {
     {
-    LOCK(cs_main);
+    LOCK(::cs_main);
 
     TxValidationState state;
     if (!chain_helper.special_tx->CheckSpecialTx(CTransaction(tx), chainman.ActiveChain().Tip(), chainman.ActiveChainstate().CoinsTip(), true, state)) {
@@ -1071,7 +1071,7 @@ static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& reques
 
     FundSpecialTx(*wallet, tx, ptx, feeSource);
 
-    const bool isV19active = DeploymentActiveAfter(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();),
+    const bool isV19active = DeploymentActiveAfter(WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip();),
                                                    Params().GetConsensus(), Consensus::DEPLOYMENT_V19);
     SignSpecialTxPayloadByHash(tx, ptx, keyOperator, !isV19active);
     SetTxPayload(tx, ptx);
@@ -1245,7 +1245,7 @@ static RPCHelpMan protx_revoke()
 
     EnsureWalletIsUnlocked(*pwallet);
 
-    const bool isV19active{DeploymentActiveAfter(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
+    const bool isV19active{DeploymentActiveAfter(WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip();), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
     CProUpRevTx ptx;
     ptx.nVersion = CProUpRevTx::GetMaxVersion(/*is_basic_scheme_active=*/isV19active);
 
@@ -1333,11 +1333,11 @@ static UniValue BuildDMNListEntry(const CWallet* const pwallet, const CDetermini
 
     if (pindex != nullptr) {
         if (confirmations > -1) {
-            confirmations -= WITH_LOCK(cs_main, return chainman.ActiveChain().Height()) - pindex->nHeight;
+            confirmations -= WITH_LOCK(::cs_main, return chainman.ActiveChain().Height()) - pindex->nHeight;
         } else {
             uint256 minedBlockHash;
             collateralTx = GetTransaction(/* pindex */ nullptr, /* mempool */ nullptr, dmn.collateralOutpoint.hash, Params().GetConsensus(), minedBlockHash);
-            const CBlockIndex* const pindexMined = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(minedBlockHash));
+            const CBlockIndex* const pindexMined = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(minedBlockHash));
             CHECK_NONFATAL(pindexMined != nullptr);
             CHECK_NONFATAL(pindex->GetAncestor(pindexMined->nHeight) == pindexMined);
             confirmations = pindex->nHeight - pindexMined->nHeight + 1;
@@ -1434,7 +1434,7 @@ static RPCHelpMan protx_list()
 
         bool detailed = !request.params[1].isNull() ? ParseBoolV(request.params[1], "detailed") : false;
 
-        LOCK2(wallet->cs_wallet, cs_main);
+        LOCK2(wallet->cs_wallet, ::cs_main);
         int height = !request.params[2].isNull() ? ParseInt32V(request.params[2], "height") : chainman.ActiveChain().Height();
         if (height < 1 || height > chainman.ActiveChain().Height()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid height specified");
@@ -1464,9 +1464,9 @@ static RPCHelpMan protx_list()
         bool detailed = !request.params[1].isNull() ? ParseBoolV(request.params[1], "detailed") : false;
 
 #ifdef ENABLE_WALLET
-        LOCK2(wallet ? wallet->cs_wallet : cs_main, cs_main);
+        LOCK2(wallet ? wallet->cs_wallet : ::cs_main, ::cs_main);
 #else
-        LOCK(cs_main);
+        LOCK(::cs_main);
 #endif
         int height = !request.params[2].isNull() ? ParseInt32V(request.params[2], "height") : chainman.ActiveChain().Height();
         if (height < 1 || height > chainman.ActiveChain().Height()) {
@@ -1531,10 +1531,10 @@ static RPCHelpMan protx_info()
     uint256 proTxHash(ParseHashV(request.params[0], "proTxHash"));
 
     if (request.params[1].isNull()) {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         pindex = chainman.ActiveChain().Tip();
     } else {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         uint256 blockHash(ParseHashV(request.params[1], "blockHash"));
         pindex = chainman.m_blockman.LookupBlockIndex(blockHash);
         if (pindex == nullptr) {
@@ -1552,9 +1552,9 @@ static RPCHelpMan protx_info()
     };
 }
 
-static uint256 ParseBlock(const UniValue& v, const ChainstateManager& chainman, const std::string& strName) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+static uint256 ParseBlock(const UniValue& v, const ChainstateManager& chainman, const std::string& strName) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     try {
         return ParseHashV(v, strName);
@@ -1585,7 +1585,7 @@ static RPCHelpMan protx_diff()
     CDeterministicMNManager& dmnman = *CHECK_NONFATAL(node.dmnman);
     const LLMQContext& llmq_ctx = *CHECK_NONFATAL(node.llmq_ctx);
 
-    LOCK(cs_main);
+    LOCK(::cs_main);
     uint256 baseBlockHash = ParseBlock(request.params[0], chainman, "baseBlock");
     uint256 blockHash = ParseBlock(request.params[1], chainman, "block");
     bool extended = false;
@@ -1607,9 +1607,9 @@ static RPCHelpMan protx_diff()
     };
 }
 
-static const CBlockIndex* ParseBlockIndex(const UniValue& v, const ChainstateManager& chainman, const std::string& strName) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+static const CBlockIndex* ParseBlockIndex(const UniValue& v, const ChainstateManager& chainman, const std::string& strName) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(::cs_main);
 
     try {
         uint256 hash = ParseHashV(v, strName);
@@ -1642,7 +1642,7 @@ static RPCHelpMan protx_listdiff()
 
     CDeterministicMNManager& dmnman = *CHECK_NONFATAL(node.dmnman);
 
-    LOCK(cs_main);
+    LOCK(::cs_main);
     UniValue ret(UniValue::VOBJ);
 
     const CBlockIndex* pBaseBlockIndex = ParseBlockIndex(request.params[0], chainman, "baseBlock");

--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <core_io.h>
+#include <node/context.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
@@ -25,7 +26,7 @@
 #include <string>
 #include <vector>
 
-struct NodeContext;
+using node::NodeContext;
 
 static RPCHelpMan estimatesmartfee()
 {

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -33,6 +33,12 @@
 #endif // ENABLE_WALLET
 
 using node::NodeContext;
+#ifdef ENABLE_WALLET
+using wallet::CWallet;
+using wallet::GetWalletForJSONRPCRequest;
+using wallet::HELP_REQUIRING_PASSPHRASE;
+using wallet::isminetype;
+#endif // ENABLE_WALLET
 
 static RPCHelpMan gobject_count()
 {

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -32,6 +32,8 @@
 #include <wallet/wallet.h>
 #endif // ENABLE_WALLET
 
+using node::NodeContext;
+
 static RPCHelpMan gobject_count()
 {
     return RPCHelpMan{"gobject count",

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -14,7 +14,7 @@
 
 static void EnsureAddressIndexAvailable()
 {
-    if (!fAddressIndex) {
+    if (!node::fAddressIndex) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "Address index is disabled. You should run Dash Core with -addressindex (requires reindex)");
     }
 }
@@ -77,7 +77,7 @@ bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const
 {
     AssertLockHeld(::cs_main);
 
-    if (!fSpentIndex) {
+    if (!node::fSpentIndex) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "Spent index is disabled. You should run Dash Core with -spentindex (requires reindex)");
     }
 
@@ -95,7 +95,7 @@ bool GetTimestampIndex(CBlockTreeDB& block_tree_db, const uint32_t high, const u
 {
     AssertLockHeld(::cs_main);
 
-    if (!fTimestampIndex) {
+    if (!node::fTimestampIndex) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "Timestamp index is disabled. You should run Dash Core with -timestampindex (requires reindex)");
     }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -37,6 +37,13 @@
 using node::GetTransaction;
 using node::NodeContext;
 using node::ReadBlockFromDisk;
+#ifdef ENABLE_WALLET
+using wallet::CCoinControl;
+using wallet::CoinType;
+using wallet::COutput;
+using wallet::CWallet;
+using wallet::GetWalletForJSONRPCRequest;
+#endif // ENABLE_WALLET
 
 static RPCHelpMan masternode_connect()
 {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -237,7 +237,7 @@ static RPCHelpMan masternode_winners()
     const ChainstateManager& chainman = EnsureChainman(node);
     const CBlockIndex* pindexTip{nullptr};
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         pindexTip = chainman.ActiveChain().Tip();
         if (!pindexTip) return NullUniValue;
     }
@@ -325,10 +325,10 @@ static RPCHelpMan masternode_payments()
     }
 
     if (request.params[0].isNull()) {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         pindex = chainman.ActiveChain().Tip();
     } else {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         uint256 blockHash(ParseHashV(request.params[0], "blockhash"));
         pindex = chainman.m_blockman.LookupBlockIndex(blockHash);
         if (pindex == nullptr) {
@@ -412,7 +412,7 @@ static RPCHelpMan masternode_payments()
         vecPayments.push_back(blockObj);
 
         if (nCount > 0) {
-            LOCK(cs_main);
+            LOCK(::cs_main);
             pindex = chainman.ActiveChain().Next(pindex);
         } else {
             pindex = pindex->pprev;
@@ -527,14 +527,14 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
             return (int)0;
         }
 
-        LOCK(cs_main);
+        LOCK(::cs_main);
         const CBlockIndex* pindex = chainman.ActiveChain()[dmn.pdmnState->nLastPaidHeight];
         return (int)pindex->nTime;
     };
 
     const bool showRecentMnsOnly = strMode == "recent";
     const bool showEvoOnly = strMode == "evo";
-    const int tipHeight = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip()->nHeight);
+    const int tipHeight = WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()->nHeight);
     mnList.ForEachMN(false, [&](auto& dmn) {
         if (showRecentMnsOnly && dmn.pdmnState->IsBanned()) {
             if (tipHeight - dmn.pdmnState->GetBannedHeight() > Params().GetConsensus().nSuperblockCycle) {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -34,7 +34,9 @@
 #include <fstream>
 #include <iomanip>
 
+using node::GetTransaction;
 using node::NodeContext;
+using node::ReadBlockFromDisk;
 
 static RPCHelpMan masternode_connect()
 {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -34,6 +34,8 @@
 #include <fstream>
 #include <iomanip>
 
+using node::NodeContext;
+
 static RPCHelpMan masternode_connect()
 {
     return RPCHelpMan{"masternode connect",

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -19,6 +19,8 @@
 #include <llmq/context.h>
 #include <llmq/instantsend.h>
 
+using node::NodeContext;
+
 static std::vector<RPCResult> MempoolEntryDescription() { return {
     RPCResult{RPCResult::Type::NUM, "vsize", "virtual transaction size. This can be different from actual serialized size for high-sigop transactions."},
     RPCResult{RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true,

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -52,6 +52,8 @@
 #include <memory>
 #include <stdint.h>
 
+using node::NodeContext;
+
 /**
  * Return average network hashes per second based on the last 'lookup' blocks,
  * or from the last difficulty change if 'lookup' is nonpositive.

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -52,7 +52,10 @@
 #include <memory>
 #include <stdint.h>
 
+using node::BlockAssembler;
+using node::CBlockTemplate;
 using node::NodeContext;
+using node::UpdateTime;
 
 /**
  * Return average network hashes per second based on the last 'lookup' blocks,

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -41,6 +41,8 @@
 #include <malloc.h>
 #endif
 
+using node::NodeContext;
+
 static RPCHelpMan debug()
 {
     return RPCHelpMan{"debug",

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -32,6 +32,8 @@
 
 #include <univalue.h>
 
+using node::NodeContext;
+
 const std::vector<std::string> CONNECTION_TYPE_DOC{
         "outbound-full-relay (default automatic connections)",
         "block-relay-only (does not relay transactions or addresses)",

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -33,6 +33,8 @@
 #include <iomanip>
 #include <optional>
 
+using node::NodeContext;
+
 static RPCHelpMan quorum_list()
 {
     return RPCHelpMan{"quorum list",

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -33,6 +33,7 @@
 #include <iomanip>
 #include <optional>
 
+using node::GetTransaction;
 using node::NodeContext;
 
 static RPCHelpMan quorum_list()

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -60,7 +60,11 @@
 
 #include <univalue.h>
 
+using node::AnalyzePSBT;
+using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
+using node::GetTransaction;
 using node::NodeContext;
+using node::PSBTAnalysis;
 
 void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const  CTxMemPool& mempool, const CChainState& active_chainstate, const llmq::CChainLocksHandler& clhandler, const llmq::CInstantSendManager& isman, UniValue& entry)
 {
@@ -77,7 +81,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const  CTxMemPool
 
     // Add spent information if spentindex is enabled
     CSpentIndexTxInfo txSpentInfo;
-    if (fSpentIndex) {
+    if (node::fSpentIndex) {
         txSpentInfo = CSpentIndexTxInfo{};
         for (const auto& txin : tx.vin) {
             if (!tx.IsCoinBase()) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -60,6 +60,8 @@
 
 #include <univalue.h>
 
+using node::NodeContext;
+
 void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const  CTxMemPool& mempool, const CChainState& active_chainstate, const llmq::CChainLocksHandler& clhandler, const llmq::CInstantSendManager& isman, UniValue& entry)
 {
     LOCK(::cs_main);

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -20,6 +20,9 @@
 #include <any>
 
 using node::NodeContext;
+#ifdef ENABLE_WALLET
+using wallet::WalletContext;
+#endif // ENABLE_WALLET
 
 NodeContext& EnsureAnyNodeContext(const CoreContext& context)
 {

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -19,6 +19,8 @@
 
 #include <any>
 
+using node::NodeContext;
+
 NodeContext& EnsureAnyNodeContext(const CoreContext& context)
 {
     auto* const node_context = GetContext<NodeContext>(context);

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -13,21 +13,23 @@ class CConnman;
 class CTxMemPool;
 class ChainstateManager;
 class PeerManager;
-struct NodeContext;
 struct LLMQContext;
+namespace node {
+struct NodeContext;
+} // namespace node
 
-NodeContext& EnsureAnyNodeContext(const CoreContext& context);
-CTxMemPool& EnsureMemPool(const NodeContext& node);
+node::NodeContext& EnsureAnyNodeContext(const CoreContext& context);
+CTxMemPool& EnsureMemPool(const node::NodeContext& node);
 CTxMemPool& EnsureAnyMemPool(const CoreContext& context);
-ArgsManager& EnsureArgsman(const NodeContext& node);
+ArgsManager& EnsureArgsman(const node::NodeContext& node);
 ArgsManager& EnsureAnyArgsman(const CoreContext& context);
-ChainstateManager& EnsureChainman(const NodeContext& node);
+ChainstateManager& EnsureChainman(const node::NodeContext& node);
 ChainstateManager& EnsureAnyChainman(const CoreContext& context);
-CBlockPolicyEstimator& EnsureFeeEstimator(const NodeContext& node);
+CBlockPolicyEstimator& EnsureFeeEstimator(const node::NodeContext& node);
 CBlockPolicyEstimator& EnsureAnyFeeEstimator(const CoreContext& context);
-LLMQContext& EnsureLLMQContext(const NodeContext& node);
+LLMQContext& EnsureLLMQContext(const node::NodeContext& node);
 LLMQContext& EnsureAnyLLMQContext(const CoreContext& context);
-CConnman& EnsureConnman(const NodeContext& node);
-PeerManager& EnsurePeerman(const NodeContext& node);
+CConnman& EnsureConnman(const node::NodeContext& node);
+PeerManager& EnsurePeerman(const node::NodeContext& node);
 
 #endif // BITCOIN_RPC_SERVER_UTIL_H

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -17,6 +17,9 @@
 #include <util/strencodings.h>
 #include <validation.h>
 
+using node::GetTransaction;
+using node::ReadBlockFromDisk;
+
 static RPCHelpMan gettxoutproof()
 {
     return RPCHelpMan{"gettxoutproof",

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -20,6 +20,7 @@
 #include <string>
 
 using namespace std::literals;
+using node::NodeContext;
 
 static NetGroupManager EMPTY_NETGROUPMAN{std::vector<bool>()};
 static const bool DETERMINISTIC{true};

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -30,6 +30,9 @@
 #include <map>
 #include <vector>
 
+using node::BlockAssembler;
+using node::GetTransaction;
+
 using SimpleUTXOMap = std::map<COutPoint, std::pair<int, CAmount>>;
 
 struct TestChainBRRBeforeActivationSetup : public TestChainSetup

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -18,6 +18,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::BlockAssembler;
+using node::CBlockTemplate;
+
 BOOST_AUTO_TEST_SUITE(blockfilter_index_tests)
 
 struct BuildChainTestingSetup : public TestChain100Setup {

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -10,6 +10,9 @@
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
 
+using node::BlockManager;
+using node::BLOCK_SERIALIZATION_HEADER_SIZE;
+
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
 BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -12,6 +12,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::CCoinsStats;
+using node::CoinStatsHashType;
+
 BOOST_AUTO_TEST_SUITE(coinstatsindex_tests)
 
 BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)

--- a/src/test/dynamic_activation_thresholds_tests.cpp
+++ b/src/test/dynamic_activation_thresholds_tests.cpp
@@ -15,6 +15,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::BlockAssembler;
+
 const auto deployment_id = Consensus::DEPLOYMENT_TESTDUMMY;
 constexpr int window{100}, th_start{80}, th_end{60};
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -28,6 +28,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::GetTransaction;
+
 using SimpleUTXOMap = std::map<COutPoint, std::pair<int, CAmount>>;
 
 static SimpleUTXOMap BuildSimpleUtxoMap(const std::vector<CTransactionRef>& txs)

--- a/src/test/evo_utils_tests.cpp
+++ b/src/test/evo_utils_tests.cpp
@@ -13,6 +13,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::NodeContext;
+
 /* TODO: rename this file and test to llmq_options_test */
 BOOST_AUTO_TEST_SUITE(evo_utils_tests)
 

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -27,6 +27,9 @@
 #include <string>
 #include <vector>
 
+using node::CCoinsStats;
+using node::CoinStatsHashType;
+
 namespace {
 const TestingSetup* g_setup;
 const Coin EMPTY_COIN{};

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -35,6 +35,8 @@
 
 #include <test/fuzz/fuzz.h>
 
+using node::SnapshotMetadata;
+
 namespace {
 const BasicTestingSetup* g_setup;
 } // namespace

--- a/src/test/fuzz/minisketch.cpp
+++ b/src/test/fuzz/minisketch.cpp
@@ -12,6 +12,8 @@
 #include <map>
 #include <numeric>
 
+using node::MakeMinisketch32;
+
 FUZZ_TARGET(minisketch)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};

--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -18,6 +18,10 @@
 #include <string>
 #include <vector>
 
+using node::AnalyzePSBT;
+using node::PSBTAnalysis;
+using node::PSBTInputAnalysis;
+
 FUZZ_TARGET(psbt)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -13,6 +13,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+using node::NodeContext;
+
 namespace {
 
 const TestingSetup* g_setup;

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -13,6 +13,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+using node::BlockAssembler;
 using node::NodeContext;
 
 namespace {

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -13,6 +13,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+using node::SnapshotMetadata;
+
 namespace {
 
 const std::vector<std::shared_ptr<CBlock>>* g_chain;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -31,6 +31,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::BlockAssembler;
+using node::CBlockTemplate;
+
 namespace miner_tests {
 struct MinerTestingSetup : public TestingSetup {
     void TestPackageSelection(const CChainParams& chainparams, const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, m_node.mempool->cs);

--- a/src/test/minisketch_tests.cpp
+++ b/src/test/minisketch_tests.cpp
@@ -11,6 +11,8 @@
 
 #include <utility>
 
+using node::MakeMinisketch32;
+
 BOOST_AUTO_TEST_SUITE(minisketch_tests)
 
 BOOST_AUTO_TEST_CASE(minisketch_test)

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -8,6 +8,9 @@
 #include <node/blockstorage.h>
 #include <validation.h>
 
+using node::ReadBlockFromDisk;
+using node::UndoReadFromDisk;
+
 bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
 {
     LOCK(::cs_main);

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -15,7 +15,7 @@
 
 #include <univalue.h>
 
-const auto NoMalleation = [](CAutoFile& file, SnapshotMetadata& meta){};
+const auto NoMalleation = [](CAutoFile& file, node::SnapshotMetadata& meta){};
 
 /**
  * Create and activate a UTXO snapshot, optionally providing a function to
@@ -42,7 +42,7 @@ CreateAndActivateUTXOSnapshot(node::NodeContext& node, const fs::path root, F ma
     //
     FILE* infile{fsbridge::fopen(snapshot_path, "rb")};
     CAutoFile auto_infile{infile, SER_DISK, CLIENT_VERSION};
-    SnapshotMetadata metadata;
+    node::SnapshotMetadata metadata;
     auto_infile >> metadata;
 
     malleation(auto_infile, metadata);

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -23,7 +23,7 @@ const auto NoMalleation = [](CAutoFile& file, SnapshotMetadata& meta){};
  */
 template<typename F = decltype(NoMalleation)>
 static bool
-CreateAndActivateUTXOSnapshot(NodeContext& node, const fs::path root, F malleation = NoMalleation)
+CreateAndActivateUTXOSnapshot(node::NodeContext& node, const fs::path root, F malleation = NoMalleation)
 {
     // Write out a snapshot to the test's tempdir.
     //

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -18,6 +18,7 @@
 #include <validation.h>
 #include <versionbits.h>
 
+using node::BlockAssembler;
 using node::NodeContext;
 
 CTxIn generatetoaddress(const NodeContext& node, const std::string& address)

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -18,6 +18,8 @@
 #include <validation.h>
 #include <versionbits.h>
 
+using node::NodeContext;
+
 CTxIn generatetoaddress(const NodeContext& node, const std::string& address)
 {
     const auto dest = DecodeDestination(address);

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -13,18 +13,20 @@ class CBlock;
 class CChainParams;
 class CScript;
 class CTxIn;
+namespace node {
 struct NodeContext;
+} // namespace node
 
 /** Create a blockchain, starting from genesis */
 std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const CChainParams& params);
 
 /** Returns the generated coin */
-CTxIn MineBlock(const NodeContext&, const CScript& coinbase_scriptPubKey);
+CTxIn MineBlock(const node::NodeContext&, const CScript& coinbase_scriptPubKey);
 
 /** Prepare a block to be mined */
-std::shared_ptr<CBlock> PrepareBlock(const NodeContext&, const CScript& coinbase_scriptPubKey);
+std::shared_ptr<CBlock> PrepareBlock(const node::NodeContext&, const CScript& coinbase_scriptPubKey);
 
 /** RPC-like helper function, returns the generated coin */
-CTxIn generatetoaddress(const NodeContext&, const std::string& address);
+CTxIn generatetoaddress(const node::NodeContext&, const std::string& address);
 
 #endif // BITCOIN_TEST_UTIL_MINING_H

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -72,7 +72,18 @@
 #include <memory>
 #include <stdexcept>
 
+using node::BlockAssembler;
+using node::CalculateCacheSizes;
+using node::DashChainstateSetup;
+using node::DashChainstateSetupClose;
+using node::DEFAULT_ADDRESSINDEX;
+using node::DEFAULT_SPENTINDEX;
+using node::DEFAULT_TIMESTAMPINDEX;
+using node::LoadChainstate;
 using node::NodeContext;
+using node::VerifyLoadedChainstate;
+using node::fPruneMode;
+using node::fReindex;
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = nullptr;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -72,6 +72,8 @@
 #include <memory>
 #include <stdexcept>
 
+using node::NodeContext;
+
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = nullptr;
 

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -109,7 +109,7 @@ struct BasicTestingSetup {
  * initialization behaviour.
  */
 struct ChainTestingSetup : public BasicTestingSetup {
-    CacheSizes m_cache_sizes{};
+    node::CacheSizes m_cache_sizes{};
 
     explicit ChainTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
     ~ChainTestingSetup();

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -85,17 +85,17 @@ static constexpr CAmount CENT{1000000};
 
 /** Initialize Dash-specific components during chainstate initialization (NodeContext-friendly aliases) */
 void DashChainstateSetup(ChainstateManager& chainman,
-                         NodeContext& node,
+                         node::NodeContext& node,
                          bool fReset,
                          bool fReindexChainState,
                          const Consensus::Params& consensus_params);
-void DashChainstateSetupClose(NodeContext& node);
+void DashChainstateSetupClose(node::NodeContext& node);
 
 /** Basic testing setup.
  * This just configures logging, data dir and chain parameters.
  */
 struct BasicTestingSetup {
-    NodeContext m_node;
+    node::NodeContext m_node;
 
     explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
     ~BasicTestingSetup();

--- a/src/test/util/wallet.cpp
+++ b/src/test/util/wallet.cpp
@@ -16,6 +16,8 @@
 #include <wallet/wallet.h>
 #endif
 
+using wallet::CWallet;
+
 const std::string ADDRESS_B58T_UNSPENDABLE = "yXXXXXXXXXXXXXXXXXXXXXXXXXXXVd2rXU";
 const std::string ADDRESS_BCRT1_UNSPENDABLE = "bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj";
 

--- a/src/test/util/wallet.h
+++ b/src/test/util/wallet.h
@@ -7,7 +7,9 @@
 
 #include <string>
 
+namespace wallet {
 class CWallet;
+} // namespace wallet
 
 // Constants //
 
@@ -17,9 +19,9 @@ extern const std::string ADDRESS_BCRT1_UNSPENDABLE;
 // RPC-like //
 
 /** Import the address to the wallet */
-void importaddress(CWallet& wallet, const std::string& address);
+void importaddress(wallet::CWallet& wallet, const std::string& address);
 /** Returns a new address from the wallet */
-std::string getnewaddress(CWallet& w);
+std::string getnewaddress(wallet::CWallet& w);
 
 
 #endif // BITCOIN_TEST_UTIL_WALLET_H

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -20,6 +20,8 @@
 
 #include <thread>
 
+using node::BlockAssembler;
+
 namespace validation_block_tests {
 struct MinerTestingSetup : public RegTestingSetup {
     std::shared_ptr<CBlock> Block(const uint256& prev_hash);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -26,6 +26,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::SnapshotMetadata;
+
 BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, ChainTestingSetup)
 
 //! Basic tests for ChainstateManager.

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -10,6 +10,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::BlockManager;
+
 BOOST_FIXTURE_TEST_SUITE(validation_flush_tests, ChainTestingSetup)
 
 //! Test utilities for detecting when we need to flush the coins cache based

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -68,6 +68,26 @@
 #include <ranges>
 #include <string>
 
+using node::BlockManager;
+using node::BlockMap;
+using node::CBlockIndexHeightOnlyComparator;
+using node::CBlockIndexWorkComparator;
+using node::CCoinsStats;
+using node::CoinStatsHashType;
+using node::DEFAULT_ADDRESSINDEX;
+using node::DEFAULT_SPENTINDEX;
+using node::DEFAULT_TIMESTAMPINDEX;
+using node::fAddressIndex;
+using node::fImporting;
+using node::fPruneMode;
+using node::fReindex;
+using node::fSpentIndex;
+using node::fTimestampIndex;
+using node::ReadBlockFromDisk;
+using node::SnapshotMetadata;
+using node::UndoReadFromDisk;
+using node::UnlinkPrunedFiles;
+
 #define MICRO 0.000001
 #define MILLI 0.001
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -51,12 +51,13 @@ class TxValidationState;
 class CChainstateHelper;
 class ChainstateManager;
 struct PrecomputedTransactionData;
-class SnapshotMetadata;
 struct ChainTxData;
 struct DisconnectedBlockTransactions;
 struct LockPoints;
 struct AssumeutxoData;
-
+namespace node {
+class SnapshotMetadata;
+} // namespace node
 namespace llmq {
 class CChainLocksHandler;
 } // namespace llmq
@@ -487,7 +488,7 @@ protected:
 public:
     //! Reference to a BlockManager instance which itself is shared across all
     //! CChainState instances.
-    BlockManager& m_blockman;
+    node::BlockManager& m_blockman;
 
     /** Chain parameters for this chainstate */
     const CChainParams& m_params;
@@ -498,7 +499,7 @@ public:
     ChainstateManager& m_chainman;
 
     explicit CChainState(CTxMemPool* mempool,
-                         BlockManager& blockman,
+                         node::BlockManager& blockman,
                          ChainstateManager& chainman,
                          CEvoDB& evoDb,
                          const std::unique_ptr<CChainstateHelper>& chain_helper,
@@ -549,7 +550,7 @@ public:
      * chainstates) and as good as our current tip or better. Entries may be failed,
      * though, and pruning nodes may be missing the data for the block.
      */
-    std::set<CBlockIndex*, CBlockIndexWorkComparator> setBlockIndexCandidates;
+    std::set<CBlockIndex*, node::CBlockIndexWorkComparator> setBlockIndexCandidates;
 
     CChainstateHelper& ChainHelper()
     {
@@ -872,7 +873,7 @@ private:
     [[nodiscard]] bool PopulateAndValidateSnapshot(
         CChainState& snapshot_chainstate,
         CAutoFile& coins_file,
-        const SnapshotMetadata& metadata);
+        const node::SnapshotMetadata& metadata);
 
     /**
      * If a block header hasn't already been seen, call CheckBlockHeader on it, ensure
@@ -889,7 +890,7 @@ public:
     std::thread m_load_block;
     //! A single BlockManager instance is shared across each constructed
     //! chainstate to avoid duplicating block metadata.
-    BlockManager m_blockman;
+    node::BlockManager m_blockman;
 
     /**
      * In order to efficiently track invalidity of headers, we keep the set of
@@ -953,7 +954,7 @@ public:
     //! - Move the new chainstate to `m_snapshot_chainstate` and make it our
     //!   ChainstateActive().
     [[nodiscard]] bool ActivateSnapshot(
-        CAutoFile& coins_file, const SnapshotMetadata& metadata, bool in_memory);
+        CAutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory);
 
     //! The most-work chain.
     CChainState& ActiveChainstate() const;
@@ -961,13 +962,13 @@ public:
     int ActiveHeight() const { return ActiveChain().Height(); }
     CBlockIndex* ActiveTip() const { return ActiveChain().Tip(); }
 
-    BlockMap& BlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    node::BlockMap& BlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
         return m_blockman.m_block_index;
     }
 
-    PrevBlockMap& PrevBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    node::PrevBlockMap& PrevBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         return m_blockman.m_prev_block_index;
     }

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -24,6 +24,7 @@
 #endif
 #endif
 
+namespace wallet {
 namespace {
 Span<const std::byte> SpanFromDbt(const BerkeleyBatch::SafeDbt& dbt)
 {
@@ -861,3 +862,4 @@ std::unique_ptr<BerkeleyDatabase> MakeBerkeleyDatabase(const fs::path& path, con
     status = DatabaseStatus::SUCCESS;
     return db;
 }
+} // namespace wallet

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -30,6 +30,7 @@ struct bilingual_str;
 #pragma GCC diagnostic pop
 #endif
 
+namespace wallet {
 struct WalletDatabaseFileId {
     uint8_t value[DB_FILE_ID_LEN];
     bool operator==(const WalletDatabaseFileId& rhs) const;
@@ -230,5 +231,6 @@ bool BerkeleyDatabaseSanityCheck();
 
 //! Return object giving access to Berkeley database at specified path.
 std::unique_ptr<BerkeleyDatabase> MakeBerkeleyDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_BDB_H

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -6,8 +6,10 @@
 
 #include <util/system.h>
 
+namespace wallet {
 CCoinControl::CCoinControl(CoinType coinType)
 : nCoinType(coinType)
 {
     m_avoid_partial_spends = gArgs.GetBoolArg("-avoidpartialspends", DEFAULT_AVOIDPARTIALSPENDS);
 }
+} // namespace wallet

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -13,6 +13,7 @@
 
 #include <optional>
 
+namespace wallet {
 enum class CoinType : uint8_t
 {
     ALL_COINS,
@@ -116,5 +117,6 @@ public:
 private:
     std::set<COutPoint> setSelected;
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_COINCONTROL_H

--- a/src/wallet/coinjoin.cpp
+++ b/src/wallet/coinjoin.cpp
@@ -14,6 +14,7 @@
 #include <wallet/wallet.h>
 #include <wallet/transaction.h>
 
+namespace wallet {
 void CWallet::InitCJSaltFromDb()
 {
     assert(nCoinJoinSalt.IsNull());
@@ -573,3 +574,4 @@ CoinJoinCredits CachedTxGetAvailableCoinJoinCredits(const CWallet& wallet, const
     }
     return ret;
 }
+} // namespace wallet

--- a/src/wallet/coinjoin.h
+++ b/src/wallet/coinjoin.h
@@ -10,10 +10,6 @@
 #include <threadsafety.h>
 #include <wallet/wallet.h>
 
-class CCoinControl;
-class CWallet;
-class CWalletTx;
-
 // Use a macro instead of a function for conditional logging to prevent
 // evaluating arguments when logging for the category is not enabled.
 #define WalletCJLogPrint(wallet, ...)               \
@@ -22,6 +18,11 @@ class CWalletTx;
             wallet->WalletLogPrintf(__VA_ARGS__);   \
         }                                           \
     } while (0)
+
+namespace wallet {
+class CCoinControl;
+class CWallet;
+class CWalletTx;
 
 CAmount GetBalanceAnonymized(const CWallet& wallet, const CCoinControl& coinControl);
 
@@ -37,5 +38,6 @@ struct CoinJoinCredits
 
 CoinJoinCredits CachedTxGetAvailableCoinJoinCredits(const CWallet& wallet, const CWalletTx& wtx)
     EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_COINJOIN_H

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -14,6 +14,7 @@
 #include <numeric>
 #include <optional>
 
+namespace wallet {
 // Descending order comparator
 struct {
     bool operator()(const OutputGroup& a, const OutputGroup& b) const
@@ -544,3 +545,4 @@ std::string GetAlgorithmName(const SelectionAlgorithm algo)
     }
     assert(false);
 }
+} // namespace wallet

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -12,6 +12,7 @@
 
 #include <optional>
 
+namespace wallet {
 //! lower bound for randomly-chosen target change amount
 static constexpr CAmount CHANGE_LOWER{50000};
 //! upper bound for randomly-chosen target change amount
@@ -299,5 +300,6 @@ std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& ut
 // Original coin selection algorithm as a fallback
 std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue,
                                               CAmount change_target, FastRandomContext& rng, bool fFullyMixedOnly, CAmount maxTxFee);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_COINSELECTION_H

--- a/src/wallet/context.cpp
+++ b/src/wallet/context.cpp
@@ -4,5 +4,7 @@
 
 #include <wallet/context.h>
 
+namespace wallet {
 WalletContext::WalletContext() {}
 WalletContext::~WalletContext() {}
+} // namespace wallet

--- a/src/wallet/context.h
+++ b/src/wallet/context.h
@@ -13,7 +13,6 @@
 #include <vector>
 
 class ArgsManager;
-class CWallet;
 namespace interfaces {
 class Chain;
 namespace CoinJoin {
@@ -24,6 +23,9 @@ class Wallet;
 namespace node {
 struct NodeContext;
 } // namespace node
+
+namespace wallet {
+class CWallet;
 
 using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wallet)>;
 
@@ -59,5 +61,6 @@ struct WalletContext {
     WalletContext();
     ~WalletContext();
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_CONTEXT_H

--- a/src/wallet/context.h
+++ b/src/wallet/context.h
@@ -14,7 +14,6 @@
 
 class ArgsManager;
 class CWallet;
-struct NodeContext;
 namespace interfaces {
 class Chain;
 namespace CoinJoin {
@@ -22,6 +21,9 @@ class Loader;
 } // namspace CoinJoin
 class Wallet;
 } // namespace interfaces
+namespace node {
+struct NodeContext;
+} // namespace node
 
 using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wallet)>;
 
@@ -49,7 +51,7 @@ struct WalletContext {
     // capabilities (even though it is a hard ask sometimes). We should get
     // rid of this at some point but until then, here's NodeContext.
     // TODO: Get rid of this. It's not nice.
-    NodeContext* node_context{nullptr};
+    node::NodeContext* node_context{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the WalletContext struct doesn't need to #include class

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+namespace wallet {
 int CCrypter::BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, const SecureString& strKeyData, int count, unsigned char *key,unsigned char *iv) const
 {
     // This mimics the behavior of openssl's EVP_BytesToKey with an aes256cbc
@@ -181,3 +182,4 @@ bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned ch
     key.Set(vchSecret.begin(), vchSecret.end(), vchPubKey.IsCompressed());
     return key.VerifyPubKey(vchPubKey);
 }
+} // namespace wallet

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -9,7 +9,7 @@
 #include <support/allocators/secure.h>
 #include <script/signingprovider.h>
 
-
+namespace wallet {
 const unsigned int WALLET_CRYPTO_KEY_SIZE = 32;
 const unsigned int WALLET_CRYPTO_SALT_SIZE = 8;
 const unsigned int WALLET_CRYPTO_IV_SIZE = 16;
@@ -109,5 +109,6 @@ bool DecryptAES256(const SecureString& sKey, const std::string& sCiphertext, con
 bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext);
 bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext);
 bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCryptedSecret, const CPubKey& vchPubKey, CKey& key);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_CRYPTER_H

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -15,6 +15,7 @@
 #include <system_error>
 #include <vector>
 
+namespace wallet {
 std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
 {
     std::vector<fs::path> paths;
@@ -145,3 +146,4 @@ void ReadDatabaseArgs(const ArgsManager& args, DatabaseOptions& options)
     options.use_shared_memory = !args.GetBoolArg("-privdb", !options.use_shared_memory);
     options.max_log_mb = args.GetIntArg("-dblogsize", options.max_log_mb);
 }
+} // namespace wallet

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -19,6 +19,7 @@
 class ArgsManager;
 struct bilingual_str;
 
+namespace wallet {
 void SplitWalletPath(const fs::path& wallet_path, fs::path& env_directory, std::string& database_filename);
 
 /** RAII class that provides access to a WalletDatabase */
@@ -241,5 +242,6 @@ fs::path BDBDataFile(const fs::path& path);
 fs::path SQLiteDataFile(const fs::path& path);
 bool IsBDBFile(const fs::path& path);
 bool IsSQLiteFile(const fs::path& path);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_DB_H

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+namespace wallet {
 static const std::string DUMP_MAGIC = "BITCOIN_CORE_WALLET_DUMP";
 uint32_t DUMP_VERSION = 1;
 
@@ -293,3 +294,4 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
 
     return ret;
 }
+} // namespace wallet

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -10,12 +10,14 @@
 #include <string>
 #include <vector>
 
-class CWallet;
-
 struct bilingual_str;
 class ArgsManager;
 
+namespace wallet {
+class CWallet;
+
 bool DumpWallet(const ArgsManager& args, CWallet& wallet, bilingual_str& error);
 bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_DUMP_H

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -8,7 +8,7 @@
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
-
+namespace wallet {
 CAmount GetRequiredFee(const CWallet& wallet, unsigned int nTxBytes)
 {
     return GetRequiredFeeRate(wallet).GetFee(nTxBytes);
@@ -89,3 +89,4 @@ CFeeRate GetDiscardRate(const CWallet& wallet)
     discard_rate = std::max(discard_rate, wallet.chain().relayDustFee());
     return discard_rate;
 }
+} // namespace wallet

--- a/src/wallet/fees.h
+++ b/src/wallet/fees.h
@@ -8,10 +8,12 @@
 
 #include <consensus/amount.h>
 
-class CCoinControl;
 class CFeeRate;
-class CWallet;
 struct FeeCalculation;
+
+namespace wallet {
+class CCoinControl;
+class CWallet;
 
 /**
  * Return the minimum required absolute fee for this size
@@ -41,5 +43,6 @@ CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_contr
  * Return the maximum feerate for discarding change.
  */
 CFeeRate GetDiscardRate(const CWallet& wallet);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_FEES_H

--- a/src/wallet/hdchain.cpp
+++ b/src/wallet/hdchain.cpp
@@ -9,6 +9,7 @@
 #include <tinyformat.h>
 #include <util/system.h>
 
+namespace wallet {
 bool CHDChain::SetNull()
 {
     LOCK(cs);
@@ -205,3 +206,4 @@ std::string CHDPubKey::GetKeyPath() const
 {
     return strprintf("m/44'/%d'/%d'/%d/%d", Params().ExtCoinType(), nAccountIndex, nChangeIndex, extPubKey.nChild);
 }
+} // namespace wallet

--- a/src/wallet/hdchain.h
+++ b/src/wallet/hdchain.h
@@ -7,6 +7,7 @@
 #include <script/keyorigin.h>
 #include <sync.h>
 
+namespace wallet {
 /* hd account data model */
 class CHDAccount
 {
@@ -139,5 +140,6 @@ public:
 
     std::string GetKeyPath() const;
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_HDCHAIN_H

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -31,6 +31,8 @@
 #include <coinjoin/client.h>
 #include <coinjoin/options.h>
 
+using node::NodeContext;
+
 class WalletInit : public WalletInitInterface
 {
 public:

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -33,6 +33,7 @@
 
 using node::NodeContext;
 
+namespace wallet {
 class WalletInit : public WalletInitInterface
 {
 public:
@@ -53,8 +54,6 @@ public:
     void InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const override;
     void InitAutoBackup() const override;
 };
-
-const WalletInitInterface& g_wallet_init_interface = WalletInit();
 
 void WalletInit::AddWalletOptions(ArgsManager& argsman) const
 {
@@ -237,3 +236,6 @@ void WalletInit::InitAutoBackup() const
 {
     CWallet::InitAutoBackup();
 }
+} // namespace wallet
+
+const WalletInitInterface& g_wallet_init_interface = wallet::WalletInit();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -668,7 +668,7 @@ public:
 } // namespace wallet
 
 namespace interfaces {
-std::unique_ptr<Wallet> MakeWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet) { return wallet ? std::make_unique<wallet::WalletImpl>(context, wallet) : nullptr; }
+std::unique_ptr<Wallet> MakeWallet(wallet::WalletContext& context, const std::shared_ptr<wallet::CWallet>& wallet) { return wallet ? std::make_unique<wallet::WalletImpl>(context, wallet) : nullptr; }
 std::unique_ptr<WalletLoader> MakeWalletLoader(Chain& chain, ArgsManager& args, NodeContext& node_context,
                                                interfaces::CoinJoin::Loader& coinjoin_loader)
 {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -221,7 +221,7 @@ public:
     }
     bool getAddress(const CTxDestination& dest,
         std::string* name,
-        isminetype* is_mine,
+        wallet::isminetype* is_mine,
         std::string* purpose) override
     {
         LOCK(m_wallet->cs_wallet);
@@ -446,22 +446,22 @@ public:
             return GetAvailableBalance(*m_wallet, &coin_control);
         }
     }
-    isminetype txinIsMine(const CTxIn& txin) override
+    wallet::isminetype txinIsMine(const CTxIn& txin) override
     {
         LOCK(m_wallet->cs_wallet);
         return InputIsMine(*m_wallet, txin);
     }
-    isminetype txoutIsMine(const CTxOut& txout) override
+    wallet::isminetype txoutIsMine(const CTxOut& txout) override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->IsMine(txout);
     }
-    CAmount getDebit(const CTxIn& txin, isminefilter filter) override
+    CAmount getDebit(const CTxIn& txin, wallet::isminefilter filter) override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->GetDebit(txin, filter);
     }
-    CAmount getCredit(const CTxOut& txout, isminefilter filter) override
+    CAmount getCredit(const CTxOut& txout, wallet::isminefilter filter) override
     {
         LOCK(m_wallet->cs_wallet);
         return OutputGetCredit(*m_wallet, txout, filter);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -49,6 +49,7 @@ using interfaces::WalletTx;
 using interfaces::WalletTxOut;
 using interfaces::WalletTxStatus;
 using interfaces::WalletValueMap;
+using node::NodeContext;
 
 namespace wallet {
 namespace {

--- a/src/wallet/ismine.h
+++ b/src/wallet/ismine.h
@@ -12,8 +12,10 @@
 #include <cstdint>
 #include <type_traits>
 
-class CWallet;
 class CScript;
+
+namespace wallet {
+class CWallet;
 
 /**
  * IsMine() return codes, which depend on ScriptPubKeyMan implementation.
@@ -66,5 +68,6 @@ struct CachableAmount
         m_value[filter] = value;
     }
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_ISMINE_H

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -24,6 +24,7 @@
 
 #include <system_error>
 
+namespace wallet {
 bool VerifyWallets(WalletContext& context)
 {
     interfaces::Chain& chain = *context.chain;
@@ -183,3 +184,4 @@ void UnloadWallets(WalletContext& context)
         UnloadWallet(std::move(wallet));
     }
 }
+} // namespace wallet

--- a/src/wallet/load.h
+++ b/src/wallet/load.h
@@ -12,7 +12,6 @@
 class ArgsManager;
 class CConnman;
 class CScheduler;
-struct WalletContext;
 
 namespace interfaces {
 class Chain;
@@ -20,6 +19,9 @@ namespace CoinJoin {
 class Loader;
 } // namespace CoinJoin
 } // namespace interfaces
+
+namespace wallet {
+struct WalletContext;
 
 //! Responsible for reading and validating the -wallet arguments and verifying the wallet database.
 bool VerifyWallets(WalletContext& context);
@@ -38,5 +40,6 @@ void StopWallets(WalletContext& context);
 
 //! Close all wallets.
 void UnloadWallets(WalletContext& context);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_LOAD_H

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -9,6 +9,7 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 isminetype InputIsMine(const CWallet& wallet, const CTxIn& txin)
 {
     AssertLockHeld(wallet.cs_wallet);
@@ -465,3 +466,4 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
 
     return ret;
 }
+} // namespace wallet

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -10,6 +10,7 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 isminetype InputIsMine(const CWallet& wallet, const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 /** Returns whether all of the inputs match the filter */
@@ -61,5 +62,6 @@ Balance GetBalance(const CWallet& wallet, int min_depth = 0, bool avoid_reuse = 
 
 std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet);
 std::set<std::set<CTxDestination>> GetAddressGroupings(const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_RECEIVE_H

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -13,6 +13,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 RPCHelpMan getnewaddress()
 {
     return RPCHelpMan{"getnewaddress",
@@ -640,4 +641,4 @@ RPCHelpMan listlabels()
 },
     };
 }
-
+} // namespace wallet

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -33,6 +33,7 @@
 
 using interfaces::FoundBlock;
 
+namespace wallet {
 std::string static EncodeDumpString(const std::string &str) {
     std::stringstream ret;
     for (const unsigned char c : str) {
@@ -2118,3 +2119,4 @@ RPCHelpMan restorewallet()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -14,6 +14,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool by_label) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     std::vector<CTxDestination> address_vector;
@@ -731,3 +732,4 @@ RPCHelpMan listunspent()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -6,6 +6,7 @@
 #include <wallet/rpc/util.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 RPCHelpMan walletpassphrase()
 {
     return RPCHelpMan{"walletpassphrase",
@@ -255,3 +256,4 @@ RPCHelpMan encryptwallet()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -10,6 +10,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 RPCHelpMan signmessage()
 {
     return RPCHelpMan{"signmessage",
@@ -66,3 +67,4 @@ RPCHelpMan signmessage()
         },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -17,6 +17,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 static void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_fee_outputs, std::vector<CRecipient> &recipients) {
     std::set<CTxDestination> destinations;
     int i = 0;
@@ -1056,3 +1057,4 @@ RPCHelpMan walletcreatefundedpsbt()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -12,6 +12,7 @@
 
 using interfaces::FoundBlock;
 
+namespace wallet {
 static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue& entry)
     EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
@@ -925,3 +926,4 @@ RPCHelpMan rescanblockchain()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -12,6 +12,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 const std::string HELP_REQUIRING_PASSPHRASE{"\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n"};
 
@@ -148,3 +149,4 @@ void HandleWalletError(const std::shared_ptr<CWallet> wallet, DatabaseStatus& st
         throw JSONRPCError(code, error.original);
     }
 }
+} // namespace wallet

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -12,11 +12,13 @@
 #include <vector>
 
 struct bilingual_str;
-class CWallet;
-enum class DatabaseStatus;
 class JSONRPCRequest;
-class LegacyScriptPubKeyMan;
 class UniValue;
+
+namespace wallet {
+class CWallet;
+class LegacyScriptPubKeyMan;
+enum class DatabaseStatus;
 struct WalletContext;
 
 extern const std::string HELP_REQUIRING_PASSPHRASE;
@@ -40,5 +42,6 @@ bool ParseIncludeWatchonly(const UniValue& include_watchonly, const CWallet& wal
 std::string LabelFromValue(const UniValue& value);
 
 void HandleWalletError(const std::shared_ptr<CWallet> wallet, DatabaseStatus& status, bilingual_str& error);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_RPC_UTIL_H

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -34,6 +34,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 /** Checks if a CKey is in the given CWallet compressed or otherwise*/
 bool HaveKey(const SigningProvider& wallet, const CKey& key)
 {
@@ -1054,3 +1055,4 @@ static const CRPCCommand commands[] =
 // clang-format on
     return commands;
 }
+} // namespace wallet

--- a/src/wallet/rpc/wallet.h
+++ b/src/wallet/rpc/wallet.h
@@ -9,6 +9,8 @@
 
 class CRPCCommand;
 
+namespace wallet {
 Span<const CRPCCommand> GetWalletRPCCommands();
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_RPC_WALLET_H

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -11,6 +11,7 @@
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
 
+namespace wallet {
 /* End of headers, beginning of key/value data */
 static const char *HEADER_END = "HEADER=END";
 /* End of key/value data */
@@ -167,3 +168,4 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
 
     return fSuccess;
 }
+} // namespace wallet

--- a/src/wallet/salvage.h
+++ b/src/wallet/salvage.h
@@ -12,6 +12,8 @@
 class ArgsManager;
 struct bilingual_str;
 
+namespace wallet {
 bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bilingual_str& error, std::vector<bilingual_str>& warnings);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_SALVAGE_H

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -15,6 +15,7 @@
 #include <util/translation.h>
 #include <wallet/scriptpubkeyman.h>
 
+namespace wallet {
 bool LegacyScriptPubKeyMan::GetNewDestination(CTxDestination& dest, bilingual_str& error)
 {
     LOCK(cs_KeyStore);
@@ -2484,3 +2485,4 @@ bool DescriptorScriptPubKeyMan::CanUpdateToWalletDescriptor(const WalletDescript
 
     return true;
 }
+} // namespace wallet

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include <optional>
 
+namespace wallet {
 // Wallet storage things that ScriptPubKeyMans need in order to be able to store things to the wallet database.
 // It provides access to things that are part of the entire wallet and not specific to a ScriptPubKeyMan such as
 // wallet flags, wallet version, encryption keys, encryption status, and the database itself. This allows a
@@ -605,5 +606,6 @@ public:
 
     void UpgradeDescriptorCache();
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_SCRIPTPUBKEYMAN_H

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -24,6 +24,7 @@
 
 using interfaces::FoundBlock;
 
+namespace wallet {
 static constexpr size_t OUTPUT_GROUP_MAX_ENTRIES{100};
 
 int GetTxSpendSize(const CWallet& wallet, const CWalletTx& wtx, unsigned int out, bool use_max_sig)
@@ -1116,3 +1117,4 @@ bool GenBudgetSystemCollateralTx(CWallet& wallet, CTransactionRef& tx, uint256 h
 
     return success;
 }
+} // namespace wallet

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -10,6 +10,7 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 /** Get the marginal bytes if spending the specified output from this transaction.
  * use_max_sig indicates whether to use the maximum sized, 72 byte signature when calculating the
  * size of the input spend. This should only be set when watch-only outputs are allowed */
@@ -89,5 +90,6 @@ bool CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, 
 bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, bilingual_str& error, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl);
 
 bool GenBudgetSystemCollateralTx(CWallet& wallet, CTransactionRef& tx, uint256 hash, CAmount amount, const COutPoint& outpoint = COutPoint());
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_SPEND_H

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+namespace wallet {
 static constexpr int32_t WALLET_SCHEMA_VERSION = 0;
 
 static Mutex g_sqlite_mutex;
@@ -589,3 +590,4 @@ std::string SQLiteDatabaseVersion()
 {
     return std::string(sqlite3_libversion());
 }
+} // namespace wallet

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -10,6 +10,8 @@
 #include <sqlite3.h>
 
 struct bilingual_str;
+
+namespace wallet {
 class SQLiteDatabase;
 
 /** RAII class that provides access to a WalletDatabase */
@@ -117,5 +119,6 @@ public:
 std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
 
 std::string SQLiteDatabaseVersion();
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_SQLITE_H

--- a/src/wallet/test/bip39_tests.cpp
+++ b/src/wallet/test/bip39_tests.cpp
@@ -17,6 +17,7 @@
 // In script_tests.cpp
 extern UniValue read_json(const std::string& jsondata);
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(bip39_tests, BasicTestingSetup)
 
 // https://github.com/trezor/python-mnemonic/blob/b502451a33a440783926e04428115e0bed87d01f/vectors.json
@@ -61,5 +62,6 @@ BOOST_AUTO_TEST_CASE(bip39_vectors)
         BOOST_CHECK(EncodeExtKey(key) == test[3].get_str());
     }
 }
+} // namespace wallet
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(coinjoin_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(coinjoin_options_tests)
@@ -314,5 +315,6 @@ BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
         BOOST_CHECK(vecOutputs.size() == 0);
     }
 }
+} // namespace wallet
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -141,7 +141,7 @@ public:
         wallet->LoadWallet();
         AddWallet(context, wallet);
         {
-            LOCK2(wallet->cs_wallet, cs_main);
+            LOCK2(wallet->cs_wallet, ::cs_main);
             wallet->GetLegacyScriptPubKeyMan()->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
             wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());
         }
@@ -172,7 +172,7 @@ public:
             blocktx = CMutableTransaction(*it->second.tx);
         }
         CreateAndProcessBlock({blocktx}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-        LOCK2(wallet->cs_wallet, cs_main);
+        LOCK2(wallet->cs_wallet, ::cs_main);
         wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());
         it->second.m_state = TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1};
         return it->second;
@@ -195,7 +195,7 @@ public:
             FeeCalculation fee_calc_out;
             BOOST_CHECK(CreateTransaction(*wallet, {{GetScriptForDestination(tallyItem.txdest), nAmount, false}}, tx, nFeeRet, nChangePosRet, strError, coinControl, fee_calc_out));
             {
-                LOCK2(wallet->cs_wallet, cs_main);
+                LOCK2(wallet->cs_wallet, ::cs_main);
                 wallet->CommitTransaction(tx, {}, {});
             }
             AddTxToChain(tx->GetHash());

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -20,6 +20,7 @@
 #include <boost/test/unit_test.hpp>
 #include <random>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(coinselector_tests, WalletTestingSetup)
 
 // how many times to run all the tests to have a chance to catch errors that only show up with particular random shuffles
@@ -869,5 +870,6 @@ BOOST_AUTO_TEST_CASE(waste_test)
     add_coin(2 * COIN, 2, selection, fee, fee + large_fee_diff);
     BOOST_CHECK_EQUAL(target_waste2, GetSelectionWaste(selection, change_cost, target));
 }
+} // namespace wallet
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(db_tests, BasicTestingSetup)
 
 static std::shared_ptr<BerkeleyEnvironment> GetWalletEnv(const fs::path& path, fs::path& database_filename)
@@ -78,3 +79,4 @@ BOOST_AUTO_TEST_CASE(getwalletenv_g_dbenvs_free_instance)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+namespace wallet {
 namespace {
 const TestingSetup* g_setup;
 
@@ -167,3 +168,4 @@ FUZZ_TARGET(wallet_notifications, .init = initialize_setup)
     }
 }
 } // namespace
+} // namespace wallet

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -12,6 +12,7 @@
 
 #include <wallet/test/init_test_fixture.h>
 
+namespace wallet {
 InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)
 {
     m_coinjoin_loader = interfaces::MakeCoinJoinLoader(m_node);
@@ -48,3 +49,4 @@ void InitWalletDirTestingSetup::SetWalletDir(const fs::path& walletdir_path)
 {
     m_args.ForceSetArg("-walletdir", fs::PathToString(walletdir_path));
 }
+} // namespace wallet

--- a/src/wallet/test/init_test_fixture.h
+++ b/src/wallet/test/init_test_fixture.h
@@ -11,7 +11,7 @@
 #include <node/context.h>
 #include <test/util/setup_common.h>
 
-
+namespace wallet {
 struct InitWalletDirTestingSetup: public BasicTestingSetup {
     explicit InitWalletDirTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~InitWalletDirTestingSetup();
@@ -23,5 +23,6 @@ struct InitWalletDirTestingSetup: public BasicTestingSetup {
     std::unique_ptr<interfaces::CoinJoin::Loader> m_coinjoin_loader;
     std::unique_ptr<interfaces::WalletLoader> m_wallet_loader;
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_TEST_INIT_TEST_FIXTURE_H

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -9,6 +9,7 @@
 #include <util/system.h>
 #include <wallet/test/init_test_fixture.h>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(init_tests, InitWalletDirTestingSetup)
 
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_default)
@@ -94,3 +95,4 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing2)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/ismine_tests.cpp
+++ b/src/wallet/test/ismine_tests.cpp
@@ -14,6 +14,7 @@
 
 using node::NodeContext;
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(ismine_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(ismine_standard)
@@ -226,3 +227,4 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/ismine_tests.cpp
+++ b/src/wallet/test/ismine_tests.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::NodeContext;
 
 BOOST_FIXTURE_TEST_SUITE(ismine_tests, BasicTestingSetup)
 

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -10,6 +10,7 @@
 #include <boost/test/unit_test.hpp>
 #include <wallet/test/wallet_test_fixture.h>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(psbt_wallet_tests, WalletTestingSetup)
 
 static void import_descriptor(CWallet& wallet, const std::string& descriptor)
@@ -147,3 +148,4 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/scriptpubkeyman_tests.cpp
+++ b/src/wallet/test/scriptpubkeyman_tests.cpp
@@ -10,6 +10,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::NodeContext;
+
 BOOST_FIXTURE_TEST_SUITE(scriptpubkeyman_tests, BasicTestingSetup)
 
 // Test LegacyScriptPubKeyMan::CanProvide behavior, making sure it returns true

--- a/src/wallet/test/scriptpubkeyman_tests.cpp
+++ b/src/wallet/test/scriptpubkeyman_tests.cpp
@@ -12,6 +12,7 @@
 
 using node::NodeContext;
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(scriptpubkeyman_tests, BasicTestingSetup)
 
 // Test LegacyScriptPubKeyMan::CanProvide behavior, making sure it returns true
@@ -43,3 +44,4 @@ BOOST_AUTO_TEST_CASE(CanProvide)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(spend_tests, WalletTestingSetup)
 
 BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
@@ -60,3 +61,4 @@ BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -15,6 +15,7 @@
 
 #include <memory>
 
+namespace wallet {
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, interfaces::CoinJoin::Loader& coinjoin_loader, CChain& cchain, ArgsManager& args, const CKey& key)
 {
     auto wallet = std::make_unique<CWallet>(&chain, &coinjoin_loader, "", args, CreateMockWalletDatabase());
@@ -44,3 +45,4 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, interfaces
     BOOST_CHECK(result.last_failed_block.IsNull());
     return wallet;
 }
+} // namespace wallet

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -10,7 +10,6 @@
 class ArgsManager;
 class CChain;
 class CKey;
-class CWallet;
 namespace interfaces {
 class Chain;
 namespace CoinJoin {
@@ -18,6 +17,10 @@ class Loader;
 } // namespace CoinJoin
 } // namespace interfaces
 
+namespace wallet {
+class CWallet;
+
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, interfaces::CoinJoin::Loader& coinjoin_loader, CChain& cchain, ArgsManager& args, const CKey& key);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_TEST_UTIL_H

--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(wallet_crypto_tests, BasicTestingSetup)
 
 void TestAES256CBC(const std::string &hexkey, const std::string &hexiv, const std::string &hexin, const std::string &hexout)
@@ -153,3 +154,4 @@ BOOST_AUTO_TEST_CASE(aes_256_cbc_testvectors) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -6,6 +6,7 @@
 
 #include <scheduler.h>
 
+namespace wallet {
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
     : TestingSetup(chainName),
       m_coinjoin_loader{interfaces::MakeCoinJoinLoader(m_node)},
@@ -21,3 +22,4 @@ WalletTestingSetup::~WalletTestingSetup()
 {
     if (m_node.scheduler) m_node.scheduler->stop();
 }
+} // namespace wallet

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+namespace wallet {
 /** Testing setup and teardown for wallet.
  */
 struct WalletTestingSetup : public TestingSetup {
@@ -27,5 +28,6 @@ struct WalletTestingSetup : public TestingSetup {
     CWallet m_wallet;
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_TEST_WALLET_TEST_FIXTURE_H

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -38,6 +38,7 @@
 using node::MAX_BLOCKFILE_SIZE;
 using node::UnlinkPrunedFiles;
 
+namespace wallet {
 RPCHelpMan importmulti();
 RPCHelpMan dumpwallet();
 RPCHelpMan importwallet();
@@ -313,7 +314,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.setArray();
         request.params.push_back(backup_file);
 
-        ::dumpwallet().HandleRequest(request);
+        wallet::dumpwallet().HandleRequest(request);
         RemoveWallet(context, wallet, /*load_on_start=*/std::nullopt);
     }
 
@@ -332,7 +333,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.push_back(backup_file);
         AddWallet(context, wallet);
         wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());
-        ::importwallet().HandleRequest(request);
+        wallet::importwallet().HandleRequest(request);
         RemoveWallet(context, wallet, /*load_on_start=*/std::nullopt);
 
         BOOST_CHECK_EQUAL(wallet->mapWallet.size(), 3U);
@@ -1468,3 +1469,4 @@ BOOST_FIXTURE_TEST_CASE(select_coins_grouped_by_addresses, ListCoinsTestingSetup
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -35,6 +35,9 @@
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
 
+using node::MAX_BLOCKFILE_SIZE;
+using node::UnlinkPrunedFiles;
+
 RPCHelpMan importmulti();
 RPCHelpMan dumpwallet();
 RPCHelpMan importwallet();

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -260,7 +260,7 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
         request.params.setArray();
         request.params.push_back(keys);
 
-        UniValue response = importmulti().HandleRequest(request);
+        UniValue response = wallet::importmulti().HandleRequest(request);
         BOOST_CHECK_EQUAL(response.write(),
             strprintf("[{\"success\":false,\"error\":{\"code\":-1,\"message\":\"Rescan failed for key with creation "
                       "timestamp %d. There was an error reading a block from time %d, which is after or within %d "
@@ -898,12 +898,12 @@ BOOST_FIXTURE_TEST_CASE(rpc_getaddressinfo, TestChain100Setup)
 
     // test p2pkh
     std::string addr;
-    BOOST_CHECK_NO_THROW(addr = ::getrawchangeaddress().HandleRequest(request).get_str());
+    BOOST_CHECK_NO_THROW(addr = wallet::getrawchangeaddress().HandleRequest(request).get_str());
 
     request.params.clear();
     request.params.setArray();
     request.params.push_back(addr);
-    BOOST_CHECK_NO_THROW(response = ::getaddressinfo().HandleRequest(request).get_obj());
+    BOOST_CHECK_NO_THROW(response = wallet::getaddressinfo().HandleRequest(request).get_obj());
 
     BOOST_CHECK_EQUAL(find_value(response, "ismine").get_bool(), true);
     BOOST_CHECK_EQUAL(find_value(response, "solvable").get_bool(), true);
@@ -918,8 +918,8 @@ BOOST_FIXTURE_TEST_CASE(rpc_getaddressinfo, TestChain100Setup)
     // test p2sh/multisig
     std::string addr1;
     std::string addr2;
-    BOOST_CHECK_NO_THROW(addr1 = ::getnewaddress().HandleRequest(request).get_str());
-    BOOST_CHECK_NO_THROW(addr2 = ::getnewaddress().HandleRequest(request).get_str());
+    BOOST_CHECK_NO_THROW(addr1 = wallet::getnewaddress().HandleRequest(request).get_str());
+    BOOST_CHECK_NO_THROW(addr2 = wallet::getnewaddress().HandleRequest(request).get_str());
 
     UniValue keys;
     keys.setArray();
@@ -931,14 +931,14 @@ BOOST_FIXTURE_TEST_CASE(rpc_getaddressinfo, TestChain100Setup)
     request.params.push_back(2);
     request.params.push_back(keys);
 
-    BOOST_CHECK_NO_THROW(response = ::addmultisigaddress().HandleRequest(request));
+    BOOST_CHECK_NO_THROW(response = wallet::addmultisigaddress().HandleRequest(request));
 
     std::string multisig = find_value(response.get_obj(), "address").get_str();
 
     request.params.clear();
     request.params.setArray();
     request.params.push_back(multisig);
-    BOOST_CHECK_NO_THROW(response = ::getaddressinfo().HandleRequest(request).get_obj());
+    BOOST_CHECK_NO_THROW(response = wallet::getaddressinfo().HandleRequest(request).get_obj());
 
     BOOST_CHECK_EQUAL(find_value(response, "ismine").get_bool(), true);
     BOOST_CHECK_EQUAL(find_value(response, "solvable").get_bool(), true);
@@ -1038,7 +1038,7 @@ public:
         bilingual_str strError;
 
         FeeCalculation fee_calc_out;
-        bool fCreationSucceeded = ::CreateTransaction(*wallet, GetRecipients(vecEntries), tx, nFeeRet, nChangePos, strError, coinControl, fee_calc_out);
+        bool fCreationSucceeded = wallet::CreateTransaction(*wallet, GetRecipients(vecEntries), tx, nFeeRet, nChangePos, strError, coinControl, fee_calc_out);
         bool fHitMaxTries = strError.original == strExceededMaxTries;
         // This should never happen.
         if (fHitMaxTries) {
@@ -1079,7 +1079,7 @@ public:
         for (auto entry : vecEntries) {
             JSONRPCRequest request;
             request.context = context;
-            vecRecipients.push_back({GetScriptForDestination(DecodeDestination(getnewaddress().HandleRequest(request).get_str())), entry.first, entry.second});
+            vecRecipients.push_back({GetScriptForDestination(DecodeDestination(wallet::getnewaddress().HandleRequest(request).get_str())), entry.first, entry.second});
         }
         return vecRecipients;
     }
@@ -1092,7 +1092,7 @@ public:
         bilingual_str strError;
         CCoinControl coinControl;
         FeeCalculation fee_calc_out;
-        BOOST_CHECK(::CreateTransaction(*wallet, GetRecipients(vecEntries), tx, nFeeRet, nChangePosRet, strError, coinControl, fee_calc_out));
+        BOOST_CHECK(wallet::CreateTransaction(*wallet, GetRecipients(vecEntries), tx, nFeeRet, nChangePosRet, strError, coinControl, fee_calc_out));
         wallet->CommitTransaction(tx, {}, {});
         CMutableTransaction blocktx;
         {

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -154,7 +154,7 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
     // Prune the older block file.
     int file_number;
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         file_number = oldTip->GetBlockPos().nFile;
         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
     }
@@ -182,7 +182,7 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
 
     // Prune the remaining block file.
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         file_number = newTip->GetBlockPos().nFile;
         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
     }
@@ -219,7 +219,7 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
     // Prune the older block file.
     int file_number;
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         file_number = oldTip->GetBlockPos().nFile;
         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
     }
@@ -378,7 +378,7 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
     SetMockTime(mockTime);
     CBlockIndex* block = nullptr;
     if (blockTime > 0) {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         auto inserted = chainman.BlockIndex().emplace(std::piecewise_construct, std::make_tuple(GetRandHash()), std::make_tuple());
         assert(inserted.second);
         const uint256& hash = inserted.first->first;

--- a/src/wallet/test/wallet_transaction_tests.cpp
+++ b/src/wallet/test/wallet_transaction_tests.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(wallet_transaction_tests, WalletTestingSetup)
 
 BOOST_AUTO_TEST_CASE(roundtrip)
@@ -22,3 +23,4 @@ BOOST_AUTO_TEST_CASE(roundtrip)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(walletdb_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(walletdb_readkeyvalue)
@@ -27,3 +28,4 @@ BOOST_AUTO_TEST_CASE(walletdb_readkeyvalue)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/transaction.cpp
+++ b/src/wallet/transaction.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/transaction.h>
 
+namespace wallet {
 bool CWalletTx::IsEquivalentTo(const CWalletTx& _tx) const
 {
         CMutableTransaction tx1 {*this->tx};
@@ -23,3 +24,4 @@ int64_t CWalletTx::GetTxTime() const
     int64_t n = nTimeSmart;
     return n ? n : nTimeReceived;
 }
+} // namespace wallet

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -19,6 +19,7 @@
 #include <variant>
 #include <vector>
 
+namespace wallet {
 //! State of transaction confirmed in a block.
 struct TxStateConfirmed {
     uint256 confirmed_block_hash;
@@ -310,5 +311,6 @@ public:
     CWalletTx(CWalletTx const &) = delete;
     void operator=(CWalletTx const &x) = delete;
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_TRANSACTION_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -56,6 +56,7 @@
 
 using interfaces::FoundBlock;
 
+namespace wallet {
 const std::map<uint64_t,std::string> WALLET_FLAG_CAVEATS{
     {WALLET_FLAG_AVOID_REUSE,
         "You need to rescan the blockchain in order to correctly mark used "
@@ -3930,3 +3931,4 @@ ScriptPubKeyMan* CWallet::AddWalletDescriptor(WalletDescriptor& desc, const Flat
 
     return spk_man;
 }
+} // namespace wallet

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -46,10 +46,17 @@
 
 #include <boost/signals2/signal.hpp>
 
+class CKey;
+class CScript;
+class CTxDSIn;
+enum class FeeEstimateMode;
+struct FeeCalculation;
 struct bilingual_str;
-struct WalletContext;
 
 using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wallet)>;
+
+namespace wallet {
+struct WalletContext;
 
 //! Explicitly unload and delete the wallet.
 //  Blocks the current thread after signaling the unload intent so that all
@@ -112,13 +119,8 @@ static constexpr size_t DUMMY_NESTED_P2PKH_INPUT_SIZE = 113;
 static const bool DEFAULT_USE_HD_WALLET = true;
 
 class CCoinControl;
-class CKey;
 class COutput;
-class CScript;
-class CTxDSIn;
 class CWalletTx;
-struct FeeCalculation;
-enum class FeeEstimateMode;
 class ReserveDestination;
 
 extern RecursiveMutex cs_main;
@@ -1098,5 +1100,6 @@ bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);
 
 //! Remove wallet name from persistent configuration so it will not be loaded on startup.
 bool RemoveWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLET_H

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -29,6 +29,7 @@
 #include <optional>
 #include <string>
 
+namespace wallet {
 namespace DBKeys {
 const std::string ACENTRY{"acentry"};
 const std::string ACTIVEEXTERNALSPK{"activeexternalspk"};
@@ -1199,3 +1200,4 @@ std::unique_ptr<WalletDatabase> CreateMockWalletDatabase()
     return std::make_unique<BerkeleyDatabase>(std::make_shared<BerkeleyEnvironment>(), "", options);
 #endif
 }
+} // namespace wallet

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -15,6 +15,23 @@
 #include <string>
 #include <vector>
 
+struct CBlockLocator;
+class CScript;
+class uint160;
+class uint256;
+namespace Governance {
+class Object;
+} // namespace Governance
+
+namespace wallet {
+class CHDChain;
+class CHDPubKey;
+class CKeyPool;
+class CMasterKey;
+class CWallet;
+class CWalletTx;
+struct WalletContext;
+
 /**
  * Overview of wallet database classes:
  *
@@ -28,23 +45,6 @@
  */
 
 static const bool DEFAULT_FLUSHWALLET = true;
-
-struct CBlockLocator;
-struct WalletContext;
-class CHDChain;
-class CHDPubKey;
-class CKeyPool;
-class CMasterKey;
-class CScript;
-class CWallet;
-class CWalletTx;
-class uint160;
-class uint256;
-
-namespace Governance
-{
-    class Object;
-} // namespace Governance
 
 /** Error statuses for the wallet database */
 enum class DBErrors
@@ -268,5 +268,6 @@ std::unique_ptr<WalletDatabase> CreateDummyWalletDatabase();
 
 /** Return object for accessing temporary in-memory database. */
 std::unique_ptr<WalletDatabase> CreateMockWalletDatabase();
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLETDB_H

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -16,6 +16,7 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
+namespace wallet {
 namespace WalletTool {
 
 // The standard wallet deleter function blocks on the validation interface
@@ -242,3 +243,4 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
     return true;
 }
 } // namespace WalletTool
+} // namespace wallet

--- a/src/wallet/wallettool.h
+++ b/src/wallet/wallettool.h
@@ -9,10 +9,12 @@
 
 class ArgsManager;
 
+namespace wallet {
 namespace WalletTool {
 
 bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command);
 
 } // namespace WalletTool
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLETTOOL_H

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -7,6 +7,7 @@
 #include <logging.h>
 #include <util/system.h>
 
+namespace wallet {
 fs::path GetWalletDir()
 {
     fs::path path;
@@ -42,3 +43,4 @@ WalletFeature GetClosestWalletFeature(int version)
     }
     return static_cast<WalletFeature>(0);
 }
+} // namespace wallet

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+namespace wallet {
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {
@@ -96,5 +97,6 @@ public:
     WalletDescriptor() {}
     WalletDescriptor(std::shared_ptr<Descriptor> descriptor, uint64_t creation_time, int32_t range_start, int32_t range_end, int32_t next_index) : descriptor(descriptor), id(DescriptorID(*descriptor)), creation_time(creation_time), range_start(range_start), range_end(range_end), next_index(next_index) { }
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLETUTIL_H

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -6,13 +6,15 @@
 #define BITCOIN_WALLETINITINTERFACE_H
 
 class ArgsManager;
-struct NodeContext;
 namespace interfaces {
 class WalletLoader;
 namespace CoinJoin {
 class Loader;
 } // namespace CoinJoin
 } // namespace interfaces
+namespace node {
+struct NodeContext;
+} // namespace node
 
 class WalletInitInterface {
 public:
@@ -23,7 +25,7 @@ public:
     /** Check wallet parameter interaction */
     virtual bool ParameterInteraction() const = 0;
     /** Add wallets that should be opened to list of chain clients. */
-    virtual void Construct(NodeContext& node) const = 0;
+    virtual void Construct(node::NodeContext& node) const = 0;
 
     // Dash Specific WalletInitInterface
     virtual void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const = 0;

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <utility>
 
+using node::ReadBlockFromDisk;
+
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 
 static const char *MSG_HASHBLOCK     = "hashblock";


### PR DESCRIPTION
## Additional Information

* [bitcoin#23497](https://github.com/bitcoin/bitcoin/pull/23497) was merged upstream in v0.23. As of this writing, the backport backlog for v0.23 is at ~91% completion. This change, while conflict-prone, is long-overdue as we have been backporting pull requests from v0.24 onwards that assume these namespaces and so far we've simply "cut out" those portions to allow those backports to be completed.
  * This is not sustainable, especially with the work undertaken for `bitcoin-chainstate` (see [bitcoin#24304](https://github.com/bitcoin/bitcoin/pull/24304) and onwards), that are invested in these separation of concerns.

* Due to the increased usage of namespacing, to avoid potential `-Werror=thread-safety-analysis` issues (see below), the usage of `cs_main` needs to be disambiguated as being a part of the global namespace, to that effect, changes have been made to ensure that in Dash-specific code and anywhere else needed to quell compiler errors.

  <details>

  <summary>Build error:</summary>

  ```
  wallet/test/wallet_tests.cpp:162:31: error: calling function 'GetBlockPos' requires holding mutex 'cs_main' exclusively [-Werror,-Wthread-safety-analysis]
    162 |         file_number = oldTip->GetBlockPos().nFile;
        |                               ^
  wallet/test/wallet_tests.cpp:163:45: error: calling function 'PruneOneBlockFile' requires holding mutex 'cs_main' exclusively [-Werror,-Wthread-safety-analysis]
    163 |         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
        |                                             ^
  wallet/test/wallet_tests.cpp:190:31: error: calling function 'GetBlockPos' requires holding mutex 'cs_main' exclusively [-Werror,-Wthread-safety-analysis]
    190 |         file_number = newTip->GetBlockPos().nFile;
        |                               ^
  wallet/test/wallet_tests.cpp:191:45: error: calling function 'PruneOneBlockFile' requires holding mutex 'cs_main' exclusively [-Werror,-Wthread-safety-analysis]
    191 |         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
        |                                             ^
  wallet/test/wallet_tests.cpp:227:31: error: calling function 'GetBlockPos' requires holding mutex 'cs_main' exclusively [-Werror,-Wthread-safety-analysis]
    227 |         file_number = oldTip->GetBlockPos().nFile;
        |                               ^
  wallet/test/wallet_tests.cpp:228:45: error: calling function 'PruneOneBlockFile' requires holding mutex 'cs_main' exclusively [-Werror,-Wthread-safety-analysis]
    228 |         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
        |                                             ^
  wallet/test/wallet_tests.cpp:386:34: error: calling function 'BlockIndex' requires holding mutex 'cs_main' exclusively [-Werror,-Wthread-safety-analysis]
    386 |         auto inserted = chainman.BlockIndex().emplace(std::piecewise_construct, std::make_tuple(GetRandHash()), std::make_tuple());
        |                                  ^`
  ```

  </details>

* Some commits have been split out to ease in the review process, due to the nature of changes, except for `NodeContext` (`node/context.{cpp,h}`), they could not be done on a file-to-file basis as it would create substantial diffs that would then be reverted in the next commit, which would make review _harder_.
  * Correctness of this pull request can be evaluated by comparing against [bitcoin#23497](https://github.com/bitcoin/bitcoin/pull/23497), the `25.x` branch upstream for changes affecting upstream code not present during the backport ([source](https://github.com/bitcoin/bitcoin/tree/25.x)) and compiler output for Dash-specific code.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
