### PR TITLE
ci: add dedicated linting job that runs in parallel with depends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,10 +94,17 @@ jobs:
       build-target: win64
       container-path: ${{ needs.container.outputs.path }}
 
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+    needs: [container]
+    with:
+      container-path: ${{ needs.container.outputs.path }}
+
   src-arm-linux:
     name: arm-linux-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-arm-linux]
+    needs: [container, depends-arm-linux, lint]
     with:
       build-target: arm-linux
       container-path: ${{ needs.container.outputs.path }}
@@ -106,7 +113,7 @@ jobs:
   src-linux64:
     name: linux64-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64]
+    needs: [container, depends-linux64, lint]
     if: ${{ vars.SKIP_LINUX64 == '' }}
     with:
       build-target: linux64
@@ -116,7 +123,7 @@ jobs:
   src-linux64_fuzz:
     name: linux64_fuzz-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64]
+    needs: [container, depends-linux64, lint]
     if: ${{ vars.SKIP_LINUX64_FUZZ == '' }}
     with:
       build-target: linux64_fuzz
@@ -126,7 +133,7 @@ jobs:
   src-linux64_multiprocess:
     name: linux64_multiprocess-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64_multiprocess]
+    needs: [container, depends-linux64_multiprocess, lint]
     if: ${{ vars.SKIP_LINUX64_MULTIPROCESS == '' }}
     with:
       build-target: linux64_multiprocess
@@ -136,7 +143,7 @@ jobs:
   src-linux64_nowallet:
     name: linux64_nowallet-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64_nowallet]
+    needs: [container, depends-linux64_nowallet, lint]
     with:
       build-target: linux64_nowallet
       container-path: ${{ needs.container.outputs.path }}
@@ -145,7 +152,7 @@ jobs:
   src-linux64_sqlite:
     name: linux64_sqlite-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64]
+    needs: [container, depends-linux64, lint]
     if: ${{ vars.SKIP_LINUX64_SQLITE == '' }}
     with:
       build-target: linux64_sqlite
@@ -155,7 +162,7 @@ jobs:
   src-linux64_tsan:
     name: linux64_tsan-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64_multiprocess]
+    needs: [container, depends-linux64_multiprocess, lint]
     if: ${{ vars.SKIP_LINUX64_TSAN == '' }}
     with:
       build-target: linux64_tsan
@@ -165,7 +172,7 @@ jobs:
   src-linux64_ubsan:
     name: linux64_ubsan-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-linux64]
+    needs: [container, depends-linux64, lint]
     if: ${{ vars.SKIP_LINUX64_UBSAN == '' }}
     with:
       build-target: linux64_ubsan
@@ -175,7 +182,7 @@ jobs:
   src-mac:
     name: mac-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-mac]
+    needs: [container, depends-mac, lint]
     with:
       build-target: mac
       container-path: ${{ needs.container.outputs.path }}
@@ -184,7 +191,7 @@ jobs:
   src-win64:
     name: win64-build
     uses: ./.github/workflows/build-src.yml
-    needs: [container, depends-win64]
+    needs: [container, depends-win64, lint]
     with:
       build-target: win64
       container-path: ${{ needs.container.outputs.path }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,13 +32,27 @@ jobs:
         run: |
           export BUILD_TARGET="linux64"
           export CHECK_DOC=1
+          
+          # Determine if this is a PR and set commit range accordingly
           if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             export COMMIT_RANGE="$(git merge-base origin/develop HEAD)..HEAD"
             export PULL_REQUEST="true"
+          elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" != "refs/heads/develop" ] && [ "${{ github.ref }}" != "refs/heads/master" ]; then
+            # For push events on feature branches, check against develop
+            export COMMIT_RANGE="$(git merge-base origin/develop HEAD)..HEAD"
+            export PULL_REQUEST="true"
           else
-            export COMMIT_RANGE="SKIP_EMPTY_NOT_A_PR"
+            # For pushes to develop/master or other events
+            export COMMIT_RANGE="HEAD~..HEAD"
             export PULL_REQUEST="false"
           fi
+          
+          echo "Event name: ${{ github.event_name }}"
+          echo "Ref: ${{ github.ref }}"
           echo "COMMIT_RANGE=${COMMIT_RANGE}"
+          echo "PULL_REQUEST=${PULL_REQUEST}"
+          echo "Running git log for commit range:"
+          git log --oneline ${COMMIT_RANGE} || echo "Could not show commit range"
+          
           ./ci/dash/lint.sh
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Run linters
         run: |
           export BUILD_TARGET="linux64"
-          source ./ci/dash/matrix.sh
-          source ./ci/lint/04_install.sh
-          source ./ci/lint/06_script.sh
+          export CHECK_DOC=1
+          export COMMIT_RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha || github.sha }}"
+          export PULL_REQUEST="${{ github.event_name == 'pull_request_target' && 'true' || 'false' }}"
+          ./ci/dash/lint.sh
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,14 +25,20 @@ jobs:
       - name: Initial setup
         run: |
           git config --global --add safe.directory "$PWD"
-          git fetch -fu origin master:master
+          git fetch -fu origin develop:develop
         shell: bash
 
       - name: Run linters
         run: |
           export BUILD_TARGET="linux64"
           export CHECK_DOC=1
-          export COMMIT_RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha || github.sha }}"
-          export PULL_REQUEST="${{ github.event_name == 'pull_request_target' && 'true' || 'false' }}"
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            export COMMIT_RANGE="$(git merge-base origin/develop HEAD)..HEAD"
+            export PULL_REQUEST="true"
+          else
+            export COMMIT_RANGE="SKIP_EMPTY_NOT_A_PR"
+            export PULL_REQUEST="false"
+          fi
+          echo "COMMIT_RANGE=${COMMIT_RANGE}"
           ./ci/dash/lint.sh
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,44 @@
+name: Lint
+
+on:
+  workflow_call:
+    inputs:
+      container-path:
+        description: "Path to built container at registry"
+        required: true
+        type: string
+
+jobs:
+  lint:
+    name: Run linters
+    runs-on: ubuntu-24.04
+    container:
+      image: ${{ inputs.container-path }}
+      options: --user root
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 50
+
+      - name: Initial setup
+        run: |
+          git config --global --add safe.directory "$PWD"
+          git fetch -fu origin master:master
+          export COMMIT_RANGE="HEAD~..HEAD"
+          echo "COMMIT_RANGE=${COMMIT_RANGE}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Install lint dependencies
+        run: |
+          export CI_RETRY_EXE="retry --"
+          source ./ci/lint/04_install.sh
+        shell: bash
+
+      - name: Run linters
+        run: |
+          export LC_ALL=C.UTF-8
+          export CI_RETRY_EXE="retry --"
+          source ./ci/lint/06_script.sh
+        shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,19 +26,12 @@ jobs:
         run: |
           git config --global --add safe.directory "$PWD"
           git fetch -fu origin master:master
-          export COMMIT_RANGE="HEAD~..HEAD"
-          echo "COMMIT_RANGE=${COMMIT_RANGE}" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Install lint dependencies
-        run: |
-          export CI_RETRY_EXE="retry --"
-          source ./ci/lint/04_install.sh
         shell: bash
 
       - name: Run linters
         run: |
-          export LC_ALL=C.UTF-8
-          export CI_RETRY_EXE="retry --"
+          export BUILD_TARGET="linux64"
+          source ./ci/dash/matrix.sh
+          source ./ci/lint/04_install.sh
           source ./ci/lint/06_script.sh
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           export BUILD_TARGET="linux64"
           export CHECK_DOC=1
-          
+
           # Determine if this is a PR and set commit range accordingly
           if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             export COMMIT_RANGE="$(git merge-base origin/develop HEAD)..HEAD"
@@ -46,13 +46,13 @@ jobs:
             export COMMIT_RANGE="HEAD~..HEAD"
             export PULL_REQUEST="false"
           fi
-          
+
           echo "Event name: ${{ github.event_name }}"
           echo "Ref: ${{ github.ref }}"
           echo "COMMIT_RANGE=${COMMIT_RANGE}"
           echo "PULL_REQUEST=${PULL_REQUEST}"
           echo "Running git log for commit range:"
           git log --oneline ${COMMIT_RANGE} || echo "Could not show commit range"
-          
+
           ./ci/dash/lint.sh
         shell: bash

--- a/ci/dash/lint.sh
+++ b/ci/dash/lint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This script runs the Dash-specific linters
+
+export LC_ALL=C.UTF-8
+
+set -e
+
+source ./ci/dash/matrix.sh
+
+# Check commit scripts for PRs
+if [ "$PULL_REQUEST" != "false" ]; then 
+    test/lint/commit-script-check.sh "$COMMIT_RANGE"
+fi
+
+# Run linters if CHECK_DOC is set
+if [ "$CHECK_DOC" = 1 ]; then
+    # TODO: Verify subtrees
+    #test/lint/git-subtree-check.sh src/crypto/ctaes
+    #test/lint/git-subtree-check.sh src/secp256k1
+    #test/lint/git-subtree-check.sh src/univalue
+    #test/lint/git-subtree-check.sh src/leveldb
+    # TODO: Check docs (re-enable after all Bitcoin PRs have been merged and docs fully fixed)
+    #test/lint/check-doc.py
+    # Run all linters
+    test/lint/all-lint.py
+fi

--- a/ci/dash/lint.sh
+++ b/ci/dash/lint.sh
@@ -12,7 +12,7 @@ set -e
 source ./ci/dash/matrix.sh
 
 # Check commit scripts for PRs
-if [ "$PULL_REQUEST" != "false" ]; then 
+if [ "$PULL_REQUEST" != "false" ]; then
     test/lint/commit-script-check.sh "$COMMIT_RANGE"
 fi
 

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -18,7 +18,7 @@ if [ -n "$QEMU_USER_CMD" ]; then
 fi
 export CONTAINER_NAME=ci_arm_linux
 # Use debian to avoid 404 apt errors when cross compiling
-export CHECK_DOC=1
+export CHECK_DOC=0
 export USE_BUSY_BOX=true
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false


### PR DESCRIPTION
## Summary

This PR creates a dedicated linting job in the CI pipeline that runs in parallel with dependency building, improving CI efficiency while maintaining code quality checks.

## Changes

- Added `.github/workflows/lint.yml` - a new reusable workflow for running linters
- Modified `.github/workflows/build.yml` to add the lint job and make all source builds depend on it
- Created `ci/dash/lint.sh` - Dash-specific linting script that mirrors the logic from `build_src.sh`
- Disabled `CHECK_DOC` in arm-linux build to avoid duplicate linting

## Benefits

1. **Faster feedback**: Linting starts immediately after containers are built, not waiting for dependencies
2. **Parallel execution**: Linting runs concurrently with dependency builds
3. **Fail-fast behavior**: Source builds are blocked if linting fails, saving compute resources
4. **Centralized linting**: All linting logic is in one place, making it easier to maintain

## Technical Details

The new lint workflow:
- Properly detects commit ranges for both PRs and push events
- Uses Dash's existing `matrix.sh` for environment setup
- Skips problematic subtree checks that Dash has intentionally disabled
- Runs the same linters that were previously run in the arm-linux build

## Testing

The lint job has been tested to ensure it:
- ✅ Detects whitespace issues correctly
- ✅ Runs in parallel with dependency builds
- ✅ Blocks source builds on failure

🤖 Generated with [Claude Code](https://claude.ai/code)