### PR TITLE
refactor: follow-up dash#6761, implement review suggestions, ChainLock and InstantSend refactoring

### DIFF
--- a/src/chainlock/chainlock.cpp
+++ b/src/chainlock/chainlock.cpp
@@ -381,7 +381,7 @@ void CChainLocksHandler::EnforceBestChainLock()
 VerifyRecSigStatus CChainLocksHandler::VerifyChainLock(const chainlock::ChainLockSig& clsig) const
 {
     const auto llmqType = Params().GetConsensus().llmqTypeChainLocks;
-    const uint256 nRequestId = ::SerializeHash(std::make_pair(chainlock::CLSIG_REQUESTID_PREFIX, clsig.getHeight()));
+    const uint256 nRequestId = chainlock::GenSigRequestId(clsig.getHeight());
 
     return llmq::VerifyRecoveredSig(llmqType, m_chainstate.m_chain, qman, clsig.getHeight(), nRequestId,
                                     clsig.getBlockHash(), clsig.getSig());

--- a/src/chainlock/chainlock.cpp
+++ b/src/chainlock/chainlock.cpp
@@ -479,6 +479,7 @@ void CChainLocksHandler::Cleanup()
             it = txFirstSeenTime.erase(it);
         } else if (!hashBlock.IsNull()) {
             const auto* pindex = m_chainstate.m_blockman.LookupBlockIndex(hashBlock);
+            assert(pindex); // GetTransaction gave us that hashBlock, it should resolve to a valid block index
             if (m_chainstate.m_chain.Tip()->GetAncestor(pindex->nHeight) == pindex &&
                 m_chainstate.m_chain.Height() - pindex->nHeight >= 6) {
                 // tx got confirmed >= 6 times, so we can stop keeping track of it

--- a/src/chainlock/chainlock.cpp
+++ b/src/chainlock/chainlock.cpp
@@ -476,8 +476,8 @@ void CChainLocksHandler::Cleanup()
             const auto* pindex = m_chainstate.m_blockman.LookupBlockIndex(hashBlock);
             assert(pindex); // GetTransaction gave us that hashBlock, it should resolve to a valid block index
             if (m_chainstate.m_chain.Tip()->GetAncestor(pindex->nHeight) == pindex &&
-                m_chainstate.m_chain.Height() - pindex->nHeight >= 6) {
-                // tx got confirmed >= 6 times, so we can stop keeping track of it
+                m_chainstate.m_chain.Height() - pindex->nHeight > chainlock::TX_CONFIRM_THRESHOLD) {
+                // tx is sufficiently deep, we can stop tracking it
                 it = txFirstSeenTime.erase(it);
             } else {
                 ++it;

--- a/src/chainlock/chainlock.h
+++ b/src/chainlock/chainlock.h
@@ -58,8 +58,8 @@ private:
     chainlock::ChainLockSig bestChainLock GUARDED_BY(cs);
 
     chainlock::ChainLockSig bestChainLockWithKnownBlock GUARDED_BY(cs);
-    const CBlockIndex* bestChainLockBlockIndex GUARDED_BY(cs) {nullptr};
-    const CBlockIndex* lastNotifyChainLockBlockIndex GUARDED_BY(cs) {nullptr};
+    const CBlockIndex* bestChainLockBlockIndex GUARDED_BY(cs){nullptr};
+    const CBlockIndex* lastNotifyChainLockBlockIndex GUARDED_BY(cs){nullptr};
 
     std::unordered_map<uint256, int64_t, StaticSaltedHasher> txFirstSeenTime GUARDED_BY(cs);
 

--- a/src/chainlock/chainlock.h
+++ b/src/chainlock/chainlock.h
@@ -61,11 +61,11 @@ private:
     const CBlockIndex* bestChainLockBlockIndex GUARDED_BY(cs){nullptr};
     const CBlockIndex* lastNotifyChainLockBlockIndex GUARDED_BY(cs){nullptr};
 
-    std::unordered_map<uint256, int64_t, StaticSaltedHasher> txFirstSeenTime GUARDED_BY(cs);
+    std::unordered_map<uint256, std::chrono::seconds, StaticSaltedHasher> txFirstSeenTime GUARDED_BY(cs);
 
-    std::map<uint256, int64_t> seenChainLocks GUARDED_BY(cs);
+    std::map<uint256, std::chrono::seconds> seenChainLocks GUARDED_BY(cs);
 
-    std::atomic<int64_t> lastCleanupTime{0};
+    std::atomic<std::chrono::seconds> lastCleanupTime{0s};
 
 public:
     explicit CChainLocksHandler(CChainState& chainstate, CQuorumManager& _qman, CSigningManager& _sigman,

--- a/src/chainlock/chainlock.h
+++ b/src/chainlock/chainlock.h
@@ -76,9 +76,12 @@ public:
     void Start(const llmq::CInstantSendManager& isman);
     void Stop();
 
-    bool AlreadyHave(const CInv& inv) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    bool GetChainLockByHash(const uint256& hash, chainlock::ChainLockSig& ret) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    chainlock::ChainLockSig GetBestChainLock() const EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool AlreadyHave(const CInv& inv) const
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool GetChainLockByHash(const uint256& hash, chainlock::ChainLockSig& ret) const
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    chainlock::ChainLockSig GetBestChainLock() const
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void UpdateTxFirstSeenMap(const std::unordered_set<uint256, StaticSaltedHasher>& tx, const int64_t& time) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
@@ -86,13 +89,19 @@ public:
                                                               const uint256& hash) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
-    void AcceptedBlockHeader(gsl::not_null<const CBlockIndex*> pindexNew) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void AcceptedBlockHeader(gsl::not_null<const CBlockIndex*> pindexNew)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void UpdatedBlockTip(const llmq::CInstantSendManager& isman);
-    void TransactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime) EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, gsl::not_null<const CBlockIndex*> pindex) EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, gsl::not_null<const CBlockIndex*> pindexDisconnected) EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    void CheckActiveState() EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    void EnforceBestChainLock() EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void TransactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, gsl::not_null<const CBlockIndex*> pindex)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, gsl::not_null<const CBlockIndex*> pindexDisconnected)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void CheckActiveState()
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void EnforceBestChainLock()
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     bool HasChainLock(int nHeight, const uint256& blockHash) const override
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
@@ -107,7 +116,8 @@ public:
     [[nodiscard]] bool IsEnabled() const override { return isEnabled; }
 
 private:
-    void Cleanup() EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void Cleanup()
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
 };
 
 bool AreChainLocksEnabled(const CSporkManager& sporkman);

--- a/src/chainlock/clsig.cpp
+++ b/src/chainlock/clsig.cpp
@@ -6,8 +6,10 @@
 
 #include <tinyformat.h>
 
+#include <string_view>
+
 namespace chainlock {
-const std::string CLSIG_REQUESTID_PREFIX = "clsig";
+static constexpr std::string_view CLSIG_REQUESTID_PREFIX{"clsig"};
 
 ChainLockSig::ChainLockSig() = default;
 ChainLockSig::~ChainLockSig() = default;
@@ -22,5 +24,10 @@ ChainLockSig::ChainLockSig(int32_t nHeight, const uint256& blockHash, const CBLS
 std::string ChainLockSig::ToString() const
 {
     return strprintf("ChainLockSig(nHeight=%d, blockHash=%s)", nHeight, blockHash.ToString());
+}
+
+uint256 GenSigRequestId(const int32_t nHeight)
+{
+    return ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, nHeight));
 }
 } // namespace chainlock

--- a/src/chainlock/clsig.h
+++ b/src/chainlock/clsig.h
@@ -13,8 +13,6 @@
 #include <cstdint>
 
 namespace chainlock {
-extern const std::string CLSIG_REQUESTID_PREFIX;
-
 struct ChainLockSig {
 private:
     int32_t nHeight{-1};
@@ -38,6 +36,9 @@ public:
         READWRITE(obj.nHeight, obj.blockHash, obj.sig);
     }
 };
+
+//! Generate clsig request ID with block height
+uint256 GenSigRequestId(const int32_t nHeight);
 } // namespace chainlock
 
 #endif // BITCOIN_CHAINLOCK_CLSIG_H

--- a/src/chainlock/signing.cpp
+++ b/src/chainlock/signing.cpp
@@ -15,9 +15,9 @@
 using node::ReadBlockFromDisk;
 
 namespace chainlock {
-ChainLockSigner::ChainLockSigner(CChainState& chainstate, ChainLockSignerParent& clhandler, llmq::CSigningManager& sigman,
-                                 llmq::CSigSharesManager& shareman, CSporkManager& sporkman,
-                                 const CMasternodeSync& mn_sync) :
+ChainLockSigner::ChainLockSigner(CChainState& chainstate, ChainLockSignerParent& clhandler,
+                                 llmq::CSigningManager& sigman, llmq::CSigSharesManager& shareman,
+                                 CSporkManager& sporkman, const CMasternodeSync& mn_sync) :
     m_chainstate{chainstate},
     m_clhandler{clhandler},
     m_sigman{sigman},
@@ -85,7 +85,8 @@ void ChainLockSigner::TrySignChainTip(const llmq::CInstantSendManager& isman)
         return;
     }
 
-    LogPrint(BCLog::CHAINLOCKS, "%s -- trying to sign %s, height=%d\n", __func__, pindex->GetBlockHash().ToString(), pindex->nHeight);
+    LogPrint(BCLog::CHAINLOCKS, "%s -- trying to sign %s, height=%d\n", __func__, pindex->GetBlockHash().ToString(),
+             pindex->nHeight);
 
     // When the new IX system is activated, we only try to ChainLock blocks which include safe transactions. A TX is
     // considered safe when it is islocked or at least known since 10 minutes (from mempool or block). These checks are
@@ -114,8 +115,9 @@ void ChainLockSigner::TrySignChainTip(const llmq::CInstantSendManager& isman)
 
             for (const auto& txid : *txids) {
                 if (!m_clhandler.IsTxSafeForMining(txid) && !isman.IsLocked(txid)) {
-                    LogPrint(BCLog::CHAINLOCKS, "%s -- not signing block %s due to TX %s not being islocked and not old enough.\n", __func__,
-                              pindexWalk->GetBlockHash().ToString(), txid.ToString());
+                    LogPrint(BCLog::CHAINLOCKS, /* Continued */
+                             "%s -- not signing block %s due to TX %s not being islocked and not old enough.\n",
+                             __func__, pindexWalk->GetBlockHash().ToString(), txid.ToString());
                     return;
                 }
             }
@@ -243,7 +245,7 @@ std::vector<std::shared_ptr<std::unordered_set<uint256, StaticSaltedHasher>>> Ch
     AssertLockNotHeld(cs_signer);
     std::vector<std::shared_ptr<std::unordered_set<uint256, StaticSaltedHasher>>> removed;
     LOCK2(::cs_main, cs_signer);
-    for (auto it = blockTxs.begin(); it != blockTxs.end(); ) {
+    for (auto it = blockTxs.begin(); it != blockTxs.end();) {
         const auto* pindex = m_chainstate.m_blockman.LookupBlockIndex(it->first);
         if (m_clhandler.HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
             removed.push_back(it->second);

--- a/src/chainlock/signing.cpp
+++ b/src/chainlock/signing.cpp
@@ -95,10 +95,10 @@ void ChainLockSigner::TrySignChainTip(const llmq::CInstantSendManager& isman)
     if (isman.IsInstantSendEnabled() && isman.RejectConflictingBlocks()) {
         const auto* pindexWalk = pindex;
         while (pindexWalk != nullptr) {
-            if (pindex->nHeight - pindexWalk->nHeight > 5) {
-                // no need to check further down, 6 confs is safe to assume that TXs below this height won't be
+            if (pindex->nHeight - pindexWalk->nHeight > TX_CONFIRM_THRESHOLD) {
+                // no need to check further down, safe to assume that TXs below this height won't be
                 // islocked anymore if they aren't already
-                LogPrint(BCLog::CHAINLOCKS, "%s -- tip and previous 5 blocks all safe\n", __func__);
+                LogPrint(BCLog::CHAINLOCKS, "%s -- tip and previous %d blocks all safe\n", __func__, TX_CONFIRM_THRESHOLD);
                 break;
             }
             if (m_clhandler.HasChainLock(pindexWalk->nHeight, pindexWalk->GetBlockHash())) {

--- a/src/chainlock/signing.cpp
+++ b/src/chainlock/signing.cpp
@@ -126,7 +126,7 @@ void ChainLockSigner::TrySignChainTip(const llmq::CInstantSendManager& isman)
         }
     }
 
-    uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, pindex->nHeight));
+    uint256 requestId = GenSigRequestId(pindex->nHeight);
     uint256 msgHash = pindex->GetBlockHash();
 
     if (m_clhandler.GetBestChainLockHeight() >= pindex->nHeight) {

--- a/src/chainlock/signing.h
+++ b/src/chainlock/signing.h
@@ -20,6 +20,9 @@ class CSigSharesManager;
 } // namespace llmq
 
 namespace chainlock {
+//! Depth of block including transactions before it's considered safe
+static constexpr int32_t TX_CONFIRM_THRESHOLD{5};
+
 class ChainLockSignerParent
 {
 public:

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -34,8 +34,6 @@ using node::fReindex;
 using node::GetTransaction;
 
 namespace llmq {
-static constexpr std::string_view INPUTLOCK_REQUESTID_PREFIX{"inlock"};
-
 namespace {
 template <typename T>
     requires std::same_as<T, CTxIn> || std::same_as<T, COutPoint>
@@ -45,7 +43,7 @@ std::unordered_set<uint256, StaticSaltedHasher> GetIdsFromLockable(const std::ve
     if (vec.empty()) return ret;
     ret.reserve(vec.size());
     for (const auto& in : vec) {
-        ret.emplace(::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, in)));
+        ret.emplace(instantsend::GenInputLockRequestId(in));
     }
     return ret;
 }

--- a/src/instantsend/lock.cpp
+++ b/src/instantsend/lock.cpp
@@ -8,9 +8,10 @@
 #include <primitives/transaction.h>
 #include <util/hasher.h>
 
-#include <string>
+#include <string_view>
 #include <unordered_set>
 
+static constexpr std::string_view INPUTLOCK_REQUESTID_PREFIX{"inlock"};
 static constexpr std::string_view ISLOCK_REQUESTID_PREFIX{"islock"};
 
 namespace instantsend {
@@ -36,4 +37,12 @@ bool InstantSendLock::TriviallyValid() const
     const std::unordered_set<COutPoint, SaltedOutpointHasher> inputs_set{inputs.begin(), inputs.end()};
     return inputs_set.size() == inputs.size();
 }
+
+template <typename T>
+uint256 GenInputLockRequestId(const T& val)
+{
+    return ::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, val));
+}
+template uint256 GenInputLockRequestId(const COutPoint& val);
+template uint256 GenInputLockRequestId(const CTxIn& val);
 } // namespace instantsend

--- a/src/instantsend/lock.h
+++ b/src/instantsend/lock.h
@@ -40,6 +40,9 @@ struct InstantSendLock {
     bool TriviallyValid() const;
 };
 
+template <typename T>
+uint256 GenInputLockRequestId(const T& val);
+
 using InstantSendLockPtr = std::shared_ptr<InstantSendLock>;
 } // namespace instantsend
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -645,7 +645,6 @@ public:
     void RequestObject(NodeId nodeid, const CInv& inv, std::chrono::microseconds current_time,
                        bool is_masternode, bool fForce = false) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     size_t GetRequestedObjectCount(NodeId nodeid) const override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool IsInvInFilter(NodeId nodeid, const uint256& hash) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void AskPeersForTransaction(const uint256& txid, bool is_masternode) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
 private:
     void _RelayTransaction(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -2315,14 +2314,6 @@ void PeerManagerImpl::AskPeersForTransaction(const uint256& txid, bool is_master
                           /*fForce=*/true);
         }
     }
-}
-
-bool PeerManagerImpl::IsInvInFilter(NodeId nodeid, const uint256& hash) const
-{
-    PeerRef peer = GetPeerRef(nodeid);
-    if (peer == nullptr)
-        return false;
-    return IsInvInFilter(*peer, hash);
 }
 
 bool PeerManagerImpl::IsInvInFilter(const Peer& peer, const uint256& hash) const

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -85,9 +85,6 @@ public:
     /** Send ping message to all peers */
     virtual void SendPings() = 0;
 
-    /** Is an inventory in the known inventory filter. Used by InstantSend. */
-    virtual bool IsInvInFilter(NodeId nodeid, const uint256& hash) const = 0;
-
     /** Ask a number of our peers, which have a transaction in their inventory, for the transaction. */
     virtual void AskPeersForTransaction(const uint256& txid, bool is_masternode) = 0;
 


### PR DESCRIPTION
## Additional Information

* Depends on https://github.com/dashpay/dash/pull/6761

* Dependency for https://github.com/dashpay/dash/pull/6821

* Assumptions surrounding `pindex` usage have been documented in response to reviewer comments in [dash#6761](https://github.com/dashpay/dash/pull/6761)  ([comment](https://github.com/dashpay/dash/pull/6761#discussion_r2233735454), [comment](https://github.com/dashpay/dash/pull/6761#discussion_r2233735456)). 

* The internal structures of `CChainLocksHandler` (`txFirstSeenTime`, `seenChainLocks`, `lastCleanupTime`) have their time resolution reduced from milliseconds to seconds while migrating to `std::chrono`.

* `CInstantSendManager::AskNodesForLockedTx()` was moved as `PeerManagerImpl::AskPeersForTransaction()` in [dash#6425](https://github.com/dashpay/dash/pull/6425) and with that, the sole external usage of `PeerManagerImpl::IsInvInFilter()` was moved internally, we can therefore safely remove it from the `PeerManager` interface.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
