### PR TITLE
feat: improve Guix build docker-compose.yml to expose guix.sigs and dash-detached-sigs

### DIFF
--- a/contrib/containers/guix/docker-compose.yml
+++ b/contrib/containers/guix/docker-compose.yml
@@ -15,3 +15,5 @@ services:
     network_mode: host
     volumes:
       - "../../..:/src/dash:rw"
+      - "../../../../dash-detached-sigs:/src/dash-detached-sigs:rw"
+      - "../../../../guix.sigs:/src/guix.sigs:rw"


### PR DESCRIPTION
## Issue being fixed or feature implemented
This pull request introduces a small update to the `docker-compose.yml` file for the Guix container setup. The change adds two new volume mounts to the `services` section, enabling access to detached signatures and Guix signatures directories.

## How Has This Been Tested?
Ran locally


## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

