### PR TITLE
feat: v21 follow-ups for wallet RPCs

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -901,7 +901,8 @@ static RPCHelpMan upgradewallet()
 {
     return RPCHelpMan{"upgradewallet",
         "\nUpgrade the wallet. Upgrades to the latest version if no version number is specified.\n"
-        "New keys may be generated and a new wallet backup will need to be made.",
+        "New keys may be generated and a new wallet backup will need to be made.\n"
+        "Consider using RPC upgradetohd instead upgradewallet if you have BIP39 mnemonic or want to set a wallet passphrase also (encrypt wallet).",
         {
             {"version", RPCArg::Type::NUM, RPCArg::Default{int{FEATURE_LATEST}}, "The version number to upgrade to. Default is the latest wallet version."}
         },

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -397,14 +397,6 @@ static RPCHelpMan upgradetohd()
             mnemonic_passphrase = std::string_view{request.params[1].get_str()};
         }
 
-        // TODO: breaking changes kept for v21!
-        // instead upgradetohd let's use more straightforward 'sethdseed'
-        constexpr bool is_v21 = false;
-        const int previous_version{pwallet->GetVersion()};
-        if (is_v21 && previous_version >= FEATURE_HD) {
-            return JSONRPCError(RPC_WALLET_ERROR, "Already at latest version. Wallet version unchanged.");
-        }
-
         // Do not do anything to HD wallets
         if (pwallet->IsHDEnabled()) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade a wallet to HD if it is already upgraded to HD");
@@ -842,7 +834,6 @@ static RPCHelpMan sethdseed()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    // TODO: add mnemonic feature to sethdseed or remove it in favour of upgradetohd
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3211,13 +3211,6 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
         return false;
     }
 
-    // TODO: consider discourage users to skip passphrase for HD wallets for v21
-    if (/* DISABLES CODE */ (false) && nMaxVersion >= FEATURE_HD && !IsHDEnabled()) {
-        error = Untranslated("You should use upgradetohd RPC to upgrade non-HD wallet to HD");
-        error = strprintf(_("Cannot upgrade a non HD wallet from version %i to version %i which is non-HD wallet. Use upgradetohd RPC"), prev_version, version);
-        return false;
-    }
-
     SetMinVersion(GetClosestWalletFeature(version));
 
     return true;


### PR DESCRIPTION
## Issue being fixed or feature implemented
`sethdseed` is used to set WIF private key and `upgradetohd` is used to set mnemonic.
This PR removes outdated todoes and update RPC doc clearer.

## What was done?
See commits

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

