### PR TITLE
chore: resolve logical conflict between dash#6691 and dash#6775, resolve compile error

### DIFF
--- a/src/test/llmq_commitment_tests.cpp
+++ b/src/test/llmq_commitment_tests.cpp
@@ -142,8 +142,8 @@ BOOST_AUTO_TEST_CASE(commitment_json_test)
     BOOST_CHECK(json.exists("signersCount"));
     BOOST_CHECK(json.exists("validMembersCount"));
 
-    BOOST_CHECK_EQUAL(json["signersCount"].get_int(), commitment.CountSigners());
-    BOOST_CHECK_EQUAL(json["validMembersCount"].get_int(), commitment.CountValidMembers());
+    BOOST_CHECK_EQUAL(json["signersCount"].getInt<int>(), commitment.CountSigners());
+    BOOST_CHECK_EQUAL(json["validMembersCount"].getInt<int>(), commitment.CountValidMembers());
 }
 
 BOOST_AUTO_TEST_CASE(commitment_bitvector_json_test)


### PR DESCRIPTION
## Additional Information

[dash#6691](https://github.com/dashpay/dash/pull/6691) and [dash#6775](https://github.com/dashpay/dash/pull/6775) were merged into `develop` in that order, neither conflicting with the other. [dash#6775](https://github.com/dashpay/dash/pull/6775) updated the UniValue subtree before its was unsubtree'd and subsequent improvements were backported. To enable this, a syntax change was required which replaced `get_int()` with `getInt<int>()`, which, the new code in [dash#6691](https://github.com/dashpay/dash/pull/6691) didn't use as it was merged _before_ [dash#6775](https://github.com/dashpay/dash/pull/6775).

As it was new code, this was not registered as a merged conflict but this logical conflict caused `develop` to fail ([build](https://github.com/dashpay/dash/actions/runs/16546102266)). This pull request remedies that issue.

## Breaking Changes

None expected

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
