### PR TITLE
test: add CoinJoin DSTX and inouts tests

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -120,6 +120,8 @@ BITCOIN_TESTS =\
   test/fs_tests.cpp \
   test/getarg_tests.cpp \
   test/governance_validators_tests.cpp \
+  test/coinjoin_inouts_tests.cpp \
+  test/coinjoin_dstxmanager_tests.cpp \
   test/hash_tests.cpp \
   test/httpserver_tests.cpp \
   test/i2p_tests.cpp \

--- a/src/test/coinjoin_dstxmanager_tests.cpp
+++ b/src/test/coinjoin_dstxmanager_tests.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/setup_common.h>
+
+#include <array>
+#include <algorithm>
+#include <vector>
+
+#include <coinjoin/coinjoin.h>
+#include <coinjoin/common.h>
+#include <coinjoin/context.h>
+#include <chain.h>
+#include <script/script.h>
+#include <uint256.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(coinjoin_dstxmanager_tests, TestingSetup)
+
+static CCoinJoinBroadcastTx MakeDSTX(int vin_vout_count = 3)
+{
+    CCoinJoinBroadcastTx dstx;
+    CMutableTransaction mtx;
+    const int count = std::max(vin_vout_count, 1);
+    for (int i = 0; i < count; ++i) {
+        mtx.vin.emplace_back(COutPoint(uint256S("0a"), i));
+        // Use denominated P2PKH outputs
+    std::array<unsigned char, 20> h{}; h.fill(static_cast<unsigned char>(i));
+    CScript spk; spk << OP_DUP << OP_HASH160 << std::vector<unsigned char>(h.begin(), h.end()) << OP_EQUALVERIFY << OP_CHECKSIG;
+        mtx.vout.emplace_back(CoinJoin::GetSmallestDenomination(), spk);
+    }
+    dstx.tx = MakeTransactionRef(mtx);
+    dstx.m_protxHash = uint256::ONE;
+    return dstx;
+}
+
+BOOST_AUTO_TEST_CASE(add_get_dstx)
+{
+    CCoinJoinBroadcastTx dstx = MakeDSTX();
+    auto& man = *Assert(Assert(m_node.cj_ctx)->dstxman);
+    // Not present initially
+    BOOST_CHECK(!man.GetDSTX(dstx.tx->GetHash()));
+    // Add
+    man.AddDSTX(dstx);
+    // Fetch back
+    auto got = man.GetDSTX(dstx.tx->GetHash());
+    BOOST_CHECK(static_cast<bool>(got));
+    BOOST_CHECK_EQUAL(got.tx->GetHash().ToString(), dstx.tx->GetHash().ToString());
+}
+
+BOOST_AUTO_TEST_CASE(update_heights_block_connect_disconnect)
+{
+    CCoinJoinBroadcastTx dstx = MakeDSTX();
+    auto& man = *Assert(Assert(m_node.cj_ctx)->dstxman);
+    man.AddDSTX(dstx);
+
+    // Create a fake block containing the tx
+    auto block = std::make_shared<CBlock>();
+    block->vtx.push_back(dstx.tx);
+    CBlockIndex index; index.nHeight = 100; uint256 bh = uint256S("0b"); index.phashBlock = &bh;
+
+    // Height should set to 100 on connect
+    man.BlockConnected(block, &index);
+
+    // Height should clear on disconnect
+    man.BlockDisconnected(block, nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/setup_common.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include <coinjoin/coinjoin.h>
+#include <coinjoin/common.h>
+#include <chainlock/chainlock.h>
+#include <chain.h>
+#include <llmq/context.h>
+#include <script/script.h>
+#include <uint256.h>
+#include <util/check.h>
+#include <util/time.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(coinjoin_inouts_tests, TestingSetup)
+
+static CScript P2PKHScript(uint8_t tag = 0x01)
+{
+    // OP_DUP OP_HASH160 <20-byte-tag> OP_EQUALVERIFY OP_CHECKSIG
+    std::array<unsigned char, 20> hash{};
+    hash.fill(tag);
+    CScript spk;
+    spk << OP_DUP << OP_HASH160 << std::vector<unsigned char>(hash.begin(), hash.end()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    return spk;
+}
+
+BOOST_AUTO_TEST_CASE(broadcasttx_isvalidstructure_good_and_bad)
+{
+    // Good: equal vin/vout sizes, vin count >= min participants, <= max*entry_size, P2PKH outputs with standard denominations
+    CCoinJoinBroadcastTx good;
+    {
+        CMutableTransaction mtx;
+        // Use min pool participants (e.g. 3). Build 3 inputs and 3 denominated outputs
+        const int participants = std::max(3, CoinJoin::GetMinPoolParticipants());
+        for (int i = 0; i < participants; ++i) {
+            CTxIn in;
+            in.prevout = COutPoint(uint256S("01"), static_cast<uint32_t>(i));
+            mtx.vin.push_back(in);
+            // Pick the smallest denomination
+            CTxOut out{CoinJoin::GetSmallestDenomination(), P2PKHScript(static_cast<uint8_t>(i))};
+            mtx.vout.push_back(out);
+        }
+        good.tx = MakeTransactionRef(mtx);
+        good.m_protxHash = uint256::ONE; // at least one of (outpoint, protxhash) must be set
+    }
+    BOOST_CHECK(good.IsValidStructure());
+
+    // Bad: both identifiers null
+    CCoinJoinBroadcastTx bad_ids = good;
+    bad_ids.m_protxHash = uint256();
+    bad_ids.masternodeOutpoint.SetNull();
+    BOOST_CHECK(!bad_ids.IsValidStructure());
+
+    // Bad: vin/vout size mismatch
+    CCoinJoinBroadcastTx bad_sizes = good;
+    {
+        CMutableTransaction mtx(*good.tx);
+        mtx.vout.pop_back();
+        bad_sizes.tx = MakeTransactionRef(mtx);
+    }
+    BOOST_CHECK(!bad_sizes.IsValidStructure());
+
+    // Bad: non-P2PKH output
+    CCoinJoinBroadcastTx bad_script = good;
+    {
+        CMutableTransaction mtx(*good.tx);
+        mtx.vout[0].scriptPubKey = CScript() << OP_RETURN << std::vector<unsigned char>{'x'};
+        bad_script.tx = MakeTransactionRef(mtx);
+    }
+    BOOST_CHECK(!bad_script.IsValidStructure());
+
+    // Bad: non-denominated amount
+    CCoinJoinBroadcastTx bad_amount = good;
+    {
+        CMutableTransaction mtx(*good.tx);
+        mtx.vout[0].nValue = 42; // not a valid denom
+        bad_amount.tx = MakeTransactionRef(mtx);
+    }
+    BOOST_CHECK(!bad_amount.IsValidStructure());
+}
+
+BOOST_AUTO_TEST_CASE(queue_timeout_bounds)
+{
+    CCoinJoinQueue dsq;
+    dsq.nDenom = CoinJoin::AmountToDenomination(CoinJoin::GetSmallestDenomination());
+    dsq.m_protxHash = uint256::ONE;
+    dsq.nTime = GetAdjustedTime();
+    // current time -> not out of bounds
+    BOOST_CHECK(!dsq.IsTimeOutOfBounds());
+
+    // Too old (beyond COINJOIN_QUEUE_TIMEOUT)
+    SetMockTime(GetTime() + (COINJOIN_QUEUE_TIMEOUT + 1));
+    BOOST_CHECK(dsq.IsTimeOutOfBounds());
+
+    // Too far in the future
+    SetMockTime(GetTime() - 2 * (COINJOIN_QUEUE_TIMEOUT + 1)); // move back to anchor baseline
+    dsq.nTime = GetAdjustedTime() + (COINJOIN_QUEUE_TIMEOUT + 1);
+    BOOST_CHECK(dsq.IsTimeOutOfBounds());
+
+    // Reset mock time
+    SetMockTime(0);
+}
+
+BOOST_AUTO_TEST_CASE(broadcasttx_expiry_height_logic)
+{
+    // Build a valid-looking CCoinJoinBroadcastTx with confirmed height
+    CCoinJoinBroadcastTx dstx;
+    {
+        CMutableTransaction mtx;
+        const int participants = std::max(3, CoinJoin::GetMinPoolParticipants());
+        for (int i = 0; i < participants; ++i) {
+            mtx.vin.emplace_back(COutPoint(uint256S("02"), i));
+            mtx.vout.emplace_back(CoinJoin::GetSmallestDenomination(), P2PKHScript(static_cast<uint8_t>(i)));
+        }
+        dstx.tx = MakeTransactionRef(mtx);
+        dstx.m_protxHash = uint256::ONE;
+        // mark as confirmed at height 100
+        dstx.SetConfirmedHeight(100);
+    }
+
+    // Minimal CBlockIndex with required fields
+    // Create a minimal block index to satisfy the interface
+    CBlockIndex index;
+    uint256 blk_hash = uint256S("03");
+    index.nHeight = 125; // 125 - 100 == 25 > 24 → expired by height
+    index.phashBlock = &blk_hash;
+    BOOST_CHECK(dstx.IsExpired(&index, *Assert(m_node.llmq_ctx->clhandler)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+


### PR DESCRIPTION
## Issue being fixed or feature implemented
This commit introduces two new test files: `coinjoin_dstxmanager_tests.cpp` and `coinjoin_inouts_tests.cpp`. The `coinjoin_dstxmanager_tests` file includes tests for managing CoinJoin broadcast transactions, while the `coinjoin_inouts_tests` file focuses on validating the structure and behavior of CoinJoin transactions. Both files are added to the test suite in the Makefile for comprehensive testing coverage.


## What was done?


## How Has This Been Tested?
Tests pass locally

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

