### PR TITLE
docs: Fix broken links from translation instructions and a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Translations
 ------------
 
 Changes to translations as well as new translations can be submitted to
-[Dash Core's Transifex page](https://www.transifex.com/projects/p/dash/).
+[Dash Core's Transifex page](https://explore.transifex.com/dash/dash/).
 
 Translations are periodically pulled from Transifex and merged into the git repository. See the
 [translation process](doc/translation_process.md) for details on how this works.

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -8,7 +8,7 @@ Transifex is setup to monitor the GitHub repo for updates, and when code contain
 
 Multiple language support is critical in assisting Dash’s global adoption, and growth. One of Dash’s greatest strengths is cross-border money transfers, any help making that easier is greatly appreciated.
 
-See the [Transifex Dash project](https://www.transifex.com/projects/p/dash/) to assist in translations. You should also join the translation mailing list for announcements - see details below.
+See the [Transifex Dash project](https://explore.transifex.com/dash/dash/) to assist in translations. You should also join the translation mailing list for announcements - see details below.
 
 ### Writing code with translations
 We use automated scripts to help extract translations in both Qt, and non-Qt source files. It is rarely necessary to manually edit the files in `src/qt/locale/`. The translation source files must adhere to the following format:
@@ -40,12 +40,12 @@ git commit
 
 
 ### Creating a Transifex account
-Visit the [Transifex Signup](https://www.transifex.com/signup/) page to create an account. Take note of your username and password, as they will be required to configure the command-line tool.
+Visit the [Transifex Signup](https://app.transifex.com/signup/) page to create an account. Take note of your username and password, as they will be required to configure the command-line tool.
 
-You can find the Dash translation project at [https://www.transifex.com/projects/p/dash/](https://www.transifex.com/projects/p/dash/).
+You can find the Dash translation project at <https://explore.transifex.com/dash/dash/>.
 
 ### Installing the Transifex client command-line tool
-The client it used to fetch updated translations. If you are having problems, or need more details, see [http://docs.transifex.com/developer/client/setup](http://docs.transifex.com/developer/client/setup)
+The client is used to fetch updated translations. If you are having problems, or need more details, see <https://developers.transifex.com/docs/cli>.
 
 **For Linux and Mac**
 
@@ -65,7 +65,7 @@ username = USERNAME
 
 **For Windows**
 
-Please see [http://docs.transifex.com/developer/client/setup#windows](http://docs.transifex.com/developer/client/setup#windows) for details on installation.
+Please see <https://developers.transifex.com/docs/cli#download-from-github-releases-linuxmacwindows> for details on installation.
 
 The Transifex Dash project config file is included as part of the repo. It can be found at `.tx/config`, however you shouldn’t need to change anything.
 
@@ -105,4 +105,4 @@ To create a new language template, you will need to edit the languages manifest 
 **Note:** that the language translation file **must end in `.qm`** (the compiled extension), and not `.ts`.
 
 ### Questions and general assistance
-Check official forum at [https://www.dash.org/forum/topic/dash-worldwide-collaboration.88/](https://www.dash.org/forum/topic/dash-worldwide-collaboration.88/).
+Check official forum at <https://www.dash.org/forum/forums/dash-worldwide-collaboration.88/>.


### PR DESCRIPTION
It fixes broken links from the translation instructions and a typo.

## Issue being fixed or feature implemented

- Contributors won't be shown a broken link


## What was done?
Just replace the links and fix the typo.


## How Has This Been Tested?
I checked that the new links work fine.


## Breaking Changes

None


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

