### PR TITLE
refactor: clean up exceeding qt includes

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -49,7 +49,6 @@
 #include <memory>
 
 #include <QApplication>
-#include <QDebug>
 #include <QLatin1String>
 #include <QLibraryInfo>
 #include <QLocale>

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -7,8 +7,6 @@
 #include <qt/bitcoinunits.h>
 #include <qt/guiutil.h>
 
-#include <QApplication>
-#include <QAbstractSpinBox>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLineEdit>

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -8,7 +8,6 @@
 #include <consensus/amount.h>
 #include <qt/bitcoinunits.h>
 
-#include <QValidator>
 #include <QWidget>
 
 class AmountLineEdit;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -52,7 +52,6 @@
 #include <QDragEnterEvent>
 #include <QInputDialog>
 #include <QKeySequence>
-#include <QListWidget>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
@@ -60,15 +59,11 @@
 #include <QProgressDialog>
 #include <QScreen>
 #include <QSettings>
-#include <QShortcut>
-#include <QStackedWidget>
 #include <QStatusBar>
-#include <QStyle>
 #include <QSystemTrayIcon>
 #include <QTimer>
 #include <QToolBar>
 #include <QToolButton>
-#include <QUrlQuery>
 #include <QVBoxLayout>
 #include <QWindow>
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -14,12 +14,11 @@
 
 #include <consensus/amount.h>
 
+#include <QAbstractButton>
 #include <QLabel>
 #include <QMainWindow>
-#include <QMap>
 #include <QMenu>
 #include <QPoint>
-#include <QPushButton>
 #include <QSystemTrayIcon>
 
 #include <memory>

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -23,12 +23,11 @@
 #include <wallet/coinselection.h>
 #include <wallet/wallet.h>
 
-#include <QApplication>
-#include <QCheckBox>
 #include <QCursor>
 #include <QDialogButtonBox>
 #include <QFlags>
 #include <QIcon>
+#include <QMessageBox>
 #include <QSettings>
 #include <QTreeWidget>
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -13,7 +13,6 @@
 #include <QList>
 #include <QMenu>
 #include <QPoint>
-#include <QString>
 #include <QTreeWidgetItem>
 
 class WalletModel;

--- a/src/qt/governancelist.cpp
+++ b/src/qt/governancelist.cpp
@@ -29,7 +29,6 @@
 
 #include <QAbstractItemView>
 #include <QDesktopServices>
-#include <QTableWidgetItem>
 #include <QUrl>
 #include <QtGui/QClipboard>
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -39,21 +39,17 @@
 #include <QButtonGroup>
 #include <QClipboard>
 #include <QDateTime>
-#include <QDebug>
 #include <QDesktopServices>
 #include <QDialog>
 #include <QDialogButtonBox>
-#include <QDoubleValidator>
 #include <QFileDialog>
 #include <QFont>
 #include <QFontDatabase>
 #include <QFontMetrics>
 #include <QGuiApplication>
 #include <QJsonObject>
-#include <QKeyEvent>
 #include <QKeySequence>
 #include <QLatin1String>
-#include <QLineEdit>
 #include <QList>
 #include <QLocale>
 #include <QMenu>
@@ -69,10 +65,8 @@
 #include <QString>
 #include <QTextDocument> // for Qt::mightBeRichText
 #include <QThread>
-#include <QTimer>
 #include <QUrlQuery>
 #include <QVBoxLayout>
-#include <QtGlobal>
 
 #include <chrono>
 #include <exception>

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -14,15 +14,12 @@
 
 #include <QApplication>
 #include <QEvent>
-#include <QHeaderView>
 #include <QItemDelegate>
 #include <QLabel>
-#include <QMessageBox>
 #include <QMetaObject>
 #include <QObject>
 #include <QProgressBar>
 #include <QString>
-#include <QTableView>
 
 #include <cassert>
 #include <chrono>

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -16,7 +16,6 @@
 #include <QObject>
 #include <QProcess>
 #include <QString>
-#include <QThread>
 
 InitExecutor::InitExecutor(interfaces::Node& node)
     : QObject(), m_node(node)

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -13,9 +13,9 @@
 
 #include <univalue.h>
 
+#include <QClipboard>
 #include <QMessageBox>
 #include <QTableWidgetItem>
-#include <QtGui/QClipboard>
 
 template <typename T>
 class CMasternodeListWidgetItem : public QTableWidgetItem

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -9,7 +9,6 @@
 #include <qt/guiutil.h>
 
 #include <QEasingCurve>
-#include <QPropertyAnimation>
 #include <QResizeEvent>
 
 ModalOverlay::ModalOverlay(bool enable_wallet, QWidget *parent) :

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -11,7 +11,6 @@
 #include <QMetaType>
 #include <QStyle>
 #include <QSystemTrayIcon>
-#include <QTemporaryFile>
 #include <QVariant>
 #ifdef USE_DBUS
 #include <QDBusMetaType>

--- a/src/qt/openuridialog.cpp
+++ b/src/qt/openuridialog.cpp
@@ -11,7 +11,6 @@
 
 #include <QAbstractButton>
 #include <QLineEdit>
-#include <QUrl>
 
 OpenURIDialog::OpenURIDialog(QWidget* parent) : QDialog(parent, GUIUtil::dialog_flags),
                                                 ui(new Ui::OpenURIDialog)

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -25,7 +25,7 @@
 
 #include <QAbstractItemDelegate>
 #include <QApplication>
-#include <QDateTime>
+#include <QMessageBox>
 #include <QPainter>
 #include <QSettings>
 #include <QStatusTipEvent>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -24,16 +24,14 @@
 #include <cstdlib>
 #include <memory>
 
-#include <QApplication>
 #include <QByteArray>
 #include <QDataStream>
-#include <QDebug>
 #include <QFile>
 #include <QFileOpenEvent>
 #include <QHash>
-#include <QList>
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <QMessageBox>
 #include <QStringList>
 #include <QUrlQuery>
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -11,7 +11,6 @@
 
 #include <utility>
 
-#include <QList>
 #include <QTimer>
 
 PeerTableModel::PeerTableModel(interfaces::Node& node, QObject* parent) :

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -8,8 +8,6 @@
 #include <util/check.h>
 
 #include <QModelIndex>
-#include <QString>
-#include <QVariant>
 
 PeerTableSortProxy::PeerTableSortProxy(QObject* parent)
     : QSortFilterProxyModel(parent)

--- a/src/qt/proposalwizard.cpp
+++ b/src/qt/proposalwizard.cpp
@@ -19,12 +19,11 @@
 #include <qt/walletmodel.h>
 
 #include <QDateTime>
-#include <QDateTimeEdit>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLabel>
 #include <QLineEdit>
-#include <QPlainTextEdit>
+#include <QMessageBox>
 #include <QPushButton>
 #include <QStackedWidget>
 #include <QTimer>

--- a/src/qt/qrdialog.cpp
+++ b/src/qt/qrdialog.cpp
@@ -10,9 +10,6 @@
 #include <qt/guiutil.h>
 #include <qt/qrimagewidget.h>
 
-#include <QPainter>
-#include <QPixmap>
-
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h> /* for USE_QRCODE */
 #endif

--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -9,7 +9,6 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDrag>
-#include <QFontDatabase>
 #include <QMenu>
 #include <QMimeData>
 #include <QMouseEvent>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -12,11 +12,8 @@
 #include <qt/recentrequeststablemodel.h>
 #include <qt/walletmodel.h>
 
-#include <QAction>
 #include <QCursor>
 #include <QMessageBox>
-#include <QScrollBar>
-#include <QTextDocument>
 
 ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) :
     QDialog(parent, GUIUtil::dialog_flags),

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -8,12 +8,9 @@
 #include <qt/guiutil.h>
 
 #include <QDialog>
-#include <QHeaderView>
 #include <QItemSelection>
-#include <QKeyEvent>
 #include <QMenu>
 #include <QPoint>
-#include <QVariant>
 
 class WalletModel;
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -43,7 +43,6 @@
 #include <QButtonGroup>
 #include <QDir>
 #include <QFont>
-#include <QFontDatabase>
 #include <QDateTime>
 #include <QKeyEvent>
 #include <QKeySequence>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -37,10 +37,8 @@ using wallet::DEFAULT_PAY_TX_FEE;
 #include <fstream>
 #include <memory>
 
-#include <QFontMetrics>
 #include <QScrollBar>
 #include <QSettings>
-#include <QTextDocument>
 
 #define SEND_CONFIRM_DELAY   3
 

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -9,7 +9,6 @@
 
 #include <QDialog>
 #include <QMessageBox>
-#include <QShowEvent>
 #include <QString>
 #include <QTimer>
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -28,7 +28,6 @@
 #include <QPainter>
 #include <QScreen>
 
-
 SplashScreen::SplashScreen(const NetworkStyle *networkStyle) :
     QWidget(), curAlignment(0)
 {

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -33,12 +33,13 @@
 #include <QAction>
 #include <QApplication>
 #include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QListView>
 #include <QPushButton>
+#include <QTableView>
+#include <QTextEdit>
 #include <QTimer>
 #include <QVBoxLayout>
-#include <QTextEdit>
-#include <QListView>
-#include <QDialogButtonBox>
 
 using wallet::AddWallet;
 using wallet::CWallet;

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -8,7 +8,6 @@
 #include <qt/trafficgraphdata.h>
 
 #include <QWidget>
-#include <QQueue>
 
 class ClientModel;
 

--- a/src/qt/transactiondescdialog.cpp
+++ b/src/qt/transactiondescdialog.cpp
@@ -9,7 +9,6 @@
 #include <qt/transactiontablemodel.h>
 
 #include <QModelIndex>
-#include <QSettings>
 #include <QString>
 
 TransactionDescDialog::TransactionDescDialog(const QModelIndex &idx, QWidget *parent) :

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -11,9 +11,7 @@
 
 #include <wallet/ismine.h>
 
-#include <stdint.h>
-
-#include <QDateTime>
+#include <cstdint>
 
 using wallet::ISMINE_ALL;
 using wallet::ISMINE_SPENDABLE;

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -20,16 +20,17 @@
 #include <interfaces/node.h>
 #include <node/interface_ui.h>
 
+#include <chrono>
 #include <optional>
 
 #include <QCalendarWidget>
-#include <chrono>
 #include <QComboBox>
 #include <QDateTimeEdit>
 #include <QDesktopServices>
 #include <QDoubleValidator>
 #include <QHBoxLayout>
 #include <QHeaderView>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
 #include <QListView>

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -10,7 +10,6 @@
 #include <uint256.h>
 
 #include <QWidget>
-#include <QKeyEvent>
 
 class TransactionFilterProxy;
 class WalletModel;

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -27,6 +27,7 @@
 #include <QMessageBox>
 #include <QMetaObject>
 #include <QMutexLocker>
+#include <QProgressDialog>
 #include <QThread>
 #include <QTimer>
 #include <QWindow>

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -15,11 +15,8 @@
 #include <string>
 #include <vector>
 
-#include <QMessageBox>
 #include <QMutex>
-#include <QProgressDialog>
 #include <QThread>
-#include <QTimer>
 #include <QString>
 
 class ClientModel;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -25,9 +25,6 @@
 #include <node/interface_ui.h>
 #include <util/strencodings.h>
 
-#include <QAction>
-#include <QActionGroup>
-#include <QFileDialog>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QProgressDialog>


### PR DESCRIPTION
## Issue being fixed or feature implemented

New code lines appear,
Old code lines are disappearing,
Includes still remain.

## What was done?
Reviewed all Qt-related includes and drop unused.
It is easy to do, because in most of the cases the include name matches to the used class name.
Popular exceptions are `qApp` for QApplication, `qDebug` for `QDebug`, `QApplication::clipboard` for `QClipboard` in our codebase.
Some leftovers have been fixed manually.

    #!/bin/bash
    
    for s in $(find . -maxdepth 1 -name '*.h' -or -name '*.cpp') ; do
        [[ $s == ./moc_* ]] && continue
        grep '^#include <Q.*>$' $s | awk '{print $NF}' | sed 's/[<>]//g' | sort | uniq | xargs -I{} bash -c "grep -c \"[^<]{}\" $s >/dev/null || echo \"$s - {}\""
    done


## How Has This Been Tested?
Run build with & without patch
It saves ~30-40seconds of single-cpu time; which equals to 3-5 seconds of building time overall for my multi-core machine.



## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone