### PR TITLE
refactor: create InstantSendStorage to break circular dependency over instantsend/signing

### DIFF
--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -14,6 +14,7 @@
 
 #include <instantsend/db.h>
 #include <instantsend/lock.h>
+#include <instantsend/signing.h>
 #include <unordered_lru_cache.h>
 
 #include <atomic>
@@ -43,7 +44,7 @@ class CQuorumManager;
 class CSigningManager;
 class CSigSharesManager;
 
-class CInstantSendManager
+class CInstantSendManager final : public instantsend::InstantSendStorage
 {
 private:
     instantsend::CInstantSendDb db;
@@ -128,9 +129,9 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
 
 public:
-    bool IsLocked(const uint256& txHash) const;
+    bool IsLocked(const uint256& txHash) const override;
     bool IsWaitingForTx(const uint256& txHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
-    instantsend::InstantSendLockPtr GetConflictingLock(const CTransaction& tx) const;
+    instantsend::InstantSendLockPtr GetConflictingLock(const CTransaction& tx) const override;
 
     PeerMsgRet ProcessMessage(const CNode& pfrom, PeerManager& peerman, std::string_view msg_type, CDataStream& vRecv);
 
@@ -152,12 +153,12 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
 
     void RemoveConflictingLock(const uint256& islockHash, const instantsend::InstantSendLock& islock);
-    void TryEmplacePendingLock(const uint256& hash, const NodeId id, const instantsend::InstantSendLockPtr& islock)
+    void TryEmplacePendingLock(const uint256& hash, const NodeId id, const instantsend::InstantSendLockPtr& islock) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
 
     size_t GetInstantSendLockCount() const;
 
-    bool IsInstantSendEnabled() const;
+    bool IsInstantSendEnabled() const override;
     /**
      * If true, MN should sign all transactions, if false, MN should not sign
      * transactions in mempool, but should sign txes included in a block. This

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -11,7 +11,6 @@
 #include <util/irange.h>
 #include <validation.h>
 
-#include <instantsend/instantsend.h>
 #include <llmq/chainlocks.h>
 #include <llmq/quorums.h>
 #include <masternode/sync.h>
@@ -31,7 +30,7 @@ namespace instantsend {
 static const std::string_view INPUTLOCK_REQUESTID_PREFIX = "inlock";
 
 InstantSendSigner::InstantSendSigner(CChainState& chainstate, llmq::CChainLocksHandler& clhandler,
-                                     llmq::CInstantSendManager& isman, llmq::CSigningManager& sigman,
+                                     InstantSendStorage& isman, llmq::CSigningManager& sigman,
                                      llmq::CSigSharesManager& shareman, llmq::CQuorumManager& qman,
                                      CSporkManager& sporkman, CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
     m_chainstate{chainstate},

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -44,7 +44,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "governance/governance -> governance/object -> governance/governance",
     "governance/governance -> masternode/sync -> governance/governance",
     "governance/governance -> net_processing -> governance/governance",
-    "instantsend/instantsend -> instantsend/signing -> instantsend/instantsend",
     "instantsend/instantsend -> llmq/chainlocks -> instantsend/instantsend",
     "instantsend/instantsend -> net_processing -> instantsend/instantsend",
     "instantsend/instantsend -> net_processing -> llmq/context -> instantsend/instantsend",


### PR DESCRIPTION
## Issue being fixed or feature implemented
It resolves newly introduced circular dependency over instantsend/signing.
Same approach can be applied for https://github.com/dashpay/dash/pull/6761/files#r2219078456

## What was done?
Created a new interface `instantsend::InstantSendStorage` that can be used all over codebase to break multiple circular dependency over instantsend. This PR is a minimal patch set to resolve instantsend/signing only. Further changes to be proposed in next PRs.

## How Has This Been Tested?
Run `test/lint/lint-circular-dependencies.py`

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone