### PR TITLE
backport: batch 2 of migratewallet RPC

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -63,6 +63,7 @@ struct WalletBalances;
 struct WalletTx;
 struct WalletTxOut;
 struct WalletTxStatus;
+struct WalletMigrationResult;
 namespace CoinJoin {
 class Loader;
 }
@@ -457,6 +458,9 @@ public:
     //! Restore backup wallet
     virtual util::Result<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) = 0;
 
+    //! Migrate a wallet
+    virtual util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase) = 0;
+
     //! Return available wallets in wallet directory.
     virtual std::vector<std::string> listWalletDir() = 0;
 
@@ -558,6 +562,15 @@ struct WalletTxOut
     int64_t time;
     int depth_in_main_chain = -1;
     bool is_spent = false;
+};
+
+//! Migrated wallet info
+struct WalletMigrationResult
+{
+    std::unique_ptr<Wallet> wallet;
+    std::optional<std::string> watchonly_wallet_name;
+    std::optional<std::string> solvables_wallet_name;
+    fs::path backup_path;
 };
 
 //! Return implementation of Wallet interface. This function is defined in

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -195,9 +195,10 @@ void AskPassphraseDialog::accept()
                                              "the first null character. If this is successful, please set a new "
                                              "passphrase to avoid this issue in the future."));
                 }
-            }
-            else
-            {
+            } else {
+                if (m_passphrase_out) {
+                    m_passphrase_out->assign(oldpass);
+                }
                 QDialog::accept(); // Success
             }
         } catch (const std::runtime_error& e) {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -493,6 +493,10 @@ void BitcoinGUI::createActions()
     m_close_all_wallets_action = new QAction(tr("Close All Wallets…"), this);
     m_close_all_wallets_action->setStatusTip(tr("Close all wallets"));
 
+    m_migrate_wallet_action = new QAction(tr("Migrate Wallet"), this);
+    m_migrate_wallet_action->setEnabled(false);
+    m_migrate_wallet_action->setStatusTip(tr("Migrate a wallet"));
+
     showHelpMessageAction = new QAction(tr("&Command-line options"), this);
     showHelpMessageAction->setMenuRole(QAction::NoRole);
     showHelpMessageAction->setStatusTip(tr("Show the %1 help message to get a list with possible Dash command-line options").arg(PACKAGE_NAME));
@@ -615,7 +619,11 @@ void BitcoinGUI::createActions()
         connect(m_close_all_wallets_action, &QAction::triggered, [this] {
             m_wallet_controller->closeAllWallets(this);
         });
-
+        connect(m_migrate_wallet_action, &QAction::triggered, [this] {
+            auto activity = new MigrateWalletActivity(m_wallet_controller, this);
+            connect(activity, &MigrateWalletActivity::migrated, this, &BitcoinGUI::setCurrentWallet);
+            activity->migrate(walletFrame->currentWalletModel());
+        });
         connect(m_mask_values_action, &QAction::toggled, this, &BitcoinGUI::setPrivacy);
     }
 #endif // ENABLE_WALLET
@@ -633,6 +641,7 @@ void BitcoinGUI::createMenuBar()
         file->addAction(m_open_wallet_action);
         file->addAction(m_close_wallet_action);
         file->addAction(m_close_all_wallets_action);
+        file->addAction(m_migrate_wallet_action);
         file->addSeparator();
         file->addAction(backupWalletAction);
         file->addAction(m_restore_wallet_action);
@@ -1051,6 +1060,7 @@ void BitcoinGUI::setCurrentWallet(WalletModel* wallet_model)
         }
     }
     updateWindowTitle();
+    m_migrate_wallet_action->setEnabled(wallet_model->wallet().isLegacy());
 }
 
 void BitcoinGUI::setCurrentWalletBySelectorIndex(int index)
@@ -1101,6 +1111,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     openAction->setEnabled(enabled);
     m_close_wallet_action->setEnabled(enabled);
     m_close_all_wallets_action->setEnabled(enabled);
+    m_migrate_wallet_action->setEnabled(enabled);
 
     updateWidth();
 }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -185,6 +185,8 @@ private:
     QAction* m_close_all_wallets_action{nullptr};
     QAction* m_wallet_selector_action = nullptr;
     QAction* m_mask_values_action{nullptr};
+    QAction* m_migrate_wallet_action{nullptr};
+    QMenu* m_migrate_wallet_menu{nullptr};
 
     QComboBox* m_wallet_selector = nullptr;
 

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -558,3 +558,67 @@ void RescanWalletActivity::finish()
 
     Q_EMIT finished();
 }
+
+void MigrateWalletActivity::migrate(WalletModel* wallet_model)
+{
+    // Warn the user about migration
+    QMessageBox box(m_parent_widget);
+    box.setWindowTitle(tr("Migrate wallet"));
+    box.setText(tr("Are you sure you wish to migrate the wallet <i>%1</i>?").arg(GUIUtil::HtmlEscape(wallet_model->getDisplayName())));
+    box.setInformativeText(tr("Migrating the wallet will convert this wallet to one or more descriptor wallets. A new wallet backup will need to be made.\n"
+                "If this wallet contains any watchonly scripts, a new wallet will be created which contains those watchonly scripts.\n"
+                "If this wallet contains any solvable but not watched scripts, a different and new wallet will be created which contains those scripts.\n\n"
+                "The migration process will create a backup of the wallet before migrating. This backup file will be named "
+                "<wallet name>-<timestamp>.legacy.bak and can be found in the directory for this wallet. In the event of "
+                "an incorrect migration, the backup can be restored with the \"Restore Wallet\" functionality."));
+    box.setStandardButtons(QMessageBox::Yes|QMessageBox::Cancel);
+    box.setDefaultButton(QMessageBox::Yes);
+    if (box.exec() != QMessageBox::Yes) return;
+
+    // Get the passphrase if it is encrypted regardless of it is locked or unlocked. We need the passphrase itself.
+    SecureString passphrase;
+    WalletModel::EncryptionStatus enc_status = wallet_model->getEncryptionStatus();
+    if (enc_status == WalletModel::EncryptionStatus::Locked || enc_status == WalletModel::EncryptionStatus::Unlocked) {
+        AskPassphraseDialog dlg(AskPassphraseDialog::Unlock, m_parent_widget, &passphrase);
+        dlg.setModel(wallet_model);
+        dlg.exec();
+    }
+
+    // GUI needs to remove the wallet so that it can actually be unloaded by migration
+    const std::string name = wallet_model->wallet().getWalletName();
+    m_wallet_controller->removeAndDeleteWallet(wallet_model);
+
+    showProgressDialog(tr("Migrate Wallet"), tr("Migrating Wallet <b>%1</b>…").arg(GUIUtil::HtmlEscape(name)));
+
+    QTimer::singleShot(0, worker(), [this, name, passphrase] {
+        auto res{node().walletLoader().migrateWallet(name, passphrase)};
+
+        if (res) {
+            m_success_message = tr("The wallet '%1' was migrated successfully.").arg(GUIUtil::HtmlEscape(res->wallet->getWalletName()));
+            if (res->watchonly_wallet_name) {
+                m_success_message += QChar(' ') + tr("Watchonly scripts have been migrated to a new wallet named '%1'.").arg(GUIUtil::HtmlEscape(res->watchonly_wallet_name.value()));
+            }
+            if (res->solvables_wallet_name) {
+                m_success_message += QChar(' ') + tr("Solvable but not watched scripts have been migrated to a new wallet named '%1'.").arg(GUIUtil::HtmlEscape(res->solvables_wallet_name.value()));
+            }
+            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(res->wallet));
+        } else {
+            m_error_message = util::ErrorString(res);
+        }
+
+        QTimer::singleShot(0, this, &MigrateWalletActivity::finish);
+    });
+}
+
+void MigrateWalletActivity::finish()
+{
+    if (!m_error_message.empty()) {
+        QMessageBox::critical(m_parent_widget, tr("Migration failed"), QString::fromStdString(m_error_message.translated));
+    } else {
+        QMessageBox::information(m_parent_widget, tr("Migration Successful"), m_success_message);
+    }
+
+    if (m_wallet_model) Q_EMIT migrated(m_wallet_model);
+
+    Q_EMIT finished();
+}

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -39,6 +39,7 @@ class path;
 class AskPassphraseDialog;
 class CreateWalletActivity;
 class CreateWalletDialog;
+class MigrateWalletActivity;
 class OpenWalletActivity;
 class WalletControllerActivity;
 
@@ -64,6 +65,8 @@ public:
     void closeWallet(WalletModel* wallet_model, QWidget* parent = nullptr);
     void closeAllWallets(QWidget* parent = nullptr);
 
+    void migrateWallet(WalletModel* wallet_model, QWidget* parent = nullptr);
+
 Q_SIGNALS:
     void walletAdded(WalletModel* wallet_model);
     void walletRemoved(WalletModel* wallet_model);
@@ -81,6 +84,7 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_load_wallet;
 
     friend class WalletControllerActivity;
+    friend class MigrateWalletActivity;
 };
 
 class WalletControllerActivity : public QObject
@@ -191,6 +195,24 @@ private:
 
     QPointer<WalletModel> m_rescan_wallet_model;
     wallet::RescanStatus m_rescan_status{};
+};
+
+class MigrateWalletActivity : public WalletControllerActivity
+{
+    Q_OBJECT
+
+public:
+    MigrateWalletActivity(WalletController* wallet_controller, QWidget* parent) : WalletControllerActivity(wallet_controller, parent) {}
+
+    void migrate(WalletModel* wallet_model);
+
+Q_SIGNALS:
+    void migrated(WalletModel* wallet_model);
+
+private:
+    QString m_success_message;
+
+    void finish();
 };
 
 #endif // BITCOIN_QT_WALLETCONTROLLER_H

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -55,6 +55,7 @@ using interfaces::Wallet;
 using interfaces::WalletAddress;
 using interfaces::WalletBalances;
 using interfaces::WalletLoader;
+using interfaces::WalletMigrationResult;
 using interfaces::WalletOrderForm;
 using interfaces::WalletTx;
 using interfaces::WalletTxOut;
@@ -935,6 +936,18 @@ public:
         } else {
             return util::Error{error};
         }
+    }
+    util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase) override
+    {
+        auto res = wallet::MigrateLegacyToDescriptor(name, passphrase, m_context);
+        if (!res) return util::Error{util::ErrorString(res)};
+        WalletMigrationResult out{
+            .wallet = MakeWallet(m_context, res->wallet),
+            .watchonly_wallet_name = res->watchonly_wallet ? std::make_optional(res->watchonly_wallet->GetName()) : std::nullopt,
+            .solvables_wallet_name = res->solvables_wallet ? std::make_optional(res->solvables_wallet->GetName()) : std::nullopt,
+            .backup_path = res->backup_path,
+        };
+        return {std::move(out)}; // std::move to work around clang bug
     }
     std::string getWalletDir() override
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3264,6 +3264,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         for (auto spk_man : walletInstance->GetActiveScriptPubKeyMans()) {
             if (spk_man->HavePrivateKeys()) {
                 warnings.push_back(strprintf(_("Warning: Private keys detected in wallet {%s} with disabled private keys"), walletFile));
+                break;
             }
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4988,7 +4988,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& walle
         // Migration successful, unload the wallet locally, then reload it.
         assert(local_wallet.use_count() == 1);
         local_wallet.reset();
-        LoadWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options, status, error, warnings);
+        res.wallet = LoadWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options, status, error, warnings);
         res.wallet_name = wallet_name;
     } else {
         // Migration failed, cleanup

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4554,16 +4554,19 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
 
     // Close this database and delete the file
     fs::path db_path = fs::PathFromString(m_database->Filename());
-    fs::path db_dir = db_path.parent_path();
     m_database->Close();
     fs::remove(db_path);
+
+    // Generate the path for the location of the migrated wallet
+    // Wallets that are plain files rather than wallet directories will be migrated to be wallet directories.
+    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(m_name));
 
     // Make new DB
     DatabaseOptions opts;
     opts.require_create = true;
     opts.require_format = DatabaseFormat::SQLITE;
     DatabaseStatus db_status;
-    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(db_dir, opts, db_status, error);
+    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(wallet_path, opts, db_status, error);
     assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
     m_database.reset();
     m_database = std::move(new_db);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1261,6 +1261,7 @@ bool FillInputToWeight(CTxIn& txin, int64_t target_weight);
 
 struct MigrationResult {
     std::string wallet_name;
+    std::shared_ptr<CWallet> wallet;
     std::shared_ptr<CWallet> watchonly_wallet;
     std::shared_ptr<CWallet> solvables_wallet;
     fs::path backup_path;

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -256,11 +256,11 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             self.options.descriptors = None
         elif self.options.descriptors is None:
             # Some wallet is either required or optionally used by the test.
-            # Prefer BDB unless it isn't available
-            if self.is_bdb_compiled():
-                self.options.descriptors = False
-            elif self.is_sqlite_compiled():
+            # Prefer SQLite unless it isn't available
+            if self.is_sqlite_compiled():
                 self.options.descriptors = True
+            elif self.is_bdb_compiled():
+                self.options.descriptors = False
             else:
                 # If neither are compiled, tests requiring a wallet will be skipped and the value of self.options.descriptors won't matter
                 # It still needs to exist and be None in order for tests to work however.

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -6,6 +6,7 @@
 
 import os
 import random
+import shutil
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -531,6 +532,40 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         self.assert_is_sqlite(nested_name)
 
+    def test_default_wallet(self):
+        self.log.info("Test migration of the wallet named as the empty string")
+        wallet = self.create_legacy_wallet("")
+
+        wallet.migratewallet()
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["format"], "sqlite")
+
+    def test_direct_file(self):
+        self.log.info("Test migration of a wallet that is not in a wallet directory")
+        wallet = self.create_legacy_wallet("plainfile")
+        wallet.unloadwallet()
+
+        wallets_dir = os.path.join(self.nodes[0].datadir, "regtest", "wallets")
+        wallet_path = os.path.join(wallets_dir, "plainfile")
+        wallet_dat_path = os.path.join(wallet_path, "wallet.dat")
+        shutil.copyfile(wallet_dat_path, os.path.join(wallets_dir, "plainfile.bak"))
+        shutil.rmtree(wallet_path)
+        shutil.move(os.path.join(wallets_dir, "plainfile.bak"), wallet_path)
+
+        self.nodes[0].loadwallet("plainfile")
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], False)
+        assert_equal(info["format"], "bdb")
+
+        wallet.migratewallet()
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["format"], "sqlite")
+
+        assert os.path.isdir(wallet_path)
+        assert os.path.isfile(wallet_dat_path)
+
     def run_test(self):
         self.generate(self.nodes[0], 101)
 
@@ -544,6 +579,8 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.test_unloaded()
         self.test_unloaded_by_path()
         self.test_wallet_name_with_slashes()
+        self.test_default_wallet()
+        self.test_direct_file()
 
 if __name__ == '__main__':
     WalletMigrationTest().main()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -37,11 +37,13 @@ class WalletMigrationTest(BitcoinTestFramework):
             assert_equal(file_magic, b'SQLite format 3\x00')
         assert_equal(self.nodes[0].get_wallet_rpc(wallet_name).getwalletinfo()["format"], "sqlite")
 
-    def create_legacy_wallet(self, wallet_name):
-        self.nodes[0].createwallet(wallet_name=wallet_name)
+    def create_legacy_wallet(self, wallet_name, disable_private_keys=False, blank=False):
+        self.nodes[0].createwallet(wallet_name=wallet_name, descriptors=False, disable_private_keys=disable_private_keys, blank=blank)
         wallet = self.nodes[0].get_wallet_rpc(wallet_name)
-        assert_equal(wallet.getwalletinfo()["descriptors"], False)
-        assert_equal(wallet.getwalletinfo()["format"], "bdb")
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], False)
+        assert_equal(info["format"], "bdb")
+        assert_equal(info["private_keys_enabled"], not disable_private_keys)
         return wallet
 
     def assert_addr_info_equal(self, addr_info, addr_info_old):
@@ -174,8 +176,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         BASIC2_SEED_WIF = "cMai6KJ8sHnNejZctqjiYdg2KSLeiaKcuTbZQrJNEjmMY5JQw6eP"
         BASIC2_SEED_XPRV = "tprv8ZgxMBicQKsPe48qChGvN9oKqP6PP2Ecaso2tZ254CTd85JyX3dPfaWw3vWN4wgQeaNrX8ZfK3Zq2Q5LHvEoyfZv3mmJpyUz1caSFLya1Ca"
 
-        self.nodes[0].createwallet(wallet_name="basic2", blank=True)
-        basic2 = self.nodes[0].get_wallet_rpc("basic2")
+        basic2 = self.create_legacy_wallet("basic2", blank=True)
         basic2.sethdseed(True, BASIC2_SEED_WIF)
         assert_equal(basic2.getbalance(), 0)
 
@@ -228,11 +229,9 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         # Some keys in multisig do not belong to this wallet
         self.log.info("Test migration of a wallet that has some keys in a multisig")
-        self.nodes[0].createwallet(wallet_name="multisig1")
-        multisig1 = self.nodes[0].get_wallet_rpc("multisig1")
+        multisig1 = self.create_legacy_wallet("multisig1")
         ms_info = multisig1.addmultisigaddress(2, [multisig1.getnewaddress(), pub1, pub2])
         ms_info2 = multisig1.addmultisigaddress(2, [multisig1.getnewaddress(), pub1, pub2])
-        assert_equal(multisig1.getwalletinfo()["descriptors"], False)
 
         addr1 = ms_info["address"]
         addr2 = ms_info2["address"]
@@ -297,9 +296,7 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         # Wallet with an imported address. Should be the same thing as the multisig test
         self.log.info("Test migration of a wallet with watchonly imports")
-        self.nodes[0].createwallet(wallet_name="imports0")
-        imports0 = self.nodes[0].get_wallet_rpc("imports0")
-        assert_equal(imports0.getwalletinfo()["descriptors"], False)
+        imports0 = self.create_legacy_wallet("imports0")
 
         # External address label
         imports0.setlabel(default.getnewaddress(), "external")
@@ -366,11 +363,7 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         # Migrating an actual watchonly wallet should not create a new watchonly wallet
         self.log.info("Test migration of a pure watchonly wallet")
-        self.nodes[0].createwallet(wallet_name="watchonly0", disable_private_keys=True)
-        watchonly0 = self.nodes[0].get_wallet_rpc("watchonly0")
-        info = watchonly0.getwalletinfo()
-        assert_equal(info["descriptors"], False)
-        assert_equal(info["private_keys_enabled"], False)
+        watchonly0 = self.create_legacy_wallet("watchonly0", disable_private_keys=True)
 
         addr = default.getnewaddress()
         desc = default.getaddressinfo(addr)["desc"]
@@ -393,11 +386,7 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         # Migrating a wallet with pubkeys added to the keypool
         self.log.info("Test migration of a pure watchonly wallet with pubkeys in keypool")
-        self.nodes[0].createwallet(wallet_name="watchonly1", disable_private_keys=True)
-        watchonly1 = self.nodes[0].get_wallet_rpc("watchonly1")
-        info = watchonly1.getwalletinfo()
-        assert_equal(info["descriptors"], False)
-        assert_equal(info["private_keys_enabled"], False)
+        watchonly1 = self.create_legacy_wallet("watchonly1", disable_private_keys=True)
 
         addr1 = default.getnewaddress()
         addr2 = default.getnewaddress()


### PR DESCRIPTION
## Issue being fixed or feature implemented
Further improvements of `migratewallet` RPC to migrate legacy wallets to descriptor wallets.

## What was done?
Backports:
 - bitcoin-core/gui#738
 - bitcoin/bitcoin#26638
 - bitcoin/bitcoin#26740

 + fix for old backport bitcoin#17261


Further changes to be done in the next batch ; out-of-scope of current PR:
 - bitcoin-core/gui#824 (fix for #738), depends on bitcoin/bitcoin#27790
 - bitcoin/bitcoin#26021 (depends on https://github.com/dashpay/dash/pull/7037)
 - bitcoin/bitcoin#28067 (depends on 26021)
 - bitcoin/bitcoin#28038 (depends on 27217)
 - bitcoin/bitcoin#28125
 - bitcoin/bitcoin#28602
 - bitcoin/bitcoin#28609 [currently doesn't work as expected, probably depends on 28125]
 - bitcoin/bitcoin#28546
 - bitcoin/bitcoin#28868
 
## How Has This Been Tested?
Run unit test & functional tests.
Click in Qt-UI "Migrate wallet" - it works as expected.

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

