### PR TITLE
test: make wallet_upgradetohd.py works with descriptors

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -536,6 +536,29 @@ def force_finish_mnsync(node):
     while not node.mnsync("status")['IsSynced']:
         node.mnsync("next")
 
+
+def get_mnemonic(node):
+    """
+    Return mnemonic if known from legacy HD wallets and Descriptor Wallets
+    Raises exception if there is none.
+    """
+    if not node.getwalletinfo()['descriptors']:
+        return node.dumphdinfo()["mnemonic"]
+
+    mnemonic = None
+    descriptors = node.listdescriptors(True)['descriptors']
+    for desc in descriptors:
+        if desc['desc'][:4] == 'pkh(':
+            if mnemonic is None:
+                mnemonic = desc['mnemonic']
+            else:
+                assert_equal(mnemonic, desc['mnemonic'])
+        elif desc['desc'][:6] == 'combo(':
+            assert 'mnemonic' not in desc
+        else:
+            raise AssertionError(f"Unknown descriptor type: {desc['desc']}")
+    return mnemonic
+
 # Transaction/Block functions
 #############################
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -321,6 +321,7 @@ BASE_SCRIPTS = [
     'wallet_encryption.py --legacy-wallet',
     'wallet_encryption.py --descriptors',
     'wallet_upgradetohd.py --legacy-wallet',
+    'wallet_upgradetohd.py --descriptors',
     'feature_dersig.py',
     'feature_cltv.py',
     'feature_new_quorum_type_activation.py',

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -88,22 +88,14 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].loadwallet("wallet_160")
         self.nodes[0].loadwallet("wallet_192")
         self.nodes[0].loadwallet("wallet_224")
-        if self.options.descriptors:
-            self.nodes[0].createwallet("wallet_256", False, True, "", False, True)  # blank Descriptors
-            self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
-            assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 15)              # 15 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 18)              # 18 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 21)              # 21 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").listdescriptors(True)["descriptors"][0]["mnemonic"].split()), 24)              # 24 words
-        else:
-            self.nodes[0].createwallet("wallet_256", False, True)  # blank HD legacy
-            self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
-            assert_equal(len(self.nodes[0].get_wallet_rpc(self.default_wallet_name).dumphdinfo()["mnemonic"].split()), 12)  # 12 words by default
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_160").dumphdinfo()["mnemonic"].split()), 15)              # 15 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_192").dumphdinfo()["mnemonic"].split()), 18)              # 18 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_224").dumphdinfo()["mnemonic"].split()), 21)              # 21 words
-            assert_equal(len(self.nodes[0].get_wallet_rpc("wallet_256").dumphdinfo()["mnemonic"].split()), 24)              # 24 words
+        self.nodes[0].createwallet("wallet_256", blank=True, descriptors=self.options.descriptors)  # blank wallet
+        self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
+
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_160")).split()), 15)              # 15 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_192")).split()), 18)              # 18 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_224")).split()), 21)              # 21 words
+        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_256")).split()), 24)              # 24 words
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_mnemonicbits.py
+++ b/test/functional/wallet_mnemonicbits.py
@@ -7,6 +7,7 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    get_mnemonic,
 )
 
 class WalletMnemonicbitsTest(BitcoinTestFramework):
@@ -17,24 +18,6 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
-    def get_mnemonic(self, node):
-        if not self.options.descriptors:
-            return node.dumphdinfo()["mnemonic"]
-
-        mnemonic = None
-        descriptors = node.listdescriptors(True)['descriptors']
-        for desc in descriptors:
-            if desc['desc'][:4] == 'pkh(':
-                if mnemonic is None:
-                    mnemonic = desc['mnemonic']
-                else:
-                    assert_equal(mnemonic, desc['mnemonic'])
-            elif desc['desc'][:6] == 'combo(':
-                assert 'mnemonic' not in desc
-            else:
-                raise AssertionError(f"Unknown descriptor type: {desc['desc']}")
-        return mnemonic
-
     def run_test(self):
         self.log.info("Test -mnemonicbits")
 
@@ -43,7 +26,7 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(['-mnemonicbits=123'], "Error: Invalid '-mnemonicbits'. Allowed values: 128, 160, 192, 224, 256.")
         self.start_node(0)
 
-        mnemonic_pre = self.get_mnemonic(self.nodes[0])
+        mnemonic_pre = get_mnemonic(self.nodes[0])
 
 
         self.nodes[0].encryptwallet('pass')
@@ -91,11 +74,11 @@ class WalletMnemonicbitsTest(BitcoinTestFramework):
         self.nodes[0].createwallet("wallet_256", blank=True, descriptors=self.options.descriptors)  # blank wallet
         self.nodes[0].get_wallet_rpc("wallet_256").upgradetohd()
 
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_160")).split()), 15)              # 15 words
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_192")).split()), 18)              # 18 words
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_224")).split()), 21)              # 21 words
-        assert_equal(len(self.get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_256")).split()), 24)              # 24 words
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc(self.default_wallet_name)).split()), 12)  # 12 words by default
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_160")).split()), 15)              # 15 words
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_192")).split()), 18)              # 18 words
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_224")).split()), 21)              # 21 words
+        assert_equal(len(get_mnemonic(self.nodes[0].get_wallet_rpc("wallet_256")).split()), 24)              # 24 words
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -249,6 +249,28 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         # All coins should be recovered
         assert_equal(balance_after, node.getbalance())
 
+        self.log.info("Test upgradetohd with user defined mnemonic")
+        custom_mnemonic = "similar behave slot swim scissors throw planet view ghost laugh drift calm"
+        # this address belongs to custom mnemonic with no passphrase
+        custom_address_1 = "yLpq97zZUsFQ2rdMqhcPKkYT36MoPK4Hob"
+        # this address belongs to custom mnemonic with passphrase "custom-passphrase"
+        custom_address_2 = "yYBPeZQcqgQHu9dxA5pKBWtYbK2hwfFHxf"
+        node.sendtoaddress(custom_address_1, 11)
+        node.sendtoaddress(custom_address_2, 12)
+        self.generate(node, 1)
+
+        node.createwallet("wallet-11", blank=True)
+        w11 = node.get_wallet_rpc("wallet-11")
+        w11.upgradetohd(custom_mnemonic)
+        assert_equal(11, w11.getbalance())
+        w11.unloadwallet()
+
+        node.createwallet("wallet-12", blank=True)
+        w12 = node.get_wallet_rpc("wallet-12")
+        w12.upgradetohd(custom_mnemonic, "custom-passphrase")
+        assert_equal(12, w12.getbalance())
+        w12.unloadwallet()
+
 
 if __name__ == '__main__':
     WalletUpgradeToHDTest().main ()

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2016 The Bitcoin Core developers
+# Copyright (c) 2016-2025 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """


### PR DESCRIPTION
## Issue being fixed or feature implemented
`upgradetohd` has comprehensive tests for case of blank legacy wallet -> HD legacy wallet. 

This PR replaces https://github.com/dashpay/dash/pull/6762

## What was done?
 - add descriptor wallets to scope of wallet_updatetohd.py
 - add tests for deterministic of generated addresses from mnemonic (with & without mnemonic_passphrase)

## How Has This Been Tested?
See `wallet_upgadetohd.py`



## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone