### PR TITLE
perf: cache mined commitment for quorum merkle root calculation

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -121,7 +121,7 @@ auto CachedGetQcHashesQcIndexedHashes(const CBlockIndex* pindexPrev, const llmq:
             }
         }
     }
-    quorums_cached = quorums;
+    std::swap(quorums_cached, quorums);
     return std::make_pair(qcHashes_cached, qcIndexedHashes_cached);
 }
 

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -96,15 +96,14 @@ auto CachedGetQcHashesQcIndexedHashes(const CBlockIndex* pindexPrev, const llmq:
         vec_hashes.reserve(vecBlockIndexes.size());
         auto& map_indexed_hashes = qcIndexedHashes_cached[llmqType];
         for (const auto& blockIndex : vecBlockIndexes) {
-            uint256 dummyHash;
-            llmq::CFinalCommitmentPtr pqc = quorum_block_processor.GetMinedCommitment(llmqType, blockIndex->GetBlockHash(), dummyHash);
-            if (pqc == nullptr) {
+            const auto [pqc, dummyHash] = quorum_block_processor.GetMinedCommitment(llmqType, blockIndex->GetBlockHash());
+            if (dummyHash == uint256::ZERO) {
                 // this should never happen
                 return std::nullopt;
             }
-            auto qcHash = ::SerializeHash(*pqc);
+            auto qcHash = ::SerializeHash(pqc);
             if (rotation_enabled) {
-                map_indexed_hashes[pqc->quorumIndex] = qcHash;
+                map_indexed_hashes[pqc.quorumIndex] = qcHash;
             } else {
                 vec_hashes.emplace_back(qcHash);
             }

--- a/src/evo/smldiff.cpp
+++ b/src/evo/smldiff.cpp
@@ -9,7 +9,6 @@
 #include <consensus/merkle.h>
 #include <core_io.h>
 #include <deploymentstatus.h>
-#include <evo/cbtx.h>
 #include <evo/deterministicmns.h>
 #include <evo/specialtx.h>
 #include <llmq/blockprocessor.h>
@@ -22,6 +21,9 @@
 #include <validation.h>
 
 using node::ReadBlockFromDisk;
+
+// Forward declaration
+std::optional<std::pair<CBLSSignature, uint32_t>> GetNonNullCoinbaseChainlock(const CBlockIndex* pindex);
 
 CSimplifiedMNListDiff::CSimplifiedMNListDiff() = default;
 

--- a/src/evo/smldiff.cpp
+++ b/src/evo/smldiff.cpp
@@ -54,12 +54,11 @@ bool CSimplifiedMNListDiff::BuildQuorumsDiff(const CBlockIndex* baseBlockIndex, 
     for (const auto& p : quorumHashes) {
         const auto& [llmqType, hash] = p;
         if (!baseQuorumHashes.count(p)) {
-            uint256 minedBlockHash;
-            llmq::CFinalCommitmentPtr qc = quorum_block_processor.GetMinedCommitment(llmqType, hash, minedBlockHash);
-            if (qc == nullptr) {
+            auto [qc, minedBlockHash] = quorum_block_processor.GetMinedCommitment(llmqType, hash);
+            if (minedBlockHash == uint256::ZERO) {
                 return false;
             }
-            newQuorums.emplace_back(*qc);
+            newQuorums.emplace_back(std::move(qc));
         }
     }
 

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -468,17 +468,6 @@ bool CQuorumBlockProcessor::HasMinedCommitment(Consensus::LLMQType llmqType, con
     return fExists;
 }
 
-CFinalCommitmentPtr CQuorumBlockProcessor::GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, uint256& retMinedBlockHash) const
-{
-    auto key = std::make_pair(DB_MINED_COMMITMENT, std::make_pair(llmqType, quorumHash));
-    std::pair<CFinalCommitment, uint256> p;
-    if (!m_evoDb.Read(key, p)) {
-        return nullptr;
-    }
-    retMinedBlockHash = p.second;
-    return std::make_unique<CFinalCommitment>(p.first);
-}
-
 std::pair<CFinalCommitment, uint256> CQuorumBlockProcessor::GetMinedCommitment(Consensus::LLMQType llmqType,
                                                                                const uint256& quorumHash) const
 {

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -479,6 +479,17 @@ CFinalCommitmentPtr CQuorumBlockProcessor::GetMinedCommitment(Consensus::LLMQTyp
     return std::make_unique<CFinalCommitment>(p.first);
 }
 
+std::pair<CFinalCommitment, uint256> CQuorumBlockProcessor::GetMinedCommitment(Consensus::LLMQType llmqType,
+                                                                               const uint256& quorumHash) const
+{
+    auto key = std::make_pair(DB_MINED_COMMITMENT, std::make_pair(llmqType, quorumHash));
+    std::pair<CFinalCommitment, uint256> ret;
+    if (!m_evoDb.Read(key, ret)) {
+        return {CFinalCommitment{}, uint256::ZERO};
+    }
+    return ret;
+}
+
 // The returned quorums are in reversed order, so the most recent one is at index 0
 std::vector<const CBlockIndex*> CQuorumBlockProcessor::GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindex, size_t maxCount) const
 {

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -602,15 +602,8 @@ std::vector<const CBlockIndex*> CQuorumBlockProcessor::GetMinedCommitmentsIndexe
             return ret;
         }
 
-        std::vector<const CBlockIndex*> cycleRetTransformed;
-        std::transform(cycleRet.begin(), cycleRet.end(), std::back_inserter(cycleRetTransformed),
-                       [](const CBlockIndex* pindex) { return pindex; });
-
         size_t needToCopy = maxCount - ret.size();
-
-        std::copy_n(cycleRetTransformed.begin(),
-                    std::min(needToCopy, cycleRetTransformed.size()),
-                    std::back_inserter(ret));
+        std::copy_n(cycleRet.begin(), std::min(needToCopy, cycleRet.size()), std::back_inserter(ret));
         cycle++;
     }
 
@@ -623,15 +616,11 @@ std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> CQuorumBlockProce
     std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> ret;
 
     for (const auto& params : Params().GetConsensus().llmqs) {
-        auto& v = ret[params.type];
-        v.reserve(params.signingActiveQuorumCount);
+        auto& commitments = ret[params.type];
         if (IsQuorumRotationEnabled(params, pindex)) {
-            std::vector<const CBlockIndex*> commitments = GetLastMinedCommitmentsPerQuorumIndexUntilBlock(params.type,
-                                                                                                          pindex, 0);
-            std::copy(commitments.begin(), commitments.end(), std::back_inserter(v));
+            commitments = GetLastMinedCommitmentsPerQuorumIndexUntilBlock(params.type, pindex, 0);
         } else {
-            auto commitments = GetMinedCommitmentsUntilBlock(params.type, pindex, params.signingActiveQuorumCount);
-            std::copy(commitments.begin(), commitments.end(), std::back_inserter(v));
+            commitments = GetMinedCommitmentsUntilBlock(params.type, pindex, params.signingActiveQuorumCount);
         }
     }
 

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -71,7 +71,9 @@ public:
     std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> GetMinedAndActiveCommitmentsUntilBlock(gsl::not_null<const CBlockIndex*> pindex) const;
 
     std::vector<const CBlockIndex*> GetMinedCommitmentsIndexedUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t maxCount) const;
-    std::vector<std::pair<int, const CBlockIndex*>> GetLastMinedCommitmentsPerQuorumIndexUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t cycle) const;
+    std::vector<const CBlockIndex*> GetLastMinedCommitmentsPerQuorumIndexUntilBlock(Consensus::LLMQType llmqType,
+                                                                                    const CBlockIndex* pindex,
+                                                                                    size_t cycle) const;
     std::optional<const CBlockIndex*> GetLastMinedCommitmentsByQuorumIndexUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, int quorumIndex, size_t cycle) const;
 private:
     static bool GetCommitmentsFromBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, std::multimap<Consensus::LLMQType, CFinalCommitment>& ret, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -33,8 +33,6 @@ namespace llmq
 class CFinalCommitment;
 class CQuorumSnapshotManager;
 
-using CFinalCommitmentPtr = std::unique_ptr<CFinalCommitment>;
-
 class CQuorumBlockProcessor
 {
 private:
@@ -65,7 +63,6 @@ public:
     std::optional<std::vector<CFinalCommitment>> GetMineableCommitments(const Consensus::LLMQParams& llmqParams, int nHeight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool GetMineableCommitmentsTx(const Consensus::LLMQParams& llmqParams, int nHeight, std::vector<CTransactionRef>& ret) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
-    CFinalCommitmentPtr GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, uint256& retMinedBlockHash) const;
     std::pair<CFinalCommitment, uint256> GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
 
     std::vector<const CBlockIndex*> GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindex, size_t maxCount) const;

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -66,6 +66,7 @@ public:
     bool GetMineableCommitmentsTx(const Consensus::LLMQParams& llmqParams, int nHeight, std::vector<CTransactionRef>& ret) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
     CFinalCommitmentPtr GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, uint256& retMinedBlockHash) const;
+    std::pair<CFinalCommitment, uint256> GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
 
     std::vector<const CBlockIndex*> GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindex, size_t maxCount) const;
     std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> GetMinedAndActiveCommitmentsUntilBlock(gsl::not_null<const CBlockIndex*> pindex) const;

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -298,12 +298,11 @@ bool BuildQuorumRotationInfo(CDeterministicMNManager& dmnman, CQuorumSnapshotMan
                                                                                                       blockIndex, 0);
 
     for (const auto& obj : qdata) {
-        uint256 minedBlockHash;
-        llmq::CFinalCommitmentPtr qc = qblockman.GetMinedCommitment(llmqType, obj->GetBlockHash(), minedBlockHash);
-        if (qc == nullptr) {
+        auto [qc, minedBlockHash] = qblockman.GetMinedCommitment(llmqType, obj->GetBlockHash());
+        if (minedBlockHash == uint256::ZERO) {
             return false;
         }
-        response.lastCommitmentPerIndex.push_back(*qc);
+        response.lastCommitmentPerIndex.emplace_back(std::move(qc));
 
         int quorumCycleStartHeight = obj->nHeight - (obj->nHeight % llmq_params_opt->dkgInterval);
         snapshotHeightsNeeded.insert(quorumCycleStartHeight - cycleLength);

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -294,17 +294,18 @@ bool BuildQuorumRotationInfo(CDeterministicMNManager& dmnman, CQuorumSnapshotMan
 
     std::set<int> snapshotHeightsNeeded;
 
-    std::vector<std::pair<int, const CBlockIndex*>> qdata = qblockman.GetLastMinedCommitmentsPerQuorumIndexUntilBlock(llmqType, blockIndex, 0);
+    std::vector<const CBlockIndex*> qdata = qblockman.GetLastMinedCommitmentsPerQuorumIndexUntilBlock(llmqType,
+                                                                                                      blockIndex, 0);
 
     for (const auto& obj : qdata) {
         uint256 minedBlockHash;
-        llmq::CFinalCommitmentPtr qc = qblockman.GetMinedCommitment(llmqType, obj.second->GetBlockHash(), minedBlockHash);
+        llmq::CFinalCommitmentPtr qc = qblockman.GetMinedCommitment(llmqType, obj->GetBlockHash(), minedBlockHash);
         if (qc == nullptr) {
             return false;
         }
         response.lastCommitmentPerIndex.push_back(*qc);
 
-        int quorumCycleStartHeight = obj.second->nHeight - (obj.second->nHeight % llmq_params_opt->dkgInterval);
+        int quorumCycleStartHeight = obj->nHeight - (obj->nHeight % llmq_params_opt->dkgInterval);
         snapshotHeightsNeeded.insert(quorumCycleStartHeight - cycleLength);
         snapshotHeightsNeeded.insert(quorumCycleStartHeight - 2 * cycleLength);
         snapshotHeightsNeeded.insert(quorumCycleStartHeight - 3 * cycleLength);

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -953,5 +953,9 @@ template void InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache
 template void InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, std::shared_ptr<llmq::CQuorum>, StaticSaltedHasher, 0ul, 0ul>, std::less<Consensus::LLMQType>, std::allocator<std::pair<Consensus::LLMQType const, unordered_lru_cache<uint256, std::shared_ptr<llmq::CQuorum>, StaticSaltedHasher, 0ul, 0ul>>>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, std::shared_ptr<llmq::CQuorum>, StaticSaltedHasher, 0ul, 0ul>, std::less<Consensus::LLMQType>, std::allocator<std::pair<Consensus::LLMQType const, unordered_lru_cache<uint256, std::shared_ptr<llmq::CQuorum>, StaticSaltedHasher, 0ul, 0ul>>>>&cache, bool limit_by_connections);
 template void InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, int, StaticSaltedHasher>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, int, StaticSaltedHasher>>& cache, bool limit_by_connections);
 template void InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, uint256, StaticSaltedHasher>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, uint256, StaticSaltedHasher>>& cache, bool limit_by_connections);
+template void
+InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, std::pair<uint256, int>, StaticSaltedHasher>>>(
+    std::map<Consensus::LLMQType, unordered_lru_cache<uint256, std::pair<uint256, int>, StaticSaltedHasher>>& cache,
+    bool limit_by_connections);
 } // namespace utils
 } // namespace llmq


### PR DESCRIPTION
## Issue being fixed or feature implemented
Every time when list of quorum is changed, the quorum final commitments for multiple active quorums are re-read from database.
It's a heavy operation in a current implementation due to heavy database reading, heavy BLS deserialization and multiple in-memory copies.

## What was done?
 - add cache for active quorums, see `llmq::utils::InitQuorumsCache(qc_hashes_cached)`
 - use RVO for GetMinedCommitment, avoid extra allocation by unique_ptr
 - adjust return value of GetLastMinedCommitmentsPerQuorumIndexUntilBlock to avoid extra data copies and transformations


## How Has This Been Tested?
Time of calculation `CheckCbTxMerkleRoots` is shortened for 40%, and this step is a significant part of block validation.
Expected impact to total time for block validation and re-index is 3-4%.

`develop`:
```
[bench]             - CachedGetQcHashesQcIndexedHashes: 1.16ms [5.22s]
[bench]       - CheckCbTxMerkleRoots: 1.30ms [6.04s]
```
vs PR:

```
[bench]             - CachedGetQcHashesQcIndexedHashes: 1.20ms [2.65s]
[bench]       - CheckCbTxMerkleRoots: 1.34ms [3.44s]
```

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone