### PR TITLE
fix: remove useless but alarming log record about spent information

### DIFF
--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -26,11 +26,7 @@ bool GetAddressIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, co
     AssertLockHeld(::cs_main);
     EnsureAddressIndexAvailable();
 
-    if (!block_tree_db.ReadAddressIndex(addressHash, type, addressIndex, start, end)) {
-        return error("Unable to get txids for address");
-    }
-
-    return true;
+    return block_tree_db.ReadAddressIndex(addressHash, type, addressIndex, start, end);
 }
 
 bool GetAddressUnspentIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
@@ -40,7 +36,7 @@ bool GetAddressUnspentIndex(CBlockTreeDB& block_tree_db, const uint160& addressH
     EnsureAddressIndexAvailable();
 
     if (!block_tree_db.ReadAddressUnspentIndex(addressHash, type, unspentOutputs))
-        return error("Unable to get txids for address");
+        return false;
 
     if (height_sort) {
         std::sort(unspentOutputs.begin(), unspentOutputs.end(),
@@ -60,7 +56,7 @@ bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
     EnsureAddressIndexAvailable();
 
     if (!mempool.getAddressIndex(addressDeltaIndex, addressDeltaEntries))
-        return error("Unable to get address delta information");
+        return false;
 
     if (timestamp_sort) {
         std::sort(addressDeltaEntries.begin(), addressDeltaEntries.end(),
@@ -84,10 +80,7 @@ bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const
     if (mempool.getSpentIndex(key, value))
         return true;
 
-    if (!block_tree_db.ReadSpentIndex(key, value))
-        return error("Unable to get spend information");
-
-    return true;
+    return block_tree_db.ReadSpentIndex(key, value);
 }
 
 bool GetTimestampIndex(CBlockTreeDB& block_tree_db, const uint32_t high, const uint32_t low,
@@ -99,8 +92,5 @@ bool GetTimestampIndex(CBlockTreeDB& block_tree_db, const uint32_t high, const u
         throw JSONRPCError(RPC_INVALID_REQUEST, "Timestamp index is disabled. You should run Dash Core with -timestampindex (requires reindex)");
     }
 
-    if (!block_tree_db.ReadTimestampIndex(high, low, hashes))
-        return error("Unable to get hashes for timestamps");
-
-    return true;
+    return block_tree_db.ReadTimestampIndex(high, low, hashes);
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

https://github.com/dashpay/dash/issues/6539
https://github.com/dashpay/dash/issues/6651

These log records are useless because RPC can be called remotely for non-existing tx:

    2025-04-28T12:53:35Z ERROR: Unable to get spend information


## What was done?
Just removed error log for it.

## How Has This Been Tested?
Call RPC for non-existing transaction:

    getspentinfo '{"txid":"0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9", "index":0}'

## Breaking Changes
N/A

Changes are only log-related

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone