### PR TITLE
feat: enhance CQuorumManager with active chain view and ancestor caching

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -622,7 +622,16 @@ bool CQuorumManager::RequestQuorumData(CNode* pfrom, CConnman& connman, const CQ
 std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(Consensus::LLMQType llmqType, size_t nCountRequested) const
 {
     auto view = GetActiveChainView();
-    const CBlockIndex* pindex = view.tip ? view.tip : WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
+    const CBlockIndex* pindex = view.tip;
+    if (pindex == nullptr) {
+        pindex = WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
+    } else {
+        // If the cached view lags behind the active chain, prefer the up-to-date tip for correctness.
+        const int active_height = WITH_LOCK(::cs_main, return m_chainstate.m_chain.Height());
+        if (view.height < active_height) {
+            pindex = WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
+        }
+    }
     return ScanQuorums(llmqType, pindex, nCountRequested);
 }
 

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -646,16 +646,17 @@ std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(Consensus::LLMQType llmqTyp
         // too early for this cycle, use the previous one
         // bail out if it's below genesis block
         if (quorumCycleMiningEndHeight < llmq_params_opt->dkgInterval) return {};
-        auto view = GetActiveChainView();
-        const CBlockIndex* ancestor = view.tip ? FindAncestorFast(view, quorumCycleMiningEndHeight - llmq_params_opt->dkgInterval) : pindexStart->GetAncestor(quorumCycleMiningEndHeight - llmq_params_opt->dkgInterval);
-        if (!ancestor) return {};
-        pindexStore = ancestor;
+        // IMPORTANT: compute ancestors strictly relative to pindexStart's chain context
+        // to avoid cross-fork/cross-tip contamination from global cached views.
+        const CBlockIndex* ancestor = pindexStart->GetAncestor(quorumCycleMiningEndHeight - llmq_params_opt->dkgInterval);
+        if (ancestor == nullptr) return {};
+        pindexStore = gsl::not_null<const CBlockIndex*>{ancestor};
     } else if (pindexStart->nHeight > quorumCycleMiningEndHeight) {
         // we are past the mining phase of this cycle, use it
-        auto view = GetActiveChainView();
-        const CBlockIndex* ancestor = view.tip ? FindAncestorFast(view, quorumCycleMiningEndHeight) : pindexStart->GetAncestor(quorumCycleMiningEndHeight);
-        if (!ancestor) return {};
-        pindexStore = ancestor;
+        // See note above: stay on pindexStart's chain
+        const CBlockIndex* ancestor = pindexStart->GetAncestor(quorumCycleMiningEndHeight);
+        if (ancestor == nullptr) return {};
+        pindexStore = gsl::not_null<const CBlockIndex*>{ancestor};
     }
     // everything else is inside the mining phase of this cycle, no pindexStore adjustment needed
 
@@ -1317,18 +1318,41 @@ CQuorumCPtr SelectQuorumForSigning(const Consensus::LLMQParams& llmq_params, con
     CBlockIndex* pindexStart;
     auto view = qman.GetActiveChainView();
     if (view.tip) {
+        // Prefer cs_main-free path via active chain view when it can satisfy the requested height.
         if (signHeight == -1) {
             signHeight = view.height;
         }
         int startBlockHeight = signHeight - signOffset;
-        if (startBlockHeight > view.height || startBlockHeight < 0) {
+        if (startBlockHeight >= 0) {
+            if (startBlockHeight <= view.height) {
+                const CBlockIndex* ancestor = qman.FindAncestorFast(view, startBlockHeight);
+                if (ancestor != nullptr) {
+                    pindexStart = const_cast<CBlockIndex*>(ancestor);
+                } else {
+                    // Fallback to cs_main if cache missed (e.g. during reorg/initialization)
+                    LOCK(::cs_main);
+                    if (signHeight == -1) {
+                        signHeight = active_chain.Height();
+                    }
+                    if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
+                        return {};
+                    }
+                    pindexStart = active_chain[startBlockHeight];
+                }
+            } else {
+                // View is behind requested height; fallback to cs_main
+                LOCK(::cs_main);
+                if (signHeight == -1) {
+                    signHeight = active_chain.Height();
+                }
+                if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
+                    return {};
+                }
+                pindexStart = active_chain[startBlockHeight];
+            }
+        } else {
             return {};
         }
-        const CBlockIndex* ancestor = qman.FindAncestorFast(view, startBlockHeight);
-        if (!ancestor) {
-            return {};
-        }
-        pindexStart = const_cast<CBlockIndex*>(ancestor);
     } else {
         LOCK(::cs_main);
         if (signHeight == -1) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -25,7 +25,9 @@
 #include <util/time.h>
 #include <util/underlying.h>
 #include <validation.h>
+#include <validationinterface.h>
 
+#include <algorithm>
 #include <cxxtimer.hpp>
 
 namespace llmq
@@ -207,6 +209,82 @@ bool CQuorum::ReadContributions(const CDBWrapper& db)
     return true;
 }
 
+size_t CQuorumManager::ComputeAncestorCacheMaxSize()
+{
+    size_t max_size = 0;
+    for (const auto& llmq : Params().GetConsensus().llmqs) {
+        size_t size = llmq.max_cycles(llmq.keepOldConnections) * (llmq.dkgMiningWindowEnd - llmq.dkgMiningWindowStart) + 128;
+        max_size = std::max(max_size, size);
+    }
+    // Clamp to reasonable bounds
+    return std::clamp(max_size, size_t(512), size_t(4096));
+}
+
+CQuorumManager::ActiveChainView CQuorumManager::GetActiveChainView() const
+{
+    LOCK(cs_active_chain_view);
+    return m_active_chain_view;
+}
+
+const CBlockIndex* CQuorumManager::FindAncestorFast(const ActiveChainView& view, int target_height) const
+{
+    if (target_height < 0 || target_height > view.height || !view.tip) {
+        return nullptr;
+    }
+    LOCK(cs_ancestor_cache);
+    if (m_lru_tip_hash != view.hash) {
+        // Distinguish extension vs reorg (or skipped updates).
+        // If the previous tip hash is an ancestor of the current tip at the recorded height,
+        // this is an extension (possibly by multiple blocks) and the cache remains valid.
+        // Otherwise, clear the cache to avoid cross-fork pollution.
+        bool is_extension = false;
+        if (m_lru_tip_height >= 0) {
+            const CBlockIndex* old_tip_as_ancestor = view.tip->GetAncestor(m_lru_tip_height);
+            if (old_tip_as_ancestor && old_tip_as_ancestor->GetBlockHash() == m_lru_tip_hash) {
+                is_extension = true;
+            }
+        }
+        if (!is_extension) {
+            m_ancestor_lru.clear();
+        }
+        m_lru_tip_hash = view.hash;
+        m_lru_tip_height = view.height;
+    }
+    const CBlockIndex* out;
+    if (m_ancestor_lru.get(target_height, out)) {
+        return out;
+    }
+    out = view.tip->GetAncestor(target_height);
+    if (out) {
+        m_ancestor_lru.insert(target_height, out);
+    }
+    return out;
+}
+
+void CQuorumManager::ChainViewSubscriber::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
+{
+    if (!pindexNew) return;
+
+    // Update snapshot
+    {
+        LOCK(m_qman.cs_active_chain_view);
+        m_qman.m_active_chain_view.tip = pindexNew;
+        m_qman.m_active_chain_view.height = pindexNew->nHeight;
+        m_qman.m_active_chain_view.hash = pindexNew->GetBlockHash();
+    }
+
+    // Handle ancestor cache: clear on reorg, keep on extension
+    {
+        LOCK(m_qman.cs_ancestor_cache);
+        if (pindexFork != pindexNew->pprev) {
+            // Reorg detected: clear cache
+            m_qman.m_ancestor_lru.clear();
+        }
+        m_qman.m_lru_tip_hash = pindexNew->GetBlockHash();
+        m_qman.m_lru_tip_height = pindexNew->nHeight;
+    }
+}
+
 CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CDeterministicMNManager& dmnman,
                                CDKGSessionManager& _dkgManager, CEvoDB& _evoDb,
                                CQuorumBlockProcessor& _quorumBlockProcessor, CQuorumSnapshotManager& qsnapman,
@@ -222,16 +300,36 @@ CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, 
     m_qsnapman{qsnapman},
     m_mn_activeman{mn_activeman},
     m_mn_sync{mn_sync},
-    m_sporkman{sporkman}
+    m_sporkman{sporkman},
+    m_ancestor_lru{ComputeAncestorCacheMaxSize()}
 {
     utils::InitQuorumsCache(mapQuorumsCache, false);
     quorumThreadInterrupt.reset();
     MigrateOldQuorumDB(_evoDb);
+
+    // Initialize snapshot from current tip (under cs_main for bootstrap)
+    {
+        LOCK(::cs_main);
+        const CBlockIndex* tip = m_chainstate.m_chain.Tip();
+        if (tip) {
+            LOCK(cs_active_chain_view);
+            m_active_chain_view.tip = tip;
+            m_active_chain_view.height = tip->nHeight;
+            m_active_chain_view.hash = tip->GetBlockHash();
+        }
+    }
+
+    // Register ValidationInterface subscriber
+    m_chain_view_subscriber = std::make_unique<ChainViewSubscriber>(*this);
+    RegisterValidationInterface(m_chain_view_subscriber.get());
 }
 
 CQuorumManager::~CQuorumManager()
 {
     Stop();
+    if (m_chain_view_subscriber) {
+        UnregisterValidationInterface(m_chain_view_subscriber.get());
+    }
 }
 
 void CQuorumManager::Start()
@@ -523,7 +621,8 @@ bool CQuorumManager::RequestQuorumData(CNode* pfrom, CConnman& connman, const CQ
 
 std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(Consensus::LLMQType llmqType, size_t nCountRequested) const
 {
-    const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
+    auto view = GetActiveChainView();
+    const CBlockIndex* pindex = view.tip ? view.tip : WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
     return ScanQuorums(llmqType, pindex, nCountRequested);
 }
 
@@ -547,10 +646,16 @@ std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(Consensus::LLMQType llmqTyp
         // too early for this cycle, use the previous one
         // bail out if it's below genesis block
         if (quorumCycleMiningEndHeight < llmq_params_opt->dkgInterval) return {};
-        pindexStore = pindexStart->GetAncestor(quorumCycleMiningEndHeight - llmq_params_opt->dkgInterval);
+        auto view = GetActiveChainView();
+        const CBlockIndex* ancestor = view.tip ? FindAncestorFast(view, quorumCycleMiningEndHeight - llmq_params_opt->dkgInterval) : pindexStart->GetAncestor(quorumCycleMiningEndHeight - llmq_params_opt->dkgInterval);
+        if (!ancestor) return {};
+        pindexStore = ancestor;
     } else if (pindexStart->nHeight > quorumCycleMiningEndHeight) {
         // we are past the mining phase of this cycle, use it
-        pindexStore = pindexStart->GetAncestor(quorumCycleMiningEndHeight);
+        auto view = GetActiveChainView();
+        const CBlockIndex* ancestor = view.tip ? FindAncestorFast(view, quorumCycleMiningEndHeight) : pindexStart->GetAncestor(quorumCycleMiningEndHeight);
+        if (!ancestor) return {};
+        pindexStore = ancestor;
     }
     // everything else is inside the mining phase of this cycle, no pindexStore adjustment needed
 
@@ -1210,7 +1315,21 @@ CQuorumCPtr SelectQuorumForSigning(const Consensus::LLMQParams& llmq_params, con
     size_t poolSize = llmq_params.signingActiveQuorumCount;
 
     CBlockIndex* pindexStart;
-    {
+    auto view = qman.GetActiveChainView();
+    if (view.tip) {
+        if (signHeight == -1) {
+            signHeight = view.height;
+        }
+        int startBlockHeight = signHeight - signOffset;
+        if (startBlockHeight > view.height || startBlockHeight < 0) {
+            return {};
+        }
+        const CBlockIndex* ancestor = qman.FindAncestorFast(view, startBlockHeight);
+        if (!ancestor) {
+            return {};
+        }
+        pindexStart = const_cast<CBlockIndex*>(ancestor);
+    } else {
         LOCK(::cs_main);
         if (signHeight == -1) {
             signHeight = active_chain.Height();

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -1325,54 +1325,17 @@ CQuorumCPtr SelectQuorumForSigning(const Consensus::LLMQParams& llmq_params, con
     size_t poolSize = llmq_params.signingActiveQuorumCount;
 
     CBlockIndex* pindexStart;
-    // If caller provided an explicit signHeight, always resolve relative to the active chain
-    // to guarantee correctness during rapid tip changes and rotations.
-    if (signHeight != -1) {
-        LOCK(::cs_main);
-        int startBlockHeight = signHeight - signOffset;
-        if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
-            return {};
-        }
-        pindexStart = active_chain[startBlockHeight];
-    } else {
-        // No explicit height: prefer cs_main-free path via active chain view
-        auto view = qman.GetActiveChainView();
-        if (view.tip) {
-            signHeight = view.height;
-            int startBlockHeight = signHeight - signOffset;
-            if (startBlockHeight < 0) {
-                return {};
-            }
-            if (startBlockHeight <= view.height) {
-                const CBlockIndex* ancestor = qman.FindAncestorFast(view, startBlockHeight);
-                if (!ancestor) {
-                    // Fallback to cs_main if cache missed (e.g. during reorg/initialization)
-                    LOCK(::cs_main);
-                    if (startBlockHeight > active_chain.Height()) {
-                        return {};
-                    }
-                    pindexStart = active_chain[startBlockHeight];
-                } else {
-                    pindexStart = const_cast<CBlockIndex*>(ancestor);
-                }
-            } else {
-                // View is behind requested height; fallback to cs_main
-                LOCK(::cs_main);
-                if (startBlockHeight > active_chain.Height()) {
-                    return {};
-                }
-                pindexStart = active_chain[startBlockHeight];
-            }
-        } else {
-        LOCK(::cs_main);
-            signHeight = active_chain.Height();
-            int startBlockHeight = signHeight - signOffset;
-            if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
-                return {};
-            }
-            pindexStart = active_chain[startBlockHeight];
-        }
+    // Resolve strictly relative to the authoritative active chain to avoid any
+    // cross-tip inconsistencies during rotations or rapid tip changes.
+    LOCK(::cs_main);
+    if (signHeight == -1) {
+        signHeight = active_chain.Height();
     }
+    int startBlockHeight = signHeight - signOffset;
+    if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
+        return {};
+    }
+    pindexStart = active_chain[startBlockHeight];
 
     if (IsQuorumRotationEnabled(llmq_params, pindexStart)) {
         auto quorums = qman.ScanQuorums(llmq_params.type, pindexStart, poolSize);

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -1325,53 +1325,53 @@ CQuorumCPtr SelectQuorumForSigning(const Consensus::LLMQParams& llmq_params, con
     size_t poolSize = llmq_params.signingActiveQuorumCount;
 
     CBlockIndex* pindexStart;
-    auto view = qman.GetActiveChainView();
-    if (view.tip) {
-        // Prefer cs_main-free path via active chain view when it can satisfy the requested height.
-        if (signHeight == -1) {
-            signHeight = view.height;
-        }
-        int startBlockHeight = signHeight - signOffset;
-        if (startBlockHeight >= 0) {
-            if (startBlockHeight <= view.height) {
-                const CBlockIndex* ancestor = qman.FindAncestorFast(view, startBlockHeight);
-                if (ancestor != nullptr) {
-                    pindexStart = const_cast<CBlockIndex*>(ancestor);
-                } else {
-                    // Fallback to cs_main if cache missed (e.g. during reorg/initialization)
-                    LOCK(::cs_main);
-                    if (signHeight == -1) {
-                        signHeight = active_chain.Height();
-                    }
-                    if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
-                        return {};
-                    }
-                    pindexStart = active_chain[startBlockHeight];
-                }
-            } else {
-                // View is behind requested height; fallback to cs_main
-                LOCK(::cs_main);
-                if (signHeight == -1) {
-                    signHeight = active_chain.Height();
-                }
-                if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
-                    return {};
-                }
-                pindexStart = active_chain[startBlockHeight];
-            }
-        } else {
-            return {};
-        }
-    } else {
+    // If caller provided an explicit signHeight, always resolve relative to the active chain
+    // to guarantee correctness during rapid tip changes and rotations.
+    if (signHeight != -1) {
         LOCK(::cs_main);
-        if (signHeight == -1) {
-            signHeight = active_chain.Height();
-        }
         int startBlockHeight = signHeight - signOffset;
         if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
             return {};
         }
         pindexStart = active_chain[startBlockHeight];
+    } else {
+        // No explicit height: prefer cs_main-free path via active chain view
+        auto view = qman.GetActiveChainView();
+        if (view.tip) {
+            signHeight = view.height;
+            int startBlockHeight = signHeight - signOffset;
+            if (startBlockHeight < 0) {
+                return {};
+            }
+            if (startBlockHeight <= view.height) {
+                const CBlockIndex* ancestor = qman.FindAncestorFast(view, startBlockHeight);
+                if (!ancestor) {
+                    // Fallback to cs_main if cache missed (e.g. during reorg/initialization)
+                    LOCK(::cs_main);
+                    if (startBlockHeight > active_chain.Height()) {
+                        return {};
+                    }
+                    pindexStart = active_chain[startBlockHeight];
+                } else {
+                    pindexStart = const_cast<CBlockIndex*>(ancestor);
+                }
+            } else {
+                // View is behind requested height; fallback to cs_main
+                LOCK(::cs_main);
+                if (startBlockHeight > active_chain.Height()) {
+                    return {};
+                }
+                pindexStart = active_chain[startBlockHeight];
+            }
+        } else {
+        LOCK(::cs_main);
+            signHeight = active_chain.Height();
+            int startBlockHeight = signHeight - signOffset;
+            if (startBlockHeight > active_chain.Height() || startBlockHeight < 0) {
+                return {};
+            }
+            pindexStart = active_chain[startBlockHeight];
+        }
     }
 
     if (IsQuorumRotationEnabled(llmq_params, pindexStart)) {

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -17,10 +17,12 @@
 #include <saltedhasher.h>
 #include <util/threadinterrupt.h>
 #include <util/time.h>
+#include <validationinterface.h>
 
 #include <gsl/pointers.h>
 
 #include <atomic>
+#include <functional>
 #include <map>
 #include <utility>
 
@@ -258,6 +260,33 @@ private:
     // it maps `quorum_hash` to `pindex`
     mutable Uint256LruHashMap<const CBlockIndex*, 128 /*max_size*/> quorumBaseBlockIndexCache;
 
+    // Active chain snapshot to avoid cs_main contention
+    struct ActiveChainView {
+        const CBlockIndex* tip{nullptr};
+        int height{-1};
+        uint256 hash;
+    };
+    mutable Mutex cs_active_chain_view;
+    ActiveChainView m_active_chain_view GUARDED_BY(cs_active_chain_view);
+
+    // Ancestor lookup cache (height -> CBlockIndex*) for current tip
+    mutable Mutex cs_ancestor_cache;
+    mutable unordered_lru_cache<int, const CBlockIndex*, std::hash<int>> m_ancestor_lru GUARDED_BY(cs_ancestor_cache);
+    mutable uint256 m_lru_tip_hash GUARDED_BY(cs_ancestor_cache);
+    mutable int m_lru_tip_height GUARDED_BY(cs_ancestor_cache){-1};
+    static size_t ComputeAncestorCacheMaxSize();
+
+    // ValidationInterface subscriber for tip updates
+    class ChainViewSubscriber : public CValidationInterface {
+    public:
+        explicit ChainViewSubscriber(CQuorumManager& qman) : m_qman(qman) {}
+        virtual ~ChainViewSubscriber() = default;
+        void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override;
+    private:
+        CQuorumManager& m_qman;
+    };
+    std::unique_ptr<ChainViewSubscriber> m_chain_view_subscriber;
+
     mutable ctpl::thread_pool workerPool;
     mutable CThreadInterrupt quorumThreadInterrupt;
 
@@ -276,10 +305,10 @@ public:
     void Stop();
 
     void TriggerQuorumDataRecoveryThreads(CConnman& connman, const CBlockIndex* pIndex) const
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_scan_quorums, !cs_map_quorums);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_scan_quorums, !cs_map_quorums, !cs_active_chain_view, !cs_ancestor_cache);
 
     void UpdatedBlockTip(const CBlockIndex* pindexNew, CConnman& connman, bool fInitialDownload) const
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_scan_quorums, !cs_map_quorums);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_scan_quorums, !cs_map_quorums, !cs_active_chain_view, !cs_ancestor_cache);
 
     [[nodiscard]] MessageProcessingResult ProcessMessage(CNode& pfrom, CConnman& connman, std::string_view msg_type,
                                                          CDataStream& vRecv)
@@ -294,17 +323,21 @@ public:
     CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_map_quorums);
     std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, size_t nCountRequested) const
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_map_quorums, !cs_scan_quorums);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_map_quorums, !cs_scan_quorums, !cs_active_chain_view, !cs_ancestor_cache);
 
     // this one is cs_main-free
     std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, const CBlockIndex* pindexStart,
                                          size_t nCountRequested) const
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_map_quorums, !cs_scan_quorums);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_map_quorums, !cs_scan_quorums, !cs_active_chain_view, !cs_ancestor_cache);
+
+    // Active chain snapshot accessors (public for use by SelectQuorumForSigning)
+    ActiveChainView GetActiveChainView() const EXCLUSIVE_LOCKS_REQUIRED(!cs_active_chain_view);
+    const CBlockIndex* FindAncestorFast(const ActiveChainView& view, int target_height) const EXCLUSIVE_LOCKS_REQUIRED(!cs_ancestor_cache);
 
 private:
     // all private methods here are cs_main-free
     void CheckQuorumConnections(CConnman& connman, const Consensus::LLMQParams& llmqParams, const CBlockIndex* pindexNew) const
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_scan_quorums, !cs_map_quorums);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_scan_quorums, !cs_map_quorums, !cs_active_chain_view, !cs_ancestor_cache);
 
     CQuorumPtr BuildQuorumFromCommitment(Consensus::LLMQType llmqType,
                                          gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,


### PR DESCRIPTION
## Issue being fixed or feature implemented
based on testing in #6953; we saw significant cs_main contention reduction. 

However; cs_main at llmq/quorums.cpp:1214 and llmq/quorums.cpp:526 now became the main (relatively easy to reduce) cs_main contention see below, and are part of the hot loop for islock creation. We should consider trying to reduce: net_processing.cpp:5462 but it seems non-trivial.

```
====================================================================================================
TOP 40 LOCATIONS BY TOTAL CONTENTION TIME
====================================================================================================
Lock Name                                Location                               Count    Total(μs)    Avg(μs)    Max(μs)  Nodes
----------------------------------------------------------------------------------------------------
cs                                       llmq/signing_shares.cpp:507             4211     37733272     8960.6     245957      1
::cs_main                                llmq/quorums.cpp:1214                  31341     29749048      949.2     107339      1
cs                                       llmq/signing_shares.cpp:1732            1007     10284045    10212.6     228759      1
cs_main                                  index/base.cpp:340                     10230      9721378      950.3    1102649      1
cs                                       txmempool.cpp:1319                      4725      9343571     1977.5    2547817      1
m_nodes_mutex                            net.cpp:2043                            8713      5978513      686.2      21902      1
pnode->cs_vSend                          net.cpp:2435                           34780      5033298      144.7      27630      1
::cs_main                                llmq/quorums.cpp:526                    2941      4881414     1659.8    2335997      1
cs_main                                  net_processing.cpp:5462                14634      3961867      270.7     663140      1
::cs_main                                validation.cpp:3747                       87       976697    11226.4     787634      1
cs_db                                    ./instantsend/db.h:139                  2389       854134      357.5     143876      1
cs_db                                    instantsend/db.cpp:239                  1744       699770      401.2      20189      1
inv_relay->m_tx_inventory_mutex          net_processing.cpp:1169                 2450       695733      284.0      21009      1
m_nodes_mutex                            ./net.h:1374                            2362       677869      287.0       8807      1
cs_cache                                 llmq/signing.cpp:85                     1890       554933      293.6      24287      1
pnode->cs_vSend                          net.cpp:4709                            1339       533799      398.7      36465      1
::cs_main                                validation.cpp:6009                     5406       532866       98.6      34916      1
cs_cache                                 spork.cpp:33                            3659       424682      116.1       7658      1
cs_args                                  util/system.cpp:1181                    3309       393147      118.8      11519      1
cs_cache                                 llmq/signing.cpp:48                     1529       381286      249.4      12190      1
cs_cache                                 spork.cpp:244                           4832       362329       75.0      11091      1
mutexMsgProc                             net.cpp:2604                             960       284558      296.4       9588      1
m_send_mutex                             net.cpp:1577                             865       232837      269.2      16881      1
connman.m_nodes_mutex                    net.cpp:4777                            1364       178812      131.1      10847      1
tx_relay->m_bloom_filter_mutex           net_processing.cpp:2415                  453       177077      390.9       9061      1
cs_main                                  net_processing.cpp:3513                  178       169523      952.4      28461      1
cs_main                                  net_processing.cpp:5911                  788       161351      204.8      56241      1
cs                                       llmq/signing_shares.cpp:742              358       130911      365.7      21276      1
cs_main                                  net_processing.cpp:4196                 1311        97819       74.6       8543      1
newTaskMutex                             scheduler.cpp:74                         199        92832      466.5      27132      1
cs_scan_quorums                          llmq/quorums.cpp:562                     362        84883      234.5       9727      1
cs                                       llmq/signing_shares.cpp:1535             110        78384      712.6       3888      1
mempool.cs                               instantsend/instantsend.cpp:751          115        71052      617.8      18867      1
m_tx_relay_mutex                         net_processing.cpp:338                   292        69852      239.2       7103      1
tx_relay->m_tx_inventory_mutex           net_processing.cpp:6136                  145        64877      447.4       8862      1
cs_db                                    instantsend/db.cpp:313                   352        63247      179.7       8314      1
cs                                       spork.cpp:273                            430        62746      145.9       5664      1
cs_cache                                 llmq/signing.cpp:200                     217        52687      242.8      12081      1
mutexMsgProc                             net.cpp:3647                             114        45645      400.4       6748      1
m_tx_relay_mutex                         net_processing.cpp:333                   320        45472      142.1       3337      1


====================================================================================================
SUMMARY STATISTICS
====================================================================================================
Total lock contentions: 157051
Total contention time: 126780252 μs (126780.25 ms)
Unique lock locations: 164
Average contention time: 807.3 μs
```


## What was done?
- Introduced ActiveChainView structure to minimize cs_main contention.
- Added ComputeAncestorCacheMaxSize method to determine cache size limits.
- Implemented FindAncestorFast for efficient ancestor lookups.
- Integrated ChainViewSubscriber for block tip updates and cache management.
- Updated relevant methods to utilize the new caching mechanism for improved performance.


## How Has This Been Tested?
Builds locally; 1 functional test passes.

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

