### PR TITLE
fix: avoid accidental v23 activation on mainnet/testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -210,8 +210,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
 
         consensus.vDeployments[Consensus::DEPLOYMENT_V23].bit = 12;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V23].nStartTime = 1751328000;    // July 1, 2025
-        consensus.vDeployments[Consensus::DEPLOYMENT_V23].nTimeout = 1782864000;      // July 1, 2026
+        consensus.vDeployments[Consensus::DEPLOYMENT_V23].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // TODO
+        consensus.vDeployments[Consensus::DEPLOYMENT_V23].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT; // TODO
         consensus.vDeployments[Consensus::DEPLOYMENT_V23].nWindowSize = 4032;
         consensus.vDeployments[Consensus::DEPLOYMENT_V23].nThresholdStart = 3226;     // 80% of 4032
         consensus.vDeployments[Consensus::DEPLOYMENT_V23].nThresholdMin = 2420;       // 60% of 4032
@@ -408,7 +408,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
 
         consensus.vDeployments[Consensus::DEPLOYMENT_V23].bit = 12;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V23].nStartTime = 1751328000;    // July 1, 2025
+        consensus.vDeployments[Consensus::DEPLOYMENT_V23].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // TODO
         consensus.vDeployments[Consensus::DEPLOYMENT_V23].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_V23].nWindowSize = 100;
         consensus.vDeployments[Consensus::DEPLOYMENT_V23].nThresholdStart = 80;       // 80% of 100


### PR DESCRIPTION
## Issue being fixed or feature implemented
`v23` hf is in semi-ready state but it can be activated if `develop` is deployed on mainnet/testnet on too many nodes because we are past `nStartTime` already.

## What was done?
Disable v23 for now, set proper start/timeout time in some future PR when we are ready.

## How Has This Been Tested?
Run `getblockchaininfo` rpc , confirm `v23` in no longer listed in `softforks`.

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

