### PR TITLE
test: fix intermittent error in wait_for_quorum_commitment

### DIFF
--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -317,6 +317,9 @@ bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, 
             if (it == contributionsCache.end()) {
                 CDataStream s(SER_DISK, CLIENT_VERSION);
                 if (!db->ReadDataStream(std::make_tuple(DB_VVEC, llmqType, pQuorumBaseBlockIndex->GetBlockHash(), proTxHash), s)) {
+                    LogPrint(BCLog::LLMQ, "%s -- this node does not have vvec for llmq=%d block=%s protx=%s\n",
+                             __func__, ToUnderlying(llmqType), pQuorumBaseBlockIndex->GetBlockHash().ToString(),
+                             proTxHash.ToString());
                     return false;
                 }
                 size_t vvec_size = ReadCompactSize(s);

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2072,6 +2072,8 @@ class DashTestFramework(BitcoinTestFramework):
                         continue
                     if c["quorumHash"] != quorum_hash:
                         continue
+                    if c["quorumPublicKey"] == '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000':
+                        continue
                     c_ok = True
                     break
                 if not c_ok:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2080,7 +2080,7 @@ class DashTestFramework(BitcoinTestFramework):
                     return False
             return True
 
-        self.wait_until(check_dkg_comitments, timeout=timeout, sleep=1)
+        self.wait_until(check_dkg_comitments, timeout=timeout)
 
     def wait_for_quorum_list(self, quorum_hash, nodes, timeout=15, llmq_type_name="llmq_test"):
         def wait_func():

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2072,7 +2072,7 @@ class DashTestFramework(BitcoinTestFramework):
                         continue
                     if c["quorumHash"] != quorum_hash:
                         continue
-                    if c["quorumPublicKey"] == '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000':
+                    if c["quorumPublicKey"] == '0' * 96:
                         continue
                     c_ok = True
                     break


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes https://github.com/dashpay/dash/issues/6748


RPC `dkgstatus` return mineable commitment even if node does not have any information about quorum commitment.
See `CQuorumBlockProcessor::GetMineableCommitments` for details of implementation.

It happens if `wait_for_quorum_commitment` is called before node received QC by p2p.


    commitment: {'version': 3,
        'llmqType': 104,
        'quorumHash': '70bd80a3e00da0c13ba11a12e5e3665baf1c5574f5b3003bb5b31500cab5cec9',
        'quorumIndex': 0,
        'signersCount': 0,
        'signers': '00',
        'validMembersCount': 0,
        'validMembers': '00',
        'quorumPublicKey': '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
        'quorumVvecHash': '0000000000000000000000000000000000000000000000000000000000000000',
        'quorumSig': '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
        'membersSig': '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
    }

This failure can happen not only for feature_asset_locks.py but for each functional tests that uses quorums, but it happened most often for feature_asset_locks.py because there is only 2 nodes instead 3 and it happens more often.

Issue indeed has been observed by me in other functional tests, but that had happens rarely compare to feature_asset_locks.py

## What was done?
Helper `wait_for_quorum_commitment` validates that not just commitment is provided (which can be mock), but a public key is not 00...00.


## How Has This Been Tested?
Run multiple feature_asset_locks.py and wait for a failure like that to happen, which happens no more with this PR:

    2025-07-08T16:39:57.003000Z TestFramework (INFO): Mining final commitment
    2025-07-08T16:39:58.019000Z TestFramework (INFO): Waiting for quorum to appear in the list
    2025-07-08T16:39:58.019000Z TestFramework (INFO): quorums: {'llmq_test': ['165c35bff42cae1499590010f323bba4e19922639ea220220017aae028df0281', '6bb33b6cd447df28f8adb171b93001e6b223bb42662466795f7fd482ddfc7fbf'], 'llmq_test_instantsend': ['165c35bff42cae1499590010f323bba4e19922639ea220220017aae028df0281', '6bb33b6cd447df28f8adb171b93001e6b223bb42662466795f7fd482ddfc7fbf'], 'llmq_test_dip0024': [], 'llmq_test_platform': ['165c35bff42cae1499590010f323bba4e19922639ea220220017aae028df0281', '6bb33b6cd447df28f8adb171b93001e6b223bb42662466795f7fd482ddfc7fbf']}
    2025-07-08T16:40:58.050000Z TestFramework.utils (ERROR): wait_until() failed. Predicate: ''''
    2025-07-08T16:40:58.9769454Z         def wait_func():
    2025-07-08T16:40:58.9769845Z             return quorum_hash in self.nodes[0].quorum('list')[llmq_type_name]


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone