### PR TITLE
refactor: follow-up dash#6742, implement review suggestions, avoid redundant transaction queries

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -106,7 +106,7 @@ void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& 
 {
     assert(m_cj_ctx && m_llmq_ctx);
 
-    m_llmq_ctx->isman->TransactionAddedToMempool(m_peerman, ptx);
+    m_llmq_ctx->isman->TransactionAddedToMempool(ptx);
     m_llmq_ctx->clhandler->TransactionAddedToMempool(ptx, nAcceptTime);
     m_cj_ctx->dstxman->TransactionAddedToMempool(ptx);
 }

--- a/src/instantsend/db.cpp
+++ b/src/instantsend/db.cpp
@@ -19,7 +19,8 @@ static const std::string_view DB_VERSION = "is_v";
 
 namespace instantsend {
 namespace {
-static std::tuple<std::string, uint32_t, uint256> BuildInversedISLockKey(std::string_view k, int nHeight, const uint256& islockHash)
+static std::tuple<std::string, uint32_t, uint256> BuildInversedISLockKey(std::string_view k, int nHeight,
+                                                                         const uint256& islockHash)
 {
     return std::make_tuple(std::string{k}, htobe32_internal(std::numeric_limits<uint32_t>::max() - nHeight), islockHash);
 }
@@ -221,7 +222,8 @@ void CInstantSendDb::WriteBlockInstantSendLocks(const gsl::not_null<std::shared_
     db->WriteBatch(batch);
 }
 
-void CInstantSendDb::RemoveBlockInstantSendLocks(const gsl::not_null<std::shared_ptr<const CBlock>>& pblock, gsl::not_null<const CBlockIndex*> pindexDisconnected)
+void CInstantSendDb::RemoveBlockInstantSendLocks(const gsl::not_null<std::shared_ptr<const CBlock>>& pblock,
+                                                 gsl::not_null<const CBlockIndex*> pindexDisconnected)
 {
     LOCK(cs_db);
     CDBBatch batch(*db);
@@ -241,7 +243,8 @@ void CInstantSendDb::RemoveBlockInstantSendLocks(const gsl::not_null<std::shared
 bool CInstantSendDb::KnownInstantSendLock(const uint256& islockHash) const
 {
     LOCK(cs_db);
-    return GetInstantSendLockByHashInternal(islockHash) != nullptr || db->Exists(std::make_tuple(DB_ARCHIVED_BY_HASH, islockHash));
+    return GetInstantSendLockByHashInternal(islockHash) != nullptr ||
+           db->Exists(std::make_tuple(DB_ARCHIVED_BY_HASH, islockHash));
 }
 
 size_t CInstantSendDb::GetInstantSendLockCount() const
@@ -354,7 +357,8 @@ std::vector<uint256> CInstantSendDb::GetInstantSendLocksByParent(const uint256& 
     return result;
 }
 
-std::vector<uint256> CInstantSendDb::RemoveChainedInstantSendLocks(const uint256& islockHash, const uint256& txid, int nHeight)
+std::vector<uint256> CInstantSendDb::RemoveChainedInstantSendLocks(const uint256& islockHash, const uint256& txid,
+                                                                   int nHeight)
 {
     LOCK(cs_db);
     std::vector<uint256> result;

--- a/src/instantsend/db.cpp
+++ b/src/instantsend/db.cpp
@@ -9,13 +9,13 @@
 #include <primitives/block.h>
 #include <util/system.h>
 
-static const std::string_view DB_ARCHIVED_BY_HASH = "is_a2";
-static const std::string_view DB_ARCHIVED_BY_HEIGHT_AND_HASH = "is_a1";
-static const std::string_view DB_HASH_BY_OUTPOINT = "is_in";
-static const std::string_view DB_HASH_BY_TXID = "is_tx";
-static const std::string_view DB_ISLOCK_BY_HASH = "is_i";
-static const std::string_view DB_MINED_BY_HEIGHT_AND_HASH = "is_m";
-static const std::string_view DB_VERSION = "is_v";
+static constexpr std::string_view DB_ARCHIVED_BY_HASH{"is_a2"};
+static constexpr std::string_view DB_ARCHIVED_BY_HEIGHT_AND_HASH{"is_a1"};
+static constexpr std::string_view DB_HASH_BY_OUTPOINT{"is_in"};
+static constexpr std::string_view DB_HASH_BY_TXID{"is_tx"};
+static constexpr std::string_view DB_ISLOCK_BY_HASH{"is_i"};
+static constexpr std::string_view DB_MINED_BY_HEIGHT_AND_HASH{"is_m"};
+static constexpr std::string_view DB_VERSION{"is_v"};
 
 namespace instantsend {
 namespace {

--- a/src/instantsend/db.h
+++ b/src/instantsend/db.h
@@ -33,9 +33,9 @@ private:
 
     static constexpr int CURRENT_VERSION{1};
 
-    int best_confirmed_height GUARDED_BY(cs_db) {0};
+    int best_confirmed_height GUARDED_BY(cs_db){0};
 
-    std::unique_ptr<CDBWrapper> db GUARDED_BY(cs_db) {nullptr};
+    std::unique_ptr<CDBWrapper> db GUARDED_BY(cs_db){nullptr};
     mutable unordered_lru_cache<uint256, InstantSendLockPtr, StaticSaltedHasher, 10000> islockCache GUARDED_BY(cs_db);
     mutable unordered_lru_cache<uint256, uint256, StaticSaltedHasher, 10000> txidCache GUARDED_BY(cs_db);
 

--- a/src/instantsend/db.h
+++ b/src/instantsend/db.h
@@ -51,7 +51,8 @@ private:
      * @param islock The InstantSend Lock object itself
      * @param keep_cache Should we still keep corresponding entries in the cache or not
      */
-    void RemoveInstantSendLock(CDBBatch& batch, const uint256& hash, InstantSendLockPtr islock, bool keep_cache = true) EXCLUSIVE_LOCKS_REQUIRED(cs_db);
+    void RemoveInstantSendLock(CDBBatch& batch, const uint256& hash, const InstantSendLock& islock,
+                               bool keep_cache = true) EXCLUSIVE_LOCKS_REQUIRED(cs_db);
     /**
      * Marks an InstantSend Lock as archived.
      * @param batch Object used to batch many calls together
@@ -88,7 +89,7 @@ public:
      * @param hash The hash of the InstantSend Lock
      * @param islock The InstantSend Lock object itself
      */
-    void WriteNewInstantSendLock(const uint256& hash, const InstantSendLock& islock) EXCLUSIVE_LOCKS_REQUIRED(!cs_db);
+    void WriteNewInstantSendLock(const uint256& hash, const InstantSendLockPtr& islock) EXCLUSIVE_LOCKS_REQUIRED(!cs_db);
     /**
      * This method updates a DB entry for an InstantSend Lock from being not included in a block to being included in a block
      * @param hash The hash of the InstantSend Lock

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -34,7 +34,7 @@ using node::fReindex;
 using node::GetTransaction;
 
 namespace llmq {
-static const std::string_view INPUTLOCK_REQUESTID_PREFIX = "inlock";
+static constexpr std::string_view INPUTLOCK_REQUESTID_PREFIX{"inlock"};
 
 namespace {
 template <typename T>

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -23,15 +23,14 @@
 
 #include <cxxtimer.hpp>
 
-using node::fImporting;
-using node::fReindex;
-
 // Forward declaration to break dependency over node/transaction.h
-namespace node
-{
+namespace node {
 CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool,
                                const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock);
 } // namespace node
+
+using node::fImporting;
+using node::fReindex;
 using node::GetTransaction;
 
 namespace llmq {

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -394,7 +394,7 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, PeerManager& peerm
         LOCK(cs_pendingLocks);
         pendingNoTxInstantSendLocks.try_emplace(hash, std::make_pair(from, islock));
     } else {
-        db.WriteNewInstantSendLock(hash, *islock);
+        db.WriteNewInstantSendLock(hash, islock);
         if (pindexMined) {
             db.WriteInstantSendLockMined(hash, pindexMined->nHeight);
         }

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -117,7 +117,7 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
     void TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock);
 
-    void RemoveMempoolConflictsForLock(PeerManager& peerman, const uint256& hash, const instantsend::InstantSendLock& islock)
+    void RemoveMempoolConflictsForLock(const uint256& hash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
     void ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry);
@@ -135,7 +135,7 @@ public:
 
     PeerMsgRet ProcessMessage(const CNode& pfrom, PeerManager& peerman, std::string_view msg_type, CDataStream& vRecv);
 
-    void TransactionAddedToMempool(PeerManager& peerman, const CTransactionRef& tx)
+    void TransactionAddedToMempool(const CTransactionRef& tx)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry);
     void TransactionRemovedFromMempool(const CTransactionRef& tx);
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -9,8 +9,8 @@
 #include <primitives/transaction.h>
 #include <protocol.h>
 #include <sync.h>
-#include <util/threadinterrupt.h>
 #include <threadsafety.h>
+#include <util/threadinterrupt.h>
 
 #include <instantsend/db.h>
 #include <instantsend/lock.h>
@@ -67,8 +67,8 @@ private:
     // Tried to verify but there is no tx yet
     std::unordered_map<uint256, std::pair<NodeId, instantsend::InstantSendLockPtr>, StaticSaltedHasher> pendingNoTxInstantSendLocks GUARDED_BY(cs_pendingLocks);
 
-    // TXs which are neither IS locked nor ChainLocked. We use this to determine for which TXs we need to retry IS locking
-    // of child TXs
+    // TXs which are neither IS locked nor ChainLocked. We use this to determine for which TXs we need to retry IS
+    // locking of child TXs
     struct NonLockedTxInfo {
         const CBlockIndex* pindexMined;
         CTransactionRef tx;

--- a/src/instantsend/lock.cpp
+++ b/src/instantsend/lock.cpp
@@ -6,9 +6,10 @@
 
 #include <hash.h>
 #include <primitives/transaction.h>
+#include <util/hasher.h>
 
-#include <set>
 #include <string>
+#include <unordered_set>
 
 static constexpr std::string_view ISLOCK_REQUESTID_PREFIX{"islock"};
 
@@ -32,13 +33,7 @@ bool InstantSendLock::TriviallyValid() const
     }
 
     // Check that each input is unique
-    std::set<COutPoint> dups;
-    for (const auto& o : inputs) {
-        if (!dups.emplace(o).second) {
-            return false;
-        }
-    }
-
-    return true;
+    const std::unordered_set<COutPoint, SaltedOutpointHasher> inputs_set{inputs.begin(), inputs.end()};
+    return inputs_set.size() == inputs.size();
 }
 } // namespace instantsend

--- a/src/instantsend/lock.cpp
+++ b/src/instantsend/lock.cpp
@@ -10,7 +10,7 @@
 #include <set>
 #include <string>
 
-static const std::string_view ISLOCK_REQUESTID_PREFIX = "islock";
+static constexpr std::string_view ISLOCK_REQUESTID_PREFIX{"islock"};
 
 namespace instantsend {
 uint256 InstantSendLock::GetRequestId() const

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -60,7 +60,7 @@ void InstantSendSigner::Stop()
 
 void InstantSendSigner::ClearInputsFromQueue(const std::unordered_set<uint256, StaticSaltedHasher>& ids)
 {
-    LOCK(cs_inputReqests);
+    LOCK(cs_input_requests);
     for (const auto& id : ids) {
         inputRequestIds.erase(id);
     }
@@ -84,7 +84,7 @@ MessageProcessingResult InstantSendSigner::HandleNewRecoveredSig(const llmq::CRe
     }
 
     uint256 txid;
-    if (LOCK(cs_inputReqests); inputRequestIds.count(recoveredSig.getId())) {
+    if (LOCK(cs_input_requests); inputRequestIds.count(recoveredSig.getId())) {
         txid = recoveredSig.getMsgHash();
     }
     if (!txid.IsNull()) {
@@ -331,7 +331,7 @@ bool InstantSendSigner::TrySignInputLocks(const CTransaction& tx, bool fRetroact
     for (const auto i : irange::range(tx.vin.size())) {
         const auto& in = tx.vin[i];
         auto& id = ids[i];
-        WITH_LOCK(cs_inputReqests, inputRequestIds.emplace(id));
+        WITH_LOCK(cs_input_requests, inputRequestIds.emplace(id));
         LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: trying to vote on input %s with id %s. fRetroactive=%d\n",
                  __func__, tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString(), fRetroactive);
         if (m_sigman.AsyncSignIfMember(llmqType, m_shareman, id, tx.GetHash(), {}, fRetroactive)) {

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -28,7 +28,7 @@ using node::fReindex;
 using node::GetTransaction;
 
 namespace instantsend {
-static const std::string_view INPUTLOCK_REQUESTID_PREFIX = "inlock";
+static constexpr std::string_view INPUTLOCK_REQUESTID_PREFIX{"inlock"};
 
 InstantSendSigner::InstantSendSigner(CChainState& chainstate, llmq::CChainLocksHandler& clhandler,
                                      llmq::CInstantSendManager& isman, llmq::CSigningManager& sigman,

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -89,7 +89,7 @@ MessageProcessingResult InstantSendSigner::HandleNewRecoveredSig(const llmq::CRe
     }
     if (!txid.IsNull()) {
         HandleNewInputLockRecoveredSig(recoveredSig, txid);
-    } else if (/*isInstantSendLock=*/ WITH_LOCK(cs_creating, return creatingInstantSendLocks.count(recoveredSig.getId()))) {
+    } else if (/*isInstantSendLock=*/WITH_LOCK(cs_creating, return creatingInstantSendLocks.count(recoveredSig.getId()))) {
         HandleNewInstantSendLockRecoveredSig(recoveredSig);
     }
     return {};
@@ -154,8 +154,7 @@ void InstantSendSigner::ProcessPendingRetryLockTxs(const std::vector<CTransactio
             if (!CheckCanLock(*tx, false, Params().GetConsensus())) {
                 continue;
             }
-            LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: retrying to lock\n", __func__,
-                     tx->GetHash().ToString());
+            LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: retrying to lock\n", __func__, tx->GetHash().ToString());
         }
 
         ProcessTx(*tx, false, Params().GetConsensus());
@@ -178,7 +177,8 @@ bool InstantSendSigner::CheckCanLock(const CTransaction& tx, bool printDebug, co
                           [&](const auto& in) { return CheckCanLock(in.prevout, printDebug, tx.GetHash(), params); });
 }
 
-bool InstantSendSigner::CheckCanLock(const COutPoint& outpoint, bool printDebug, const uint256& txHash, const Consensus::Params& params) const
+bool InstantSendSigner::CheckCanLock(const COutPoint& outpoint, bool printDebug, const uint256& txHash,
+                                     const Consensus::Params& params) const
 {
     int nInstantSendConfirmationsRequired = params.nInstantSendConfirmationsRequired;
 
@@ -201,8 +201,8 @@ bool InstantSendSigner::CheckCanLock(const COutPoint& outpoint, bool printDebug,
     // this relies on enabled txindex and won't work if we ever try to remove the requirement for txindex for masternodes
     if (!tx) {
         if (printDebug) {
-            LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to find parent TX %s\n", __func__,
-                     txHash.ToString(), outpoint.hash.ToString());
+            LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to find parent TX %s\n", __func__, txHash.ToString(),
+                     outpoint.hash.ToString());
         }
         return false;
     }
@@ -215,7 +215,8 @@ bool InstantSendSigner::CheckCanLock(const COutPoint& outpoint, bool printDebug,
         nTxAge = m_chainstate.m_chain.Height() - pindexMined->nHeight + 1;
     }
 
-    if (nTxAge < nInstantSendConfirmationsRequired && !m_clhandler.HasChainLock(pindexMined->nHeight, pindexMined->GetBlockHash())) {
+    if (nTxAge < nInstantSendConfirmationsRequired &&
+        !m_clhandler.HasChainLock(pindexMined->nHeight, pindexMined->GetBlockHash())) {
         if (printDebug) {
             LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: outpoint %s too new and not ChainLocked. nTxAge=%d, nInstantSendConfirmationsRequired=%d\n", __func__,
                      txHash.ToString(), outpoint.ToStringShort(), nTxAge, nInstantSendConfirmationsRequired);
@@ -243,8 +244,8 @@ void InstantSendSigner::HandleNewInstantSendLockRecoveredSig(const llmq::CRecove
     }
 
     if (islock->txid != recoveredSig.getMsgHash()) {
-        LogPrintf("%s -- txid=%s: islock conflicts with %s, dropping own version\n", __func__,
-                islock->txid.ToString(), recoveredSig.getMsgHash().ToString());
+        LogPrintf("%s -- txid=%s: islock conflicts with %s, dropping own version\n", __func__, islock->txid.ToString(),
+                  recoveredSig.getMsgHash().ToString());
         return;
     }
 
@@ -263,16 +264,15 @@ void InstantSendSigner::ProcessTx(const CTransaction& tx, bool fRetroactive, con
     }
 
     if (!CheckCanLock(tx, true, params)) {
-        LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: CheckCanLock returned false\n", __func__,
-                  tx.GetHash().ToString());
+        LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: CheckCanLock returned false\n", __func__, tx.GetHash().ToString());
         return;
     }
 
     auto conflictingLock = m_isman.GetConflictingLock(tx);
     if (conflictingLock != nullptr) {
         auto conflictingLockHash = ::SerializeHash(*conflictingLock);
-        LogPrintf("%s -- txid=%s: conflicts with islock %s, txid=%s\n", __func__,
-                  tx.GetHash().ToString(), conflictingLockHash.ToString(), conflictingLock->txid.ToString());
+        LogPrintf("%s -- txid=%s: conflicts with islock %s, txid=%s\n", __func__, tx.GetHash().ToString(),
+                  conflictingLockHash.ToString(), conflictingLock->txid.ToString());
         return;
     }
 
@@ -291,7 +291,8 @@ void InstantSendSigner::ProcessTx(const CTransaction& tx, bool fRetroactive, con
     TrySignInstantSendLock(tx);
 }
 
-bool InstantSendSigner::TrySignInputLocks(const CTransaction& tx, bool fRetroactive, Consensus::LLMQType llmqType, const Consensus::Params& params)
+bool InstantSendSigner::TrySignInputLocks(const CTransaction& tx, bool fRetroactive, Consensus::LLMQType llmqType,
+                                          const Consensus::Params& params)
 {
     std::vector<uint256> ids;
     ids.reserve(tx.vin.size());
@@ -313,8 +314,8 @@ bool InstantSendSigner::TrySignInputLocks(const CTransaction& tx, bool fRetroact
 
         // don't even try the actual signing if any input is conflicting
         if (m_sigman.IsConflicting(params.llmqTypeDIP0024InstantSend, id, tx.GetHash())) {
-            LogPrintf("%s -- txid=%s: m_sigman.IsConflicting returned true. id=%s\n", __func__,
-                      tx.GetHash().ToString(), id.ToString());
+            LogPrintf("%s -- txid=%s: m_sigman.IsConflicting returned true. id=%s\n", __func__, tx.GetHash().ToString(),
+                      id.ToString());
             return false;
         }
     }
@@ -324,15 +325,15 @@ bool InstantSendSigner::TrySignInputLocks(const CTransaction& tx, bool fRetroact
         return true;
     }
 
-    LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: trying to vote on %d inputs\n", __func__,
-             tx.GetHash().ToString(), tx.vin.size());
+    LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: trying to vote on %d inputs\n", __func__, tx.GetHash().ToString(),
+             tx.vin.size());
 
     for (const auto i : irange::range(tx.vin.size())) {
         const auto& in = tx.vin[i];
         auto& id = ids[i];
         WITH_LOCK(cs_inputReqests, inputRequestIds.emplace(id));
-        LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: trying to vote on input %s with id %s. fRetroactive=%d\n", __func__,
-                 tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString(), fRetroactive);
+        LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: trying to vote on input %s with id %s. fRetroactive=%d\n",
+                 __func__, tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString(), fRetroactive);
         if (m_sigman.AsyncSignIfMember(llmqType, m_shareman, id, tx.GetHash(), {}, fRetroactive)) {
             LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: voted on input %s with id %s\n", __func__,
                      tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString());
@@ -354,7 +355,7 @@ void InstantSendSigner::TrySignInstantSendLock(const CTransaction& tx)
     }
 
     LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: got all recovered sigs, creating InstantSendLock\n", __func__,
-            tx.GetHash().ToString());
+             tx.GetHash().ToString());
 
     InstantSendLock islock;
     islock.txid = tx.GetHash();
@@ -373,8 +374,8 @@ void InstantSendSigner::TrySignInstantSendLock(const CTransaction& tx)
     const auto quorum = llmq::SelectQuorumForSigning(llmq_params_opt.value(), m_chainstate.m_chain, m_qman, id);
 
     if (!quorum) {
-        LogPrint(BCLog::INSTANTSEND, "%s -- failed to select quorum. islock id=%s, txid=%s\n",
-                 __func__, id.ToString(), tx.GetHash().ToString());
+        LogPrint(BCLog::INSTANTSEND, "%s -- failed to select quorum. islock id=%s, txid=%s\n", __func__, id.ToString(),
+                 tx.GetHash().ToString());
         return;
     }
 

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -11,7 +11,6 @@
 #include <util/irange.h>
 #include <validation.h>
 
-#include <instantsend/instantsend.h>
 #include <llmq/chainlocks.h>
 #include <llmq/quorums.h>
 #include <masternode/sync.h>
@@ -31,7 +30,7 @@ namespace instantsend {
 static constexpr std::string_view INPUTLOCK_REQUESTID_PREFIX{"inlock"};
 
 InstantSendSigner::InstantSendSigner(CChainState& chainstate, llmq::CChainLocksHandler& clhandler,
-                                     llmq::CInstantSendManager& isman, llmq::CSigningManager& sigman,
+                                     InstantSendSignerParent& isman, llmq::CSigningManager& sigman,
                                      llmq::CSigSharesManager& shareman, llmq::CQuorumManager& qman,
                                      CSporkManager& sporkman, CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
     m_chainstate{chainstate},

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -106,8 +106,8 @@ void InstantSendSigner::HandleNewInputLockRecoveredSig(const llmq::CRecoveredSig
         g_txindex->BlockUntilSyncedToCurrentChain();
     }
 
-    uint256 hashBlock{};
-    const auto tx = GetTransaction(nullptr, &m_mempool, txid, Params().GetConsensus(), hashBlock);
+    uint256 _hashBlock{};
+    const auto tx = GetTransaction(nullptr, &m_mempool, txid, Params().GetConsensus(), _hashBlock);
     if (!tx) {
         return;
     }

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -25,12 +25,23 @@ class CQuorumManager;
 } // namespace llmq
 
 namespace instantsend {
-class InstantSendSigner : public llmq::CRecoveredSigsListener
+class InstantSendSignerParent
+{
+public:
+    virtual ~InstantSendSignerParent() = default;
+
+    virtual bool IsInstantSendEnabled() const = 0;
+    virtual bool IsLocked(const uint256& txHash) const = 0;
+    virtual InstantSendLockPtr GetConflictingLock(const CTransaction& tx) const = 0;
+    virtual void TryEmplacePendingLock(const uint256& hash, const NodeId id, const InstantSendLockPtr& islock) = 0;
+};
+
+class InstantSendSigner final : public llmq::CRecoveredSigsListener
 {
 private:
     CChainState& m_chainstate;
     llmq::CChainLocksHandler& m_clhandler;
-    llmq::CInstantSendManager& m_isman;
+    InstantSendSignerParent& m_isman;
     llmq::CSigningManager& m_sigman;
     llmq::CSigSharesManager& m_shareman;
     llmq::CQuorumManager& m_qman;
@@ -59,7 +70,7 @@ private:
 
 public:
     explicit InstantSendSigner(CChainState& chainstate, llmq::CChainLocksHandler& clhandler,
-                               llmq::CInstantSendManager& isman, llmq::CSigningManager& sigman,
+                               InstantSendSignerParent& isman, llmq::CSigningManager& sigman,
                                llmq::CSigSharesManager& shareman, llmq::CQuorumManager& qman, CSporkManager& sporkman,
                                CTxMemPool& mempool, const CMasternodeSync& mn_sync);
     ~InstantSendSigner();

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -39,14 +39,14 @@ private:
     const CMasternodeSync& m_mn_sync;
 
 private:
-    mutable Mutex cs_inputReqests;
+    mutable Mutex cs_input_requests;
     mutable Mutex cs_creating;
 
     /**
      * Request ids of inputs that we signed. Used to determine if a recovered signature belongs to an
      * in-progress input lock.
      */
-    std::unordered_set<uint256, StaticSaltedHasher> inputRequestIds GUARDED_BY(cs_inputReqests);
+    std::unordered_set<uint256, StaticSaltedHasher> inputRequestIds GUARDED_BY(cs_input_requests);
 
     /**
      * These are the islocks that are currently in the middle of being created. Entries are created when we observed
@@ -68,18 +68,18 @@ public:
     void Stop();
 
     void ClearInputsFromQueue(const std::unordered_set<uint256, StaticSaltedHasher>& ids)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_inputReqests);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_input_requests);
 
     void ClearLockFromQueue(const InstantSendLockPtr& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_creating);
 
     [[nodiscard]] MessageProcessingResult HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig) override
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_creating, !cs_inputReqests);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_creating, !cs_input_requests);
 
     void ProcessPendingRetryLockTxs(const std::vector<CTransactionRef>& retryTxs)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_creating, !cs_inputReqests);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_creating, !cs_input_requests);
     void ProcessTx(const CTransaction& tx, bool fRetroactive, const Consensus::Params& params)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_creating, !cs_inputReqests);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_creating, !cs_input_requests);
 
 private:
     [[nodiscard]] bool CheckCanLock(const CTransaction& tx, bool printDebug, const Consensus::Params& params) const;
@@ -95,7 +95,7 @@ private:
 
     [[nodiscard]] bool TrySignInputLocks(const CTransaction& tx, bool allowResigning, Consensus::LLMQType llmqType,
                                          const Consensus::Params& params)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_inputReqests);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_input_requests);
     void TrySignInstantSendLock(const CTransaction& tx)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_creating);
 };

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -50,8 +50,8 @@ private:
 
     /**
      * These are the islocks that are currently in the middle of being created. Entries are created when we observed
-     * recovered signatures for all inputs of a TX. At the same time, we initiate signing of our sigshare for the islock.
-     * When the recovered sig for the islock later arrives, we can finish the islock and propagate it.
+     * recovered signatures for all inputs of a TX. At the same time, we initiate signing of our sigshare for the
+     * islock. When the recovered sig for the islock later arrives, we can finish the islock and propagate it.
      */
     std::unordered_map<uint256, InstantSendLock, StaticSaltedHasher> creatingInstantSendLocks GUARDED_BY(cs_creating);
     // maps from txid to the in-progress islock

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -44,7 +44,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "governance/governance -> governance/object -> governance/governance",
     "governance/governance -> masternode/sync -> governance/governance",
     "governance/governance -> net_processing -> governance/governance",
-    "instantsend/instantsend -> instantsend/signing -> instantsend/instantsend",
     "instantsend/instantsend -> llmq/chainlocks -> instantsend/instantsend",
     "instantsend/instantsend -> net_processing -> instantsend/instantsend",
     "instantsend/instantsend -> net_processing -> llmq/context -> instantsend/instantsend",


### PR DESCRIPTION
## Additional Information

* Dependent on https://github.com/dashpay/dash/pull/6742

* This pull request aims to address reviewer concerns raised during [dash#6742](https://github.com/dashpay/dash/pull/6742), the following changes were made with that in mind
  * Marking unused variable `hashBlock` by prefixing with underscore, [comment](https://github.com/dashpay/dash/pull/6742#discussion_r2208121015)
  * Correct typo in variable name `cs_inputReqests` (now `cs_input_requests`, [comment](https://github.com/dashpay/dash/pull/6770#discussion_r2227556317)), [comment](https://github.com/dashpay/dash/pull/6742#discussion_r2207961050)
  * Using `constexpr` for `std::string_view`s, [comment](https://github.com/dashpay/dash/pull/6742#discussion_r2208113306)
  * Utilizing a faster way to validate uniqueness of entries (`std::unordered_set`), [comment](https://github.com/dashpay/dash/pull/6742#discussion_r2208097191). The construction of the unordered set is inspired by similar usage in `policy/package.cpp` ([source](https://github.com/dashpay/dash/blob/f648039258d2192ec5e505721e34edaa0bda568c/src/policy/packages.cpp#L51)).
  * Avoiding unnecessary `std::shared_ptr` copying (`InstantSendLockPtr` is a `std::shared_ptr<InstantSendLock>`), [comment](https://github.com/dashpay/dash/pull/6742#discussion_r2208107196)
  * Resolving circular dependency by cherry-picking 1e2e854a1d8b5e80e23c2a25896ec4d366708dc7, [comment](https://github.com/dashpay/dash/pull/6742#discussion_r2190942929) but has been renamed to `InstantSendSignerParent`. For rationale, see [comment](https://github.com/dashpay/dash/pull/6761#discussion_r2224895142).

* Additionally, optimizations have been made to `ProcessInstantSendLock()`
  * The _cheaper_ database checks have been moved _earlier_ in the function to allow for faster bail-out. This is alongside consolidating network requests to the tail of the function and general cleanup for better clarity.

  * Dropping the peer request for a transaction we know about in `RemoveMempoolConflictsForLock()` (introduced in [dash#2898](https://github.com/dashpay/dash/pull/2898)) as `ProcessInstantSendLock()` calls it when we _know_ about the transaction and seek to remove conflicts ([source](https://github.com/dashpay/dash/blob/f648039258d2192ec5e505721e34edaa0bda568c/src/instantsend/instantsend.cpp#L419-L420))

    The only other caller, `TransactionAddedToMempool()` calls it when we have knowledge of the transaction and want to purge conflicts from the mempool ([source](https://github.com/dashpay/dash/blob/f648039258d2192ec5e505721e34edaa0bda568c/src/instantsend/instantsend.cpp#L455-L463)).

    In both cases, we already know the _good_ transaction. Additionally, tests introduced in [dash#2898](https://github.com/dashpay/dash/pull/2898) still pass ([source](https://github.com/dashpay/dash/blob/f648039258d2192ec5e505721e34edaa0bda568c/test/functional/p2p_instantsend.py#L95-L142)), indicating a lack of regression but this change may require additional scrutiny.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
