### PR TITLE
fix: assign `nKeysLeftSinceAutoBackup` a bit later

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -871,10 +871,6 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             if (!strErr.empty())
                 pwallet->WalletLogPrintf("%s\n", strErr);
         }
-
-        // Store initial external keypool size since we mostly use external keys in mixing
-        pwallet->nKeysLeftSinceAutoBackup = pwallet->KeypoolCountExternalKeys();
-        pwallet->WalletLogPrintf("nKeysLeftSinceAutoBackup: %d\n", pwallet->nKeysLeftSinceAutoBackup);
     } catch (...) {
         result = DBErrors::CORRUPT;
     }
@@ -923,6 +919,10 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     // upgrading, we don't want to make it worse.
     if (result != DBErrors::LOAD_OK)
         return result;
+
+    // Store initial external keypool size since we mostly use external keys in mixing
+    pwallet->nKeysLeftSinceAutoBackup = pwallet->KeypoolCountExternalKeys();
+    pwallet->WalletLogPrintf("nKeysLeftSinceAutoBackup: %d\n", pwallet->nKeysLeftSinceAutoBackup);
 
     // Last client version to open this wallet
     int last_client = CLIENT_VERSION;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Wallet balance benchmarks are crashing. Not 100% sure what's going on but this patch helps.

## What was done?
Assign `nKeysLeftSinceAutoBackup` a bit later.

## How Has This Been Tested?
`./src/bench/bench_dash -sanity-check -priority-level=high`
`./src/bench/bench_dash --filter=".*WalletBalance.*"`

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

