### PR TITLE
backport: Merge bitcoin/bitcoin#23751: build, qt: No need to set inapplicable QPA backend for Android

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -193,7 +193,6 @@ $(package)_config_opts_android += -android-sdk $(ANDROID_SDK)
 $(package)_config_opts_android += -android-ndk $(ANDROID_NDK)
 $(package)_config_opts_android += -android-ndk-platform android-$(ANDROID_API_LEVEL)
 $(package)_config_opts_android += -egl
-$(package)_config_opts_android += -qpa xcb
 $(package)_config_opts_android += -no-dbus
 $(package)_config_opts_android += -opengl es2
 $(package)_config_opts_android += -qt-freetype


### PR DESCRIPTION
Backports bitcoin/bitcoin#23751

Original commit: 7097a63033

Backported from Bitcoin Core v0.24

## Changes Applied
- Removed `-qpa xcb` from Android Qt configuration in depends/packages/qt.mk
- The Java file changes were not applicable as Dash has already removed Android Java source files (only .gitignore remains in src/qt/android/)

## Note
This is a partial backport as Dash appears to have removed Android support files while still maintaining Android build configuration in the depends system.