### PR TITLE
fix(qt): adjust css for SendCoinsEntry

### DIFF
--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1727,7 +1727,7 @@ QDialog#SendCoinsDialog QPushButton#sendButton {
 SendCoinsEntry
 ******************************************************/
 
-QStackedWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry Labels */
+QWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry Labels */
     background-color: #00000000;
     min-width: 50px;
     min-height: 25px;
@@ -1735,29 +1735,29 @@ QStackedWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry L
     padding-right: 5px;
 }
 
-QStackedWidget#SendCoinsEntry .QFrame#SendCoins .QLabel#amountLabel {
+QWidget#SendCoinsEntry .QFrame#SendCoins .QLabel#amountLabel {
 }
 
-QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo { /* Pay To Input Field */
+QWidget#SendCoinsEntry .QValidatedLineEdit#payTo { /* Pay To Input Field */
 }
 
-QStackedWidget#SendCoinsEntry .QToolButton { /* General Settings for Pay To Icons */
+QWidget#SendCoinsEntry .QToolButton { /* General Settings for Pay To Icons */
     background-color: #00000000;
     margin-left: 5px;
     margin-right: 5px;
     border: 0;
 }
 
-QStackedWidget#SendCoinsEntry .QToolButton#addressBookButton { /* Address Book Button */
+QWidget#SendCoinsEntry .QToolButton#addressBookButton { /* Address Book Button */
     margin-left: 10px;
 }
 
-QStackedWidget#SendCoinsEntry .QToolButton#addressBookButton,
-QStackedWidget#SendCoinsEntry .QToolButton#pasteButton,
-QStackedWidget#SendCoinsEntry .QToolButton#deleteButton {
+QWidget#SendCoinsEntry .QToolButton#addressBookButton,
+QWidget#SendCoinsEntry .QToolButton#pasteButton,
+QWidget#SendCoinsEntry .QToolButton#deleteButton {
 }
 
-QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
+QWidget#SendCoinsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
 }
 
 /******************************************************


### PR DESCRIPTION
## Issue being fixed or feature implemented
d496df033f3ffe330b21e0cdf678694769a6de4e (#6829) changed `SendCoinsEntry` class from `QStackedWidget` to `QWidget` but we forgot to update `css` accordingly so GUI is a bit broken now.

<img width="947" height="51" alt="Screenshot 2025-09-29 at 19 06 30" src="https://github.com/user-attachments/assets/ecb184db-82c2-4a0b-a37c-f4f00c4e9e33" />

## What was done?
Adjust css to match cpp

## How Has This Been Tested?
Compile and check GUI, should look the same way it did before d496df033f3ffe330b21e0cdf678694769a6de4e

<img width="928" height="49" alt="Screenshot 2025-09-29 at 19 07 25" src="https://github.com/user-attachments/assets/ad51c157-294f-4ef8-a3e4-97ab5f211226" />

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

