### PR TITLE
fix: avoid short-circuit when evaluating platform identifier for <v0.12.3.x and bail out on macOS, make `feature_unsupported_utxo_db` Linux-only 

### DIFF
--- a/test/functional/feature_unsupported_utxo_db.py
+++ b/test/functional/feature_unsupported_utxo_db.py
@@ -20,6 +20,7 @@ class UnsupportedUtxoDbTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_previous_releases()
+        self.skip_if_platform_not_linux()
 
     def setup_network(self):
         self.add_nodes(

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -134,7 +134,8 @@ def download_binary(tag, args) -> int:
         if platform in ["arm-linux-gnueabihf"]:
             platform = "RPi2"
         elif platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
-            platform = "osx"
+            print(f"Binaries not available for {tag} on {platform}")
+            return 1
         elif platform in ["i686-pc-linux-gnu"]:
             platform = "linux32"
         elif platform in ["x86_64-linux-gnu"]:

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -130,7 +130,7 @@ def download_binary(tag, args) -> int:
         platform = "win32"
     elif platform in ["x86_64-w64-mingw32"]:
         platform = "win64"
-    elif tag < "v0.12.2.3":
+    elif tag < "v0.12.3":
         if platform in ["arm-linux-gnueabihf"]:
             platform = "RPi2"
         elif platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -130,8 +130,6 @@ def download_binary(tag, args) -> int:
         platform = "win32"
     elif platform in ["x86_64-w64-mingw32"]:
         platform = "win64"
-    elif tag < "v20" and platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
-        platform = "osx64"
     elif tag < "v0.12.2.3":
         if platform in ["arm-linux-gnueabihf"]:
             platform = "RPi2"
@@ -141,6 +139,8 @@ def download_binary(tag, args) -> int:
             platform = "linux32"
         elif platform in ["x86_64-linux-gnu"]:
             platform = "linux64"
+    elif tag < "v20" and platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
+        platform = "osx64"
     tarball = 'dashcore-{tag}-{platform}.tar.gz'.format(
         tag=tag[1:], platform=platform)
     tarballUrl = 'https://github.com/dashpay/dash/{bin_path}/{tarball}'.format(


### PR DESCRIPTION
## Motivation

`feature_unsupported_utxo_db.py` (introduced with [bitcoin#24236](https://github.com/bitcoin/bitcoin/pull/24236) as 79fcd30d73 in [dash#6733](https://github.com/dashpay/dash/pull/6733)) creates problems on macOS for the following reasons:
* The platform identifier detection code was placed _after_ v20 when it should've been positioned _before_, as the prior condition was met, platform identifier was taken to be `osx64`, which is incorrect ([release](https://github.com/dashpay/dash/releases/tag/v0.12.1.5)).

  <details>

  <summary>Error log:</summary>

  ```
  $ ./test/get_previous_releases.py -b -t "releases" ${PREVIOUS_RELEASES_TO_DOWNLOAD}
  Releases directory: releases
  Fetching: https://github.com/dashpay/dash/releases/download/v0.12.1.5/dashcore-0.12.1.5-osx64.tar.gz
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
    0     9    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
  100     9  100     9    0     0     34      0 --:--:-- --:--:-- --:--:--    34
  Checksum for given version doesn't exist
  ```

  </details>

* Dash Core v0.12.2.x and earlier did not include daemon or utility binaries for macOS (i.e. `dashd`, as needed by the functional test suite), shipping only Dash-Qt using a disk image, in comparison to v0.12.3.x which do offer them in a tarbundle ([release](https://github.com/dashpay/dash/releases/tag/v0.12.3.1)).
* Dash Core v0.12.2.3 was incorrectly excluded from the old platform determination logic due to the _less than_ comparison.

In light of this, `get_previous_releases.py` will now error out if attempting to download versions <v0.12.3.x as we _cannot_ obtain the binaries needed to run functional tests. Additionally, `feature_unsupported_utxo_db.py` will bail out on non-Linux platforms as previous release tests assume all the versions are populated and will otherwise cause general failure.

<details>

<summary>Error log:</summary>

```
$ ./test/functional/feature_unsupported_utxo_db.py
2025-07-18T10:09:06.884000Z TestFramework (INFO): PRNG seed is: 5491056264691271257
2025-07-18T10:09:06.884000Z TestFramework (INFO): Initializing test directory /tmp/dash_func_test_dkrhioh0
2025-07-18T10:09:06.885000Z TestFramework (INFO): Create previous version (v0.12.1.5) utxo db
2025-07-18T10:09:06.885000Z TestFramework (ERROR): Unexpected exception caught during testing
Traceback (most recent call last):
  File "/src/dash/test/functional/test_framework/test_framework.py", line 162, in main
    self.run_test()
  File "/src/dash/./test/functional/feature_unsupported_utxo_db.py", line 35, in run_test
    self.start_node(0)
  File "/src/dash/test/functional/test_framework/test_framework.py", line 644, in start_node
    node.start(*args, **kwargs)
  File "/src/dash/test/functional/test_framework/test_node.py", line 249, in start
    self.process = subprocess.Popen(all_args, env=subp_env, stdout=stdout, stderr=stderr, cwd=cwd, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1901, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/src/dash/releases/v0.12.1.5/bin/dashd'
2025-07-18T10:09:06.936000Z TestFramework (INFO): Stopping nodes
[...]
```

</details>

Special thanks to PastaPastaPasta for flagging this issue!

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
