### PR TITLE
test: compatibility of upgradetohd wih encryption and determinism of addresses for descriptor wallets

### DIFF
--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -88,22 +88,14 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].loadwallet("wallet_160")
         self.nodes[0].loadwallet("wallet_192")
         self.nodes[0].loadwallet("wallet_224")
-        if self.options.descriptors:
-            self.nodes[0].createwallet("wallet_256", False, True, "", False, True)  # blank Descriptors
-            self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
-            assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 15)              # 15 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 18)              # 18 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 21)              # 21 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 24)              # 24 words
-        else:
-            self.nodes[0].createwallet("wallet_256", False, True)  # blank HD legacy
-            self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
-            assert_equal(len(self.nodes[0].get_wallet_rpc(self.default_wallet_name).dumphdinfo()["mnemonic"].split()), 12)  # 12 words by default
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").dumphdinfo()["mnemonic"].split()), 15)              # 15 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").dumphdinfo()["mnemonic"].split()), 18)              # 18 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").dumphdinfo()["mnemonic"].split()), 21)              # 21 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").dumphdinfo()["mnemonic"].split()), 24)              # 24 words
+        self.nodes[0].createwallet("wallet_256", blank=True, descriptors=self.options.descriptors)  # blank wallet
+        self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
+
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_160")).split()), 15)              # 15 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_192")).split()), 18)              # 18 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_224")).split()), 21)              # 21 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_256")).split()), 24)              # 24 words
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -101,30 +101,35 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
 
     def test_upgradetohd_custom(self):
         self.log.info("Test upgradetohd with user defined mnemonic")
-        self.nodes[0].createwallet("w-custom-1a", blank=True)
-        self.nodes[0].createwallet("w-custom-1b", blank=True)
-        self.nodes[0].createwallet("w-custom-2", blank=True)
+        wname_1a = "w-custom-1a"
+        wname_1b = "w-custom-1b"
+        wname_2 = "w-custom-2"
+
+        wnames = [wname_1a, wname_1b, wname_2]
+        for wname in wnames:
+            self.nodes[0].createwallet(wname, blank=True)
+
         custom_mnemonic = "similar behave slot swim scissors throw planet view ghost laugh drift calm"
         # this address belongs to custom mnemonic with no passphrase
         custom_address_1 = "yLpq97zZUsFQ2rdMqhcPKkYT36MoPK4Hob"
         # this address belongs to custom mnemonic with passphrase "custom-passphrase"
         custom_address_2 = "yYBPeZQcqgQHu9dxA5pKBWtYbK2hwfFHxf"
 
-        self.nodes[0].get_wallet_rpc('w-custom-1a').upgradetohd(custom_mnemonic)
-        self.nodes[0].get_wallet_rpc('w-custom-1b').upgradetohd(custom_mnemonic, "")
-        self.nodes[0].get_wallet_rpc('w-custom-2').upgradetohd(custom_mnemonic, "custom-passphrase")
+        self.nodes[0].get_wallet_rpc(wname_1a).upgradetohd(custom_mnemonic)
+        self.nodes[0].get_wallet_rpc(wname_1b).upgradetohd(custom_mnemonic, "")
+        self.nodes[0].get_wallet_rpc(wname_2).upgradetohd(custom_mnemonic, "custom-passphrase")
         self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 
         self.nodes[0].get_wallet_rpc(self.default_wallet_name).sendtoaddress(custom_address_1, 11)
         self.nodes[0].get_wallet_rpc(self.default_wallet_name).sendtoaddress(custom_address_2, 12)
         self.generate(self.nodes[0], 1)
         self.restart_node(0)
-        self.nodes[0].loadwallet('w-custom-1a')
-        self.nodes[0].loadwallet('w-custom-1b')
-        self.nodes[0].loadwallet('w-custom-2')
-        assert_equal(11, self.nodes[0].get_wallet_rpc('w-custom-1a').getbalance())
-        assert_equal(11, self.nodes[0].get_wallet_rpc('w-custom-1b').getbalance())
-        assert_equal(12, self.nodes[0].get_wallet_rpc('w-custom-2').getbalance())
+        for wname in wnames:
+            self.nodes[0].loadwallet(wname)
+
+        assert_equal(11, self.nodes[0].get_wallet_rpc(wname_1a).getbalance())
+        assert_equal(11, self.nodes[0].get_wallet_rpc(wname_1b).getbalance())
+        assert_equal(12, self.nodes[0].get_wallet_rpc(wname_2).getbalance())
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2016 The Bitcoin Core developers
+# Copyright (c) 2016 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -5,7 +5,8 @@
 """
 wallet_upgradetohd.py
 
-Test upgrade to a Hierarchical Deterministic wallet via upgradetohd rpc
+Test upgrade to a Hierarchical Deterministic wallet via upgradetohd rpc for legacy wallets
+For tests of upgradetohd for descriptor wallets see wallet_mnemonicbits.py
 """
 
 import shutil


### PR DESCRIPTION
## Issue being fixed or feature implemented
`upgradetohd` has comprehensive tests for case of blank legacy wallet -> HD legacy wallet. See `wallet_upgradetohd.py`. But there are lack of some scenarios for descriptor wallets; such as: determinism of addresses, compatibility of mnemonic between legacy & descriptors wallets and upgradetohd for wallets with passwords.


## What was done?
- add tests for mnemonic + mnemonic_passphrase for descriptor wallet
- add tests for upgradetohd for encrypted wallet
- add tests for encryption for wallets with mnemonic
- add tests for deterministic of generated addresses from mnemonic (with & without mnemonic_passphrase)

## How Has This Been Tested?
See changes in `wallet_mnemonicbits.py`

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
