### PR TITLE
test: reduce waste quorum generation and duplicated sleep in feature_llmq_is_retroactive.py

### DIFF
--- a/test/functional/feature_llmq_connections.py
+++ b/test/functional/feature_llmq_connections.py
@@ -88,7 +88,7 @@ class LLMQConnections(DashTestFramework):
                 try:
                     with mn.get_node(self).assert_debug_log(['removing masternodes quorum connections']):
                         with mn.get_node(self).assert_debug_log(['keeping mn quorum connections']):
-                            self.mine_cycle_quorum(is_first=False)
+                            self.mine_cycle_quorum()
                             mn.get_node(self).mockscheduler(60) # we check for old connections via the scheduler every 60 seconds
                     removed = True
                 except:
@@ -103,7 +103,7 @@ class LLMQConnections(DashTestFramework):
             if len(mn.get_node(self).quorum("memberof", mn.proTxHash)) > 0:
                 try:
                     with mn.get_node(self).assert_debug_log(['adding mn inter-quorum connections']):
-                        self.mine_cycle_quorum(is_first=False)
+                        self.mine_cycle_quorum()
                     added = True
                 except:
                     pass # it's ok to not add connections sometimes

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -25,11 +25,8 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.set_dash_test_params(5, 4, [["-whitelist=127.0.0.1"], [], [], [], ["-minrelaytxfee=0.001"]])
 
     def check_no_is(self, txid, node):
-        try:
-            self.log.info(f"Expecting no InstantLock for {txid}")
-            assert not node.getrawtransaction(txid, True)["instantlock"]
-        except:
-            assert False
+        self.log.info(f"Expecting no InstantLock for {txid}")
+        assert not node.getrawtransaction(txid, True)["instantlock"]
 
     def sleep_and_check_no_is(self, txid, node, sleep):
         time.sleep(sleep)

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -27,13 +27,13 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
     def check_no_is(self, txid, node):
         try:
             self.log.info(f"Expecting no InstantLock for {txid}")
-            return node.getrawtransaction(txid, True)["instantlock"]
+            assert not node.getrawtransaction(txid, True)["instantlock"]
         except:
-            return False
+            assert False
 
     def sleep_and_check_no_is(self, txid, node, sleep):
         time.sleep(sleep)
-        return self.check_no_is(node, txid)
+        self.check_no_is(txid, node)
 
     # random delay before tx is actually send by network could take up to 30 seconds
     def wait_for_tx(self, txid, node, expected=True, timeout=60):

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -128,33 +128,31 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         assert txid in self.nodes[0].getblock(block, 1)['tx']
         self.wait_for_chainlocked_block_all_nodes(block)
 
-        self.log.info("testing retroactive signing with partially known TX and all nodes session timeout")
-        self.test_all_nodes_session_timeout(False)
+        self.log.info("testing retroactive signing with partially known TX and session timeout")
+        self.test_session_timeout(False)
         self.log.info("repeating test, but with cycled LLMQs")
-        self.test_all_nodes_session_timeout(True)
+        self.test_session_timeout(True)
 
-        self.log.info("testing retroactive signing with partially known TX and single node session timeout")
-        self.test_single_node_session_timeout(False)
-        self.log.info("repeating test, but with cycled LLMQs")
-        self.test_single_node_session_timeout(True)
 
-    def cycle_llmqs(self):
-        self.mine_quorum()
-        self.mine_quorum()
-        self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash(), timeout=30)
-
-    def test_all_nodes_session_timeout(self, do_cycle_llmqs):
+    def test_session_timeout(self, do_cycle_llmqs):
         set_node_times(self.nodes, self.mocktime)
         self.isolate_node(3)
         rawtx = self.nodes[0].createrawtransaction([], {self.nodes[0].getnewaddress(): 1})
         rawtx = self.nodes[0].fundrawtransaction(rawtx)['hex']
         rawtx = self.nodes[0].signrawtransactionwithwallet(rawtx)['hex']
-        txid = self.nodes[0].sendrawtransaction(rawtx)
-        txid = self.nodes[3].sendrawtransaction(rawtx)
+        txid_all_nodes = self.nodes[0].sendrawtransaction(rawtx)
+        txid_all_nodes = self.nodes[3].sendrawtransaction(rawtx)
+
+
+        rawtx_1 = self.nodes[0].createrawtransaction([], {self.nodes[0].getnewaddress(): 1})
+        rawtx_1 = self.nodes[0].fundrawtransaction(rawtx_1)['hex']
+        rawtx_1 = self.nodes[0].signrawtransactionwithwallet(rawtx_1)['hex']
+        txid_single_node = self.nodes[3].sendrawtransaction(rawtx_1)
+
         # Make sure nodes 1 and 2 received the TX before we continue
         self.bump_mocktime(30)
-        self.wait_for_tx(txid, self.nodes[1])
-        self.wait_for_tx(txid, self.nodes[2])
+        self.wait_for_tx(txid_all_nodes, self.nodes[1])
+        self.wait_for_tx(txid_all_nodes, self.nodes[2])
         # Make sure signing is done on nodes 1 and 2 (it's async)
         time.sleep(5)
         # Make the signing session for the IS lock timeout on nodes 1-3
@@ -164,48 +162,31 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # Make sure nodes actually try re-connecting quorum connections
         self.bump_mocktime(30)
         self.wait_for_mnauth(self.nodes[3], 2)
-        # node 3 fully reconnected but the signing session is already timed out on all nodes, so no IS lock
-        self.wait_for_instantlock(txid, self.nodes[0], False, 5)
-        if do_cycle_llmqs:
-            self.cycle_llmqs()
-            self.wait_for_instantlock(txid, self.nodes[0], False, 5)
-        # Make node 0 consider the TX as safe
-        self.bump_mocktime(10 * 60 + 1)
-        block = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
-        assert txid in self.nodes[0].getblock(block, 1)['tx']
-        self.wait_for_chainlocked_block_all_nodes(block)
 
-    def test_single_node_session_timeout(self, do_cycle_llmqs):
-        set_node_times(self.nodes, self.mocktime)
-        self.isolate_node(3)
-        rawtx = self.nodes[0].createrawtransaction([], {self.nodes[0].getnewaddress(): 1})
-        rawtx = self.nodes[0].fundrawtransaction(rawtx)['hex']
-        rawtx = self.nodes[0].signrawtransactionwithwallet(rawtx)['hex']
-        txid = self.nodes[3].sendrawtransaction(rawtx)
-        time.sleep(2) # make sure signing is done on node 2 (it's async)
-        # Make the signing session for the IS lock timeout on node 3
-        self.bump_mocktime(61)
-        time.sleep(2) # make sure Cleanup() is called
-        self.reconnect_isolated_node(3, 0)
-        # Make sure nodes actually try re-connecting quorum connections
-        self.bump_mocktime(30)
-        self.wait_for_mnauth(self.nodes[3], 2)
-        self.nodes[0].sendrawtransaction(rawtx)
+        self.nodes[0].sendrawtransaction(rawtx_1)
         # Make sure nodes 1 and 2 received the TX
         self.bump_mocktime(30)
-        self.wait_for_tx(txid, self.nodes[1])
-        self.wait_for_tx(txid, self.nodes[2])
+        self.wait_for_tx(txid_single_node, self.nodes[1])
+        self.wait_for_tx(txid_single_node, self.nodes[2])
         self.bump_mocktime(30)
         # Make sure signing is done on nodes 1 and 2 (it's async)
-        # node 3 fully reconnected but the signing session is already timed out on it, so no IS lock
-        self.wait_for_instantlock(txid, self.nodes[0], False, 5)
+        time.sleep(5)
+
+        # node 3 fully reconnected but the signing session is already timed out, so no IS lock
+        self.wait_for_instantlock(txid_all_nodes, self.nodes[0], False, 5)
+        self.wait_for_instantlock(txid_single_node, self.nodes[0], False, 5)
         if do_cycle_llmqs:
-            self.cycle_llmqs()
-            self.wait_for_instantlock(txid, self.nodes[0], False, 5)
+            self.mine_quorum()
+            self.mine_quorum()
+            self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash(), timeout=30)
+
+            self.wait_for_instantlock(txid_all_nodes, self.nodes[0], False, 5)
+            self.wait_for_instantlock(txid_single_node, self.nodes[0], False, 5)
         # Make node 0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
         block = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
-        assert txid in self.nodes[0].getblock(block, 1)['tx']
+        assert txid_all_nodes in self.nodes[0].getblock(block, 1)['tx']
+        assert txid_single_node in self.nodes[0].getblock(block, 1)['tx']
         self.wait_for_chainlocked_block_all_nodes(block)
 
 if __name__ == '__main__':

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -24,13 +24,13 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # -whitelist is needed to avoid the trickling logic on node0
         self.set_dash_test_params(5, 4, [["-whitelist=127.0.0.1"], [], [], [], ["-minrelaytxfee=0.001"]])
 
-    def check_no_is(self, txid, node):
+    def assert_no_instantlock(self, txid, node):
         self.log.info(f"Expecting no InstantLock for {txid}")
         assert not node.getrawtransaction(txid, True)["instantlock"]
 
-    def sleep_and_check_no_is(self, txid, node, sleep=5):
+    def sleep_and_assert_no_instantlock(self, txid, node, sleep=5):
         time.sleep(sleep)
-        self.check_no_is(txid, node)
+        self.assert_no_instantlock(txid, node)
 
     # random delay before tx is actually send by network could take up to 30 seconds
     def wait_for_tx(self, txid, node, expected=True, timeout=60):
@@ -64,7 +64,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # 3 nodes should be enough to create an IS lock even if nodes 4 and 5 (which have no tx itself)
         # are the only "neighbours" in intra-quorum connections for one of them.
         self.bump_mocktime(30)
-        self.sleep_and_check_no_is(txid, self.nodes[0])
+        self.sleep_and_assert_no_instantlock(txid, self.nodes[0])
         # Have to disable ChainLocks to avoid signing a block with a "safe" tx too early
         self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", 4000000000)
         self.wait_for_sporks_same()
@@ -102,7 +102,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.bump_mocktime(30)
         self.wait_for_mnauth(self.nodes[3], 2)
         # node 3 fully reconnected but the TX wasn't relayed to it, so there should be no IS lock
-        self.sleep_and_check_no_is(txid, self.nodes[0])
+        self.sleep_and_assert_no_instantlock(txid, self.nodes[0])
         # push the tx directly via rpc
         self.nodes[3].sendrawtransaction(self.nodes[0].getrawtransaction(txid))
         # node 3 should vote on a tx now since it became aware of it via sendrawtransaction
@@ -133,7 +133,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.bump_mocktime(30)
         self.wait_for_mnauth(self.nodes[3], 2)
         # node 3 fully reconnected but the TX wasn't relayed to it, so there should be no IS lock
-        self.sleep_and_check_no_is(txid, self.nodes[0])
+        self.sleep_and_assert_no_instantlock(txid, self.nodes[0])
         # Make node0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
         block = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
@@ -181,16 +181,16 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         time.sleep(5)
 
         # node 3 fully reconnected but the signing session is already timed out, so no IS lock
-        self.check_no_is(txid_all_nodes, self.nodes[0])
-        self.check_no_is(txid_single_node, self.nodes[0])
+        self.assert_no_instantlock(txid_all_nodes, self.nodes[0])
+        self.assert_no_instantlock(txid_single_node, self.nodes[0])
         if do_cycle_llmqs:
             self.mine_cycle_quorum()
             self.mine_cycle_quorum()
             self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash(), timeout=30)
 
             time.sleep(5)
-            self.check_no_is(txid_all_nodes, self.nodes[0])
-            self.check_no_is(txid_single_node, self.nodes[0])
+            self.assert_no_instantlock(txid_all_nodes, self.nodes[0])
+            self.assert_no_instantlock(txid_single_node, self.nodes[0])
         # Make node 0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
         block = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -28,7 +28,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.log.info(f"Expecting no InstantLock for {txid}")
         assert not node.getrawtransaction(txid, True)["instantlock"]
 
-    def sleep_and_check_no_is(self, txid, node, sleep):
+    def sleep_and_check_no_is(self, txid, node, sleep=5):
         time.sleep(sleep)
         self.check_no_is(txid, node)
 
@@ -64,7 +64,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # 3 nodes should be enough to create an IS lock even if nodes 4 and 5 (which have no tx itself)
         # are the only "neighbours" in intra-quorum connections for one of them.
         self.bump_mocktime(30)
-        self.sleep_and_check_no_is(txid, self.nodes[0], 5)
+        self.sleep_and_check_no_is(txid, self.nodes[0])
         # Have to disable ChainLocks to avoid signing a block with a "safe" tx too early
         self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", 4000000000)
         self.wait_for_sporks_same()
@@ -102,7 +102,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.bump_mocktime(30)
         self.wait_for_mnauth(self.nodes[3], 2)
         # node 3 fully reconnected but the TX wasn't relayed to it, so there should be no IS lock
-        self.sleep_and_check_no_is(txid, self.nodes[0], 5)
+        self.sleep_and_check_no_is(txid, self.nodes[0])
         # push the tx directly via rpc
         self.nodes[3].sendrawtransaction(self.nodes[0].getrawtransaction(txid))
         # node 3 should vote on a tx now since it became aware of it via sendrawtransaction
@@ -133,7 +133,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.bump_mocktime(30)
         self.wait_for_mnauth(self.nodes[3], 2)
         # node 3 fully reconnected but the TX wasn't relayed to it, so there should be no IS lock
-        self.sleep_and_check_no_is(txid, self.nodes[0], 5)
+        self.sleep_and_check_no_is(txid, self.nodes[0])
         # Make node0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
         block = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -175,8 +175,8 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.wait_for_instantlock(txid_all_nodes, self.nodes[0], False, 5)
         self.wait_for_instantlock(txid_single_node, self.nodes[0], False, 5)
         if do_cycle_llmqs:
-            self.mine_quorum()
-            self.mine_quorum()
+            self.mine_cycle_quorum()
+            self.mine_cycle_quorum()
             self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash(), timeout=30)
 
             self.wait_for_instantlock(txid_all_nodes, self.nodes[0], False, 5)

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -135,6 +135,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         self.log.info("Cycle H+2C height:" + str(self.nodes[0].getblockcount()))
         self.log.info("Wait for chainlock")
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
+        self.cycle_quorum_is_ready = True
 
         b_0 = self.nodes[0].getbestblockhash()
 
@@ -150,8 +151,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
             self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_blocks(nodes))
             self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
 
-
-        (quorum_info_0_0, quorum_info_0_1) = self.mine_cycle_quorum(is_first=False)
+        (quorum_info_0_0, quorum_info_0_1) = self.mine_cycle_quorum()
         assert(self.test_quorum_listextended(quorum_info_0_0, llmq_type_name))
         assert(self.test_quorum_listextended(quorum_info_0_1, llmq_type_name))
         quorum_members_0_0 = extract_quorum_members(quorum_info_0_0)
@@ -173,7 +173,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         self.log.info("Wait for chainlock")
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
 
-        (quorum_info_1_0, quorum_info_1_1) = self.mine_cycle_quorum(is_first=False)
+        (quorum_info_1_0, quorum_info_1_1) = self.mine_cycle_quorum()
         assert(self.test_quorum_listextended(quorum_info_1_0, llmq_type_name))
         assert(self.test_quorum_listextended(quorum_info_1_1, llmq_type_name))
         quorum_members_1_0 = extract_quorum_members(quorum_info_1_0)
@@ -207,7 +207,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
 
         self.log.info("Mine a quorum to invalidate")
-        (quorum_info_3_0, quorum_info_3_1) = self.mine_cycle_quorum(is_first=False)
+        (quorum_info_3_0, quorum_info_3_1) = self.mine_cycle_quorum()
 
         new_quorum_list = self.nodes[0].quorum("list", llmq_type)
         assert_equal(len(new_quorum_list[llmq_type_name]), len(quorum_list[llmq_type_name]) + 2)

--- a/test/functional/rpc_verifyislock.py
+++ b/test/functional/rpc_verifyislock.py
@@ -58,7 +58,7 @@ class RPCVerifyISLockTest(DashTestFramework):
         assert node.verifyislock(request_id, txid, rec_sig, node.getblockcount() + 100)
 
         # Mine one more cycle of rotated quorums
-        self.mine_cycle_quorum(is_first=False)
+        self.mine_cycle_quorum()
         # Create an ISLOCK using an active quorum which will be replaced when a new cycle happens
         request_id = None
         utxos = node.listunspent()
@@ -81,7 +81,7 @@ class RPCVerifyISLockTest(DashTestFramework):
         # Create the ISDLOCK, then mine a cycle quorum to move renew active set
         isdlock = self.create_isdlock(rawtx)
         # Mine one block to trigger the "signHeight + dkgInterval" verification for the ISDLOCK
-        self.mine_cycle_quorum(is_first=False)
+        self.mine_cycle_quorum()
         # Verify the ISLOCK for a transaction that is not yet known by the node
         rawtx_txid = node.decoderawtransaction(rawtx)["txid"]
         assert_raises_rpc_error(-5, "No such mempool or blockchain transaction", node.getrawtransaction, rawtx_txid)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1529,6 +1529,8 @@ class DashTestFramework(BitcoinTestFramework):
         # This is EXPIRATION_TIMEOUT + EXPIRATION_BIAS in CQuorumDataRequest
         self.quorum_data_request_expiration_timeout = 360
 
+        # used by helper mine_cycle_quorum
+        self.cycle_quorum_is_ready = False
 
     def delay_v20_and_mn_rr(self, height=None):
         self.v20_height = height
@@ -2194,7 +2196,7 @@ class DashTestFramework(BitcoinTestFramework):
 
         return new_quorum
 
-    def mine_cycle_quorum(self, is_first=True):
+    def mine_cycle_quorum(self):
         spork21_active = self.nodes[0].spork('show')['SPORK_21_QUORUM_ALL_CONNECTED'] <= 1
         spork23_active = self.nodes[0].spork('show')['SPORK_23_QUORUM_POSE'] <= 1
 
@@ -2217,9 +2219,11 @@ class DashTestFramework(BitcoinTestFramework):
 
         skip_count = cycle_length - (cur_block % cycle_length)
         # move forward to next 3 DKG rounds for the first quorum
-        extra_blocks = 24 * 3 if is_first else 0
+        extra_blocks = 0 if self.cycle_quorum_is_ready else 24 * 3
         self.move_blocks(nodes, extra_blocks + skip_count)
         self.log.info('Moved from block %d to %d' % (cur_block, self.nodes[0].getblockcount()))
+
+        self.cycle_quorum_is_ready = True
 
         q_0 = self.nodes[0].getbestblockhash()
         self.log.info("Expected quorum_0 at:" + str(self.nodes[0].getblockcount()))

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1930,7 +1930,7 @@ class DashTestFramework(BitcoinTestFramework):
     # due to privacy reasons random delay is used before sending transaction by network
     # most times is just 2-5 seconds, but once in 1000 it's up to 1000 seconds.
     # it's recommended to bump mocktime for 30 seconds before wait_for_instantlock
-    def wait_for_instantlock(self, txid, node, expected=True, timeout=60):
+    def wait_for_instantlock(self, txid, node, timeout=60):
 
         def check_instantlock():
             try:
@@ -1939,8 +1939,7 @@ class DashTestFramework(BitcoinTestFramework):
                 return False
 
         self.log.info(f"Expecting InstantLock for {txid}")
-        if self.wait_until(check_instantlock, timeout=timeout, do_assert=expected) and not expected:
-            raise AssertionError("waiting unexpectedly succeeded")
+        self.wait_until(check_instantlock, timeout=timeout)
 
     def wait_for_chainlocked_block(self, node, block_hash, expected=True, timeout=15):
         def check_chainlocked_block():

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1920,11 +1920,12 @@ class DashTestFramework(BitcoinTestFramework):
         message_hash = tx.hash
 
         llmq_type = 103
+        llmq_cycle_len = 24
 
         rec_sig = self.get_recovered_sig(request_id, message_hash, llmq_type=llmq_type)
 
         block_count = self.mninfo[0].get_node(self).getblockcount()
-        cycle_hash = int(self.mninfo[0].get_node(self).getblockhash(block_count - (block_count % 24)), 16)
+        cycle_hash = int(self.mninfo[0].get_node(self).getblockhash(block_count - (block_count % llmq_cycle_len)), 16)
         isdlock = msg_isdlock(1, inputs, tx.sha256, cycle_hash, bytes.fromhex(rec_sig['sig']))
 
         return isdlock
@@ -2131,7 +2132,8 @@ class DashTestFramework(BitcoinTestFramework):
         nodes = [self.nodes[0]] + [mn.get_node(self) for mn in mninfos_online]
 
         # move forward to next DKG
-        skip_count = 24 - (self.nodes[0].getblockcount() % 24)
+        llmq_cycle_len = 24
+        skip_count = llmq_cycle_len - (self.nodes[0].getblockcount() % llmq_cycle_len)
         if skip_count != 0:
             self.bump_mocktime(1)
             self.generate(self.nodes[0], skip_count, sync_fun=lambda: self.sync_blocks(nodes))
@@ -2202,6 +2204,7 @@ class DashTestFramework(BitcoinTestFramework):
 
         llmq_type_name="llmq_test_dip0024"
         llmq_type=103
+        llmq_cycle_len = 24
         expected_connections = (self.llmq_size_dip0024 - 1) if spork21_active else 2
         expected_members = self.llmq_size_dip0024
         expected_contributions = self.llmq_size_dip0024
@@ -2214,12 +2217,11 @@ class DashTestFramework(BitcoinTestFramework):
 
         nodes = [self.nodes[0]] + [mn.get_node(self) for mn in mninfos_online]
 
-        cycle_length = 24
         cur_block = self.nodes[0].getblockcount()
 
-        skip_count = cycle_length - (cur_block % cycle_length)
+        skip_count = llmq_cycle_len - (cur_block % llmq_cycle_len)
         # move forward to next 3 DKG rounds for the first quorum
-        extra_blocks = 0 if self.cycle_quorum_is_ready else 24 * 3
+        extra_blocks = 0 if self.cycle_quorum_is_ready else llmq_cycle_len * 3
         self.move_blocks(nodes, extra_blocks + skip_count)
         self.log.info('Moved from block %d to %d' % (cur_block, self.nodes[0].getblockcount()))
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
`feature_llmq_is_retroactive.py` is one of the slowest functional test and it has bunch of duplicated logic for "single node" and "all nodes" logic.

## What was done?

 - Refactored case of "single node" and "all nodes" to test simultaneously instead of doing 1-by-1
It reduced amount of code and extra delays and improvement performance.

 - This PR fixes feature_llmq_is_retroactive.py test by generating real extra quorum for instant send (previously wrong type of quorum has been generated). Issue has been introduced by #5553 when only 1 helper mine_quorum has been replaced to proper rotation quorum.

 - This PR introduces a minor refactoring `mine_cycle_quorum` to prevent a perf bug when 24*3 blocks generated again and again for sub-sequent quorums (they are needed only once) when this helper is misused.

## How Has This Been Tested?
Run 20 parallel jobs. Median time for `feature_llmq_is_retroactive.py` is decreased from 134s to just 103s on my localhost.
Median time for `interface_zmq_dash.py` got 3seconds boost (54s -> 51s) as expected, see related `mine_cycle_quorum` helper.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
