### PR TITLE
fix: Reset all collections before reading in `CDeterministicMNListDiff::Unserialize()`

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -540,6 +540,8 @@ public:
     template <typename Stream>
     void Unserialize(Stream& s)
     {
+        // Reset all collections before reading
+        addedMNs.clear();
         updatedMNs.clear();
         removedMns.clear();
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fix the issue found by @coderabbitai while reviewing #6813 https://github.com/dashpay/dash/pull/6813#pullrequestreview-3107131892

## What was done?


## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

