### PR TITLE
feat: improve logging of non-existing destinations for masternode payment

### DIFF
--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -126,10 +126,14 @@ CAmount PlatformShare(const CAmount reward)
     for (const auto& txout : voutMasternodePayments) {
         bool found = ranges::any_of(txNew.vout, [&txout](const auto& txout2) {return txout == txout2;});
         if (!found) {
-            CTxDestination dest;
-            if (!ExtractDestination(txout.scriptPubKey, dest))
-                assert(false);
-            LogPrintf("CMNPaymentsProcessor::%s -- ERROR! Failed to find expected payee %s in block at height %s\n", __func__, EncodeDestination(dest), nBlockHeight);
+            std::string str_payout;
+            if (CTxDestination dest; ExtractDestination(txout.scriptPubKey, dest)) {
+                str_payout = EncodeDestination(dest);
+            } else {
+                str_payout = HexStr(txout.scriptPubKey);
+            }
+            LogPrintf("CMNPaymentsProcessor::%s -- ERROR! Failed to find expected payee %s in block at height %s\n",
+                      __func__, str_payout, nBlockHeight);
             return false;
         }
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
In case if destination is invalid for cbtx, the logs are missing

## What was done?
Improved logs for case if invalid destination


## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone