### PR TITLE
test: stabilize governance superblock waits

### DIFF
--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -11,7 +11,11 @@ from test_framework.test_framework import (
     DashTestFramework,
     MasternodeInfo,
 )
-from test_framework.governance import have_trigger_for_height, prepare_object
+from test_framework.governance import (
+    have_funded_trigger_for_height,
+    have_trigger_for_height,
+    prepare_object,
+)
 from test_framework.util import assert_equal, satoshi_round
 
 GOVERNANCE_UPDATE_MIN = 60 * 60 # src/governance/object.h
@@ -310,7 +314,7 @@ class DashGovernanceTest (DashTestFramework):
         # voted NO vote for the trigger non-isolated node created.
         # So everyone should be on the same page now with 25 votes total.
         for node in self.nodes:
-            assert_equal(node.gobject("count")["votes"], 25)
+            self.wait_until(lambda node=node: node.gobject("count")["votes"] == 25, timeout=5)
 
         self.log.info("Remember vote count")
         before = self.nodes[1].gobject("count")["votes"]
@@ -330,9 +334,13 @@ class DashGovernanceTest (DashTestFramework):
 
         block_count = self.nodes[0].getblockcount()
         n = sb_cycle - block_count % sb_cycle
+        sb_block_height = block_count + n
 
         self.log.info("Move remaining n blocks until actual Superblock")
         for i in range(n):
+            if i == n - 1:
+                self.log.info("Wait for Superblock trigger before mining actual Superblock")
+                self.wait_until(lambda: have_funded_trigger_for_height(self.nodes, sb_block_height))
             self.bump_mocktime(1)
             self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks())
             # comparing to 159 because bip9 forks are active when the tip is one block behind the activation height
@@ -364,7 +372,7 @@ class DashGovernanceTest (DashTestFramework):
             self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks())
             self.wait_until(lambda: have_trigger_for_height(self.nodes, 180), timeout=1, do_assert=False)
         self.log.info("Wait for new trigger and votes")
-        self.wait_until(lambda: have_trigger_for_height(self.nodes, 180))
+        self.wait_until(lambda: have_funded_trigger_for_height(self.nodes, 180))
         self.log.info("Mine superblock")
         self.bump_mocktime(1)
         self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks())
@@ -379,9 +387,13 @@ class DashGovernanceTest (DashTestFramework):
             for _ in range(sb_maturity_window - 1):
                 self.bump_mocktime(1)
                 self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks())
-                self.wait_until(lambda: have_trigger_for_height(self.nodes, sb_block_height), timeout=1, do_assert=False)
+                self.wait_until(
+                    lambda sb_height=sb_block_height: have_trigger_for_height(self.nodes, sb_height),
+                    timeout=1,
+                    do_assert=False,
+                )
             # Wait for new trigger and votes
-            self.wait_until(lambda: have_trigger_for_height(self.nodes, sb_block_height))
+            self.wait_until(lambda sb_height=sb_block_height: have_funded_trigger_for_height(self.nodes, sb_height))
             # Mine superblock
             self.bump_mocktime(1)
             self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks())

--- a/test/functional/test_framework/governance.py
+++ b/test/functional/test_framework/governance.py
@@ -32,11 +32,11 @@ def prepare_object(node, object_type, parent_hash, creation_time, revision, name
         "data": proposal_template,
     }
 
-def have_trigger_for_height(nodes, sb_block_height):
+def have_trigger_for_height(nodes, sb_block_height, signal="valid"):
     count = 0
     for node in nodes:
-        valid_triggers = node.gobject("list", "valid", "triggers")
-        for trigger in list(valid_triggers.values()):
+        triggers = node.gobject("list", signal, "triggers")
+        for trigger in list(triggers.values()):
             if json.loads(trigger["DataString"])["event_block_height"] != sb_block_height:
                 continue
             if trigger['AbsoluteYesCount'] > 0:
@@ -44,3 +44,6 @@ def have_trigger_for_height(nodes, sb_block_height):
                 break
     return count == len(nodes)
 
+
+def have_funded_trigger_for_height(nodes, sb_block_height):
+    return have_trigger_for_height(nodes, sb_block_height, signal="funding")


### PR DESCRIPTION
# Summary

Fixes dashpay/dash#7328.

`feature_governance.py` can observe governance votes and triggers before every
node has finished updating the aggregate vote count, or before a trigger is in
the same funded state used by superblock mining. This made the test
intermittently fail on the final vote-count assertion and, locally, at the first
superblock payment check.

## Changes

- Wait for each node's aggregate governance vote count to reach 25 before
  continuing.
- Extend `have_trigger_for_height()` so callers can wait on a specific
  governance vote signal.
- Add `have_funded_trigger_for_height()` and use it before mining superblocks,
  aligning the test wait with superblock processing's cached-funding condition.

## Validation

```bash
PYTHONPYCACHEPREFIX=/private/tmp/tracker-2129-pycache \
  python3 -m py_compile \
    test/functional/feature_governance.py \
    test/functional/test_framework/governance.py
```

- `feature_governance.py --descriptors`: passed twice with PRNG seeds
  `7310226623689214072` and `5676185504401363752`.
- `feature_governance.py --legacy-wallet`: passed twice with PRNG seeds
  `7488827763781849512` and `3282526354881486806`.
- Pre-publication code-review gate: `ship` with zero findings.
