### PR TITLE
feat: add support for internet domains, CJDNS, I2P and Tor to extended addresses, permit registering internet domains for Platform HTTPS API

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -442,7 +442,17 @@ private:
         DMNL_NO_TEMPLATE(NetInfoInterface);
         DMNL_NO_TEMPLATE(std::shared_ptr<NetInfoInterface>);
 #undef DMNL_NO_TEMPLATE
-        return ::SerializeHash(v);
+        int ser_version{PROTOCOL_VERSION};
+        if constexpr (std::is_same_v<std::decay_t<T>, CService>) {
+            // Special handling is required if we're using addresses that can only be (de)serialized using
+            // ADDRv2. Without this step, the address gets truncated, the hashmap gets contaminated with
+            // an invalid entry and subsequent attempts at registering ADDRv2 entries get blocked. We cannot
+            // apply this treatment ADDRv1 compatible addresses for backwards compatibility with the existing map.
+            if (!v.IsAddrV1Compatible()) {
+                ser_version |= ADDRV2_FORMAT;
+            }
+        }
+        return ::SerializeHash(v, /*nType=*/SER_GETHASH, /*nVersion=*/ser_version);
     }
     template <typename T>
     [[nodiscard]] bool AddUniqueProperty(const CDeterministicMN& dmn, const T& v)

--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -449,7 +449,7 @@ NetInfoStatus ExtNetInfo::ValidateService(const CService& service)
     if (!service.IsValid()) {
         return NetInfoStatus::BadAddress;
     }
-    if (!service.IsIPv4() && !service.IsIPv6()) {
+    if (!service.IsCJDNS() && !service.IsIPv4() && !service.IsIPv6()) {
         return NetInfoStatus::BadType;
     }
     if (Params().RequireRoutableExternalIP() && !service.IsRoutable()) {
@@ -513,9 +513,10 @@ NetInfoStatus ExtNetInfo::AddEntry(const NetInfoPurpose purpose, const std::stri
 
     // IP:port safe, try to parse it as IP:port
     if (auto service_opt{Lookup(addr, /*portDefault=*/port, /*fAllowLookup=*/false)}) {
-        const auto ret{ValidateService(*service_opt)};
+        const auto service{MaybeFlipIPv6toCJDNS(*service_opt)};
+        const auto ret{ValidateService(service)};
         if (ret == NetInfoStatus::Success) {
-            return ProcessCandidate(purpose, NetInfoEntry{*service_opt});
+            return ProcessCandidate(purpose, NetInfoEntry{service});
         }
         return ret; /* ValidateService() failed */
     }

--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -41,6 +41,7 @@ static constexpr std::array<std::string_view, 13> TLDS_BAD{
     // RFC 6762, Appendix G
     ".corp", ".home", ".internal", ".intranet", ".lan", ".private",
 };
+static constexpr std::array<std::string_view, 2> TLDS_PRIVACY{".i2p", ".onion"};
 
 bool MatchCharsFilter(std::string_view input, std::string_view filter)
 {
@@ -449,14 +450,22 @@ NetInfoStatus ExtNetInfo::ValidateService(const CService& service)
     if (!service.IsValid()) {
         return NetInfoStatus::BadAddress;
     }
-    if (!service.IsCJDNS() && !service.IsIPv4() && !service.IsIPv6()) {
+    if (!service.IsCJDNS() && !service.IsI2P() && !service.IsIPv4() && !service.IsIPv6() && !service.IsTor()) {
         return NetInfoStatus::BadType;
     }
     if (Params().RequireRoutableExternalIP() && !service.IsRoutable()) {
         return NetInfoStatus::NotRoutable;
     }
-    if (IsBadPort(service.GetPort()) || service.GetPort() == 0) {
-        return NetInfoStatus::BadPort;
+    const uint16_t service_port{service.GetPort()};
+    if (service.IsI2P()) {
+        if (service_port != I2P_SAM31_PORT) {
+            // I2P SAM 3.1 and earlier don't support arbitrary ports
+            return NetInfoStatus::BadPort;
+        }
+    } else {
+        if (service_port == 0 || IsBadPort(service_port)) {
+            return NetInfoStatus::BadPort;
+        }
     }
 
     return NetInfoStatus::Success;
@@ -472,7 +481,7 @@ NetInfoStatus ExtNetInfo::ValidateDomainPort(const DomainPort& domain)
         return NetInfoStatus::BadPort;
     }
     const std::string& addr{domain.ToStringAddr()};
-    if (MatchSuffix(addr, TLDS_BAD)) {
+    if (MatchSuffix(addr, TLDS_BAD) || MatchSuffix(addr, TLDS_PRIVACY)) {
         return NetInfoStatus::BadInput;
     }
     if (const auto labels{SplitString(addr, '.')}; !MatchCharsFilter(labels.at(labels.size() - 1), SAFE_CHARS_ALPHA)) {
@@ -500,15 +509,27 @@ NetInfoStatus ExtNetInfo::AddEntry(const NetInfoPurpose purpose, const std::stri
             return NetInfoStatus::BadInput;
         }
 
-        // Not IP:port safe but domain safe, treat as domain.
-        if (DomainPort domain; domain.Set(addr, port) == DomainPort::Status::Success) {
+        // Not IP:port safe but domain safe
+        if (MatchSuffix(addr, TLDS_PRIVACY)) {
+            // Special domain, try storing it as CService
+            CNetAddr netaddr;
+            if (netaddr.SetSpecial(addr)) {
+                const CService service{netaddr, port};
+                const auto ret{ValidateService(service)};
+                if (ret == NetInfoStatus::Success) {
+                    return ProcessCandidate(purpose, NetInfoEntry{service});
+                }
+                return ret; /* ValidateService() failed */
+            }
+        } else if (DomainPort domain; domain.Set(addr, port) == DomainPort::Status::Success) {
+            // Regular domain
             const auto ret{ValidateDomainPort(domain)};
             if (ret == NetInfoStatus::Success) {
                 return ProcessCandidate(purpose, NetInfoEntry{domain});
             }
             return ret; /* ValidateDomainPort() failed */
         }
-        return NetInfoStatus::BadInput; /* DomainPort::Set() failed */
+        return NetInfoStatus::BadInput; /* CNetAddr::SetSpecial() or DomainPort::Set() failed */
     }
 
     // IP:port safe, try to parse it as IP:port

--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -25,13 +25,45 @@ static constexpr uint8_t DOMAIN_MAX_LEN{253};
 /** Minimum length of a FQDN */
 static constexpr uint8_t DOMAIN_MIN_LEN{3};
 
+static constexpr std::string_view SAFE_CHARS_ALPHA{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"};
 static constexpr std::string_view SAFE_CHARS_IPV4{"1234567890."};
 static constexpr std::string_view SAFE_CHARS_IPV4_6{"abcdefABCDEF1234567890.:[]"};
 static constexpr std::string_view SAFE_CHARS_RFC1035{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-"};
+static constexpr std::array<std::string_view, 13> TLDS_BAD{
+    // ICANN resolution 2018.02.04.12
+    ".mail",
+    // Infrastructure TLD
+    ".arpa",
+    // RFC 6761
+    ".example", ".invalid", ".localhost", ".test",
+    // RFC 6762
+    ".local",
+    // RFC 6762, Appendix G
+    ".corp", ".home", ".internal", ".intranet", ".lan", ".private",
+};
 
 bool MatchCharsFilter(std::string_view input, std::string_view filter)
 {
     return std::all_of(input.begin(), input.end(), [&filter](char c) { return filter.find(c) != std::string_view::npos; });
+}
+
+bool MatchSuffix(const std::string& str, Span<const std::string_view> list)
+{
+    if (str.empty()) return false;
+    for (const auto& suffix : list) {
+        if (suffix.size() > str.size()) continue;
+        if (std::string_view{str}.ends_with(suffix)) return true;
+    }
+    return false;
+}
+
+bool IsAllowedPlatformHTTPPort(uint16_t port)
+{
+    switch (port) {
+    case 443:
+        return true;
+    }
+    return false;
 }
 } // anonymous namespace
 
@@ -387,6 +419,10 @@ NetInfoStatus ExtNetInfo::ProcessCandidate(const NetInfoPurpose purpose, const N
     if (IsAddrPortDuplicate(candidate)) {
         return NetInfoStatus::Duplicate;
     }
+    if (candidate.GetDomainPort().has_value() && purpose != NetInfoPurpose::PLATFORM_HTTPS) {
+        // Domains only allowed for Platform HTTPS API
+        return NetInfoStatus::BadInput;
+    }
     if (auto it{m_data.find(purpose)}; it != m_data.end()) {
         // Existing entries list found, check limit
         auto& [_, entries] = *it;
@@ -426,6 +462,26 @@ NetInfoStatus ExtNetInfo::ValidateService(const CService& service)
     return NetInfoStatus::Success;
 }
 
+NetInfoStatus ExtNetInfo::ValidateDomainPort(const DomainPort& domain)
+{
+    if (!domain.IsValid()) {
+        return NetInfoStatus::BadInput;
+    }
+    const uint16_t domain_port{domain.GetPort()};
+    if (domain_port == 0 || (IsBadPort(domain_port) && !IsAllowedPlatformHTTPPort(domain_port))) {
+        return NetInfoStatus::BadPort;
+    }
+    const std::string& addr{domain.ToStringAddr()};
+    if (MatchSuffix(addr, TLDS_BAD)) {
+        return NetInfoStatus::BadInput;
+    }
+    if (const auto labels{SplitString(addr, '.')}; !MatchCharsFilter(labels.at(labels.size() - 1), SAFE_CHARS_ALPHA)) {
+        return NetInfoStatus::BadInput;
+    }
+
+    return NetInfoStatus::Success;
+}
+
 NetInfoStatus ExtNetInfo::AddEntry(const NetInfoPurpose purpose, const std::string& input)
 {
     if (!IsValidPurpose(purpose)) {
@@ -437,11 +493,25 @@ NetInfoStatus ExtNetInfo::AddEntry(const NetInfoPurpose purpose, const std::stri
     std::string addr;
     uint16_t port{0};
     SplitHostPort(input, port, addr);
-    // Contains invalid characters, unlikely to pass Lookup(), fast-fail
+
     if (!MatchCharsFilter(addr, SAFE_CHARS_IPV4_6)) {
-        return NetInfoStatus::BadInput;
+        if (!MatchCharsFilter(addr, SAFE_CHARS_RFC1035)) {
+            // Neither IP:port safe nor domain-safe, we can safely assume it's bad input
+            return NetInfoStatus::BadInput;
+        }
+
+        // Not IP:port safe but domain safe, treat as domain.
+        if (DomainPort domain; domain.Set(addr, port) == DomainPort::Status::Success) {
+            const auto ret{ValidateDomainPort(domain)};
+            if (ret == NetInfoStatus::Success) {
+                return ProcessCandidate(purpose, NetInfoEntry{domain});
+            }
+            return ret; /* ValidateDomainPort() failed */
+        }
+        return NetInfoStatus::BadInput; /* DomainPort::Set() failed */
     }
 
+    // IP:port safe, try to parse it as IP:port
     if (auto service_opt{Lookup(addr, /*portDefault=*/port, /*fAllowLookup=*/false)}) {
         const auto ret{ValidateService(*service_opt)};
         if (ret == NetInfoStatus::Success) {
@@ -514,6 +584,15 @@ NetInfoStatus ExtNetInfo::Validate() const
             if (const auto& service_opt{entry.GetAddrPort()}) {
                 if (auto ret{ValidateService(*service_opt)}; ret != NetInfoStatus::Success) {
                     // Stores CService underneath but doesn't pass validation rules
+                    return ret;
+                }
+            } else if (const auto domain_opt{entry.GetDomainPort()}) {
+                if (purpose != NetInfoPurpose::PLATFORM_HTTPS) {
+                    // Domains only allowed for Platform HTTPS API
+                    return NetInfoStatus::BadInput;
+                }
+                if (auto ret{ValidateDomainPort(*domain_opt)}; ret != NetInfoStatus::Success) {
+                    // Stores DomainPort underneath but doesn't pass validation rules
                     return ret;
                 }
             } else {

--- a/src/evo/netinfo.h
+++ b/src/evo/netinfo.h
@@ -384,6 +384,7 @@ private:
 
     /** Validate CService candidate address against ruleset */
     static NetInfoStatus ValidateService(const CService& service);
+    static NetInfoStatus ValidateDomainPort(const DomainPort& domain);
 
 private:
     uint8_t m_version{CURRENT_VERSION};

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -262,6 +262,10 @@ bool CSpecialTxProcessor::BuildNewListFromBlock(const CBlock& block, gsl::not_nu
                     if (newList.HasUniqueProperty(*service_opt)) {
                         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-netinfo-entry");
                     }
+                } else if (const auto domain_opt{entry.GetDomainPort()}) {
+                    if (newList.HasUniqueProperty(*domain_opt)) {
+                        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-netinfo-entry");
+                    }
                 } else {
                     return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-netinfo-entry");
                 }
@@ -296,6 +300,11 @@ bool CSpecialTxProcessor::BuildNewListFromBlock(const CBlock& block, gsl::not_nu
                 if (const auto service_opt{entry.GetAddrPort()}) {
                     if (newList.HasUniqueProperty(*service_opt) &&
                         newList.GetUniquePropertyMN(*service_opt)->proTxHash != opt_proTx->proTxHash) {
+                        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-netinfo-entry");
+                    }
+                } else if (const auto domain_opt{entry.GetDomainPort()}) {
+                    if (newList.HasUniqueProperty(*domain_opt) &&
+                        newList.GetUniquePropertyMN(*domain_opt)->proTxHash != opt_proTx->proTxHash) {
                         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-netinfo-entry");
                     }
                 } else {


### PR DESCRIPTION
This pull request implements the following:
* "Extension A" (Internet domain names) of DIP-0003's Appendix C (Network Information) by allowing the storage of ASCII domain names in extended address structures if used to register a Platform HTTPS address.
* Support for storing address information of privacy networks like Tor, I2P and CJDNS for all purpose codes.

## Additional Information

* Depends on https://github.com/dashpay/dash/pull/6666

* Due to SAM 3.1 and earlier not supporting the specification of ports (see [bitcoin#22112](https://github.com/bitcoin/bitcoin/pull/22112)), we do not allow defining a port for I2P and it _must_ always be zero.

* Tor and I2P depend on the ADDRv2 format for storing address information. By default, serialization logic will use ADDRv1, which will truncate that information. We cannot migrate the unique properties map to ADDRv2 as it's hashed so we opt to use ADDRv1 _unless_ it is _not_ an ADDRv1 compatible type, in which case we use ADDRv2.

  This fix is validated by `test_uniqueness()` in `rpc_netinfo.py`, which validates that the unique properties map correctly recognizes duplicates while allowing unique entries to be registered (false-positive duplicate detection is a sign of potential truncation and map contamination).

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
