### PR TITLE
docs(rpc): revert gating of `service`/`address` behind `-deprecatedrpc=service`, mark `platform{P2P,HTTP}Port` as deprecated

### DIFF
--- a/doc/release-notes-6665.md
+++ b/doc/release-notes-6665.md
@@ -6,8 +6,8 @@ Updated RPCs
 
 * The key `service` has been deprecated for some RPCs (`decoderawtransaction`, `decodepsbt`, `getblock`, `getrawtransaction`,
   `gettransaction`, `masternode status` (only for the `dmnState` key), `protx diff`, `protx listdiff`) and has been replaced
-  with the field `addresses`.
-  * The deprecated field can be re-enabled using `-deprecatedrpc=service` but is liable to be removed in future versions
+  with the key `addresses`.
+  * The deprecated key is still available without additional runtime arguments but is liable to be removed in future versions
     of Dash Core.
   * This change does not affect `masternode status` (except for the `dmnState` key) as `service` does not represent a payload
     value but the external address advertised by the active masternode.

--- a/doc/release-notes-6665.md
+++ b/doc/release-notes-6665.md
@@ -7,6 +7,7 @@ Updated RPCs
 * The key `service` has been deprecated for some RPCs (`decoderawtransaction`, `decodepsbt`, `getblock`, `getrawtransaction`,
   `gettransaction`, `masternode status` (only for the `dmnState` key), `protx diff`, `protx listdiff`) and has been replaced
   with the key `addresses`.
+  * This deprecation also extends to the functionally identical key, `address` in `masternode list` (and its alias, `masternodelist`)
   * The deprecated key is still available without additional runtime arguments but is liable to be removed in future versions
     of Dash Core.
   * This change does not affect `masternode status` (except for the `dmnState` key) as `service` does not represent a payload

--- a/doc/release-notes-6811.md
+++ b/doc/release-notes-6811.md
@@ -1,0 +1,8 @@
+Updated RPCs
+------------
+
+* The keys `platformP2PPort` and `platformHTTPPort` have been deprecated for the following RPCs, `decoderawtransaction`,
+  `decodepsbt`, `getblock`, `getrawtransaction`, `gettransaction`, `masternode status` (only the `dmnState` key),
+  `protx diff`, `protx listdiff` and has been replaced with the key `addresses`.
+  * The deprecated key is still available without additional runtime arguments but is liable to be removed in future versions
+    of Dash Core.

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1873,9 +1873,7 @@ void CCoinJoinClientSession::GetJsonInfo(UniValue& obj) const
         assert(mixingMasternode->pdmnState);
         obj.pushKV("protxhash", mixingMasternode->proTxHash.ToString());
         obj.pushKV("outpoint", mixingMasternode->collateralOutpoint.ToStringShort());
-        if (m_wallet->chain().rpcEnableDeprecated("service")) {
-            obj.pushKV("service", mixingMasternode->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
-        }
+        obj.pushKV("service", mixingMasternode->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
         obj.pushKV("addrs_core_p2p", mixingMasternode->pdmnState->netInfo->ToJson(NetInfoPurpose::CORE_P2P));
     }
     obj.pushKV("denomination", ValueFromAmount(CoinJoin::DenominationToAmount(nSessionDenom)));

--- a/src/evo/core_write.cpp
+++ b/src/evo/core_write.cpp
@@ -72,9 +72,7 @@
     ret.pushKV("type", ToUnderlying(nType));
     ret.pushKV("collateralHash", collateralOutpoint.hash.ToString());
     ret.pushKV("collateralIndex", collateralOutpoint.n);
-    if (IsServiceDeprecatedRPCEnabled()) {
-        ret.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
-    }
+    ret.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
     ret.pushKV("addresses", GetNetInfoWithLegacyFields(*this, nType));
     ret.pushKV("ownerAddress", EncodeDestination(PKHash(keyIDOwner)));
     ret.pushKV("votingAddress", EncodeDestination(PKHash(keyIDVoting)));
@@ -122,9 +120,7 @@
     ret.pushKV("version", nVersion);
     ret.pushKV("type", ToUnderlying(nType));
     ret.pushKV("proTxHash", proTxHash.ToString());
-    if (IsServiceDeprecatedRPCEnabled()) {
-        ret.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
-    }
+    ret.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
     ret.pushKV("addresses", GetNetInfoWithLegacyFields(*this, nType));
     if (CTxDestination dest; ExtractDestination(scriptOperatorPayout, dest)) {
         ret.pushKV("operatorPayoutAddress", EncodeDestination(dest));
@@ -162,9 +158,7 @@
     obj.pushKV("nType", ToUnderlying(nType));
     obj.pushKV("proRegTxHash", proRegTxHash.ToString());
     obj.pushKV("confirmedHash", confirmedHash.ToString());
-    if (IsServiceDeprecatedRPCEnabled()) {
-        obj.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
-    }
+    obj.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
     obj.pushKV("addresses", GetNetInfoWithLegacyFields(*this, nType));
     obj.pushKV("pubKeyOperator", pubKeyOperator.ToString());
     obj.pushKV("votingAddress", EncodeDestination(PKHash(keyIDVoting)));

--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -36,9 +36,7 @@ UniValue CDeterministicMNState::ToJson(MnType nType) const
 {
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("version", nVersion);
-    if (IsServiceDeprecatedRPCEnabled()) {
-        obj.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
-    }
+    obj.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
     obj.pushKV("addresses", GetNetInfoWithLegacyFields(*this, nType));
     obj.pushKV("registeredHeight", nRegisteredHeight);
     obj.pushKV("lastPaidHeight", nLastPaidHeight);
@@ -73,9 +71,7 @@ UniValue CDeterministicMNStateDiff::ToJson(MnType nType) const
         obj.pushKV("version", state.nVersion);
     }
     if (fields & Field_netInfo) {
-        if (IsServiceDeprecatedRPCEnabled()) {
-            obj.pushKV("service", state.netInfo->GetPrimary().ToStringAddrPort());
-        }
+        obj.pushKV("service", state.netInfo->GetPrimary().ToStringAddrPort());
     }
     if (fields & Field_nRegisteredHeight) {
         obj.pushKV("registeredHeight", state.nRegisteredHeight);

--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -42,12 +42,6 @@ UniValue ArrFromService(const CService& addr)
     return obj;
 }
 
-bool IsServiceDeprecatedRPCEnabled()
-{
-    const auto args = gArgs.GetArgs("-deprecatedrpc");
-    return std::find(args.begin(), args.end(), "service") != args.end();
-}
-
 bool NetInfoEntry::operator==(const NetInfoEntry& rhs) const
 {
     if (m_type != rhs.m_type) return false;

--- a/src/evo/netinfo.h
+++ b/src/evo/netinfo.h
@@ -100,9 +100,6 @@ constexpr std::string_view PurposeToString(const NetInfoPurpose purpose)
 /** Will return true if node is running on mainnet */
 bool IsNodeOnMainnet();
 
-/** Identical to IsDeprecatedRPCEnabled("service"). For use outside of RPC code */
-bool IsServiceDeprecatedRPCEnabled();
-
 /** Creates a one-element array using CService::ToStringPortAddr() output */
 UniValue ArrFromService(const CService& addr);
 

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -433,7 +433,7 @@ static RPCHelpMan getcoinjoininfo()
                                 {
                                     {RPCResult::Type::STR_HEX, "protxhash", "The ProTxHash of the masternode"},
                                     {RPCResult::Type::STR_HEX, "outpoint", "The outpoint of the masternode"},
-                                    {RPCResult::Type::STR, "service", "The IP address and port of the masternode (DEPRECATED, returned only if config option -deprecatedrpc=service is passed)"},
+                                    {RPCResult::Type::STR, "service", "(DEPRECATED) The IP address and port of the masternode"},
                                     {RPCResult::Type::ARR, "addrs_core_p2p", "Network addresses of the masternode used for protocol P2P",
                                         {
                                             {RPCResult::Type::STR, "address", ""},

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -614,9 +614,7 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
                 strOutpoint.find(strFilter) == std::string::npos) return;
             UniValue objMN(UniValue::VOBJ);
             objMN.pushKV("proTxHash", dmn.proTxHash.ToString());
-            if (IsDeprecatedRPCEnabled("service")) {
-                objMN.pushKV("address", dmn.pdmnState->netInfo->GetPrimary().ToStringAddrPort());
-            }
+            objMN.pushKV("address", dmn.pdmnState->netInfo->GetPrimary().ToStringAddrPort());
             objMN.pushKV("addresses", GetNetInfoWithLegacyFields(*dmn.pdmnState, dmn.nType));
             objMN.pushKV("payee", payeeStr);
             objMN.pushKV("status", dmnToStatus(dmn));

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -205,9 +205,7 @@ static UniValue BuildQuorumInfo(const llmq::CQuorumBlockProcessor& quorum_block_
             const auto& dmn = quorum->members[i];
             UniValue mo(UniValue::VOBJ);
             mo.pushKV("proTxHash", dmn->proTxHash.ToString());
-            if (IsDeprecatedRPCEnabled("service")) {
-                mo.pushKV("service", dmn->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
-            }
+            mo.pushKV("service", dmn->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
             mo.pushKV("addresses", GetNetInfoWithLegacyFields(*dmn->pdmnState, dmn->nType));
             mo.pushKV("pubKeyOperator", dmn->pdmnState->pubKeyOperator.ToString());
             mo.pushKV("valid", static_cast<bool>(quorum->qc->validMembers[i]));


### PR DESCRIPTION
## Additional Information

* https://github.com/dashpay/dash/pull/6666

* No help text has been updated to mark `platformP2PPort` and `platformHTTPPort` as deprecated outputs as we do not generate help text that mentions what these fields represent. This gap will be addressed in a future PR and the text "(DEPRECATED)" will be appended there.
  * Like `service`, the field is only marked as deprecated in documentation but is accessible without any additional runtime flags.

## Breaking Changes

Refer to release notes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
