### PR TITLE
feat: allow running in native wayland

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -135,6 +135,15 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       if test -d "$qt_plugin_path/platforms/android"; then
         QT_LIBS="$QT_LIBS -L$qt_plugin_path/platforms/android -lqtfreetype -lEGL"
       fi
+      if test -d "$qt_plugin_path/wayland-decoration-client"; then
+        QT_LIBS="$QT_LIBS -L$qt_plugin_path/wayland-decoration-client"
+      fi
+      if test -d "$qt_plugin_path/wayland-graphics-integration-client"; then
+        QT_LIBS="$QT_LIBS -L$qt_plugin_path/wayland-graphics-integration-client"
+      fi
+      if test -d "$qt_plugin_path/wayland-shell-integration"; then
+        QT_LIBS="$QT_LIBS -L$qt_plugin_path/wayland-shell-integration"
+      fi
     fi
 
     if test "$TARGET_OS" != "android"; then
@@ -150,7 +159,12 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       AC_DEFINE([QT_QPA_PLATFORM_WINDOWS], [1], [Define this symbol if the qt platform is windows])
     elif test "$TARGET_OS" = "linux" -o "$TARGET_OS" = "freebsd"; then
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QXcbIntegrationPlugin], [-lqxcb])
-      AC_DEFINE([QT_QPA_PLATFORM_XCB], [1], [Define this symbol if the qt platform is xcb])
+      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWaylandIntegrationPlugin], [-lqwayland-generic])
+      AX_CHECK_LINK_FLAG([-lwayland-egl], [QT_LIBS="-lwayland-egl $QT_LIBS"], [AC_MSG_ERROR([could not link against -lwayland-egl])])
+      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWaylandEglClientBufferPlugin], [-lqt-plugin-wayland-egl])
+      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWaylandBradientDecorationPlugin], [-lbradient])
+      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWaylandXdgShellIntegrationPlugin], [-lxdg-shell])
+      AC_DEFINE([QT_QPA_PLATFORM_LINUX], [1], [Define this symbol if the qt platform is xcb or wayland])
     elif test "$TARGET_OS" = "darwin"; then
       AX_CHECK_LINK_FLAG([-framework Carbon], [QT_LIBS="$QT_LIBS -framework Carbon"], [AC_MSG_ERROR(could not link against Carbon framework)])
       AX_CHECK_LINK_FLAG([-framework IOSurface], [QT_LIBS="$QT_LIBS -framework IOSurface"], [AC_MSG_ERROR(could not link against IOSurface framework)])
@@ -365,6 +379,8 @@ AC_DEFUN([_BITCOIN_QT_CHECK_STATIC_LIBS], [
     PKG_CHECK_MODULES([QT_SERVICE], [${qt_lib_prefix}ServiceSupport], [QT_LIBS="$QT_SERVICE_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_XCBQPA], [${qt_lib_prefix}XcbQpa], [QT_LIBS="$QT_XCBQPA_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_XKBCOMMON], [${qt_lib_prefix}XkbCommonSupport], [QT_LIBS="$QT_XKBCOMMON_LIBS $QT_LIBS"])
+    PKG_CHECK_MODULES([QT_EGL], [${qt_lib_prefix}EglSupport], [QT_LIBS="$QT_EGL_LIBS $QT_LIBS"])
+    PKG_CHECK_MODULES([QT_WAYLANDCLIENT], [${qt_lib_prefix}WaylandClient], [QT_LIBS="$QT_WAYLANDCLIENT_LIBS $QT_LIBS"])
   elif test "$TARGET_OS" = "darwin"; then
     PKG_CHECK_MODULES([QT_CLIPBOARD], [${qt_lib_prefix}ClipboardSupport${qt_lib_suffix}], [QT_LIBS="$QT_CLIPBOARD_LIBS $QT_LIBS"])
     PKG_CHECK_MODULES([QT_GRAPHICS], [${qt_lib_prefix}GraphicsSupport${qt_lib_suffix}], [QT_LIBS="$QT_GRAPHICS_LIBS $QT_LIBS"])

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -11,7 +11,7 @@ export HOST=arm-linux-gnueabihf
 # If the host is arm and wants to run the tests natively, it can set QEMU_USER_CMD to the empty string.
 if [ -z ${QEMU_USER_CMD+x} ]; then export QEMU_USER_CMD="${QEMU_USER_CMD:-"qemu-arm -L /usr/arm-linux-gnueabihf/"}"; fi
 export DPKG_ADD_ARCH="armhf"
-export PACKAGES="python3-zmq g++-arm-linux-gnueabihf busybox libc6:armhf libstdc++6:armhf libfontconfig1:armhf libxcb1:armhf"
+export PACKAGES="python3-zmq g++-arm-linux-gnueabihf busybox libc6:armhf libstdc++6:armhf libfontconfig1:armhf libxcb1:armhf libexpat1-dev"
 if [ -n "$QEMU_USER_CMD" ]; then
   # Likely cross-compiling, so install the needed gcc and qemu-user
   export PACKAGES="$PACKAGES qemu-user"

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_tsan
-export PACKAGES="clang-19 llvm-19 libclang-rt-19-dev libc++abi-19-dev libc++-19-dev python3-zmq"
+export PACKAGES="clang-19 llvm-19 libclang-rt-19-dev libc++abi-19-dev libc++-19-dev python3-zmq libexpat1-dev"
 export DEP_OPTS="CC=clang-19 CXX='clang++-19 -stdlib=libc++'"
 export TEST_RUNNER_EXTRA="--extended --exclude feature_pruning,feature_dbcrash,wallet_multiwallet.py" # Temporarily suppress ASan heap-use-after-free (see issue #14163)
 export TEST_RUNNER_EXTRA="${TEST_RUNNER_EXTRA} --timeout-factor=4"  # Increase timeout because sanitizers slow down

--- a/contrib/containers/ci/ci.Dockerfile
+++ b/contrib/containers/ci/ci.Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
     wine-stable \
     wine64 \
     zip \
+    libexpat1-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Clang + LLVM and set it as default

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -111,13 +111,10 @@ ELF_ALLOWED_LIBRARIES = {
 'ld-linux-riscv64-lp64d.so.1', # 64-bit RISC-V dynamic linker
 'libz.so.1', # zlib
 # dash-qt only
-'libxcb.so.1', # part of X11
-'libxcb-shm.so.0', # X11 shared memory extension
-'libxkbcommon.so.0', # keyboard keymapping
-'libxkbcommon-x11.so.0', # keyboard keymapping
+'libdl.so.2', # programming interface to dynamic linker
 'libfontconfig.so.1', # font support
 'libfreetype.so.6', # font parsing
-'libdl.so.2', # programming interface to dynamic linker
+# XCB platform plugin (QXcbIntegrationPlugin)
 'libxcb-icccm.so.4',
 'libxcb-image.so.0',
 'libxcb-shm.so.0',
@@ -130,6 +127,16 @@ ELF_ALLOWED_LIBRARIES = {
 'libxcb-xfixes.so.0',
 'libxcb-xinerama.so.0',
 'libxcb-xkb.so.1',
+'libxcb.so.1', # part of X11
+'libxkbcommon-x11.so.0', # keyboard keymapping
+'libxkbcommon.so.0', # keyboard keymapping
+# Wayland platform plugin (QWaylandIntegrationPlugin)
+"libwayland-client.so.0",
+"libwayland-cursor.so.0",
+# Wayland OpenGL integration plugin (QWaylandEglClientBufferPlugin)
+'libEGL.so.1',
+'libGLESv2.so.2',
+'libwayland-egl.so.1',
 }
 
 MACHO_ALLOWED_LIBRARIES = {

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -21,6 +21,7 @@
              ((gnu packages python-crypto) #:select (python-asn1crypto))
              ((gnu packages tls) #:select (openssl))
              ((gnu packages version-control) #:select (git-minimal))
+             ((gnu packages xml) #:select (expat))
              (guix build-system cmake)
              (guix build-system gnu)
              (guix build-system python)
@@ -536,7 +537,8 @@ inspecting signatures in Mach-O binaries.")
           ((string-contains target "-linux-")
            (list bison
                  (list gcc-toolchain-12 "static")
-                 (make-bitcoin-cross-toolchain target)))
+                 (make-bitcoin-cross-toolchain target)
+                 expat))
           ((string-contains target "darwin")
            (list clang-toolchain-19
                  lld-19

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -4,6 +4,8 @@
 print-%: FORCE
 	@echo '$*'='$($*)'
 
+SYSTEM_PKG_CONFIG_PATH := $(PKG_CONFIG_PATH)
+
 # When invoking a sub-make, keep only the command line variable definitions
 # matching the pattern in the filter function.
 #
@@ -165,6 +167,7 @@ libevent_packages_$(NO_LIBEVENT) = $(libevent_packages)
 qrencode_packages_$(NO_QR) = $(qrencode_$(host_os)_packages)
 
 qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages) $(qrencode_packages_)
+qt_native_packages_$(NO_QT) = $(qt_native_packages) $(qt_$(host_os)_native_packages) $(qt_$(host_arch)_$(host_os)_native_packages)
 
 bdb_packages_$(NO_BDB) = $(bdb_packages)
 sqlite_packages_$(NO_SQLITE) = $(sqlite_packages)
@@ -178,7 +181,7 @@ multiprocess_packages_$(MULTIPROCESS) = $(multiprocess_packages)
 usdt_packages_$(NO_USDT) = $(usdt_$(host_os)_packages)
 
 packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(boost_packages_) $(libevent_packages_) $(qt_packages_) $(wallet_packages_) $(upnp_packages_) $(natpmp_packages_) $(usdt_packages_)
-native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
+native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages) $(qt_native_packages_)
 
 ifneq ($(zmq_packages_),)
 packages += $(zmq_packages)

--- a/depends/packages/libffi.mk
+++ b/depends/packages/libffi.mk
@@ -1,0 +1,29 @@
+package := libffi
+$(package)_version := 3.4.2
+$(package)_download_path := https://github.com/libffi/$(package)/releases/download/v$($(package)_version)
+$(package)_file_name := $(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash := 540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620
+
+define $(package)_set_vars
+  $(package)_config_opts := --enable-option-checking --disable-dependency-tracking
+  $(package)_config_opts += --enable-shared --disable-static --disable-docs
+  $(package)_config_opts += --disable-multi-os-directory
+  # libffi uses GNU C extensions (asm, ssize_t) that require gnu11 instead of c11
+  $(package)_cflags := -std=gnu11
+endef
+
+define $(package)_config_cmds
+  $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf share
+endef

--- a/depends/packages/libglvnd.mk
+++ b/depends/packages/libglvnd.mk
@@ -1,0 +1,28 @@
+package := libglvnd
+$(package)_version := 1.4.0
+$(package)_download_path := https://gitlab.freedesktop.org/glvnd/$(package)/-/archive/v$($(package)_version)
+$(package)_file_name := $(package)-v$($(package)_version).tar.bz2
+$(package)_sha256_hash := fdf395391d95f270528dbff6ce2ee54c186753d286ad62e0da5f62c6f67ba915
+
+define $(package)_set_vars
+  $(package)_config_opts := --enable-option-checking --disable-dependency-tracking
+  $(package)_config_opts += --enable-shared --disable-static
+  $(package)_config_opts += --disable-x11 --disable-gles1
+endef
+
+define $(package)_config_cmds
+  ./autogen.sh && \
+  $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/native_wayland_scanner.mk
+++ b/depends/packages/native_wayland_scanner.mk
@@ -1,0 +1,25 @@
+package := native_wayland_scanner
+$(package)_version := 1.19.0
+$(package)_download_path := https://wayland.freedesktop.org/releases
+$(package)_file_name := wayland-$($(package)_version).tar.xz
+$(package)_sha256_hash := baccd902300d354581cd5ad3cc49daa4921d55fb416a5883e218750fef166d15
+
+define $(package)_set_vars
+  $(package)_config_opts := --enable-option-checking --disable-dependency-tracking
+  $(package)_config_opts += --disable-libraries --disable-documentation
+  $(package)_config_opts += --disable-dtd-validation
+endef
+
+define $(package)_config_cmds
+  EXPAT_LIBS=$$$$(env -u PKG_CONFIG_LIBDIR PKG_CONFIG_PATH=$(SYSTEM_PKG_CONFIG_PATH) pkg-config --libs expat) \
+  EXPAT_CFLAGS=$$$$(env -u PKG_CONFIG_LIBDIR PKG_CONFIG_PATH=$(SYSTEM_PKG_CONFIG_PATH) PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --cflags expat) \
+  $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -9,7 +9,8 @@ qrencode_android_packages = qrencode
 qrencode_darwin_packages = qrencode
 qrencode_mingw32_packages = qrencode
 
-qt_linux_packages:=qt expat libxcb xcb_proto libXau xproto freetype fontconfig libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
+qt_linux_packages:=qt expat libxcb xcb_proto libXau xproto freetype fontconfig libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm libffi wayland libglvnd
+qt_linux_native_packages:=native_wayland_scanner
 qt_freebsd_packages:=$(qt_linux_packages)
 qt_android_packages=qt
 qt_darwin_packages=qt

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://download.qt.io/archive/qt/5.15/$($(package)_ver
 $(package)_suffix=everywhere-opensource-src-$($(package)_version).tar.xz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=7b632550ea1048fc10c741e46e2e3b093e5ca94dfa6209e9e0848800e247023b
-$(package)_linux_dependencies := freetype fontconfig libxcb libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
+$(package)_linux_dependencies := freetype fontconfig libxcb libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm wayland libglvnd
 $(package)_freebsd_dependencies := $($(package)_linux_dependencies)
 $(package)_qt_libs=corelib network widgets gui plugins testlib
 $(package)_linguist_tools = lrelease lupdate lconvert
@@ -34,8 +34,12 @@ $(package)_qttranslations_sha256_hash=e5625757913caf66a9d702ba102ae92cb165d8dde1
 $(package)_qttools_file_name=qttools-$($(package)_suffix)
 $(package)_qttools_sha256_hash=931e0969d9f9d8f233e5e9bf9db0cea9ce9914d49982f1795fe6191010113568
 
+$(package)_qtwayland_file_name = qtwayland-$($(package)_suffix)
+$(package)_qtwayland_sha256_hash = 83f00d2b83bc9badd18add6e9c650c41f2aeb6483eb19013dbdae21e4d7bf81d
+
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)
+$(package)_extra_sources += $($(package)_qtwayland_file_name)
 
 define $(package)_set_vars
 $(package)_config_env = QT_MAC_SDK_NO_VERSION_CHECK=1
@@ -49,7 +53,6 @@ $(package)_config_opts += -confirm-license
 $(package)_config_opts += -hostprefix $(build_prefix)
 $(package)_config_opts += -no-compile-examples
 $(package)_config_opts += -no-cups
-$(package)_config_opts += -no-egl
 $(package)_config_opts += -no-eglfs
 $(package)_config_opts += -no-evdev
 $(package)_config_opts += -no-gif
@@ -131,6 +134,7 @@ $(package)_config_opts += -no-feature-wizard
 $(package)_config_opts += -no-feature-xml
 
 $(package)_config_opts_darwin = -no-dbus
+$(package)_config_opts_darwin += -no-egl
 $(package)_config_opts_darwin += -no-opengl
 $(package)_config_opts_darwin += -pch
 $(package)_config_opts_darwin += -no-feature-corewlan
@@ -156,9 +160,22 @@ $(package)_config_opts_linux += -no-xcb-xlib
 $(package)_config_opts_linux += -no-feature-xlib
 $(package)_config_opts_linux += -system-freetype
 $(package)_config_opts_linux += -fontconfig
-$(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_linux += -no-feature-vulkan
 $(package)_config_opts_linux += -dbus-runtime
+
+# Wayland-specific options:
+$(package)_config_opts_linux += -egl
+$(package)_config_opts_linux += -opengl es2
+$(package)_config_opts_linux += -no-opengles3
+$(package)_config_opts_linux += -no-feature-wayland-drm-egl-server-buffer
+$(package)_config_opts_linux += -no-feature-wayland-shm-emulation-server-buffer
+$(package)_config_opts_linux += -no-feature-wayland-client-fullscreen-shell-v1
+$(package)_config_opts_linux += -no-feature-wayland-client-ivi-shell
+$(package)_config_opts_linux += -no-feature-wayland-client-wl-shell
+$(package)_config_opts_linux += -no-feature-wayland-client-xdg-shell-v5
+$(package)_config_opts_linux += -no-feature-wayland-client-xdg-shell-v6
+$(package)_config_opts_linux += -no-feature-wayland-server
+
 ifneq ($(LTO),)
 $(package)_config_opts_linux += -ltcg
 endif
@@ -175,6 +192,7 @@ else
 endif
 
 $(package)_config_opts_mingw32 = -no-opengl
+$(package)_config_opts_mingw32 += -no-egl
 $(package)_config_opts_mingw32 += -no-dbus
 $(package)_config_opts_mingw32 += -no-freetype
 $(package)_config_opts_mingw32 += -xplatform win32-g++
@@ -212,7 +230,8 @@ endef
 define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttranslations_file_name),$($(package)_qttranslations_file_name),$($(package)_qttranslations_sha256_hash)) && \
-$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttools_file_name),$($(package)_qttools_file_name),$($(package)_qttools_sha256_hash))
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttools_file_name),$($(package)_qttools_file_name),$($(package)_qttools_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtwayland_file_name),$($(package)_qtwayland_file_name),$($(package)_qtwayland_sha256_hash))
 endef
 
 define $(package)_extract_cmds
@@ -220,13 +239,16 @@ define $(package)_extract_cmds
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qttranslations_sha256_hash)  $($(package)_source_dir)/$($(package)_qttranslations_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qttools_sha256_hash)  $($(package)_source_dir)/$($(package)_qttools_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qtwayland_sha256_hash)  $($(package)_source_dir)/$($(package)_qtwayland_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   mkdir qtbase && \
   $(build_TAR) --no-same-owner --strip-components=1 -xf $($(package)_source) -C qtbase && \
   mkdir qttranslations && \
   $(build_TAR) --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttranslations_file_name) -C qttranslations && \
   mkdir qttools && \
-  $(build_TAR) --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttools_file_name) -C qttools
+  $(build_TAR) --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttools_file_name) -C qttools && \
+  mkdir qtwayland && \
+  $(build_TAR) --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtwayland_file_name) -C qtwayland
 endef
 
 # Preprocessing steps work as follows:
@@ -291,6 +313,10 @@ define $(package)_stage_cmds
   $(MAKE) -C qttools/src/linguist INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_linguist_tools))) && \
   $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets
 endef
+
+ifeq ($(host_os),linux)
+  $(package)_stage_cmds += && $(MAKE) -C qtwayland/src INSTALL_ROOT=$($(package)_staging_dir) sub-plugins-install_subtargets
+endif
 
 define $(package)_postprocess_cmds
   rm -rf native/mkspecs/ native/lib/ lib/cmake/ && \

--- a/depends/packages/wayland.mk
+++ b/depends/packages/wayland.mk
@@ -1,0 +1,30 @@
+package := wayland
+native_package := native_wayland_scanner
+$(package)_version := $($(native_package)_version)
+$(package)_download_path := $($(native_package)_download_path)
+$(package)_file_name := $($(native_package)_file_name)
+$(package)_sha256_hash := $($(native_package)_sha256_hash)
+$(package)_dependencies := $(native_package) libffi expat
+
+define $(package)_set_vars
+  $(package)_config_opts := --enable-option-checking --disable-dependency-tracking
+  $(package)_config_opts += --enable-shared --disable-static --disable-documentation
+  $(package)_config_opts += --disable-dtd-validation --with-host-scanner
+  $(package)_cflags += -D_GNU_SOURCE
+endef
+
+define $(package)_config_cmds
+  ac_cv_have_decl_CLOCK_MONOTONIC=yes $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/patches/qt/qt.pro
+++ b/depends/patches/qt/qt.pro
@@ -8,9 +8,10 @@ CONFIG += $$prl
 cache(CONFIG, add stash, prl)
 
 TEMPLATE = subdirs
-SUBDIRS = qtbase qttools qttranslations
+SUBDIRS = qtbase qttools qttranslations qtwayland
 
 qttools.depends = qtbase
 qttranslations.depends = qttools
+qtwayland.depends = qtbase
 
 load(qt_configure)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -62,14 +62,18 @@
 
 #if defined(QT_STATIC)
 #include <QtPlugin>
-#if defined(QT_QPA_PLATFORM_XCB)
-Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#if defined(QT_QPA_PLATFORM_LINUX)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandEglClientBufferPlugin)
+Q_IMPORT_PLUGIN(QWaylandBradientDecorationPlugin)
+Q_IMPORT_PLUGIN(QWaylandXdgShellIntegrationPlugin)
 #elif defined(QT_QPA_PLATFORM_WINDOWS)
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
-Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin)
 #elif defined(QT_QPA_PLATFORM_COCOA)
-Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
-Q_IMPORT_PLUGIN(QMacStylePlugin);
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
+Q_IMPORT_PLUGIN(QMacStylePlugin)
 #elif defined(QT_QPA_PLATFORM_ANDROID)
 Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
 #endif

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -32,14 +32,18 @@
 #if defined(QT_STATIC)
 #include <QtPlugin>
 #if defined(QT_QPA_PLATFORM_MINIMAL)
-Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
+Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)
 #endif
-#if defined(QT_QPA_PLATFORM_XCB)
-Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#if defined(QT_QPA_PLATFORM_LINUX)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandEglClientBufferPlugin)
+Q_IMPORT_PLUGIN(QWaylandBradientDecorationPlugin)
+Q_IMPORT_PLUGIN(QWaylandXdgShellIntegrationPlugin)
 #elif defined(QT_QPA_PLATFORM_WINDOWS)
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 #elif defined(QT_QPA_PLATFORM_COCOA)
-Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
 #elif defined(QT_QPA_PLATFORM_ANDROID)
 Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
 #endif


### PR DESCRIPTION
## Issue being fixed or feature implemented
AI implemented: https://github.com/bitcoin/bitcoin/pull/22708#issuecomment-1100861599 

A primary goal being to modify our flatpak to have the container use wayland instead of X11. Currently, Dash Core crashes if a system online exposes wayland and no X11 compatibility layer.


## How Has This Been Tested?
Ran on fedora 43 Gnome VM forcing wayland (Qt on Gnome will always fallback to X11 unless forced, inside KDE (knst please test) it should use wayland natively.

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

