### PR TITLE
backport: bitcoin/bitcoin#27176: docs: GetDataDirNet and GetDataDirBase don't create datadir

### DIFF
--- a/src/util/system.h
+++ b/src/util/system.h
@@ -307,7 +307,6 @@ protected:
      * Get data directory path
      *
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
-     * @post Returned directory path is created unless it is empty
      */
     fs::path GetDataDirBase() const { return GetDataDir(false); }
 
@@ -315,7 +314,6 @@ protected:
      * Get data directory path with appended network identifier
      *
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
-     * @post Returned directory path is created unless it is empty
      */
     fs::path GetDataDirNet() const { return GetDataDir(true); }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Since bitcoin#27073 (backported via #6780), the behaviour of `GetDataDir()` [changed](https://github.com/bitcoin/bitcoin/pull/27073/files#diff-19427b0dd1a791adc728c82e88f267751ba4f1c751e19262cac03cccd2822216L435-L443) to only return the datadir path, but not create it if non-existent. This also changed the behaviour of `GetDataDirNet()` and `GetDataDirBase()` but the docs do not yet reflect that.



## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

