### PR TITLE
test: add a case for `upgradetohd` with null characters in mnemonic passphrase

### DIFF
--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -247,6 +247,14 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         assert_equal(12, w12.getbalance())
         w12.unloadwallet()
 
+        self.log.info("Test upgradetohd with null characters in mnemonic passphrase")
+        # Null characters aren't allowed in mnemonic passphrases, the first one and everything after it is ignored
+        node.createwallet("wallet-13", blank=True)
+        w13 = node.get_wallet_rpc("wallet-13")
+        w13.upgradetohd(custom_mnemonic, "custom-passphrase\0with\0null\0characters")
+        assert_equal(12, w13.getbalance())
+        w13.unloadwallet()
+
 
 if __name__ == '__main__':
     WalletUpgradeToHDTest().main ()


### PR DESCRIPTION
## Issue being fixed or feature implemented
Null characters aren't allowed in mnemonic passphrases, the first one and everything after it is ignored. This might change after #6792 but let's add a test to make sure it's working like that right now anyway.

## What was done?


## How Has This Been Tested?
Run test

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

