### PR TITLE
fix: correct thread pool sizing logic in LLMQ and BLS workers

### DIFF
--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -59,7 +59,7 @@ CBLSWorker::~CBLSWorker()
 void CBLSWorker::Start()
 {
     int workerCount = std::thread::hardware_concurrency() / 2;
-    workerCount = std::max(std::min(1, workerCount), 4);
+    workerCount = std::clamp(workerCount, 1, 4);
     workerPool.resize(workerCount);
     RenameThreadPool(workerPool, "bls-work");
 }

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -234,7 +234,7 @@ CQuorumManager::~CQuorumManager() { Stop(); }
 void CQuorumManager::Start()
 {
     int workerCount = std::thread::hardware_concurrency() / 2;
-    workerCount = std::max(std::min(1, workerCount), 4);
+    workerCount = std::clamp(workerCount, 1, 4);
     workerPool.resize(workerCount);
     RenameThreadPool(workerPool, "q-mngr");
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
The previous logic using std::max(std::min(1, workerCount), 4) always resulted in 4 threads regardless of hardware_concurrency().

This was because:
- std::min(1, workerCount) always returns 1 (when workerCount >= 1)
- std::max(1, 4) always returns 4

Changed to std::clamp(workerCount, 1, 4) which properly clamps the worker count between 1 and 4 threads based on CPU count.

Fixes undersizing on low-end hardware and potential oversizing issues.


## What was done?
use std::clamp

## How Has This Been Tested?


## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

