### PR TITLE
backport: merge bitcoin#24711, #24666, #25083, #25005, #25410, #24236, #25438, #25036, #25489, #25544, #25594, #13226, partial bitcoin#25218, #26005 (wallet backports: part 6)

### DIFF
--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -14,5 +14,5 @@ export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude fe
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
 export GOAL="install"
-export PREVIOUS_RELEASES_TO_DOWNLOAD="v0.15.0.0 v0.16.1.1 v0.17.0.3 v18.2.2 v19.3.0 v20.0.1"
+export PREVIOUS_RELEASES_TO_DOWNLOAD="v0.12.1.5 v0.15.0.0 v0.16.1.1 v0.17.0.3 v18.2.2 v19.3.0 v20.0.1"
 export BITCOIN_CONFIG="--enable-zmq --with-libs=no --enable-reduce-exports --disable-fuzz-binary LDFLAGS=-static-libstdc++ --with-boost-process"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -367,6 +367,7 @@ BITCOIN_CORE_H = \
   util/overloaded.h \
   util/ranges.h \
   util/readwritefile.h \
+  util/result.h \
   util/underlying.h \
   util/serfloat.h \
   util/settings.h \

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -56,7 +56,7 @@ static void CoinSelection(benchmark::Bench& bench)
     // Create coins
     std::vector<COutput> coins;
     for (const auto& wtx : wtxs) {
-        coins.emplace_back(COutPoint(wtx->GetHash(), 0), wtx->tx->vout.at(0), /*depth=*/6 * 24, GetTxSpendSize(wallet, *wtx, 0), /*spendable=*/true, /*solvable=*/true, /*safe=*/true, wtx->GetTxTime(), /*from_me=*/true);
+        coins.emplace_back(COutPoint(wtx->GetHash(), 0), wtx->tx->vout.at(0), /*depth=*/6 * 24, GetTxSpendSize(wallet, *wtx, 0), /*spendable=*/true, /*solvable=*/true, /*safe=*/true, wtx->GetTxTime(), /*from_me=*/true, /*fees=*/ 0);
     }
     const CoinEligibilityFilter filter_standard(1, 6, 0);
     FastRandomContext rand{};
@@ -85,7 +85,7 @@ static void add_coin(const CAmount& nValue, int nInput, std::vector<OutputGroup>
     CMutableTransaction tx;
     tx.vout.resize(nInput + 1);
     tx.vout[nInput].nValue = nValue;
-    COutput output(COutPoint(tx.GetHash(), nInput), tx.vout.at(nInput), /*depth=*/ 0, /*input_bytes=*/ -1, /*spendable=*/ true, /*solvable=*/ true, /*safe=*/ true, /*time=*/ 0, /*from_me=*/ true);
+    COutput output(COutPoint(tx.GetHash(), nInput), tx.vout.at(nInput), /*depth=*/ 0, /*input_bytes=*/ -1, /*spendable=*/ true, /*solvable=*/ true, /*safe=*/ true, /*time=*/ 0, /*from_me=*/ true, /*fees=*/ 0);
     set.emplace_back();
     set.back().Insert(output, /*ancestors=*/ 0, /*descendants=*/ 0, /*positive_only=*/ false);
 }

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1561,7 +1561,7 @@ bool CCoinJoinClientSession::CreateCollateralTransaction(CMutableTransaction& tx
     CCoinControl coin_control;
     coin_control.nCoinType = CoinType::ONLY_COINJOIN_COLLATERAL;
 
-    AvailableCoins(*m_wallet, vCoins, &coin_control);
+    AvailableCoinsListUnspent(*m_wallet, vCoins, &coin_control);
 
     if (vCoins.empty()) {
         strReason = strprintf("%s requires a collateral transaction and could not locate an acceptable input!", gCoinJoinName);

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1557,11 +1557,8 @@ bool CCoinJoinClientSession::CreateCollateralTransaction(CMutableTransaction& tx
 {
     AssertLockHeld(m_wallet->cs_wallet);
 
-    std::vector<COutput> vCoins;
     CCoinControl coin_control(CoinType::ONLY_COINJOIN_COLLATERAL);
-
-    AvailableCoinsListUnspent(*m_wallet, vCoins, &coin_control);
-
+    std::vector<COutput> vCoins{AvailableCoinsListUnspent(*m_wallet, &coin_control).coins};
     if (vCoins.empty()) {
         strReason = strprintf("%s requires a collateral transaction and could not locate an acceptable input!", gCoinJoinName);
         return false;

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1558,8 +1558,7 @@ bool CCoinJoinClientSession::CreateCollateralTransaction(CMutableTransaction& tx
     AssertLockHeld(m_wallet->cs_wallet);
 
     std::vector<COutput> vCoins;
-    CCoinControl coin_control;
-    coin_control.nCoinType = CoinType::ONLY_COINJOIN_COLLATERAL;
+    CCoinControl coin_control(CoinType::ONLY_COINJOIN_COLLATERAL);
 
     AvailableCoinsListUnspent(*m_wallet, vCoins, &coin_control);
 

--- a/src/coinjoin/util.h
+++ b/src/coinjoin/util.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_COINJOIN_UTIL_H
 #define BITCOIN_COINJOIN_UTIL_H
 
+#include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
 class CTransactionBuilder;

--- a/src/coins.h
+++ b/src/coins.h
@@ -158,7 +158,6 @@ public:
 
     virtual bool GetKey(COutPoint &key) const = 0;
     virtual bool GetValue(Coin &coin) const = 0;
-    virtual unsigned int GetValueSize() const = 0;
 
     virtual bool Valid() const = 0;
     virtual void Next() = 0;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -189,11 +189,6 @@ public:
         }
         return true;
     }
-
-    unsigned int GetValueSize() {
-        return piter->value().size();
-    }
-
 };
 
 class CDBWrapper
@@ -373,27 +368,10 @@ public:
         return size;
     }
 
-    /**
-     * Compact a certain range of keys in the database.
-     */
-    template<typename K>
-    void CompactRange(const K& key_begin, const K& key_end) const
-    {
-        CDataStream ssKey1(SER_DISK, CLIENT_VERSION), ssKey2(SER_DISK, CLIENT_VERSION);
-        ssKey1.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey1 << key_begin;
-        ssKey2 << key_end;
-        leveldb::Slice slKey1(CharCast(ssKey1.data()), ssKey1.size());
-        leveldb::Slice slKey2(CharCast(ssKey2.data()), ssKey2.size());
-        pdb->CompactRange(&slKey1, &slKey2);
-    }
-
     void CompactFull() const
     {
         pdb->CompactRange(nullptr, nullptr);
     }
-
 };
 
 template<typename CDBTransaction>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2037,8 +2037,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 strLoadError = _("Error initializing block database");
                 break;
             case ChainstateLoadingError::ERROR_CHAINSTATE_UPGRADE_FAILED:
-                strLoadError = _("Error upgrading chainstate database");
-                break;
+                return InitError(_("Unsupported chainstate database format found. "
+                                   "Please restart with -reindex-chainstate. This will "
+                                   "rebuild the chainstate database."));
             case ChainstateLoadingError::ERROR_REPLAYBLOCKS_FAILED:
                 strLoadError = _("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.");
                 break;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -128,6 +128,10 @@ public:
     //! Get locator for the current chain tip.
     virtual CBlockLocator getTipLocator() = 0;
 
+    //! Return a locator that refers to a block in the active chain.
+    //! If specified block is not in the active chain, return locator for the latest ancestor that is in the chain.
+    virtual CBlockLocator getActiveChainLocator(const uint256& block_hash) = 0;
+
     //! Return height of the highest block on chain in common with the locator,
     //! which will either be the original block used to create the locator,
     //! or one of its ancestors.

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -12,6 +12,7 @@
 #include <script/standard.h>           // For CTxDestination
 #include <support/allocators/secure.h> // For SecureString
 #include <util/message.h>
+#include <util/result.h>
 #include <util/ui_change_type.h>
 
 #include <cstdint>
@@ -357,7 +358,7 @@ public:
    virtual std::string getWalletDir() = 0;
 
    //! Restore backup wallet
-   virtual std::unique_ptr<Wallet> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;
+   virtual BResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) = 0;
 
    //! Return available wallets in wallet directory.
    virtual std::vector<std::string> listWalletDir() = 0;

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -156,9 +156,9 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
             chainstate->CoinsErrorCatcher().AddReadErrCallback(coins_error_cb);
         }
 
-        // If necessary, upgrade from older database format.
+        // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
-        if (!chainstate->CoinsDB().Upgrade()) {
+        if (chainstate->CoinsDB().NeedsUpgrade()) {
             return ChainstateLoadingError::ERROR_CHAINSTATE_UPGRADE_FAILED;
         }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -733,7 +733,7 @@ public:
     }
     bool haveBlockOnDisk(int height) override
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         const CChain& active = Assert(m_node.chainman)->ActiveChain();
         CBlockIndex* block = active[height];
         return block && ((block->nStatus & BLOCK_HAVE_DATA) != 0) && block->nTx > 0;
@@ -758,12 +758,19 @@ public:
     }
     CBlockLocator getTipLocator() override
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         return chainman().ActiveChain().GetLocator();
+    }
+    CBlockLocator getActiveChainLocator(const uint256& block_hash) override
+    {
+        LOCK(::cs_main);
+        const CBlockIndex* index = chainman().m_blockman.LookupBlockIndex(block_hash);
+        if (!index) return {};
+        return chainman().ActiveChain().GetLocator(index);
     }
     std::optional<int> findLocatorFork(const CBlockLocator& locator) override
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         const CChainState& active = Assert(m_node.chainman)->ActiveChainstate();
         if (const CBlockIndex* fork = active.FindForkInGlobalIndex(locator)) {
             return fork->nHeight;
@@ -845,7 +852,7 @@ public:
     void findCoins(std::map<COutPoint, Coin>& coins) override { return FindCoins(m_node, coins); }
     double guessVerificationProgress(const uint256& block_hash) override
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         return GuessVerificationProgress(Params().TxData(), chainman().m_blockman.LookupBlockIndex(block_hash));
     }
     bool hasBlocks(const uint256& block_hash, int min_height, std::optional<int> max_height) override
@@ -935,7 +942,7 @@ public:
     CFeeRate relayDustFee() override { return ::dustRelayFee; }
     bool havePruned() override
     {
-        LOCK(cs_main);
+        LOCK(::cs_main);
         return m_node.chainman->m_blockman.m_have_pruned;
     }
     bool isReadyToBroadcast() override { return !node::fImporting && !node::fReindex && !isInitialBlockDownload(); }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -16,10 +16,11 @@
 #include <qt/optionsmodel.h>
 #include <qt/walletmodel.h>
 
-#include <wallet/coincontrol.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <policy/policy.h>
+#include <wallet/coincontrol.h>
+#include <wallet/coinselection.h>
 #include <wallet/wallet.h>
 
 #include <QApplication>

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -142,7 +142,7 @@ void TestGUI(interfaces::Node& node)
     {
         WalletRescanReserver reserver(*wallet);
         reserver.reserve();
-        CWallet::ScanResult result = wallet->ScanForWalletTransactions(Params().GetConsensus().hashGenesisBlock, 0 /* start_height */, {} /* max_height */, reserver, true /* fUpdate */);
+        CWallet::ScanResult result = wallet->ScanForWalletTransactions(Params().GetConsensus().hashGenesisBlock, /*start_height=*/0, /*max_height=*/{}, reserver, /*fUpdate=*/true, /*save_progress=*/false);
         QCOMPARE(result.status, CWallet::ScanResult::SUCCESS);
         QCOMPARE(result.last_scanned_block, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
         QVERIFY(result.last_failed_block.IsNull());

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -373,9 +373,10 @@ void RestoreWalletActivity::restore(const fs::path& backup_file, const std::stri
         tr("Restoring Wallet <b>%1</b>…").arg(name.toHtmlEscaped()));
 
     QTimer::singleShot(0, worker(), [this, backup_file, wallet_name] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletLoader().restoreWallet(backup_file, wallet_name, m_error_message, m_warning_message);
+        auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, m_warning_message)};
 
-        if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
+        m_error_message = wallet ? bilingual_str{} : wallet.GetError();
+        if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(wallet.ReleaseObj());
 
         QTimer::singleShot(0, this, &RestoreWalletActivity::finish);
     });

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -31,9 +31,9 @@ class WalletModelTransaction;
 
 class CKeyID;
 class COutPoint;
-class COutput;
 class CPubKey;
 class uint256;
+struct COutput;
 
 namespace interfaces {
 class Node;

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -273,10 +273,7 @@ static void FundSpecialTx(CWallet& wallet, CMutableTransaction& tx, const Specia
     coinControl.destChange = fundDest;
     coinControl.fRequireAllInputs = false;
 
-    std::vector<COutput> vecOutputs;
-    AvailableCoinsListUnspent(wallet, vecOutputs);
-
-    for (const auto& out : vecOutputs) {
+    for (const auto& out : AvailableCoinsListUnspent(wallet).coins) {
         CTxDestination txDest;
         if (ExtractDestination(out.txout.scriptPubKey, txDest) && txDest == fundDest) {
             coinControl.Select(out.outpoint);
@@ -802,7 +799,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
         // referencing external collateral
 
         const bool unlockOnError = [&]() {
-            if (LOCK(pwallet->cs_wallet); !pwallet->IsLockedCoin(ptx.collateralOutpoint.hash, ptx.collateralOutpoint.n)) {
+            if (LOCK(pwallet->cs_wallet); !pwallet->IsLockedCoin(ptx.collateralOutpoint)) {
                 pwallet->LockCoin(ptx.collateralOutpoint);
                 return true;
             }

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -274,7 +274,7 @@ static void FundSpecialTx(CWallet& wallet, CMutableTransaction& tx, const Specia
     coinControl.fRequireAllInputs = false;
 
     std::vector<COutput> vecOutputs;
-    AvailableCoins(wallet, vecOutputs);
+    AvailableCoinsListUnspent(wallet, vecOutputs);
 
     for (const auto& out : vecOutputs) {
         CTxDestination txDest;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -147,7 +147,7 @@ static RPCHelpMan masternode_outputs()
     coin_control.nCoinType = CoinType::ONLY_MASTERNODE_COLLATERAL;
     {
         LOCK(wallet->cs_wallet);
-        AvailableCoins(*wallet, vPossibleCoins, &coin_control);
+        AvailableCoinsListUnspent(*wallet, vPossibleCoins, &coin_control);
     }
     UniValue outputsArr(UniValue::VARR);
     for (const auto& out : vPossibleCoins) {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -143,8 +143,7 @@ static RPCHelpMan masternode_outputs()
 
     // Find possible candidates
     std::vector<COutput> vPossibleCoins;
-    CCoinControl coin_control;
-    coin_control.nCoinType = CoinType::ONLY_MASTERNODE_COLLATERAL;
+    CCoinControl coin_control(CoinType::ONLY_MASTERNODE_COLLATERAL);
     {
         LOCK(wallet->cs_wallet);
         AvailableCoinsListUnspent(*wallet, vPossibleCoins, &coin_control);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -142,14 +142,10 @@ static RPCHelpMan masternode_outputs()
     if (!wallet) return NullUniValue;
 
     // Find possible candidates
-    std::vector<COutput> vPossibleCoins;
     CCoinControl coin_control(CoinType::ONLY_MASTERNODE_COLLATERAL);
-    {
-        LOCK(wallet->cs_wallet);
-        AvailableCoinsListUnspent(*wallet, vPossibleCoins, &coin_control);
-    }
+
     UniValue outputsArr(UniValue::VARR);
-    for (const auto& out : vPossibleCoins) {
+    for (const auto& out : WITH_LOCK(wallet->cs_wallet, return AvailableCoinsListUnspent(*wallet, &coin_control).coins)) {
         outputsArr.push_back(out.outpoint.ToStringShort());
     }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -214,7 +214,6 @@ public:
 
     bool GetKey(COutPoint &key) const override;
     bool GetValue(Coin &coin) const override;
-    unsigned int GetValueSize() const override;
 
     bool Valid() const override;
     void Next() override;
@@ -258,11 +257,6 @@ bool CCoinsViewDBCursor::GetKey(COutPoint &key) const
 bool CCoinsViewDBCursor::GetValue(Coin &coin) const
 {
     return pcursor->GetValue(coin);
-}
-
-unsigned int CCoinsViewDBCursor::GetValueSize() const
-{
-    return pcursor->GetValueSize();
 }
 
 bool CCoinsViewDBCursor::Valid() const

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -6,7 +6,6 @@
 #include <txdb.h>
 
 #include <chain.h>
-#include <node/interface_ui.h>
 #include <pow.h>
 #include <random.h>
 #include <shutdown.h>
@@ -18,7 +17,6 @@
 #include <stdint.h>
 
 static constexpr uint8_t DB_COIN{'C'};
-static constexpr uint8_t DB_COINS{'c'};
 static constexpr uint8_t DB_BLOCK_FILES{'f'};
 static constexpr uint8_t DB_ADDRESSINDEX{'a'};
 static constexpr uint8_t DB_ADDRESSUNSPENTINDEX{'u'};
@@ -33,6 +31,7 @@ static constexpr uint8_t DB_REINDEX_FLAG{'R'};
 static constexpr uint8_t DB_LAST_BLOCK{'l'};
 
 // Keys used in previous version that might still be found in the DB:
+static constexpr uint8_t DB_COINS{'c'};
 static constexpr uint8_t DB_TXINDEX_BLOCK{'T'};
 //               uint8_t DB_TXINDEX{'t'}
 
@@ -54,6 +53,15 @@ std::optional<bilingual_str> CheckLegacyTxindex(CBlockTreeDB& block_tree_db)
     return std::nullopt;
 }
 
+bool CCoinsViewDB::NeedsUpgrade()
+{
+    std::unique_ptr<CDBIterator> cursor{m_db->NewIterator()};
+    // DB_COINS was deprecated in v0.15.0, commit
+    // 1088b02f0ccd7358d2b7076bb9e122d59d502d02
+    cursor->Seek(std::make_pair(DB_COINS, uint256{}));
+    return cursor->Valid();
+}
+
 namespace {
 
 struct CoinEntry {
@@ -64,7 +72,7 @@ struct CoinEntry {
     SERIALIZE_METHODS(CoinEntry, obj) { READWRITE(obj.key, obj.outpoint->hash, VARINT(obj.outpoint->n)); }
 };
 
-}
+} // namespace
 
 CCoinsViewDB::CCoinsViewDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe) :
     m_db(std::make_unique<CDBWrapper>(ldb_path, nCacheSize, fMemory, fWipe, true)),
@@ -472,126 +480,4 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
     }
 
     return true;
-}
-
-namespace {
-
-//! Legacy class to deserialize pre-pertxout database entries without reindex.
-class CCoins
-{
-public:
-    //! whether transaction is a coinbase
-    bool fCoinBase;
-
-    //! unspent transaction outputs; spent outputs are .IsNull(); spent outputs at the end of the array are dropped
-    std::vector<CTxOut> vout;
-
-    //! at which height this transaction was included in the active block chain
-    int nHeight;
-
-    //! empty constructor
-    CCoins() : fCoinBase(false), vout(0), nHeight(0) { }
-
-    template<typename Stream>
-    void Unserialize(Stream &s) {
-        unsigned int nCode = 0;
-        // version
-        unsigned int nVersionDummy;
-        ::Unserialize(s, VARINT(nVersionDummy));
-        // header code
-        ::Unserialize(s, VARINT(nCode));
-        fCoinBase = nCode & 1;
-        std::vector<bool> vAvail(2, false);
-        vAvail[0] = (nCode & 2) != 0;
-        vAvail[1] = (nCode & 4) != 0;
-        unsigned int nMaskCode = (nCode / 8) + ((nCode & 6) != 0 ? 0 : 1);
-        // spentness bitmask
-        while (nMaskCode > 0) {
-            unsigned char chAvail = 0;
-            ::Unserialize(s, chAvail);
-            for (unsigned int p = 0; p < 8; p++) {
-                bool f = (chAvail & (1 << p)) != 0;
-                vAvail.push_back(f);
-            }
-            if (chAvail != 0)
-                nMaskCode--;
-        }
-        // txouts themself
-        vout.assign(vAvail.size(), CTxOut());
-        for (unsigned int i = 0; i < vAvail.size(); i++) {
-            if (vAvail[i])
-                ::Unserialize(s, Using<TxOutCompression>(vout[i]));
-        }
-        // coinbase height
-        ::Unserialize(s, VARINT_MODE(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
-    }
-};
-
-}
-
-/** Upgrade the database from older formats.
- *
- * Currently implemented: from the per-tx utxo model (0.8..0.14.x) to per-txout.
- */
-bool CCoinsViewDB::Upgrade() {
-    std::unique_ptr<CDBIterator> pcursor(m_db->NewIterator());
-    pcursor->Seek(std::make_pair(DB_COINS, uint256()));
-    if (!pcursor->Valid()) {
-        return true;
-    }
-
-    int64_t count = 0;
-    LogPrintf("Upgrading utxo-set database...\n");
-    LogPrintf("[0%%]..."); /* Continued */
-    uiInterface.ShowProgress(_("Upgrading UTXO database").translated, 0, true);
-    size_t batch_size = 1 << 24;
-    CDBBatch batch(*m_db);
-    int reportDone = 0;
-    std::pair<unsigned char, uint256> key;
-    std::pair<unsigned char, uint256> prev_key = {DB_COINS, uint256()};
-    while (pcursor->Valid()) {
-        if (ShutdownRequested()) {
-            break;
-        }
-        if (pcursor->GetKey(key) && key.first == DB_COINS) {
-            if (count++ % 256 == 0) {
-                uint32_t high = 0x100 * *key.second.begin() + *(key.second.begin() + 1);
-                int percentageDone = (int)(high * 100.0 / 65536.0 + 0.5);
-                uiInterface.ShowProgress(_("Upgrading UTXO database").translated, percentageDone, true);
-                if (reportDone < percentageDone/10) {
-                    // report max. every 10% step
-                    LogPrintf("[%d%%]...", percentageDone); /* Continued */
-                    reportDone = percentageDone/10;
-                }
-            }
-            CCoins old_coins;
-            if (!pcursor->GetValue(old_coins)) {
-                return error("%s: cannot parse CCoins record", __func__);
-            }
-            COutPoint outpoint(key.second, 0);
-            for (size_t i = 0; i < old_coins.vout.size(); ++i) {
-                if (!old_coins.vout[i].IsNull() && !old_coins.vout[i].scriptPubKey.IsUnspendable()) {
-                    Coin newcoin(std::move(old_coins.vout[i]), old_coins.nHeight, old_coins.fCoinBase);
-                    outpoint.n = i;
-                    CoinEntry entry(&outpoint);
-                    batch.Write(entry, newcoin);
-                }
-            }
-            batch.Erase(key);
-            if (batch.SizeEstimate() > batch_size) {
-                m_db->WriteBatch(batch);
-                batch.Clear();
-                m_db->CompactRange(prev_key, key);
-                prev_key = key;
-            }
-            pcursor->Next();
-        } else {
-            break;
-        }
-    }
-    m_db->WriteBatch(batch);
-    m_db->CompactRange({DB_COINS, uint256()}, key);
-    uiInterface.ShowProgress("", 100, false);
-    LogPrintf("[%s].\n", ShutdownRequested() ? "CANCELLED" : "DONE");
-    return !ShutdownRequested();
 }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -68,8 +68,8 @@ public:
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true) override;
     std::unique_ptr<CCoinsViewCursor> Cursor() const override;
 
-    //! Attempt to update from an older database format. Returns whether an error occurred.
-    bool Upgrade();
+    //! Whether an unsupported database format is used.
+    bool NeedsUpgrade();
     size_t EstimateSize() const override;
 
     //! Dynamically alter the underlying leveldb cache size.

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_RESULT_H
+#define BITCOIN_UTIL_RESULT_H
+
+#include <util/translation.h>
+#include <variant>
+
+/*
+ * 'BResult' is a generic class useful for wrapping a return object
+ * (in case of success) or propagating the error cause.
+*/
+template<class T>
+class BResult {
+private:
+    std::variant<bilingual_str, T> m_variant;
+
+public:
+    BResult() : m_variant(Untranslated("")) {}
+    BResult(const T& _obj) : m_variant(_obj) {}
+    BResult(const bilingual_str& error) : m_variant(error) {}
+
+    /* Whether the function succeeded or not */
+    bool HasRes() const { return std::holds_alternative<T>(m_variant); }
+
+    /* In case of success, the result object */
+    const T& GetObj() const {
+        assert(HasRes());
+        return std::get<T>(m_variant);
+    }
+
+    /* In case of failure, the error cause */
+    const bilingual_str& GetError() const {
+        assert(!HasRes());
+        return std::get<bilingual_str>(m_variant);
+    }
+
+    explicit operator bool() const { return HasRes(); }
+};
+
+#endif // BITCOIN_UTIL_RESULT_H

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_RESULT_H
 
 #include <util/translation.h>
+
 #include <variant>
 
 /*
@@ -18,9 +19,9 @@ private:
     std::variant<bilingual_str, T> m_variant;
 
 public:
-    BResult() : m_variant(Untranslated("")) {}
-    BResult(const T& _obj) : m_variant(_obj) {}
-    BResult(const bilingual_str& error) : m_variant(error) {}
+    BResult() : m_variant{Untranslated("")} {}
+    BResult(T obj) : m_variant{std::move(obj)} {}
+    BResult(bilingual_str error) : m_variant{std::move(error)} {}
 
     /* Whether the function succeeded or not */
     bool HasRes() const { return std::holds_alternative<T>(m_variant); }
@@ -29,6 +30,11 @@ public:
     const T& GetObj() const {
         assert(HasRes());
         return std::get<T>(m_variant);
+    }
+    T ReleaseObj()
+    {
+        assert(HasRes());
+        return std::move(std::get<T>(m_variant));
     }
 
     /* In case of failure, the error cause */

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -8,7 +8,7 @@
 
 namespace wallet {
 CCoinControl::CCoinControl(CoinType coinType)
-: nCoinType(coinType)
+    : nCoinType{coinType}
 {
     m_avoid_partial_spends = gArgs.GetBoolArg("-avoidpartialspends", DEFAULT_AVOIDPARTIALSPENDS);
 }

--- a/src/wallet/coinjoin.cpp
+++ b/src/wallet/coinjoin.cpp
@@ -61,8 +61,7 @@ bool CWallet::SelectTxDSInsByDenomination(int nDenom, CAmount nValueMax, std::ve
     }
     CAmount nDenomAmount = CoinJoin::DenominationToAmount(nDenom);
 
-    CCoinControl coin_control;
-    coin_control.nCoinType = CoinType::ONLY_READY_TO_MIX;
+    CCoinControl coin_control(CoinType::ONLY_READY_TO_MIX);
     AvailableCoinsListUnspent(*this, vCoins, &coin_control);
     WalletCJLogPrint(this, "CWallet::%s -- vCoins.size(): %d\n", __func__, vCoins.size());
 
@@ -108,8 +107,7 @@ bool CWallet::SelectDenominatedAmounts(CAmount nValueMax, std::set<CAmount>& set
     setAmountsRet.clear();
 
     std::vector<COutput> vCoins;
-    CCoinControl coin_control;
-    coin_control.nCoinType = CoinType::ONLY_READY_TO_MIX;
+    CCoinControl coin_control(CoinType::ONLY_READY_TO_MIX);
     // CompareByPriority() cares about effective value, which is only calculable when supplied a feerate
     AvailableCoins(*this, vCoins, &coin_control, /*feerate=*/CFeeRate(0));
     // larger denoms first
@@ -233,9 +231,8 @@ bool CWallet::HasCollateralInputs(bool fOnlyConfirmed) const
     LOCK(cs_wallet);
 
     std::vector<COutput> vCoins;
-    CCoinControl coin_control;
+    CCoinControl coin_control(CoinType::ONLY_COINJOIN_COLLATERAL);
     coin_control.m_include_unsafe_inputs = !fOnlyConfirmed;
-    coin_control.nCoinType = CoinType::ONLY_COINJOIN_COLLATERAL;
     AvailableCoinsListUnspent(*this, vCoins, &coin_control);
 
     return !vCoins.empty();

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -19,9 +19,7 @@ static constexpr CAmount CHANGE_LOWER{50000};
 static constexpr CAmount CHANGE_UPPER{1000000};
 
 /** A UTXO under consideration for use in funding a new transaction. */
-class COutput
-{
-public:
+struct COutput {
     /** The outpoint identifying this UTXO */
     COutPoint outpoint;
 
@@ -67,21 +65,22 @@ public:
     CAmount long_term_fee{0};
 
     COutput(const COutPoint& outpoint, const CTxOut& txout, int depth, int input_bytes, bool spendable, bool solvable, bool safe, int64_t time, bool from_me)
-        : outpoint(outpoint),
-        txout(txout),
-        depth(depth),
-        input_bytes(input_bytes),
-        spendable(spendable),
-        solvable(solvable),
-        safe(safe),
-        time(time),
-        from_me(from_me),
-        effective_value(txout.nValue)
+        : outpoint{outpoint},
+          txout{txout},
+          depth{depth},
+          input_bytes{input_bytes},
+          spendable{spendable},
+          solvable{solvable},
+          safe{safe},
+          time{time},
+          from_me{from_me},
+          effective_value{txout.nValue}
     {}
 
     std::string ToString() const;
 
-    bool operator<(const COutput& rhs) const {
+    bool operator<(const COutput& rhs) const
+    {
         return outpoint < rhs.outpoint;
     }
 };

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -129,7 +129,7 @@ WalletTxOut MakeWalletTxOut(const CWallet& wallet,
     result.txout = wtx.tx->vout[n];
     result.time = wtx.GetTxTime();
     result.depth_in_main_chain = depth;
-    result.is_spent = wallet.IsSpent(wtx.GetHash(), n);
+    result.is_spent = wallet.IsSpent(COutPoint(wtx.GetHash(), n));
     return result;
 }
 
@@ -140,7 +140,7 @@ WalletTxOut MakeWalletTxOut(const CWallet& wallet,
     result.txout = output.txout;
     result.time = output.time;
     result.depth_in_main_chain = output.depth;
-    result.is_spent = wallet.IsSpent(output.outpoint.hash, output.outpoint.n);
+    result.is_spent = wallet.IsSpent(output.outpoint);
     return result;
 }
 
@@ -272,7 +272,7 @@ public:
     bool isLockedCoin(const COutPoint& output) override
     {
         LOCK(m_wallet->cs_wallet);
-        return m_wallet->IsLockedCoin(output.hash, output.n);
+        return m_wallet->IsLockedCoin(output);
     }
     std::vector<COutPoint> listLockedCoins() override
     {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -628,10 +628,13 @@ public:
         options.require_existing = true;
         return MakeWallet(m_context, LoadWallet(m_context, name, true /* load_on_start */, options, status, error, warnings));
     }
-    std::unique_ptr<Wallet> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bilingual_str& error, std::vector<bilingual_str>& warnings) override
+    BResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) override
     {
         DatabaseStatus status;
-        return MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings));
+        bilingual_str error;
+        BResult<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings))};
+        if (!wallet) return error;
+        return wallet;
     }
     std::string getWalletDir() override
     {

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -133,6 +133,8 @@ bool LoadWallets(WalletContext& context)
                 chain.initError(error_string);
                 return false;
             }
+
+            NotifyWalletLoaded(context, pwallet);
             AddWallet(context, pwallet);
         }
         return true;

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -179,10 +179,9 @@ CAmount CachedTxGetAvailableCredit(const CWallet& wallet, const CWalletTx& wtx, 
     bool allow_used_addresses = (filter & ISMINE_USED) || !wallet.IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE);
     CAmount nCredit = 0;
     uint256 hashTx = wtx.GetHash();
-    for (unsigned int i = 0; i < wtx.tx->vout.size(); i++)
-    {
-        if (!wallet.IsSpent(hashTx, i) && (allow_used_addresses || !wallet.IsSpentKey(hashTx, i))) {
-            const CTxOut &txout = wtx.tx->vout[i];
+    for (unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
+        const CTxOut& txout = wtx.tx->vout[i];
+        if (!wallet.IsSpent(COutPoint(hashTx, i)) && (allow_used_addresses || !wallet.IsSpentKey(txout.scriptPubKey))) {
             nCredit += OutputGetCredit(wallet, txout, filter);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error(std::string(__func__) + ": value out of range");
@@ -357,15 +356,15 @@ std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet)
             if (nDepth < (CachedTxIsFromMe(wallet, wtx, ISMINE_ALL) ? 0 : 1) && !wallet.IsTxLockedByInstantSend(wtx))
                 continue;
 
-            for (unsigned int i = 0; i < wtx.tx->vout.size(); i++)
-            {
+            for (unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
+                const auto& output = wtx.tx->vout[i];
                 CTxDestination addr;
-                if (!wallet.IsMine(wtx.tx->vout[i]))
+                if (!wallet.IsMine(output))
                     continue;
-                if(!ExtractDestination(wtx.tx->vout[i].scriptPubKey, addr))
+                if(!ExtractDestination(output.scriptPubKey, addr))
                     continue;
 
-                CAmount n = wallet.IsSpent(walletEntry.first, i) ? 0 : wtx.tx->vout[i].nValue;
+                CAmount n = wallet.IsSpent(COutPoint(walletEntry.first, i)) ? 0 : output.nValue;
                 balances[addr] += n;
             }
         }

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -116,12 +116,10 @@ CAmount CachedTxGetCredit(const CWallet& wallet, const CWalletTx& wtx, const ism
         return 0;
 
     CAmount credit = 0;
-    if (filter & ISMINE_SPENDABLE) {
+    const isminefilter get_amount_filter{filter & ISMINE_ALL};
+    if (get_amount_filter) {
         // GetBalance can assume transactions in mapWallet won't change
-        credit += GetCachableAmount(wallet, wtx, CWalletTx::CREDIT, ISMINE_SPENDABLE);
-    }
-    if (filter & ISMINE_WATCH_ONLY) {
-        credit += GetCachableAmount(wallet, wtx, CWalletTx::CREDIT, ISMINE_WATCH_ONLY);
+        credit += GetCachableAmount(wallet, wtx, CWalletTx::CREDIT, get_amount_filter);
     }
     return credit;
 }
@@ -132,11 +130,9 @@ CAmount CachedTxGetDebit(const CWallet& wallet, const CWalletTx& wtx, const ismi
         return 0;
 
     CAmount debit = 0;
-    if (filter & ISMINE_SPENDABLE) {
-        debit += GetCachableAmount(wallet, wtx, CWalletTx::DEBIT, ISMINE_SPENDABLE);
-    }
-    if (filter & ISMINE_WATCH_ONLY) {
-        debit += GetCachableAmount(wallet, wtx, CWalletTx::DEBIT, ISMINE_WATCH_ONLY);
+    const isminefilter get_amount_filter{filter & ISMINE_ALL};
+    if (get_amount_filter) {
+        debit += GetCachableAmount(wallet, wtx, CWalletTx::DEBIT, get_amount_filter);
     }
     return debit;
 }

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -806,7 +806,7 @@ RPCHelpMan importelectrumwallet()
     if (!reserver.reserve()) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait.");
     }
-    pwallet->ScanForWalletTransactions(pwallet->chain().getBlockHash(nStartHeight), nStartHeight, {}, reserver, true);
+    pwallet->ScanForWalletTransactions(pwallet->chain().getBlockHash(nStartHeight), nStartHeight, {}, reserver, /*fUpdate=*/true, /*save_progress=*/false);
 
     if (!fGood)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -603,8 +603,7 @@ RPCHelpMan listunspent()
     CAmount nMaximumAmount = MAX_MONEY;
     CAmount nMinimumSumAmount = MAX_MONEY;
     uint64_t nMaximumCount = 0;
-    CCoinControl coinControl;
-    coinControl.nCoinType = CoinType::ALL_COINS;
+    CCoinControl coinControl(CoinType::ALL_COINS);
 
     if (!request.params[4].isNull()) {
         const UniValue& options = request.params[4].get_obj();

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -660,7 +660,7 @@ RPCHelpMan listunspent()
         coinControl.m_include_unsafe_inputs = include_unsafe;
 
         LOCK(pwallet->cs_wallet);
-        AvailableCoins(*pwallet, vecOutputs, &coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount);
+        AvailableCoinsListUnspent(*pwallet, vecOutputs, &coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount);
     }
 
     LOCK(pwallet->cs_wallet);

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -347,11 +347,11 @@ RPCHelpMan lockunspent()
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout index out of bounds");
         }
 
-        if (pwallet->IsSpent(outpt.hash, outpt.n)) {
+        if (pwallet->IsSpent(outpt)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected unspent output");
         }
 
-        const bool is_locked = pwallet->IsLockedCoin(outpt.hash, outpt.n);
+        const bool is_locked = pwallet->IsLockedCoin(outpt);
 
         if (fUnlock && !is_locked) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected locked output");
@@ -659,7 +659,7 @@ RPCHelpMan listunspent()
         coinControl.m_include_unsafe_inputs = include_unsafe;
 
         LOCK(pwallet->cs_wallet);
-        AvailableCoinsListUnspent(*pwallet, vecOutputs, &coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount);
+        vecOutputs = AvailableCoinsListUnspent(*pwallet, &coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount).coins;
     }
 
     LOCK(pwallet->cs_wallet);
@@ -670,7 +670,7 @@ RPCHelpMan listunspent()
         CTxDestination address;
         const CScript& scriptPubKey = out.txout.scriptPubKey;
         bool fValidAddress = ExtractDestination(scriptPubKey, address);
-        bool reused = avoid_reuse && pwallet->IsSpentKey(out.outpoint.hash, out.outpoint.n);
+        bool reused = avoid_reuse && pwallet->IsSpentKey(scriptPubKey);
 
         if (destinations.size() && (!fValidAddress || !destinations.count(address)))
             continue;

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -909,7 +909,7 @@ RPCHelpMan rescanblockchain()
     }
 
     CWallet::ScanResult result =
-        pwallet->ScanForWalletTransactions(start_block, start_height, stop_height, reserver, true /* fUpdate */);
+        pwallet->ScanForWalletTransactions(start_block, start_height, stop_height, reserver, /*fUpdate=*/true, /*save_progress=*/false);
     switch (result.status) {
     case CWallet::ScanResult::SUCCESS:
         break;

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -423,7 +423,7 @@ static RPCHelpMan upgradetohd()
         if (!reserver.reserve()) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait.");
         }
-        CWallet::ScanResult result = pwallet->ScanForWalletTransactions(pwallet->chain().getBlockHash(0), 0, {}, reserver, true);
+        CWallet::ScanResult result = pwallet->ScanForWalletTransactions(pwallet->chain().getBlockHash(0), 0, {}, reserver, /*fUpdate=*/true, /*save_progress=*/false);
         switch (result.status) {
         case CWallet::ScanResult::SUCCESS:
             break;

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -216,14 +216,13 @@ CoinsResult AvailableCoinsListUnspent(const CWallet& wallet, const CCoinControl*
 CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl)
 {
     LOCK(wallet.cs_wallet);
-    return AvailableCoins(wallet,
-                          coinControl,
-                          std::nullopt, /*feerate=*/
-                          1,            /*nMinimumAmount*/
-                          MAX_MONEY,    /*nMaximumAmount*/
-                          MAX_MONEY,    /*nMinimumSumAmount*/
-                          0             /*nMaximumCount*/
-                          ).total_amount;
+    return AvailableCoins(wallet, coinControl,
+            /*feerate=*/ std::nullopt,
+            /*nMinimumAmount=*/ 1,
+            /*nMaximumAmount=*/ MAX_MONEY,
+            /*nMinimumSumAmount=*/ MAX_MONEY,
+            /*nMaximumCount=*/ 0
+    ).total_amount;
 }
 
 const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const CTransaction& tx, int output)

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -67,14 +67,20 @@ int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wall
     return CalculateMaximumSignedTxSize(tx, wallet, txouts, use_max_sig);
 }
 
-void AvailableCoins(const CWallet& wallet, std::vector<COutput>& vCoins, const CCoinControl* coinControl, std::optional<CFeeRate> feerate, const CAmount& nMinimumAmount, const CAmount& nMaximumAmount, const CAmount& nMinimumSumAmount, const uint64_t nMaximumCount)
+CoinsResult AvailableCoins(const CWallet& wallet,
+                           const CCoinControl* coinControl,
+                           std::optional<CFeeRate> feerate,
+                           const CAmount& nMinimumAmount,
+                           const CAmount& nMaximumAmount,
+                           const CAmount& nMinimumSumAmount,
+                           const uint64_t nMaximumCount,
+                           bool only_spendable)
 {
     AssertLockHeld(wallet.cs_wallet);
 
-    vCoins.clear();
     CoinType nCoinType = coinControl ? coinControl->nCoinType : CoinType::ALL_COINS;
 
-    CAmount nTotal = 0;
+    CoinsResult result;
     // Either the WALLET_FLAG_AVOID_REUSE flag is not set (in which case we always allow), or we default to avoiding, and only in the case where
     // a coin control object is provided, and has the avoid address reuse flag set to false, do we allow already used addresses
     bool allow_used_addresses = !wallet.IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE) || (coinControl && !coinControl->m_avoid_address_reuse);
@@ -110,30 +116,33 @@ void AvailableCoins(const CWallet& wallet, std::vector<COutput>& vCoins, const C
         bool tx_from_me = CachedTxIsFromMe(wallet, wtx, ISMINE_ALL);
 
         for (unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
+            const CTxOut& output = wtx.tx->vout[i];
+            const COutPoint outpoint(wtxid, i);
+
             bool found = false;
             switch (nCoinType) {
                 case CoinType::ONLY_FULLY_MIXED: {
-                    found = CoinJoin::IsDenominatedAmount(wtx.tx->vout[i].nValue) &&
-                            wallet.IsFullyMixed(COutPoint(wtxid, i));
+                    found = CoinJoin::IsDenominatedAmount(output.nValue) &&
+                            wallet.IsFullyMixed(outpoint);
                     break;
                 }
                 case CoinType::ONLY_READY_TO_MIX: {
-                    found = CoinJoin::IsDenominatedAmount(wtx.tx->vout[i].nValue) &&
-                            !wallet.IsFullyMixed(COutPoint(wtxid, i));
+                    found = CoinJoin::IsDenominatedAmount(output.nValue) &&
+                            !wallet.IsFullyMixed(outpoint);
                     break;
                 }
                 case CoinType::ONLY_NONDENOMINATED: {
                     // NOTE: do not use collateral amounts
-                    found = !CoinJoin::IsCollateralAmount(wtx.tx->vout[i].nValue) &&
-                            !CoinJoin::IsDenominatedAmount(wtx.tx->vout[i].nValue);
+                    found = !CoinJoin::IsCollateralAmount(output.nValue) &&
+                            !CoinJoin::IsDenominatedAmount(output.nValue);
                     break;
                 }
                 case CoinType::ONLY_MASTERNODE_COLLATERAL: {
-                    found = dmn_types::IsCollateralAmount(wtx.tx->vout[i].nValue);
+                    found = dmn_types::IsCollateralAmount(output.nValue);
                     break;
                 }
                 case CoinType::ONLY_COINJOIN_COLLATERAL: {
-                    found = CoinJoin::IsCollateralAmount(wtx.tx->vout[i].nValue);
+                    found = CoinJoin::IsCollateralAmount(output.nValue);
                     break;
                 }
                 case CoinType::ALL_COINS: {
@@ -144,75 +153,77 @@ void AvailableCoins(const CWallet& wallet, std::vector<COutput>& vCoins, const C
             if(!found) continue;
 
             // Only consider selected coins if add_inputs is false
-            if (coinControl && !coinControl->m_add_inputs && !coinControl->IsSelected(COutPoint(wtxid, i))) {
+            if (coinControl && !coinControl->m_add_inputs && !coinControl->IsSelected(outpoint)) {
                 continue;
             }
 
-            if (wtx.tx->vout[i].nValue < nMinimumAmount || wtx.tx->vout[i].nValue > nMaximumAmount)
+            if (output.nValue < nMinimumAmount || output.nValue > nMaximumAmount)
                 continue;
 
-            if (coinControl && coinControl->HasSelected() && !coinControl->fAllowOtherInputs && !coinControl->IsSelected(COutPoint(wtxid, i)))
+            if (coinControl && coinControl->HasSelected() && !coinControl->fAllowOtherInputs && !coinControl->IsSelected(outpoint))
                 continue;
 
-            if (wallet.IsLockedCoin(wtxid, i) && nCoinType != CoinType::ONLY_MASTERNODE_COLLATERAL)
+            if (wallet.IsLockedCoin(outpoint) && nCoinType != CoinType::ONLY_MASTERNODE_COLLATERAL)
                 continue;
 
-            if (wallet.IsSpent(wtxid, i))
+            if (wallet.IsSpent(outpoint))
                 continue;
 
-            isminetype mine = wallet.IsMine(wtx.tx->vout[i]);
+            isminetype mine = wallet.IsMine(output);
 
             if (mine == ISMINE_NO) {
                 continue;
             }
 
-            if (!allow_used_addresses && wallet.IsSpentKey(wtxid, i)) {
+            if (!allow_used_addresses && wallet.IsSpentKey(output.scriptPubKey)) {
                 continue;
             }
 
-            std::unique_ptr<SigningProvider> provider = wallet.GetSolvingProvider(wtx.tx->vout[i].scriptPubKey);
+            std::unique_ptr<SigningProvider> provider = wallet.GetSolvingProvider(output.scriptPubKey);
 
-            bool solvable = provider ? IsSolvable(*provider, wtx.tx->vout[i].scriptPubKey) : false;
+            bool solvable = provider ? IsSolvable(*provider, output.scriptPubKey) : false;
             bool spendable = ((mine & ISMINE_SPENDABLE) != ISMINE_NO) || (((mine & ISMINE_WATCH_ONLY) != ISMINE_NO) && (coinControl && coinControl->fAllowWatchOnly && solvable));
-            int input_bytes = GetTxSpendSize(wallet, wtx, i, (coinControl && coinControl->fAllowWatchOnly));
 
-            vCoins.emplace_back(COutPoint(wtx.GetHash(), i), wtx.tx->vout.at(i), nDepth, input_bytes, spendable, solvable, safeTx, wtx.GetTxTime(), tx_from_me, feerate);
+            // Filter by spendable outputs only
+            if (!spendable && only_spendable) continue;
+
+            int input_bytes = GetTxSpendSize(wallet, wtx, i, (coinControl && coinControl->fAllowWatchOnly));
+            result.coins.emplace_back(outpoint, output, nDepth, input_bytes, spendable, solvable, safeTx, wtx.GetTxTime(), tx_from_me, feerate);
+            result.total_amount += output.nValue;
 
             // Checks the sum amount of all UTXO's.
             if (nMinimumSumAmount != MAX_MONEY) {
-                nTotal += wtx.tx->vout[i].nValue;
-
-                if (nTotal >= nMinimumSumAmount) {
-                    return;
+                if (result.total_amount >= nMinimumSumAmount) {
+                    return result;
                 }
             }
 
             // Checks the maximum number of UTXO's.
-            if (nMaximumCount > 0 && vCoins.size() >= nMaximumCount) {
-                return;
+            if (nMaximumCount > 0 && result.coins.size() >= nMaximumCount) {
+                return result;
             }
         }
     }
+
+    return result;
 }
 
-void AvailableCoinsListUnspent(const CWallet& wallet, std::vector<COutput>& vCoins, const CCoinControl* coinControl, const CAmount& nMinimumAmount, const CAmount& nMaximumAmount, const CAmount& nMinimumSumAmount, const uint64_t nMaximumCount)
+CoinsResult AvailableCoinsListUnspent(const CWallet& wallet, const CCoinControl* coinControl, const CAmount& nMinimumAmount, const CAmount& nMaximumAmount, const CAmount& nMinimumSumAmount, const uint64_t nMaximumCount)
 {
-    AvailableCoins(wallet, vCoins, coinControl, /*feerate=*/ std::nullopt, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount);
+    return AvailableCoins(wallet, coinControl, /*feerate=*/ std::nullopt, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, /*only_spendable=*/false);
 }
 
 CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl)
 {
     LOCK(wallet.cs_wallet);
-
-    CAmount balance = 0;
-    std::vector<COutput> vCoins;
-    AvailableCoinsListUnspent(wallet, vCoins, coinControl);
-    for (const COutput& out : vCoins) {
-        if (out.spendable) {
-            balance += out.txout.nValue;
-        }
-    }
-    return balance;
+    return AvailableCoins(wallet,
+                          coinControl,
+                          std::nullopt, /*feerate=*/
+                          1,            /*nMinimumAmount*/
+                          MAX_MONEY,    /*nMaximumAmount*/
+                          MAX_MONEY,    /*nMinimumSumAmount*/
+                          0             /*nMaximumCount*/
+                          ).total_amount;
 }
 
 const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const CTransaction& tx, int output)
@@ -244,11 +255,8 @@ std::map<CTxDestination, std::vector<COutput>> ListCoins(const CWallet& wallet)
     AssertLockHeld(wallet.cs_wallet);
 
     std::map<CTxDestination, std::vector<COutput>> result;
-    std::vector<COutput> availableCoins;
 
-    AvailableCoinsListUnspent(wallet, availableCoins);
-
-    for (const COutput& coin : availableCoins) {
+    for (const COutput& coin : AvailableCoinsListUnspent(wallet).coins) {
         CTxDestination address;
         if ((coin.spendable || (wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && coin.solvable)) &&
             ExtractDestination(FindNonChangeParentOutput(wallet, coin.outpoint).scriptPubKey, address)) {
@@ -784,11 +792,16 @@ static bool CreateTransactionInternal(
     CAmount selection_target = recipients_sum + not_input_fees;
 
     // Get available coins
-    std::vector<COutput> vAvailableCoins;
-    AvailableCoins(wallet, vAvailableCoins, &coin_control, coin_selection_params.m_effective_feerate, 1, MAX_MONEY, MAX_MONEY, 0);
+    auto res_available_coins = AvailableCoins(wallet,
+                                              &coin_control,
+                                              coin_selection_params.m_effective_feerate,
+                                              1,            /*nMinimumAmount*/
+                                              MAX_MONEY,    /*nMaximumAmount*/
+                                              MAX_MONEY,    /*nMinimumSumAmount*/
+                                              0);           /*nMaximumCount*/
 
     // Choose coins to use
-    std::optional<SelectionResult> result = SelectCoins(wallet, vAvailableCoins, /* nTargetValue */ selection_target, coin_control, coin_selection_params);
+    std::optional<SelectionResult> result = SelectCoins(wallet, res_available_coins.coins, /* nTargetValue */ selection_target, coin_control, coin_selection_params);
     if (!result) {
         if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
             error = _("Unable to locate enough non-denominated funds for this transaction.");

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -26,16 +26,29 @@ int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* pwallet,
 int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, bool use_max_sig = false) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
 int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, const std::vector<CTxOut>& txouts, bool use_max_sig = false);
 
+struct CoinsResult {
+    std::vector<COutput> coins;
+    // Sum of all the coins amounts
+    CAmount total_amount{0};
+};
 /**
- * populate vCoins with vector of available COutputs.
+ * Return vector of available COutputs.
+ * By default, returns only the spendable coins.
  */
-void AvailableCoins(const CWallet& wallet, std::vector<COutput>& vCoins, const CCoinControl* coinControl = nullptr, std::optional<CFeeRate> feerate = std::nullopt, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+CoinsResult AvailableCoins(const CWallet& wallet,
+                           const CCoinControl* coinControl = nullptr,
+                           std::optional<CFeeRate> feerate = std::nullopt,
+                           const CAmount& nMinimumAmount = 1,
+                           const CAmount& nMaximumAmount = MAX_MONEY,
+                           const CAmount& nMinimumSumAmount = MAX_MONEY,
+                           const uint64_t nMaximumCount = 0,
+                           bool only_spendable = true) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 /**
  * Wrapper function for AvailableCoins which skips the `feerate` parameter. Use this function
  * to list all available coins (e.g. listunspent RPC) while not intending to fund a transaction.
  */
-void AvailableCoinsListUnspent(const CWallet& wallet, std::vector<COutput>& vCoins, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+CoinsResult AvailableCoinsListUnspent(const CWallet& wallet, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl = nullptr);
 

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -29,7 +29,13 @@ int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wall
 /**
  * populate vCoins with vector of available COutputs.
  */
-void AvailableCoins(const CWallet& wallet, std::vector<COutput>& vCoins, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+void AvailableCoins(const CWallet& wallet, std::vector<COutput>& vCoins, const CCoinControl* coinControl = nullptr, std::optional<CFeeRate> feerate = std::nullopt, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+
+/**
+ * Wrapper function for AvailableCoins which skips the `feerate` parameter. Use this function
+ * to list all available coins (e.g. listunspent RPC) while not intending to fund a transaction.
+ */
+void AvailableCoinsListUnspent(const CWallet& wallet, std::vector<COutput>& vCoins, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl = nullptr);
 

--- a/src/wallet/test/bip39_tests.cpp
+++ b/src/wallet/test/bip39_tests.cpp
@@ -60,6 +60,6 @@ BOOST_AUTO_TEST_CASE(bip39_vectors)
         BOOST_CHECK(EncodeExtKey(key) == test[3].get_str());
     }
 }
-} // namespace wallet
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -150,7 +150,7 @@ public:
         reserver.reserve();
         CWallet::ScanResult result = wallet->ScanForWalletTransactions(/*start_block=*/wallet->chain().getBlockHash(0),
                                                                        /*start_height=*/0, /*max_height=*/{}, reserver,
-                                                                       /*fUpdate=*/true);
+                                                                       /*fUpdate=*/true, /*save_progress=*/false);
         BOOST_CHECK_EQUAL(result.status, CWallet::ScanResult::SUCCESS);
     }
 

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -315,6 +315,6 @@ BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
         BOOST_CHECK(vecOutputs.size() == 0);
     }
 }
-} // namespace wallet
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -870,6 +870,6 @@ BOOST_AUTO_TEST_CASE(waste_test)
     add_coin(2 * COIN, 2, selection, fee, fee + large_fee_diff);
     BOOST_CHECK_EQUAL(target_waste2, GetSelectionWaste(selection, change_cost, target));
 }
-} // namespace wallet
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, interfaces
     }
     WalletRescanReserver reserver(*wallet);
     reserver.reserve();
-    CWallet::ScanResult result = wallet->ScanForWalletTransactions(cchain.Genesis()->GetBlockHash(), 0 /* start_height */, {} /* max_height */, reserver, false /* update */);
+    CWallet::ScanResult result = wallet->ScanForWalletTransactions(cchain.Genesis()->GetBlockHash(), /*start_height=*/0, /*max_height=*/{}, reserver, /*fUpdate=*/false, /*save_progress=*/false);
     BOOST_CHECK_EQUAL(result.status, CWallet::ScanResult::SUCCESS);
     BOOST_CHECK_EQUAL(result.last_scanned_block, cchain.Tip()->GetBlockHash());
     BOOST_CHECK_EQUAL(*result.last_scanned_height, cchain.Height());

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -599,7 +599,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     {
         LOCK(wallet->cs_wallet);
         std::vector<COutput> available;
-        AvailableCoins(*wallet, available);
+        AvailableCoinsListUnspent(*wallet, available);
         BOOST_CHECK_EQUAL(available.size(), 2U);
     }
     for (const auto& group : list) {
@@ -611,7 +611,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     {
         LOCK(wallet->cs_wallet);
         std::vector<COutput> available;
-        AvailableCoins(*wallet, available);
+        AvailableCoinsListUnspent(*wallet, available);
         BOOST_CHECK_EQUAL(available.size(), 0U);
     }
     // Confirm ListCoins still returns same result as before, despite coins
@@ -1292,7 +1292,7 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
         std::vector<COutput> vecAvailable;
         {
             LOCK(wallet->cs_wallet);
-            AvailableCoins(*wallet, vecAvailable);
+            AvailableCoinsListUnspent(*wallet, vecAvailable);
             for (auto coin : vecAvailable) {
                 if (std::find(setCoins.begin(), setCoins.end(), coin.outpoint) == setCoins.end()) {
                     wallet->LockCoin(coin.outpoint);
@@ -1350,7 +1350,7 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
             std::vector<COutput> vecAvailable;
             {
                 LOCK(wallet->cs_wallet);
-                AvailableCoins(*wallet, vecAvailable);
+                AvailableCoinsListUnspent(*wallet, vecAvailable);
                 for (auto coin : vecAvailable) {
                     wallet->LockCoin(coin.outpoint);
                 }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -598,9 +598,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     // Lock both coins. Confirm number of available coins drops to 0.
     {
         LOCK(wallet->cs_wallet);
-        std::vector<COutput> available;
-        AvailableCoinsListUnspent(*wallet, available);
-        BOOST_CHECK_EQUAL(available.size(), 2U);
+        BOOST_CHECK_EQUAL(AvailableCoinsListUnspent(*wallet).coins.size(), 2U);
     }
     for (const auto& group : list) {
         for (const auto& coin : group.second) {
@@ -610,9 +608,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     }
     {
         LOCK(wallet->cs_wallet);
-        std::vector<COutput> available;
-        AvailableCoinsListUnspent(*wallet, available);
-        BOOST_CHECK_EQUAL(available.size(), 0U);
+        BOOST_CHECK_EQUAL(AvailableCoinsListUnspent(*wallet).coins.size(), 0U);
     }
     // Confirm ListCoins still returns same result as before, despite coins
     // being locked.
@@ -1289,11 +1285,9 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
                                   {1100, false}, {1200, false}, {1300, false}, {1400, false}, {1500, false},
                                   {3000, false}, {3000, false}, {2000, false}, {2000, false}, {1000, false}});
         // Lock all other coins which were already in the wallet
-        std::vector<COutput> vecAvailable;
         {
             LOCK(wallet->cs_wallet);
-            AvailableCoinsListUnspent(*wallet, vecAvailable);
-            for (auto coin : vecAvailable) {
+            for (auto coin : AvailableCoinsListUnspent(*wallet).coins) {
                 if (std::find(setCoins.begin(), setCoins.end(), coin.outpoint) == setCoins.end()) {
                     wallet->LockCoin(coin.outpoint);
                 }
@@ -1347,11 +1341,9 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
         // First try to send something without any coins available
         {
             // Lock all other coins
-            std::vector<COutput> vecAvailable;
             {
                 LOCK(wallet->cs_wallet);
-                AvailableCoinsListUnspent(*wallet, vecAvailable);
-                for (auto coin : vecAvailable) {
+                for (auto coin : AvailableCoinsListUnspent(*wallet).coins) {
                     wallet->LockCoin(coin.outpoint);
                 }
             }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -67,6 +67,7 @@ static const std::shared_ptr<CWallet> TestLoadWallet(WalletContext& context)
         // TODO: see CreateWalletWithoutChain
         AddWallet(context, wallet);
     }
+    NotifyWalletLoaded(context, wallet);
     if (context.chain) {
         wallet->postInitProcess();
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1782,8 +1782,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         WalletLogPrintf("Rescan interrupted by shutdown request at block %d. Progress=%f\n", block_height, progress_current);
         result.status = ScanResult::USER_ABORT;
     } else {
-        auto duration_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(reserver.now() - start_time);
-        WalletLogPrintf("Rescan completed in %15dms\n", duration_milliseconds.count());
+        WalletLogPrintf("Rescan completed in %15dms\n", Ticks<std::chrono::milliseconds>(reserver.now() - start_time));
     }
     return result;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -390,25 +390,31 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
     ReadDatabaseArgs(*context.args, options);
     options.require_existing = true;
 
-    if (!fs::exists(backup_file)) {
-        error = Untranslated("Backup file does not exist");
-        status = DatabaseStatus::FAILED_INVALID_BACKUP_FILE;
-        return nullptr;
-    }
-
     const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::u8path(wallet_name));
-
-    if (fs::exists(wallet_path) || !TryCreateDirectories(wallet_path)) {
-        error = Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(wallet_path)));
-        status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-        return nullptr;
-    }
-
     auto wallet_file = wallet_path / "wallet.dat";
-    fs::copy_file(backup_file, wallet_file, fs::copy_options::none);
+    std::shared_ptr<CWallet> wallet;
 
-    auto wallet = LoadWallet(context, wallet_name, load_on_start, options, status, error, warnings);
+    try {
+        if (!fs::exists(backup_file)) {
+            error = Untranslated("Backup file does not exist");
+            status = DatabaseStatus::FAILED_INVALID_BACKUP_FILE;
+            return nullptr;
+        }
 
+        if (fs::exists(wallet_path) || !TryCreateDirectories(wallet_path)) {
+            error = Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(wallet_path)));
+            status = DatabaseStatus::FAILED_ALREADY_EXISTS;
+            return nullptr;
+        }
+
+        fs::copy_file(backup_file, wallet_file, fs::copy_options::none);
+
+        wallet = LoadWallet(context, wallet_name, load_on_start, options, status, error, warnings);
+    } catch (const std::exception& e) {
+        assert(!wallet);
+        if (!error.empty()) error += Untranslated("\n");
+        error += strprintf(Untranslated("Unexpected exception: %s"), e.what());
+    }
     if (!wallet) {
         fs::remove(wallet_file);
         fs::remove(wallet_path);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -23,7 +23,6 @@
 #include <util/strencodings.h>
 #include <util/ui_change_type.h>
 #include <validationinterface.h>
-#include <wallet/coincontrol.h>
 #include <wallet/crypter.h>
 #include <wallet/coinselection.h>
 #include <wallet/scriptpubkeyman.h>
@@ -120,7 +119,6 @@ static constexpr size_t DUMMY_NESTED_P2PKH_INPUT_SIZE = 113;
 static const bool DEFAULT_USE_HD_WALLET = true;
 
 class CCoinControl;
-class COutput;
 class CWalletTx;
 class ReserveDestination;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -549,15 +549,15 @@ public:
     bool IsDenominated(const COutPoint& outpoint) const;
     bool IsFullyMixed(const COutPoint& outpoint) const;
 
-    bool IsSpent(const uint256& hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsSpent(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     // Whether this or any known UTXO with the same single key has been spent.
-    bool IsSpentKey(const uint256& hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsSpentKey(const CScript& scriptPubKey) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void SetSpentKeyState(WalletBatch& batch, const uint256& hash, unsigned int n, bool used, std::set<CTxDestination>& tx_destinations) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     void RecalculateMixedCredit(const uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    bool IsLockedCoin(uint256 hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsLockedCoin(const COutPoint& output) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool LockCoin(const COutPoint& output, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool UnlockCoin(const COutPoint& output, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool UnlockAllCoins() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -74,6 +74,7 @@ std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& n
 std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
 std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
+void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
 std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
 
 //! -paytxfee default

--- a/test/README.md
+++ b/test/README.md
@@ -103,7 +103,7 @@ test/functional/test_runner.py --extended
 In order to run backwards compatibility tests, download the previous node binaries:
 
 ```
-test/get_previous_releases.py -b v19.3.0 v18.2.2 v0.17.0.3 v0.16.1.1 v0.15.0.0
+test/get_previous_releases.py -b v19.3.0 v18.2.2 v0.17.0.3 v0.16.1.1 v0.15.0.0 v0.12.1.5
 ```
 
 By default, up to 4 tests will be run in parallel by test_runner. To specify

--- a/test/functional/feature_unsupported_utxo_db.py
+++ b/test/functional/feature_unsupported_utxo_db.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that unsupported utxo db causes an init error.
+
+Previous releases are required by this test, see test/README.md.
+"""
+
+import shutil
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class UnsupportedUtxoDbTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_previous_releases()
+
+    def setup_network(self):
+        self.add_nodes(
+            self.num_nodes,
+            versions=[
+                120105,  # Last release with previous utxo db format
+                None,    # For MiniWallet, without migration code
+            ],
+        )
+
+    def run_test(self):
+        self.log.info("Create previous version (v0.12.1.5) utxo db")
+        self.start_node(0)
+        # 'generatetoaddress' was introduced in v0.12.3, use legacy 'generate' call
+        block = self.nodes[0].rpc.generate(1)[-1]
+        assert_equal(self.nodes[0].getbestblockhash(), block)
+        assert_equal(self.nodes[0].gettxoutsetinfo()["total_amount"], 500)
+        self.stop_nodes()
+
+        self.log.info("Check init error")
+        legacy_utxos_dir = self.nodes[0].chain_path / "chainstate"
+        legacy_blocks_dir = self.nodes[0].chain_path / "blocks"
+        recent_utxos_dir = self.nodes[1].chain_path / "chainstate"
+        recent_blocks_dir = self.nodes[1].chain_path / "blocks"
+        shutil.copytree(legacy_utxos_dir, recent_utxos_dir)
+        shutil.copytree(legacy_blocks_dir, recent_blocks_dir)
+        self.nodes[1].assert_start_raises_init_error(
+            expected_msg="Error: Unsupported chainstate database format found. "
+            "Please restart with -reindex-chainstate. "
+            "This will rebuild the chainstate database.",
+        )
+
+        self.log.info("Drop legacy utxo db")
+        self.start_node(1, extra_args=["-reindex-chainstate", "-txindex=0"])
+        assert_equal(self.nodes[1].getbestblockhash(), block)
+        assert_equal(self.nodes[1].gettxoutsetinfo()["total_amount"], 500)
+
+
+if __name__ == "__main__":
+    UnsupportedUtxoDbTest().main()

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -131,6 +131,8 @@ class AuthServiceProxy():
             params = dict(args=args, **argsn)
         else:
             params = args or argsn
+            # v0.12.2.x and lower cannot make sense of objects, only arrays. If passing no arguments, use array.
+            params = [] if len(params) == 0 and isinstance(params, dict) else params
         return {'version': '1.1',
                 'method': self._service_name,
                 'params': params,

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -74,7 +74,8 @@ class AuthServiceProxy():
         self.ensure_ascii = ensure_ascii  # can be toggled on the fly by tests
         self.__url = urllib.parse.urlparse(service_url)
         user = None if self.__url.username is None else self.__url.username.encode('utf8')
-        passwd = None if self.__url.password is None else self.__url.password.encode('utf8')
+        # v0.12.1.x and lower used URL unsafe Base64 for their passwords, quote it
+        passwd = None if self.__url.password is None else urllib.parse.unquote(self.__url.password).encode('utf8')
         authpair = user + b':' + passwd
         self.__auth_header = b'Basic ' + base64.b64encode(authpair)
         # clamp the socket timeout, since larger values can cause an

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -17,6 +17,7 @@ import random
 import shutil
 import re
 import time
+import urllib.parse
 
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
@@ -364,6 +365,7 @@ def rpc_url(datadir, i, chain, rpchost=None):
             host, port = parts
         else:
             host = rpchost
+    rpc_p = urllib.parse.quote(rpc_p, safe='') # v0.12.1.x and lower used URL unsafe Base64 for their passwords, quote it
     return "http://%s:%s@%s:%d" % (rpc_u, rpc_p, host, int(port))
 
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -368,6 +368,7 @@ BASE_SCRIPTS = [
     'p2p_sendtxrcncl.py',
     'rpc_scantxoutset.py',
     'feature_txindex_compatibility.py',
+    'feature_unsupported_utxo_db.py',
     'feature_logging.py',
     'feature_anchors.py',
     'feature_coinstatsindex.py',

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -124,6 +124,15 @@ def download_binary(tag, args) -> int:
         platform = "win64"
     elif tag < "v20" and platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
         platform = "osx64"
+    elif tag < "v0.12.2.3":
+        if platform in ["arm-linux-gnueabihf"]:
+            platform = "RPi2"
+        elif platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
+            platform = "osx"
+        elif platform in ["i686-pc-linux-gnu"]:
+            platform = "linux32"
+        elif platform in ["x86_64-linux-gnu"]:
+            platform = "linux64"
     tarball = 'dashcore-{tag}-{platform}.tar.gz'.format(
         tag=tag[1:], platform=platform)
     tarballUrl = 'https://github.com/dashpay/dash/{bin_path}/{tarball}'.format(

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -118,7 +118,11 @@ def download_binary(tag, args) -> int:
         bin_path = 'releases/download/test.{}'.format(
             match.group(1), match.group(2))
     platform = args.platform
-    if tag < "v20" and platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
+    if platform in ["i686-w64-mingw32"]:
+        platform = "win32"
+    elif platform in ["x86_64-w64-mingw32"]:
+        platform = "win64"
+    elif tag < "v20" and platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
         platform = "osx64"
     tarball = 'dashcore-{tag}-{platform}.tar.gz'.format(
         tag=tag[1:], platform=platform)

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -19,7 +19,6 @@ import subprocess
 import sys
 import hashlib
 
-
 SHA256_SUMS = {
     "d1f7121a7d7bdd4077709284076860389d6a0f4481a934ad9acb85cae3d7b83e":  "dashcore-20.0.1-aarch64-linux-gnu.tar.gz",
     "37375229e5ab18d7050b729fb016df24acdd72d60bc3fa074270d89030a27827":  "dashcore-20.0.1-arm-linux-gnueabihf.tar.gz",
@@ -92,6 +91,15 @@ SHA256_SUMS = {
     "f532bc7e0360e80908eb6b9c3aeec7e0037e70e25dee3b040dbbf7a124e05619":  "dashcore-0.15.0.0-win64-setup.exe",
     "3ba6ff98113af30319fb1499d132d993633380476f9980443d630d21a40e0efb":  "dashcore-0.15.0.0-win64.zip",
     "4cc0815ebd595f3d0134a8df9e6224cbe3d79398a5a899b60ca5f4ab8a576160":  "dashcore-0.15.0.0-x86_64-linux-gnu.tar.gz",
+    #
+    "060c86587176ffcea5615ea46aa080152ea5ebd035d2a7e0340d312345c2eee0":  "dashcore-0.12.1.5-RPi2.tar.gz",
+    "369dee3e2ae8854592ca696fd5fd7314bc8bbdd865920407bc96d59acb06f81d":  "dashcore-0.12.1.5-linux32.tar.gz",
+    "81692699b99d64b50d1bb1db427f6a0d68c84b98d0e0152f854cfbe048c08fc4":  "dashcore-0.12.1.5-linux64.tar.gz",
+    "b4514d4a705cc1adb400ec0c69630612fe394508decd7bf3edef068021fc47b5":  "dashcore-0.12.1.5-osx.dmg",
+    "35eb7bd9f5883d986b32ae84ddd074566c9e01a438bddd0d147c4a1e96b81b02":  "dashcore-0.12.1.5-win32-setup.exe",
+    "2ea20e8671dcae6ed4f980b8b7dcaa1024961e0267956f4e8bd9eea31b0030e4":  "dashcore-0.12.1.5-win32.zip",
+    "db276b7697777203e98f93e1f498bdab0016f2a96f6454a56c51846120aae0b7":  "dashcore-0.12.1.5-win64-setup.exe",
+    "15ee0d8405609aaf70c31ff320b0468c86e7c6bc1f061ae90d6295a540576c39":  "dashcore-0.12.1.5-win64.zip",
 }
 
 


### PR DESCRIPTION
## Additional Information

* When backporting [bitcoin#23497](https://github.com/bitcoin/bitcoin/pull/23497) (see [dash#6732](https://github.com/dashpay/dash/pull/6732)), some `BOOST_AUTO_TEST_SUITE_END()`s were placed _outside_ the `wallet` namespace scope, which resulted in incorrect behavior when rebasing this pull request over [dash#6732](https://github.com/dashpay/dash/pull/6732). This has been resolved.

* Backports of [bitcoin#25083](https://github.com/bitcoin/bitcoin/pull/25083) and [bitcoin#25005](https://github.com/bitcoin/bitcoin/pull/25005) do not include changes to `wallet/rpc/spend.cpp` as the `sendall()` RPC has not been implemented in `develop` (f453998b) as of this writing.

* Backporting [bitcoin#24236](https://github.com/bitcoin/bitcoin/pull/24236) required a fair number of additional considerations, firstly because the pull request introduces a test, `feature_unsupported_utxo_db.py`, that requires the last-capable of version Dash Core to generate a legacy UTXO database (the current database format debuted in [dash#1701](https://github.com/dashpay/dash/pull/1701), included in v0.12.2.2) and secondly, because v0.15 is the earliest expected version of Dash Core to work smoothly with our test framework ([source](https://github.com/dashpay/dash/blob/f453998bb76dee8fe016138da664dc281fc7f1d3/test/functional/mempool_compatibility.py#L29)).

  As we require the last release cycle that generates the legacy UTXO database by default, we used the last version of the v0.12.1.x family, v0.12.1.5 as the old node used in `feature_unsupported_utxo_db.py`. This brings unique challenges which are elaborated on below.

  * The test framework relies on `generatetoaddress`, a wallet-independent RPC call that was introduced in [bitcoin#7671](https://github.com/bitcoin/bitcoin/pull/7671) to replace the old wallet-dependent `generate` RPC. It was backported as 760d58e3 in [dash#1790](https://github.com/dashpay/dash/pull/1790) and debuted in v0.12.3. We cannot use the `self.generate()` helper as simply dispatches a `generatetoaddress` ([source](https://github.com/dashpay/dash/blob/f453998bb76dee8fe016138da664dc281fc7f1d3/test/functional/test_framework/test_node.py#L343-L345)), which does not exist in v0.12.1.5.

    We work around this by using the more archaic `self.nodes[0].rpc.generate()`, in line with usage in `rpc_generate.py` ([source](https://github.com/dashpay/dash/blob/f453998bb76dee8fe016138da664dc281fc7f1d3/test/functional/rpc_generate.py#L25-L26)).

  * Releases before v0.12.3.x did not include the target triples in their naming convention (see tag [`v0.12.3.1`](https://github.com/dashpay/dash/releases/tag/v0.12.3.1) vs [`v0.12.1.5`](https://github.com/dashpay/dash/releases/tag/v0.12.1.5)), which causes problems when fetching packages based on the target `HOST` of the build environment. This has been remedied by introducing awareness for `RPi2`, `osx` and `linux{32,64}` labels.

    * Note, `RPi2` corresponds to `arm-linux-gnueabihf` based on the Gitian descriptor that was removed in [dash#2183](https://github.com/dashpay/dash/pull/2183) ([source](https://github.com/dashpay/dash/blob/dac090964fbdd96d896f725932aada71db736abf/contrib/gitian-descriptors/gitian-rpi2.yml#L26))

   * This was also taken as an opportunity to introduce awareness for the `win32` and `win64` labels which persist even now (see tag [`v22.1.2`](https://github.com/dashpay/dash/releases/tag/v22.1.2))

  * Currently, when we want to make RPC calls without arguments, a blank object is sent to by the RPC dispatcher. This is acceptable as objects are supported since [bitcoin#8811](https://github.com/bitcoin/bitcoin/pull/8811) (backported as eb7a6b08 in [dash#1851](https://github.com/dashpay/dash/pull/1858)), included in v0.12.3.

    Unfortunately, since we are dealing with a version of Dash that is ancient even by previous release standards, this prevents the dispatcher from even acknowledging the RPC server is active (see below).


    <details>
    
    <summary>Test failure:</summary>
    
    ```
    $ ./test/functional/feature_unsupported_utxo_db.py
    2025-06-24T15:06:53.642000Z TestFramework (INFO): PRNG seed is: 1995903613070947610
    2025-06-24T15:06:53.642000Z TestFramework (INFO): Initializing test directory /tmp/dash_func_test_1tqzf43o
    2025-06-24T15:06:53.642000Z TestFramework (INFO): Create previous version (v0.12.1.5) utxo db
    2025-06-24T15:06:53.895000Z TestFramework (ERROR): JSONRPC error
    Traceback (most recent call last):
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/test_framework.py", line 161, in main
        self.run_test()
      File "/home/eclair/Repositories/dashpay/dash/./test/functional/feature_unsupported_utxo_db.py", line 35, in run_test
        self.start_node(0)
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/test_framework.py", line 647, in start_node
        node.wait_for_rpc_connection()
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/test_node.py", line 276, in wait_for_rpc_connection
        rpc.getblockcount()
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/coverage.py", line 49, in __call__
        return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/authproxy.py", line 144, in __call__
        raise JSONRPCException(response['error'], status)
    test_framework.authproxy.JSONRPCException: Params must be an array (-32600)
    2025-06-24T15:06:53.947000Z TestFramework (INFO): Stopping nodes
    [...]
    ```
    
    </details>

      * This is worked around by dispatching an empty array instead of an empty object, it has the same practical effect (conveying the lack of arguments) and is forwards-compatible.

  * Currently, the password used for RPC authentication in Base16 encoded. This is a result of [dash#1454](https://github.com/dashpay/dash/pull/1454), which switched away from Base64. Unfortunately, this benefit only extends to v0.12.2.0 onwards, which is too new for the old node needed in our functional test.

    Worse still, it was not the URL-safe variant of Base64, so attempting to establish a connection with the old node resulted in sporadic failures (see below).

    <details>
    
    <summary>Test failure:</summary>
    
    ```
    $ ./test/functional/feature_unsupported_utxo_db.py
    2025-06-24T15:13:27.517000Z TestFramework (INFO): PRNG seed is: 3228606794541395700
    2025-06-24T15:13:27.518000Z TestFramework (INFO): Initializing test directory /tmp/dash_func_test_97d987gf
    2025-06-24T15:13:27.518000Z TestFramework (INFO): Create previous version (v0.12.1.5) utxo db
    2025-06-24T15:13:27.769000Z TestFramework (ERROR): Unexpected exception caught during testing
    Traceback (most recent call last):
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/test_framework.py", line 161, in main
        self.run_test()
      File "/home/eclair/Repositories/dashpay/dash/./test/functional/feature_unsupported_utxo_db.py", line 35, in run_test
        self.start_node(0)
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/test_framework.py", line 647, in start_node
        node.wait_for_rpc_connection()
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/test_node.py", line 270, in wait_for_rpc_connection
        rpc = get_rpc_proxy(
              ^^^^^^^^^^^^^^
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/util.py", line 341, in get_rpc_proxy
        proxy = AuthServiceProxy(url, **proxy_kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/eclair/Repositories/dashpay/dash/test/functional/test_framework/authproxy.py", line 78, in __init__
        authpair = user + b':' + passwd
                  ~~~~~^~~~~~
    TypeError: unsupported operand type(s) for +: 'NoneType' and 'bytes'
    2025-06-24T15:13:27.822000Z TestFramework (INFO): Stopping nodes
    [...]
    ```
    
    </details>

      * This is worked around by escaping URL special characters for the password field. It is practically a no-op for the Base16 passwords generated from v0.12.2.0 onwards but allows connection and authentication with older versions of Dash Core.

## How Has This Been Tested?

A full CoinJoin session run on 89cd4978c141

![CoinJoin session run on build 89cd4978c141](https://github.com/user-attachments/assets/29caa752-0103-490b-a0e1-56c1030105f2)

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
