### PR TITLE
fix: partially revert 6730

### DIFF
--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -587,9 +587,8 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(const CBlock& block, const CB
         LogPrint(BCLog::BENCHMARK, "      - m_qblockman: %.2fms [%.2fs]\n", 0.001 * (nTime5 - nTime4),
                  nTimeQuorum * 0.000001);
 
-
-        if (opt_cbTx.has_value() && pindex->pprev) {
-            CDeterministicMNList mn_list;
+        CDeterministicMNList mn_list;
+        if (DeploymentActiveAt(*pindex, m_consensus_params, Consensus::DEPLOYMENT_DIP0003)) {
             if (!BuildNewListFromBlock(block, pindex->pprev, view, true, state, mn_list)) {
                 // pass the state returned by the function above
                 return false;
@@ -600,6 +599,7 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(const CBlock& block, const CB
                 // pass the state returned by the function above
                 return false;
             }
+        }
 
             int64_t nTime5_1 = GetTimeMicros();
             nTimeDMN += nTime5_1 - nTime5;
@@ -607,6 +607,7 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(const CBlock& block, const CB
             LogPrint(BCLog::BENCHMARK, "      - m_dmnman: %.2fms [%.2fs]\n", 0.001 * (nTime5_1 - nTime5),
                      nTimeDMN * 0.000001);
 
+        if (opt_cbTx.has_value()) {
             uint256 calculatedMerkleRoot;
             if (!CalcCbTxMerkleRootMNList(calculatedMerkleRoot, CSimplifiedMNList{std::move(mn_list)}, state)) {
                 // pass the state returned by the function above


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash/pull/6730/commits/1011f6b8baa4724a47677cc787371083441070f9 broke `develop` - can't sync from genesis or reindex atm. The reason is that `opt_cbTx == nullopt` below `assumevalid` but we must always build/process mn lists after dip0003 activation.

## What was done?
Partially revert that commit. I'm keeping it small intentionally, will refactor in a follow-up PR.

## How Has This Been Tested?
reindex, sync from scratch

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

