### PR TITLE
fix: let upgradetohd work for encrypted Descriptor wallets same as legacy wallets

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3228,7 +3228,24 @@ bool CWallet::UpgradeToHD(const SecureString& secureMnemonic, const SecureString
     SetMinVersion(FEATURE_HD);
 
     if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+        if (IsCrypted()) {
+            if (secureWalletPassphrase.empty()) {
+                error = Untranslated("Error: Wallet encrypted but supplied empty wallet passphrase");
+                return false;
+            }
+
+            // Unlock the wallet
+            if (!Unlock(secureWalletPassphrase)) {
+                error = Untranslated("Error: The wallet passphrase entered was incorrect");
+                return false;
+            }
+        }
         SetupDescriptorScriptPubKeyMans(secureMnemonic, secureMnemonicPassphrase);
+
+        if (IsCrypted()) {
+            // Relock the wallet
+            Lock();
+        }
     } else {
         if (!GenerateNewHDChain(secureMnemonic, secureMnemonicPassphrase, secureWalletPassphrase)) {
             error = Untranslated("Failed to generate HD wallet");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -10,7 +10,6 @@
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
-#include <consensus/validation.h>
 #include <crypto/common.h>
 #include <fs.h>
 #include <interfaces/chain.h>
@@ -19,7 +18,6 @@
 #include <key_io.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
-#include <policy/settings.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/descriptor.h>
@@ -28,10 +26,8 @@
 #include <script/signingprovider.h>
 #include <support/cleanse.h>
 #include <txmempool.h>
-#include <util/bip32.h>
 #include <util/check.h>
 #include <util/error.h>
-#include <util/fees.h>
 #include <util/moneystr.h>
 #include <util/string.h>
 #include <util/translation.h>
@@ -40,11 +36,9 @@
 #endif
 #include <wallet/bip39.h> // TODO(refactor): move dependency it to scriptpubkeyman.cpp
 #include <wallet/coincontrol.h>
-#include <wallet/coinselection.h>
 #include <wallet/context.h>
 #include <warnings.h>
 
-#include <coinjoin/common.h>
 #include <coinjoin/options.h>
 #include <evo/providertx.h>
 #include <governance/vote.h>


### PR DESCRIPTION
## Issue being fixed or feature implemented
`upgradetohd` has 3rd argument 'passphrase' specially for encrypted wallet but it is ignored for Descriptor Wallet and wallet should be manually unlocked before call of `upgradetohd`.


## What was done?
RPC `upgradetohd` actually works now with enctypred Descriptor Wallets without requirement to unlock them first.


## How Has This Been Tested?
Tests to be merged in https://github.com/dashpay/dash/pull/6763

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone