### PR TITLE
perf: temporary cache for consequent calls of CDeterministicMNList for historical blocks

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -16,6 +16,7 @@
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
 #include <messagesigner.h>
+#include <node/blockstorage.h>
 #include <script/standard.h>
 #include <stats/client.h>
 #include <uint256.h>
@@ -778,7 +779,7 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlockInternal(gsl::not_n
     for (const auto& diffIndex : listDiffIndexes) {
         const auto& diff = mnListDiffsCache.at(diffIndex->GetBlockHash());
         snapshot.ApplyDiff(diffIndex, diff);
-        if (snapshot.GetHeight() % 32 == 0) {
+        if (!fReindex && snapshot.GetHeight() % 32 == 0) {
             // Add this temporary mini-snapshot to cache.
             // This extra cached mn-list helps to improve performance of GetListForBlock
             // for close blocks, because in the worst cases each of them requires to retrieve

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -778,6 +778,13 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlockInternal(gsl::not_n
     for (const auto& diffIndex : listDiffIndexes) {
         const auto& diff = mnListDiffsCache.at(diffIndex->GetBlockHash());
         snapshot.ApplyDiff(diffIndex, diff);
+        if (snapshot.GetHeight() % 32 == 0) {
+            // Add this temporary mini-snapshot to cache.
+            // This extra cached mn-list helps to improve performance of GetListForBlock
+            // for close blocks, because in the worst cases each of them requires to retrieve
+            // and apply up to 575 diffs
+            mnListsCache.emplace(snapshot.GetBlockHash(), snapshot);
+        }
     }
 
     if (tipIndex) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Each call of `CDeterministicMNManager::GetListForBlock` for historical block can require up to 575 diff applying from snapshot.
Consequent calls for close blocks repeat this calculation twice.


## What was done?
This PR abuses `mnListsCache` by adding mini-snapshot each 32 blocks between snapshots in database (each 576 blocks).

Downside of this solution: extra RAM usage.
Though, this cache is cleaned every 10 seconds by `CDeterministicMNManager::DoMaintenance`, so, the RAM usage is temporary.



## How Has This Been Tested?
It speeds up RPC `protx diff` up to 8x.
`develop`:
```
$ time ( for j in $(seq 500) ; do src/dash-cli protx diff $((2121000+$j)) $((2121000+$j+1)) ; done ) > /dev/null
real    0m47,743s
user    0m0,472s
sys     0m1,467s
```

PR:
```
$ time ( for j in $(seq 500) ; do src/dash-cli protx diff $((2121000+$j)) $((2121000+$j+1)) ; done ) > /dev/null
real    0m6,032s
user    0m0,423s
sys     0m1,300s
```

It speeds ups blocks's Undo up to 10x; measured by calling `invalidateblock blockhash` where blockhash is distant block, far from the tip (500+).

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone