### PR TITLE
feat(stats): add support for IPv6, introduce functional tests, deprecate `-statsport`

### DIFF
--- a/doc/release-notes-6837.md
+++ b/doc/release-notes-6837.md
@@ -1,0 +1,17 @@
+Statistics
+----------
+
+- IPv6 hosts are now supported by the StatsD client.
+
+- `-statshost` now accepts URLs to allow specifying the protocol, host and port in one argument.
+
+- Specifying invalid values will no longer result in silent disablement of the StatsD client and will now cause errors
+  at startup.
+
+### Deprecations
+
+- `-statsport` has been deprecated and ports are now specified using the new URL syntax supported by `-statshost`.
+  `-statsport` will be removed in a future release.
+
+  - If both `-statsport` and `-statshost` with a URL specifying a port is supplied, the `-statsport` value will be
+    ignored.

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -11,6 +11,8 @@
 #include <streams.h>
 #include <validation.h>
 
+#include <memory>
+
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using
 // compact block relay.
@@ -38,8 +40,8 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
     ArgsManager bench_args;
     const auto chainParams = CreateChainParams(bench_args, CBaseChainParams::MAIN);
     // CheckBlock calls g_stats_client internally, we aren't using a testing setup
-    // so we need to do this manually.
-    ::g_stats_client = InitStatsClient(bench_args);
+    // so we need to do this manually. We can use the stub interface for this.
+    ::g_stats_client = std::make_unique<StatsdClient>();
 
     bench.unit("block").run([&] {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1587,7 +1587,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // We need to initialize g_stats_client early as currently, g_stats_client is called
     // regardless of whether transmitting stats are desirable or not and if
     // g_stats_client isn't present when that attempt is made, the client will crash.
-    ::g_stats_client = InitStatsClient(args);
+    ::g_stats_client = StatsdClient::make(args);
 
     {
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -783,7 +783,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-statsbatchsize=<bytes>", strprintf("Specify the size of each batch of stats messages (default: %d)", DEFAULT_STATSD_BATCH_SIZE), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsduration=<ms>", strprintf("Specify the number of milliseconds between stats messages (default: %d)", DEFAULT_STATSD_DURATION), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statshost=<ip>", strprintf("Specify statsd host (default: %s)", DEFAULT_STATSD_HOST), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
-    argsman.AddArg("-statsport=<port>", strprintf("Specify statsd port (default: %u)", DEFAULT_STATSD_PORT), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
+    hidden_args.emplace_back("-statsport");
     argsman.AddArg("-statsperiod=<seconds>", strprintf("Specify the number of seconds between periodic measurements (default: %d)", DEFAULT_STATSD_PERIOD), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statsprefix=<string>", strprintf("Specify an optional string prepended to every stats key (default: %s)", DEFAULT_STATSD_PREFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);
     argsman.AddArg("-statssuffix=<string>", strprintf("Specify an optional string appended to every stats key (default: %s)", DEFAULT_STATSD_SUFFIX), ArgsManager::ALLOW_ANY, OptionsCategory::STATSD);

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -164,7 +164,7 @@ inline bool StatsdClientImpl::_send(std::string_view key, T1 value, std::string_
 
     // Send it and report an error if we encounter one
     if (auto error_opt = Assert(m_sender)->Send(msg); error_opt.has_value()) {
-        LogPrintf("ERROR: %s.\n", error_opt.value());
+        LogPrintf("ERROR: %s.\n", error_opt->original);
         return false;
     }
 

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -39,24 +39,24 @@ public:
     ~StatsdClientImpl() = default;
 
 public:
-    bool dec(const std::string& key, float sample_rate) override { return count(key, -1, sample_rate); }
-    bool inc(const std::string& key, float sample_rate) override { return count(key, 1, sample_rate); }
-    bool count(const std::string& key, int64_t delta, float sample_rate) override { return _send(key, delta, STATSD_METRIC_COUNT, sample_rate); }
-    bool gauge(const std::string& key, int64_t value, float sample_rate) override { return _send(key, value, STATSD_METRIC_GAUGE, sample_rate); }
-    bool gaugeDouble(const std::string& key, double value, float sample_rate) override { return _send(key, value, STATSD_METRIC_GAUGE, sample_rate); }
-    bool timing(const std::string& key, uint64_t ms, float sample_rate) override { return _send(key, ms, STATSD_METRIC_TIMING, sample_rate); }
+    bool dec(std::string_view key, float sample_rate) override { return count(key, -1, sample_rate); }
+    bool inc(std::string_view key, float sample_rate) override { return count(key, 1, sample_rate); }
+    bool count(std::string_view key, int64_t delta, float sample_rate) override { return _send(key, delta, STATSD_METRIC_COUNT, sample_rate); }
+    bool gauge(std::string_view key, int64_t value, float sample_rate) override { return _send(key, value, STATSD_METRIC_GAUGE, sample_rate); }
+    bool gaugeDouble(std::string_view key, double value, float sample_rate) override { return _send(key, value, STATSD_METRIC_GAUGE, sample_rate); }
+    bool timing(std::string_view key, uint64_t ms, float sample_rate) override { return _send(key, ms, STATSD_METRIC_TIMING, sample_rate); }
 
-    bool send(const std::string& key, double value, const std::string& type, float sample_rate) override { return _send(key, value, type, sample_rate); }
-    bool send(const std::string& key, int32_t value, const std::string& type, float sample_rate) override { return _send(key, value, type, sample_rate); }
-    bool send(const std::string& key, int64_t value, const std::string& type, float sample_rate) override { return _send(key, value, type, sample_rate); }
-    bool send(const std::string& key, uint32_t value, const std::string& type, float sample_rate) override { return _send(key, value, type, sample_rate); }
-    bool send(const std::string& key, uint64_t value, const std::string& type, float sample_rate) override { return _send(key, value, type, sample_rate); }
+    bool send(std::string_view key, double value, std::string_view type, float sample_rate) override { return _send(key, value, type, sample_rate); }
+    bool send(std::string_view key, int32_t value, std::string_view type, float sample_rate) override { return _send(key, value, type, sample_rate); }
+    bool send(std::string_view key, int64_t value, std::string_view type, float sample_rate) override { return _send(key, value, type, sample_rate); }
+    bool send(std::string_view key, uint32_t value, std::string_view type, float sample_rate) override { return _send(key, value, type, sample_rate); }
+    bool send(std::string_view key, uint64_t value, std::string_view type, float sample_rate) override { return _send(key, value, type, sample_rate); }
 
     bool active() const override { return m_sender != nullptr; }
 
 private:
     template <typename T1>
-    inline bool _send(const std::string& key, T1 value, const std::string& type, float sample_rate);
+    inline bool _send(std::string_view key, T1 value, std::string_view type, float sample_rate);
 
 private:
     /* Mutex to protect PRNG */
@@ -122,7 +122,7 @@ StatsdClientImpl::StatsdClientImpl(const std::string& host, uint16_t port, uint6
 }
 
 template <typename T1>
-inline bool StatsdClientImpl::_send(const std::string& key, T1 value, const std::string& type, float sample_rate)
+inline bool StatsdClientImpl::_send(std::string_view key, T1 value, std::string_view type, float sample_rate)
 {
     static_assert(std::is_arithmetic<T1>::value, "Must specialize to an arithmetic type");
 

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -16,8 +16,6 @@
 
 class ArgsManager;
 
-/** Default port used to connect to a Statsd server */
-static constexpr uint16_t DEFAULT_STATSD_PORT{8125};
 /** Default host assumed to be running a Statsd server */
 static const std::string DEFAULT_STATSD_HOST{""};
 /** Default prefix prepended to Statsd message keys */

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -7,6 +7,8 @@
 #ifndef BITCOIN_STATS_CLIENT_H
 #define BITCOIN_STATS_CLIENT_H
 
+#include <util/result.h>
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -37,7 +39,7 @@ static constexpr int MAX_STATSD_PERIOD{60 * 60};
 class StatsdClient
 {
 public:
-    static std::unique_ptr<StatsdClient> make(const ArgsManager& args);
+    static util::Result<std::unique_ptr<StatsdClient>> make(const ArgsManager& args);
     virtual ~StatsdClient() = default;
 
     /* Statsd-defined APIs */

--- a/src/stats/client.h
+++ b/src/stats/client.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 
 class ArgsManager;
 
@@ -40,19 +41,19 @@ public:
     virtual ~StatsdClient() = default;
 
     /* Statsd-defined APIs */
-    virtual bool dec(const std::string& key, float sample_rate = 1.f) { return false; }
-    virtual bool inc(const std::string& key, float sample_rate = 1.f) { return false; }
-    virtual bool count(const std::string& key, int64_t delta, float sample_rate = 1.f) { return false; }
-    virtual bool gauge(const std::string& key, int64_t value, float sample_rate = 1.f) { return false; }
-    virtual bool gaugeDouble(const std::string& key, double value, float sample_rate = 1.f) { return false; }
-    virtual bool timing(const std::string& key, uint64_t ms, float sample_rate = 1.f) { return false; }
+    virtual bool dec(std::string_view key, float sample_rate = 1.f) { return false; }
+    virtual bool inc(std::string_view key, float sample_rate = 1.f) { return false; }
+    virtual bool count(std::string_view key, int64_t delta, float sample_rate = 1.f) { return false; }
+    virtual bool gauge(std::string_view key, int64_t value, float sample_rate = 1.f) { return false; }
+    virtual bool gaugeDouble(std::string_view key, double value, float sample_rate = 1.f) { return false; }
+    virtual bool timing(std::string_view key, uint64_t ms, float sample_rate = 1.f) { return false; }
 
     /* Statsd-compatible APIs */
-    virtual bool send(const std::string& key, double value, const std::string& type, float sample_rate = 1.f) { return false; }
-    virtual bool send(const std::string& key, int32_t value, const std::string& type, float sample_rate = 1.f) { return false; }
-    virtual bool send(const std::string& key, int64_t value, const std::string& type, float sample_rate = 1.f) { return false; }
-    virtual bool send(const std::string& key, uint32_t value, const std::string& type, float sample_rate = 1.f) { return false; }
-    virtual bool send(const std::string& key, uint64_t value, const std::string& type, float sample_rate = 1.f) { return false; }
+    virtual bool send(std::string_view key, double value, std::string_view type, float sample_rate = 1.f) { return false; }
+    virtual bool send(std::string_view key, int32_t value, std::string_view type, float sample_rate = 1.f) { return false; }
+    virtual bool send(std::string_view key, int64_t value, std::string_view type, float sample_rate = 1.f) { return false; }
+    virtual bool send(std::string_view key, uint32_t value, std::string_view type, float sample_rate = 1.f) { return false; }
+    virtual bool send(std::string_view key, uint64_t value, std::string_view type, float sample_rate = 1.f) { return false; }
 
     /* Check if a StatsdClient instance is ready to send messages */
     virtual bool active() const { return false; }

--- a/src/stats/rawsender.cpp
+++ b/src/stats/rawsender.cpp
@@ -68,7 +68,7 @@ RawSender::~RawSender()
               m_host, m_port, m_successes, m_failures);
 }
 
-std::optional<std::string> RawSender::Send(const RawMessage& msg)
+std::optional<bilingual_str> RawSender::Send(const RawMessage& msg)
 {
     // If there is a thread, append to queue
     if (m_thread.joinable()) {
@@ -79,11 +79,11 @@ std::optional<std::string> RawSender::Send(const RawMessage& msg)
     return SendDirectly(msg);
 }
 
-std::optional<std::string> RawSender::SendDirectly(const RawMessage& msg)
+std::optional<bilingual_str> RawSender::SendDirectly(const RawMessage& msg)
 {
     if (!m_sock) {
         m_failures++;
-        return "Socket not initialized, cannot send message";
+        return _("Socket not initialized, cannot send message");
     }
 
     if (::sendto(m_sock->Get(), reinterpret_cast<const char*>(msg.data()),
@@ -94,7 +94,7 @@ std::optional<std::string> RawSender::SendDirectly(const RawMessage& msg)
 #endif // WIN32
                  /*flags=*/0, reinterpret_cast<struct sockaddr*>(&m_server.first), m_server.second) == SOCKET_ERROR) {
         m_failures++;
-        return strprintf("Unable to send message to %s (sendto() returned error %s)", this->ToStringHostPort(),
+        return strprintf(_("Unable to send message to %s (::sendto() returned error %s)"), this->ToStringHostPort(),
                          NetworkErrorString(WSAGetLastError()));
     }
 

--- a/src/stats/rawsender.cpp
+++ b/src/stats/rawsender.cpp
@@ -24,7 +24,7 @@ RawSender::RawSender(const std::string& host, uint16_t port, std::pair<uint64_t,
     }
 
     if (auto netaddr = LookupHost(m_host, /*fAllowLookup=*/true); netaddr.has_value()) {
-        if (!netaddr->IsIPv4()) {
+        if (!netaddr->IsIPv4() && !netaddr->IsIPv6()) {
             error = strprintf(_("Host %s on unsupported network"), m_host);
             return;
         }
@@ -37,7 +37,7 @@ RawSender::RawSender(const std::string& host, uint16_t port, std::pair<uint64_t,
         return;
     }
 
-    SOCKET hSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    SOCKET hSocket = ::socket(reinterpret_cast<struct sockaddr*>(&m_server.first)->sa_family, SOCK_DGRAM, IPPROTO_UDP);
     if (hSocket == INVALID_SOCKET) {
         error = strprintf(_("Cannot create socket (socket() returned error %s)"), NetworkErrorString(WSAGetLastError()));
         return;

--- a/src/stats/rawsender.cpp
+++ b/src/stats/rawsender.cpp
@@ -12,34 +12,34 @@
 #include <util/thread.h>
 
 RawSender::RawSender(const std::string& host, uint16_t port, std::pair<uint64_t, uint8_t> batching_opts,
-                     uint64_t interval_ms, std::optional<std::string>& error) :
+                     uint64_t interval_ms, std::optional<bilingual_str>& error) :
     m_host{host},
     m_port{port},
     m_batching_opts{batching_opts},
     m_interval_ms{interval_ms}
 {
     if (host.empty()) {
-        error = "No host specified";
+        error = _("No host specified");
         return;
     }
 
     if (auto netaddr = LookupHost(m_host, /*fAllowLookup=*/true); netaddr.has_value()) {
         if (!netaddr->IsIPv4()) {
-            error = strprintf("Host %s on unsupported network", m_host);
+            error = strprintf(_("Host %s on unsupported network"), m_host);
             return;
         }
         if (!CService(*netaddr, port).GetSockAddr(reinterpret_cast<struct sockaddr*>(&m_server.first), &m_server.second)) {
-            error = strprintf("Cannot get socket address for %s", m_host);
+            error = strprintf(_("Cannot get socket address for %s"), m_host);
             return;
         }
     } else {
-        error = strprintf("Unable to lookup host %s", m_host);
+        error = strprintf(_("Unable to lookup host %s"), m_host);
         return;
     }
 
     SOCKET hSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (hSocket == INVALID_SOCKET) {
-        error = strprintf("Cannot create socket (socket() returned error %s)", NetworkErrorString(WSAGetLastError()));
+        error = strprintf(_("Cannot create socket (socket() returned error %s)"), NetworkErrorString(WSAGetLastError()));
         return;
     }
     m_sock = std::make_unique<Sock>(hSocket);

--- a/src/stats/rawsender.h
+++ b/src/stats/rawsender.h
@@ -63,14 +63,26 @@ public:
     RawSender& operator=(const RawSender&) = delete;
     RawSender(RawSender&&) = delete;
 
+    //! Request a message to be sent based on configuration (queueing, batching)
     std::optional<std::string> Send(const RawMessage& msg) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+
+private:
+    //! Send a message directly using ::send{,to}()
     std::optional<std::string> SendDirectly(const RawMessage& msg);
 
+    //! Get target server address as string
     std::string ToStringHostPort() const;
 
+    //! Add message to queue
     void QueueAdd(const RawMessage& msg) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+
+    //! Send all messages in queue of RawSender entity and flush it
     void QueueFlush() EXCLUSIVE_LOCKS_REQUIRED(!cs);
+
+    //! Send all messages in given queue and flush it
     void QueueFlush(std::deque<RawMessage>& queue);
+
+    //! Worker thread function if queueing is requested
     void QueueThreadMain() EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
 private:

--- a/src/stats/rawsender.h
+++ b/src/stats/rawsender.h
@@ -65,11 +65,11 @@ public:
     RawSender(RawSender&&) = delete;
 
     //! Request a message to be sent based on configuration (queueing, batching)
-    std::optional<std::string> Send(const RawMessage& msg) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    std::optional<bilingual_str> Send(const RawMessage& msg) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
 private:
     //! Send a message directly using ::send{,to}()
-    std::optional<std::string> SendDirectly(const RawMessage& msg);
+    std::optional<bilingual_str> SendDirectly(const RawMessage& msg);
 
     //! Get target server address as string
     std::string ToStringHostPort() const;

--- a/src/stats/rawsender.h
+++ b/src/stats/rawsender.h
@@ -9,6 +9,7 @@
 #include <compat/compat.h>
 #include <sync.h>
 #include <util/threadinterrupt.h>
+#include <util/translation.h>
 
 #include <deque>
 #include <memory>
@@ -55,8 +56,8 @@ struct RawMessage : public std::vector<uint8_t>
 class RawSender
 {
 public:
-    RawSender(const std::string& host, uint16_t port, std::pair<uint64_t, uint8_t> batching_opts,
-              uint64_t interval_ms, std::optional<std::string>& error);
+    RawSender(const std::string& host, uint16_t port, std::pair<uint64_t, uint8_t> batching_opts, uint64_t interval_ms,
+              std::optional<bilingual_str>& error);
     ~RawSender();
 
     RawSender(const RawSender&) = delete;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -188,7 +188,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     SetupNetworking();
     InitSignatureCache();
     InitScriptExecutionCache();
-    ::g_stats_client = InitStatsClient(*m_node.args);
+    ::g_stats_client = StatsdClient::make(*m_node.args);
     m_node.chain = interfaces::MakeChain(m_node);
 
     m_node.netgroupman = std::make_unique<NetGroupManager>(/*asmap=*/std::vector<bool>());

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -188,7 +188,6 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     SetupNetworking();
     InitSignatureCache();
     InitScriptExecutionCache();
-    ::g_stats_client = StatsdClient::make(*m_node.args);
     m_node.chain = interfaces::MakeChain(m_node);
 
     m_node.netgroupman = std::make_unique<NetGroupManager>(/*asmap=*/std::vector<bool>());
@@ -202,6 +201,13 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
         throw std::runtime_error(
             strprintf("Invalid -socketevents ('%s') specified. Only these modes are supported: %s",
                       sem_str, GetSupportedSocketEventsStr()));
+    }
+    {
+        auto stats_client = StatsdClient::make(*m_node.args);
+        if (!stats_client) {
+            throw std::runtime_error{strprintf("Cannot init Statsd client (%s)", util::ErrorString(stats_client).original)};
+        }
+        ::g_stats_client = std::move(*stats_client);
     }
 
     m_node.connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman); // Deterministic randomness for tests.

--- a/test/functional/feature_stats.py
+++ b/test/functional/feature_stats.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test stats reporting"""
+
+import queue
+import socket
+import time
+import threading
+
+from test_framework.netutil import test_ipv6_local
+from test_framework.test_framework import BitcoinTestFramework
+from queue import Queue
+
+ONION_ADDR = "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion"
+
+class StatsServer:
+    def __init__(self, host: str, port: int):
+        self.running = False
+        self.thread = None
+        self.queue: Queue[str] = Queue()
+
+        addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_DGRAM)
+        self.af = addr_info[0][0]
+        self.addr = (host, port)
+
+        self.s = socket.socket(self.af, socket.SOCK_DGRAM)
+        self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.s.bind(self.addr)
+        self.s.settimeout(0.1)
+
+    def run(self):
+        while self.running:
+            try:
+                data, _ = self.s.recvfrom(4096)
+                messages = data.decode('utf-8').strip().split('\n')
+                for msg in messages:
+                    if msg:
+                        self.queue.put(msg)
+            except socket.timeout:
+                continue
+            except Exception as e:
+                if self.running:
+                    raise AssertionError("Unexpected exception raised: " + type(e).__name__)
+
+    def start(self):
+        assert not self.running
+        self.running = True
+        self.thread = threading.Thread(target=self.run)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def stop(self):
+        self.running = False
+        if self.thread:
+            self.thread.join(timeout=2)
+        self.s.close()
+
+    def assert_msg_received(self, expected_msg: str, timeout: int = 30):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                msg = self.queue.get(timeout=5)
+                if expected_msg in msg:
+                    return
+            except queue.Empty:
+                continue
+        raise AssertionError(f"Did not receive message containing '{expected_msg}' within {timeout} seconds")
+
+
+class StatsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.log.info("Test invalid command line options")
+        self.test_invalid_command_line_options()
+
+        self.log.info("Test command line behavior")
+        self.test_command_behavior()
+
+        self.log.info("Check that server can receive stats client messages")
+        self.have_ipv6 = test_ipv6_local()
+        self.test_conn('127.0.0.1')
+        if self.have_ipv6:
+            self.test_conn('::1')
+        else:
+            self.log.warning("Testing without local IPv6 support")
+
+    def test_invalid_command_line_options(self):
+        self.stop_node(0)
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Cannot init Statsd client (Port must be between 1 and 65535, supplied 65536)',
+            extra_args=['-statshost=127.0.0.1', '-statsport=65536'],
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Cannot init Statsd client (No text before the scheme delimiter, malformed URL)',
+            extra_args=['-statshost=://127.0.0.1'],
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Cannot init Statsd client (Unsupported URL scheme, must begin with udp://)',
+            extra_args=['-statshost=http://127.0.0.1'],
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Cannot init Statsd client (No host specified, malformed URL)',
+            extra_args=['-statshost=udp://'],
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg=f'Error: Cannot init Statsd client (Host {ONION_ADDR} on unsupported network)',
+            extra_args=[f'-statshost=udp://{ONION_ADDR}'],
+        )
+
+    def test_command_behavior(self):
+        with self.nodes[0].assert_debug_log(expected_msgs=['Transmitting stats are disabled, will not init Statsd client']):
+            self.restart_node(0, extra_args=[])
+        # The port specified in the URL supercedes -statsport
+        with self.nodes[0].assert_debug_log(expected_msgs=[
+            'Supplied URL with port, ignoring -statsport',
+            'StatsdClient initialized to transmit stats to 127.0.0.1:8126',
+            'Started threaded RawSender sending messages to 127.0.0.1:8126'
+        ]):
+            self.restart_node(0, extra_args=['-debug=net', '-statshost=udp://127.0.0.1:8126', '-statsport=8125'])
+        # Not specifying the port in the URL or -statsport will select the default port. Also, validate -statsduration behavior.
+        with self.nodes[0].assert_debug_log(expected_msgs=[
+            'Send interval is zero, not starting RawSender queueing thread',
+            'StatsdClient initialized to transmit stats to 127.0.0.1:8125',
+            'Started RawSender sending messages to 127.0.0.1:8125'
+        ]):
+            self.restart_node(0, extra_args=['-debug=net', '-statshost=udp://127.0.0.1', '-statsduration=0'])
+
+    def test_conn(self, host: str):
+        server = StatsServer(host, 8125)
+        server.start()
+        self.restart_node(0, extra_args=[f'-statshost=udp://{host}', '-statsbatchsize=0', '-statsduration=0'])
+        server.assert_msg_received("CheckBlock_us")
+        server.stop()
+
+if __name__ == '__main__':
+    StatsTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -308,6 +308,7 @@ BASE_SCRIPTS = [
     'mining_basic.py',
     'rpc_named_arguments.py',
     'feature_startupnotify.py',
+    'feature_stats.py',
     'wallet_simulaterawtx.py --legacy-wallet',
     'wallet_simulaterawtx.py --descriptors',
     'wallet_listsinceblock.py --legacy-wallet',


### PR DESCRIPTION
## Additional Information

* Support for URLs have been introduced for `statshost` and can be formatted as `udp://127.0.0.1:8125`. As `statshost` can also include the port, `statsport` has been deprecated and will be removed in a future release of Dash Core.

* Startup validation errors are no longer ignored and trigger an `InitError()`. Connection failure will **not** halt startup but lookup failure **will**, this is because `LookupHost()` is used to identify if the connection is IPv4/IPv6.

## Breaking Changes

See release notes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
