### PR TITLE
refactor: shed avoidable casts, follow-up to bitcoin#25611

### DIFF
--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -50,7 +50,7 @@ public:
     [[nodiscard]] UniValue ToJson() const
     {
         UniValue obj(UniValue::VOBJ);
-        obj.pushKV("versionBit", (int)versionBit);
+        obj.pushKV("versionBit", versionBit);
         obj.pushKV("quorumHash", quorumHash.ToString());
         obj.pushKV("sig", sig.ToString());
         return obj;

--- a/src/llmq/debug.cpp
+++ b/src/llmq/debug.cpp
@@ -34,7 +34,7 @@ UniValue CDKGDebugSessionStatus::ToJson(CDeterministicMNManager& dmnman, CQuorum
 
     ret.pushKV("llmqType", ToUnderlying(llmqType));
     ret.pushKV("quorumHash", quorumHash.ToString());
-    ret.pushKV("quorumHeight", (int)quorumHeight);
+    ret.pushKV("quorumHeight", quorumHeight);
     ret.pushKV("phase", ToUnderlying(phase));
 
     ret.pushKV("sentContributions", statusBits.sentContributions);
@@ -61,10 +61,10 @@ UniValue CDKGDebugSessionStatus::ToJson(CDeterministicMNManager& dmnman, CQuorum
             if (detailLevel == 0) {
                 v.count++;
             } else if (detailLevel == 1) {
-                v.arr.push_back((int)idx);
+                v.arr.push_back(idx);
             } else if (detailLevel == 2) {
                 UniValue a(UniValue::VOBJ);
-                a.pushKV("memberIndex", (int)idx);
+                a.pushKV("memberIndex", idx);
                 if (idx < dmnMembers.size()) {
                     a.pushKV("proTxHash", dmnMembers[idx]->proTxHash.ToString());
                 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Small follow-up for bitcoin#25611 (merged via #6775)

## What was done?
Shed avoidable casts in evo/mnhftx, llmq/debug

## How Has This Been Tested?
See CI

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone