### PR TITLE
feat(qt): add shift-click range selection to coin control dialog

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -166,6 +166,11 @@ CoinControlDialog::~CoinControlDialog()
     delete ui;
 }
 
+void CoinControlDialog::refreshLabels()
+{
+    CoinControlDialog::updateLabels(m_coin_control, model, this);
+}
+
 // ok button
 void CoinControlDialog::buttonBoxClicked(QAbstractButton* button)
 {
@@ -650,6 +655,7 @@ void CoinControlDialog::updateView()
 
     bool treeMode = ui->radioTreeMode->isChecked();
     ui->treeWidget->clear();
+    ui->treeWidget->resetAnchor();
     ui->treeWidget->setEnabled(false); // performance, otherwise updateLabels would be called for every checked checkbox
     ui->treeWidget->setAlternatingRowColors(!treeMode);
     QFlags<Qt::ItemFlag> flgCheckbox = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -165,6 +165,11 @@ CoinControlDialog::~CoinControlDialog()
     delete ui;
 }
 
+void CoinControlDialog::refreshLabels()
+{
+    CoinControlDialog::updateLabels(m_coin_control, model, this);
+}
+
 // ok button
 void CoinControlDialog::buttonBoxClicked(QAbstractButton* button)
 {
@@ -648,6 +653,7 @@ void CoinControlDialog::updateView()
 
     bool treeMode = ui->radioTreeMode->isChecked();
     ui->treeWidget->clear();
+    ui->treeWidget->resetAnchor();
     ui->treeWidget->setEnabled(false); // performance, otherwise updateLabels would be called for every checked checkbox
     ui->treeWidget->setAlternatingRowColors(!treeMode);
     QFlags<Qt::ItemFlag> flgCheckbox = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -48,6 +48,8 @@ public:
     // static because also called from sendcoinsdialog
     static void updateLabels(wallet::CCoinControl& m_coin_control, WalletModel*, QDialog*);
 
+    void refreshLabels();
+
     static QList<CAmount> payAmounts;
     static bool fSubtractFeeFromAmount;
 

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -58,13 +58,16 @@ void CoinControlTreeWidget::mouseReleaseEvent(QMouseEvent *event)
                         && m_lastClickedItem
                         && clickedItem
                         && clickedItem != m_lastClickedItem
-                        && isLeafItem(clickedItem);
+                        && isLeafItem(clickedItem)
+                        && !clickedItem->isDisabled()
+                        && !m_lastClickedItem->isDisabled();
 
     if (!isShiftClick) {
         // Normal click — let Qt handle the checkbox toggle on release
         QTreeWidget::mouseReleaseEvent(event);
         // Record anchor after toggle so we capture the post-toggle state
-        if (clickedItem && isLeafItem(clickedItem)) {
+        if (event->button() == Qt::LeftButton && clickedItem
+                && isLeafItem(clickedItem) && !clickedItem->isDisabled()) {
             m_lastClickedItem = clickedItem;
         }
         return;

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -5,10 +5,17 @@
 #include <qt/coincontroltreewidget.h>
 #include <qt/coincontroldialog.h>
 
+#include <QTreeWidgetItemIterator>
+
 CoinControlTreeWidget::CoinControlTreeWidget(QWidget *parent) :
     QTreeWidget(parent)
 {
 
+}
+
+void CoinControlTreeWidget::resetAnchor()
+{
+    m_lastClickedItem = nullptr;
 }
 
 void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
@@ -31,4 +38,79 @@ void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
     {
         this->QTreeWidget::keyPressEvent(event);
     }
+}
+
+// Helper: check if an item is a leaf node (UTXO) by its 64-char tx hash
+static bool isLeafItem(QTreeWidgetItem* item)
+{
+    int COLUMN_ADDRESS = 3;
+    return item && item->data(COLUMN_ADDRESS, Qt::UserRole).toString().length() == 64;
+}
+
+void CoinControlTreeWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+    int COLUMN_CHECKBOX = 0;
+
+    QTreeWidgetItem* clickedItem = itemAt(event->pos());
+
+    bool isShiftClick = (event->button() == Qt::LeftButton)
+                        && (event->modifiers() & Qt::ShiftModifier)
+                        && m_lastClickedItem
+                        && clickedItem
+                        && clickedItem != m_lastClickedItem
+                        && isLeafItem(clickedItem);
+
+    if (!isShiftClick) {
+        // Normal click — let Qt handle the checkbox toggle on release
+        QTreeWidget::mouseReleaseEvent(event);
+        // Record anchor after toggle so we capture the post-toggle state
+        if (clickedItem && isLeafItem(clickedItem)) {
+            m_lastClickedItem = clickedItem;
+        }
+        return;
+    }
+
+    // Shift+click: select/deselect the range between anchor and target
+    // Read the anchor's current check state live (not cached) so it stays
+    // correct after bulk operations like Select All or parent tristate changes
+    Qt::CheckState stateToApply = m_lastClickedItem->checkState(COLUMN_CHECKBOX);
+
+    // Collect visible leaf items in display order, skipping children of
+    // collapsed parent nodes so we don't toggle coins the user can't see
+    std::vector<QTreeWidgetItem*> leafItems;
+    int anchorIdx = -1;
+    int targetIdx = -1;
+    QTreeWidgetItemIterator it(this);
+    while (*it) {
+        if (isLeafItem(*it)) {
+            QTreeWidgetItem* parent = (*it)->parent();
+            if (!parent || parent->isExpanded()) {
+                if (*it == m_lastClickedItem) anchorIdx = leafItems.size();
+                if (*it == clickedItem) targetIdx = leafItems.size();
+                leafItems.push_back(*it);
+            }
+        }
+        ++it;
+    }
+
+    if (anchorIdx < 0 || targetIdx < 0) {
+        QTreeWidget::mouseReleaseEvent(event);
+        return;
+    }
+
+    if (anchorIdx > targetIdx) std::swap(anchorIdx, targetIdx);
+
+    // Batch update: disable widget to suppress per-item updateLabels calls
+    setEnabled(false);
+    for (int i = anchorIdx; i <= targetIdx; ++i) {
+        QTreeWidgetItem* item = leafItems[i];
+        if (!item->isDisabled() && item->checkState(COLUMN_CHECKBOX) != stateToApply) {
+            item->setCheckState(COLUMN_CHECKBOX, stateToApply);
+        }
+    }
+    setEnabled(true);
+
+    // Single label update for the whole batch
+    CoinControlDialog* coinControlDialog = qobject_cast<CoinControlDialog*>(this->parentWidget());
+    if (coinControlDialog) coinControlDialog->refreshLabels();
 }

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -5,6 +5,8 @@
 #include <qt/coincontroltreewidget.h>
 #include <qt/coincontroldialog.h>
 
+#include <QStyle>
+#include <QStyleOptionViewItem>
 #include <QTreeWidgetItemIterator>
 
 CoinControlTreeWidget::CoinControlTreeWidget(QWidget *parent) :
@@ -47,27 +49,55 @@ static bool isLeafItem(QTreeWidgetItem* item)
     return item && item->data(COLUMN_ADDRESS, Qt::UserRole).toString().length() == 64;
 }
 
+static bool isCheckboxClick(QTreeWidget* tree, QTreeWidgetItem* item, const QPoint& pos)
+{
+    int COLUMN_CHECKBOX = 0;
+
+    if (!tree || !item || tree->columnAt(pos.x()) != COLUMN_CHECKBOX) {
+        return false;
+    }
+
+    const QModelIndex index = tree->indexFromItem(item, COLUMN_CHECKBOX);
+    if (!index.isValid()) {
+        return false;
+    }
+
+    QStyleOptionViewItem option;
+    option.initFrom(tree);
+    option.rect = tree->visualRect(index);
+    option.features = QStyleOptionViewItem::HasCheckIndicator;
+    option.checkState = item->checkState(COLUMN_CHECKBOX);
+
+    return tree->style()->subElementRect(QStyle::SE_ItemViewItemCheckIndicator, &option, tree).contains(pos);
+}
+
 void CoinControlTreeWidget::mouseReleaseEvent(QMouseEvent *event)
 {
     int COLUMN_CHECKBOX = 0;
 
     QTreeWidgetItem* clickedItem = itemAt(event->pos());
+    const bool isCheckboxInteraction = isCheckboxClick(this, clickedItem, event->pos());
 
     bool isShiftClick = (event->button() == Qt::LeftButton)
                         && (event->modifiers() & Qt::ShiftModifier)
                         && m_lastClickedItem
                         && clickedItem
                         && clickedItem != m_lastClickedItem
+                        && isCheckboxInteraction
                         && isLeafItem(clickedItem)
                         && !clickedItem->isDisabled()
                         && !m_lastClickedItem->isDisabled();
 
     if (!isShiftClick) {
         // Normal click — let Qt handle the checkbox toggle on release
+        const Qt::CheckState previousState = clickedItem ? clickedItem->checkState(COLUMN_CHECKBOX) : Qt::Unchecked;
         QTreeWidget::mouseReleaseEvent(event);
         // Record anchor after toggle so we capture the post-toggle state
         if (event->button() == Qt::LeftButton && clickedItem
-                && isLeafItem(clickedItem) && !clickedItem->isDisabled()) {
+                && isCheckboxInteraction
+                && isLeafItem(clickedItem)
+                && !clickedItem->isDisabled()
+                && clickedItem->checkState(COLUMN_CHECKBOX) != previousState) {
             m_lastClickedItem = clickedItem;
         }
         return;

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -5,6 +5,8 @@
 #include <qt/coincontroltreewidget.h>
 #include <qt/coincontroldialog.h>
 
+#include <QStyle>
+#include <QStyleOptionViewItem>
 #include <QTreeWidgetItemIterator>
 
 CoinControlTreeWidget::CoinControlTreeWidget(QWidget *parent) :
@@ -47,27 +49,55 @@ static bool isLeafItem(QTreeWidgetItem* item)
     return item && item->data(COLUMN_ADDRESS, Qt::UserRole).toString().length() == 64;
 }
 
+bool CoinControlTreeWidget::isCheckboxClick(QTreeWidgetItem* item, const QPoint& pos) const
+{
+    int COLUMN_CHECKBOX = 0;
+
+    if (!item || columnAt(pos.x()) != COLUMN_CHECKBOX) {
+        return false;
+    }
+
+    const QModelIndex index = indexFromItem(item, COLUMN_CHECKBOX);
+    if (!index.isValid()) {
+        return false;
+    }
+
+    QStyleOptionViewItem option;
+    option.initFrom(this);
+    option.rect = visualRect(index);
+    option.features = QStyleOptionViewItem::HasCheckIndicator;
+    option.checkState = item->checkState(COLUMN_CHECKBOX);
+
+    return style()->subElementRect(QStyle::SE_ItemViewItemCheckIndicator, &option, this).contains(pos);
+}
+
 void CoinControlTreeWidget::mouseReleaseEvent(QMouseEvent *event)
 {
     int COLUMN_CHECKBOX = 0;
 
     QTreeWidgetItem* clickedItem = itemAt(event->pos());
+    const bool isCheckboxInteraction = isCheckboxClick(clickedItem, event->pos());
 
     bool isShiftClick = (event->button() == Qt::LeftButton)
                         && (event->modifiers() & Qt::ShiftModifier)
                         && m_lastClickedItem
                         && clickedItem
                         && clickedItem != m_lastClickedItem
+                        && isCheckboxInteraction
                         && isLeafItem(clickedItem)
                         && !clickedItem->isDisabled()
                         && !m_lastClickedItem->isDisabled();
 
     if (!isShiftClick) {
         // Normal click — let Qt handle the checkbox toggle on release
+        const Qt::CheckState previousState = clickedItem ? clickedItem->checkState(COLUMN_CHECKBOX) : Qt::Unchecked;
         QTreeWidget::mouseReleaseEvent(event);
         // Record anchor after toggle so we capture the post-toggle state
         if (event->button() == Qt::LeftButton && clickedItem
-                && isLeafItem(clickedItem) && !clickedItem->isDisabled()) {
+                && isCheckboxInteraction
+                && isLeafItem(clickedItem)
+                && !clickedItem->isDisabled()
+                && clickedItem->checkState(COLUMN_CHECKBOX) != previousState) {
             m_lastClickedItem = clickedItem;
         }
         return;

--- a/src/qt/coincontroltreewidget.h
+++ b/src/qt/coincontroltreewidget.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_COINCONTROLTREEWIDGET_H
 
 #include <QKeyEvent>
+#include <QMouseEvent>
 #include <QTreeWidget>
 
 class CoinControlTreeWidget : public QTreeWidget
@@ -14,9 +15,14 @@ class CoinControlTreeWidget : public QTreeWidget
 
 public:
     explicit CoinControlTreeWidget(QWidget *parent = nullptr);
+    void resetAnchor();
 
 protected:
-    virtual void keyPressEvent(QKeyEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+
+private:
+    QTreeWidgetItem* m_lastClickedItem{nullptr};
 };
 
 #endif // BITCOIN_QT_COINCONTROLTREEWIDGET_H

--- a/src/qt/coincontroltreewidget.h
+++ b/src/qt/coincontroltreewidget.h
@@ -22,6 +22,8 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
 
 private:
+    bool isCheckboxClick(QTreeWidgetItem* item, const QPoint& pos) const;
+
     QTreeWidgetItem* m_lastClickedItem{nullptr};
 };
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Users with many UTXOs must click each coin individually in the coin control dialog. This adds standard shift-click range selection, allowing a contiguous block of coins to be selected or deselected in one action.

## What was done?
Overrode `mousePressEvent` and `mouseReleaseEvent` in `CoinControlTreeWidget` to support shift-click range selection:

- **Anchor tracking:** On a normal click, the clicked leaf item and its post-toggle check state are recorded as the "anchor"
- **Range selection:** On shift+click, all leaf items (UTXOs) between the anchor and the shift-clicked target are set to the anchor's check state
- **Performance:** Uses the existing `setEnabled(false)` bulk-update pattern to suppress per-item `updateLabels()` calls, with a single `refreshLabels()` call after the batch
- **Safety:** Locked (disabled) coins in the range are skipped; anchor pointer is reset via `resetAnchor()` when `updateView()` rebuilds the tree to prevent dangling pointers
- Works in both tree mode (grouped by address) and list mode (flat)

## How Has This Been Tested?
Manual testing:
- List mode: click item A, shift-click item D — items A through D all check/uncheck correctly
- Tree mode: shift-click across address groups — range spans groups as expected
- Locked coins within a range remain unaffected
- Unchecking range: click a checked item (anchor = unchecked), shift-click another — range unchecks
- Mode switch between tree/list does not crash (anchor reset on view rebuild)
- Re-sorting then shift-clicking follows the new visual order

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone