### PR TITLE
test: optimize feature_llmq_data_recovery.py

### DIFF
--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -41,29 +41,40 @@ class QuorumDataRecoveryTest(DashTestFramework):
             args.append('-llmq-qvvec-sync=%s:%d' % (llmq_type_strings[llmq_sync[0]], llmq_sync[1]))
         if reindex:
             args.append('-reindex')
-            bb_hash = mn.get_node(self).getbestblockhash()
             self.restart_node(mn.nodeIdx, args)
-            self.wait_until(lambda: mn.get_node(self).getbestblockhash() == bb_hash)
         else:
             self.restart_node(mn.nodeIdx, args)
+
+    def wait_restarted_mn(self, mn: MasternodeInfo, reindex=False, block_count=None):
+        if reindex:
+            self.wait_until(lambda: mn.get_node(self).getblockcount() >= block_count)
+
         force_finish_mnsync(mn.get_node(self))
         self.connect_nodes(mn.nodeIdx, 0)
-        if qdata_recovery_enabled:
-            # trigger recovery threads and wait for them to start
-            self.generate(self.nodes[0], 1, sync_fun=self.no_op)
-
-            self.bump_mocktime(self.quorum_data_thread_request_timeout_seconds + 1)
-            time.sleep(1)
-        self.sync_blocks()
 
     def restart_mns(self, mns=None, exclude=None, reindex=False, qvvec_sync=None, qdata_recovery_enabled=True):
         if exclude is None:
             exclude = []
         if qvvec_sync is None:
             qvvec_sync = []
+
+        block_count = self.nodes[0].getblockcount()
         for mn in self.mninfo if mns is None else mns: # type: MasternodeInfo
             if mn not in exclude:
                 self.restart_mn(mn, reindex, qvvec_sync, qdata_recovery_enabled)
+
+        for mn in self.mninfo if mns is None else mns: # type: MasternodeInfo
+            if mn not in exclude:
+                self.wait_restarted_mn(mn, reindex, block_count)
+
+        if qdata_recovery_enabled:
+            # trigger recovery threads and wait for them to start
+            self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+
+            self.bump_mocktime(self.quorum_data_thread_request_timeout_seconds + 1)
+            time.sleep(1)
+
+        self.sync_blocks()
         self.wait_for_sporks_same()
 
     def test_mns(self, quorum_type_in, quorum_hash_in, valid_mns=None, all_mns=None, test_secret=True, expect_secret=True,

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -135,10 +135,11 @@ class QuorumDataRecoveryTest(DashTestFramework):
                 quorum_hash_2 = None
                 members_only_in_1 = []
                 members_only_in_2 = []
+                member_mns_2 = []
                 while len(members_only_in_1) == 0 or len(members_only_in_2) == 0:
-                    quorum_hash_1 = self.mine_quorum()
+                    quorum_hash_1 = quorum_hash_2
                     quorum_hash_2 = self.mine_quorum()
-                    member_mns_1 = self.get_member_mns(llmq_type, quorum_hash_1)
+                    member_mns_1 = member_mns_2
                     member_mns_2 = self.get_member_mns(llmq_type, quorum_hash_2)
                     members_only_in_1 = self.get_subset_only_in_left(member_mns_1, member_mns_2)
                     members_only_in_2 = self.get_subset_only_in_left(member_mns_2, member_mns_1)

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -28,8 +28,8 @@ llmq_type_strings = {llmq_test: 'llmq_test', llmq_test_v17: 'llmq_test_v17'}
 
 class QuorumDataRecoveryTest(DashTestFramework):
     def set_test_params(self):
-        extra_args = [["-vbparams=testdummy:0:999999999999:0:10:8:6:5:-1"] for _ in range(9)]
-        self.set_dash_test_params(9, 7, extra_args=extra_args)
+        extra_args = [["-vbparams=testdummy:0:999999999999:0:10:8:6:5:-1"] for _ in range(7)]
+        self.set_dash_test_params(7, 6, extra_args=extra_args)
         self.set_dash_llmq_test_params(4, 3)
 
     def restart_mn(self, mn: MasternodeInfo, reindex=False, qvvec_sync=None, qdata_recovery_enabled=True):


### PR DESCRIPTION
## Issue being fixed or feature implemented
The functional test feature_llmq_data_recover.py is currently the slowest one

## What was done?
See commits. Coderabbit says:

> 

## How Has This Been Tested?
Run 20 jobs in parallel.

This PR: test run takes 3360s accumulated; 90% jobs are finished in interval [159...179] seconds with median 167 seconds.
`develop`: test run takes 4353 s (accumulated); 90% jobs are finished in interval [207..229] seconds with median 217 seconds.
It is 30% improvement for the worst case scenario; for median and for average.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone