### PR TITLE
fix: resolve race condition in quorum data recovery thread management

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -923,11 +923,11 @@ void CQuorumManager::StartQuorumDataRecoveryThread(CConnman& connman, const CQuo
 {
     assert(m_mn_activeman);
 
-    if (pQuorum->fQuorumDataRecoveryThreadRunning) {
+    bool expected = false;
+    if (!pQuorum->fQuorumDataRecoveryThreadRunning.compare_exchange_strong(expected, true)) {
         LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Already running\n", __func__);
         return;
     }
-    pQuorum->fQuorumDataRecoveryThreadRunning = true;
 
     workerPool.push([&connman, pQuorum, pIndex, nDataMaskIn, this](int threadId) {
         size_t nTries{0};


### PR DESCRIPTION
## Summary

This PR fixes a thread safety issue in the quorum data recovery system where multiple threads could be started for the same quorum due to a race condition.

### Problem

The original code used a check-then-set pattern:
```cpp
if (pQuorum->fQuorumDataRecoveryThreadRunning) {  // Check
    return;
}
pQuorum->fQuorumDataRecoveryThreadRunning = true;  // Set
```

Even though `fQuorumDataRecoveryThreadRunning` is declared as `std::atomic<bool>`, this pattern creates a race condition window where multiple threads can pass the check before any of them sets the flag.

### Solution

Replace the check-then-set pattern with an atomic `compare_exchange_strong` operation:
```cpp
bool expected = false;
if (\!pQuorum->fQuorumDataRecoveryThreadRunning.compare_exchange_strong(expected, true)) {
    return;
}
```

This ensures thread-safe access by atomically checking the current value and setting it to `true` only if it was previously `false`.

### Impact

- Prevents multiple data recovery threads from being started for the same quorum
- Eliminates potential resource conflicts and duplicate operations
- Maintains the same functional behavior while ensuring thread safety

## Test plan

- [x] Code compiles successfully
- [x] Change maintains existing API and functionality
- [x] Race condition eliminated through atomic operation

Generated with [Claude Code](https://claude.ai/code)