### PR TITLE
test: further improvement of feature_llmq_simplepose.py

### DIFF
--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -93,9 +93,10 @@ class LLMQSimplePoSeTest(DashTestFramework):
         return False, True
 
     def test_no_banning(self, invalidate_proc, expected_connections=None):
-        invalidate_proc(self.mninfo[0])
-        for i in range(3):
-            self.log.info(f"Testing no PoSe banning in normal conditions {i + 1}/3")
+        [_, instant_ban] = invalidate_proc(self.mninfo[0])
+        iters = 2 if instant_ban else 6
+        for i in range(iters):
+            self.log.info(f"Testing no PoSe banning in normal conditions {i + 1}/{iters}")
             self.mine_quorum(expected_connections=expected_connections)
 
     def mine_quorum_less_checks(self, expected_good_nodes, mninfos_online):

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -195,6 +195,8 @@ class LLMQSimplePoSeTest(DashTestFramework):
                     self.log.info(f"Accumulating PoSe penalty {j + 1}/6")
                     self.reset_probe_timeouts()
                     self.mine_quorum_less_checks(expected_contributors - 1, mninfos_online)
+                    if check_banned(self.nodes[0], mn):
+                        break
 
             assert check_banned(self.nodes[0], mn)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
There's generating too many quorums when it's not needed and not enough quorums in particular case.

## What was done?
See commits.


## How Has This Been Tested?
Run locally.
feature_llmq_simplepose.py (which is slowest functional test now) got 20-40 seconds faster.

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone