### PR TITLE
fix(rpc): `upgradetohd` rpc should allow null characters in wallet passphrase

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -379,9 +379,7 @@ static RPCHelpMan upgradetohd()
             throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Wallet encrypted but passphrase not supplied to RPC.");
         }
     } else {
-        // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
-        // Alternately, find a way to make request.params[0] mlock()'d to begin with.
-        secureWalletPassphrase = request.params[2].get_str().c_str();
+        secureWalletPassphrase = std::string_view{request.params[2].get_str()};
     }
 
     SecureString secureMnemonic;

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -175,7 +175,8 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         self.recover_non_hd()
 
         self.log.info("Same mnemonic, same mnemonic passphrase, encrypt wallet on upgrade, should recover all coins after rescan")
-        walletpass = "111pass222"
+        # Null characters are allowed in wallet passphrases now
+        walletpass = "111\0pass222"
         assert node.upgradetohd(mnemonic, "", walletpass)
         node.stop()
         node.wait_until_stopped()


### PR DESCRIPTION
## Issue being fixed or feature implemented
A follow-up for [27068](https://github.com/dashpay/dash/pull/6780/commits/2fcb230f7d22e56c13c239c05ca17468640b0e16) from #6780 to make sure `upgradetohd` allows null characters in wallet passphrase like encryption RPCs do now. It's a slimmer alternative to #6792 that touches wallet passphrase only with a tiny test adjustment and no refactoring.

## What was done?
Fix it, tweak tests

## How Has This Been Tested?
Run tests

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

