### PR TITLE
backport: Merge bitcoin#27254

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -236,7 +236,6 @@ BITCOIN_CORE_H = \
   external_signer.h \
   flat-database.h \
   flatfile.h \
-  fs.h \
   governance/common.h \
   governance/governance.h \
   governance/net_governance.h \
@@ -418,6 +417,8 @@ BITCOIN_CORE_H = \
   util/error.h \
   util/fastrange.h \
   util/fees.h \
+  util/fs.h \
+  util/fs_helpers.h \
   util/getuniquepath.h \
   util/golombrice.h \
   util/hash_type.h \
@@ -1006,7 +1007,6 @@ libbitcoin_util_a_SOURCES = \
   clientversion.cpp \
   coinjoin/common.cpp \
   coinjoin/options.cpp \
-  fs.cpp \
   interfaces/echo.cpp \
   interfaces/handler.cpp \
   interfaces/init.cpp \
@@ -1025,6 +1025,8 @@ libbitcoin_util_a_SOURCES = \
   util/edge.cpp \
   util/error.cpp \
   util/fees.cpp \
+  util/fs.cpp \
+  util/fs_helpers.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
   util/message.cpp \
@@ -1269,7 +1271,6 @@ libdashkernel_la_SOURCES = \
   evo/specialtx_filter.cpp \
   evo/specialtxman.cpp \
   flatfile.cpp \
-  fs.cpp \
   governance/common.cpp \
   governance/object.cpp \
   governance/superblock.cpp \
@@ -1351,6 +1352,8 @@ libdashkernel_la_SOURCES = \
   uint256.cpp \
   util/bytevectorhash.cpp \
   util/check.cpp \
+  util/fs.cpp \
+  util/fs_helpers.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
   util/message.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -8,7 +8,6 @@
 #include <addrman.h>
 #include <chainparams.h>
 #include <clientversion.h>
-#include <fs.h>
 #include <hash.h>
 #include <logging/timer.h>
 #include <netbase.h>
@@ -17,6 +16,8 @@
 #include <streams.h>
 #include <tinyformat.h>
 #include <univalue.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/settings.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -6,9 +6,9 @@
 #ifndef BITCOIN_ADDRDB_H
 #define BITCOIN_ADDRDB_H
 
-#include <fs.h>
 #include <net_types.h> // For banmap_t
 #include <univalue.h>
+#include <util/fs.h>
 #include <util/result.h>
 
 #include <memory>

--- a/src/banman.h
+++ b/src/banman.h
@@ -7,9 +7,9 @@
 
 #include <addrdb.h>
 #include <common/bloom.h>
-#include <fs.h>
 #include <net_types.h> // For banmap_t
 #include <sync.h>
+#include <util/fs.h>
 
 #include <chrono>
 #include <cstdint>

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -4,8 +4,8 @@
 
 #include <bench/bench.h>
 
-#include <fs.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <util/string.h>
 
 #include <algorithm>

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_BENCH_BENCH_H
 #define BITCOIN_BENCH_BENCH_H
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/macros.h>
 
 #include <chrono>

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -8,7 +8,7 @@
 #include <clientversion.h>
 #include <crypto/sha256.h>
 #include <crypto/x11/dispatch.h>
-#include <fs.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -13,13 +13,13 @@
 #include <consensus/consensus.h>
 #include <core_io.h>
 #include <key_io.h>
-#include <fs.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <univalue.h>
+#include <util/fs.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -19,6 +19,7 @@
 #include <netmessagemaker.h>
 #include <shutdown.h>
 #include <util/check.h>
+#include <util/fs_helpers.h>
 #include <util/moneystr.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,9 +4,10 @@
 
 #include <dbwrapper.h>
 
-#include <fs.h>
 #include <logging.h>
 #include <random.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -7,11 +7,11 @@
 
 #include <assert.h>
 #include <clientversion.h>
-#include <fs.h>
 #include <logging.h>
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
+#include <util/fs.h>
 
 #include <sys/types.h>
 

--- a/src/flat-database.h
+++ b/src/flat-database.h
@@ -7,9 +7,9 @@
 
 #include <clientversion.h>
 #include <chainparams.h>
-#include <fs.h>
 #include <hash.h>
 #include <streams.h>
+#include <util/fs.h>
 #include <util/system.h>
 
 /**

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -8,6 +8,7 @@
 #include <flatfile.h>
 #include <logging.h>
 #include <tinyformat.h>
+#include <util/fs_helpers.h>
 #include <util/system.h>
 
 FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -8,8 +8,8 @@
 
 #include <string>
 
-#include <fs.h>
 #include <serialize.h>
+#include <util/fs.h>
 
 struct FlatFilePos
 {

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -6,7 +6,6 @@
 #include <compat/compat.h>
 #include <compat/endian.h>
 #include <crypto/sha256.h>
-#include <fs.h>
 #include <i2p.h>
 #include <logging.h>
 #include <netaddress.h>
@@ -14,6 +13,7 @@
 #include <random.h>
 #include <sync.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/readwritefile.h>
 #include <util/sock.h>
 #include <util/spanparsing.h>

--- a/src/i2p.h
+++ b/src/i2p.h
@@ -6,10 +6,10 @@
 #define BITCOIN_I2P_H
 
 #include <compat/compat.h>
-#include <fs.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <sync.h>
+#include <util/fs.h>
 #include <util/sock.h>
 #include <util/threadinterrupt.h>
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -9,6 +9,7 @@
 #include <index/blockfilterindex.h>
 #include <node/blockstorage.h>
 #include <serialize.h>
+#include <util/fs_helpers.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -22,7 +22,6 @@
 #include <context.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
-#include <fs.h>
 #include <hash.h>
 #include <httpserver.h>
 #include <httprpc.h>
@@ -76,6 +75,8 @@
 #include <txmempool.h>
 #include <util/asmap.h>
 #include <util/error.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -8,13 +8,14 @@
 
 #include <bls/bls.h>
 #include <clientversion.h>
-#include <fs.h>
 #include <logging.h>
 #include <node/interface_ui.h>
 #include <tinyformat.h>
-#include <util/time.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/string.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <util/translation.h>
 
 #include <algorithm>

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -6,12 +6,12 @@
 #define BITCOIN_INTERFACES_WALLET_H
 
 #include <consensus/amount.h>          // For CAmount
-#include <fs.h>
 #include <governance/common.h>
 #include <interfaces/chain.h>          // For ChainClient
 #include <pubkey.h>                    // For CKeyID and CScriptID (definitions needed in CTxDestination instantiation)
 #include <script/standard.h>           // For CTxDestination
 #include <support/allocators/secure.h> // For SecureString
+#include <util/fs.h>
 #include <util/message.h>
 #include <util/result.h>
 #include <util/ui_change_type.h>

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <ipc/capnp/protocol.h>
@@ -10,6 +9,7 @@
 #include <ipc/protocol.h>
 #include <logging.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/system.h>
 
 #include <cstdio>

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <ipc/process.h>
 #include <ipc/protocol.h>
 #include <mp/util.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 #include <cstdint>

--- a/src/ipc/process.h
+++ b/src/ipc/process.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_IPC_PROCESS_H
 #define BITCOIN_IPC_PROCESS_H
 
+#include <util/fs.h>
+
 #include <memory>
 #include <string>
 

--- a/src/kernel/mempool_persist.cpp
+++ b/src/kernel/mempool_persist.cpp
@@ -6,7 +6,6 @@
 
 #include <clientversion.h>
 #include <consensus/amount.h>
-#include <fs.h>
 #include <logging.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
@@ -15,7 +14,8 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <uint256.h>
-#include <util/system.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/time.h>
 #include <validation.h>
 

--- a/src/kernel/mempool_persist.h
+++ b/src/kernel/mempool_persist.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_KERNEL_MEMPOOL_PERSIST_H
 #define BITCOIN_KERNEL_MEMPOOL_PERSIST_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 class Chainstate;
 class CTxMemPool;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <logging.h>
+#include <util/fs.h>
 #include <util/string.h>
 #include <util/threadnames.h>
 #include <util/time.h>

--- a/src/logging.h
+++ b/src/logging.h
@@ -6,9 +6,9 @@
 #ifndef BITCOIN_LOGGING_H
 #define BITCOIN_LOGGING_H
 
-#include <fs.h>
 #include <threadsafety.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/string.h>
 
 #include <atomic>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -19,7 +19,6 @@
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>
 #include <node/eviction.h>
-#include <fs.h>
 #include <i2p.h>
 #include <key.h>
 #include <memusage.h>
@@ -30,6 +29,7 @@
 #include <protocol.h>
 #include <random.h>
 #include <scheduler.h>
+#include <util/fs.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/system.h>

--- a/src/net.h
+++ b/src/net.h
@@ -12,7 +12,6 @@
 #include <compat/compat.h>
 #include <consensus/amount.h>
 #include <consensus/params.h>
-#include <fs.h>
 #include <crypto/siphash.h>
 #include <hash.h>
 #include <i2p.h>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -9,12 +9,12 @@
 #include <clientversion.h>
 #include <consensus/validation.h>
 #include <flatfile.h>
-#include <fs.h>
 #include <hash.h>
 #include <pow.h>
 #include <shutdown.h>
 #include <streams.h>
 #include <undo.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <validation.h>
 #include <walletinitinterface.h>

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -8,11 +8,11 @@
 #include <attributes.h>
 #include <chain.h>
 #include <chainparams.h>
-#include <fs.h>
 #include <kernel/blockmanager_opts.h>
 #include <protocol.h>
 #include <sync.h>
 #include <txdb.h>
+#include <util/fs.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -17,6 +17,7 @@
 #include <txdb.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <util/translation.h>
 #include <validation.h>
 

--- a/src/node/mempool_persist_args.cpp
+++ b/src/node/mempool_persist_args.cpp
@@ -4,7 +4,7 @@
 
 #include <node/mempool_persist_args.h>
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/node/mempool_persist_args.h
+++ b/src/node/mempool_persist_args.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_NODE_MEMPOOL_PERSIST_ARGS_H
 #define BITCOIN_NODE_MEMPOOL_PERSIST_ARGS_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 class ArgsManager;
 

--- a/src/node/utxo_snapshot.cpp
+++ b/src/node/utxo_snapshot.cpp
@@ -4,10 +4,10 @@
 
 #include <node/utxo_snapshot.h>
 
-#include <fs.h>
 #include <logging.h>
 #include <streams.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -6,9 +6,9 @@
 #ifndef BITCOIN_NODE_UTXO_SNAPSHOT_H
 #define BITCOIN_NODE_UTXO_SNAPSHOT_H
 
-#include <fs.h>
-#include <uint256.h>
 #include <serialize.h>
+#include <uint256.h>
+#include <util/fs.h>
 #include <validation.h>
 
 #include <optional>

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -7,7 +7,6 @@
 
 #include <clientversion.h>
 #include <consensus/amount.h>
-#include <fs.h>
 #include <logging.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
@@ -18,6 +17,7 @@
 #include <tinyformat.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <util/serfloat.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -6,12 +6,12 @@
 #define BITCOIN_POLICY_FEES_H
 
 #include <consensus/amount.h>
-#include <fs.h>
 #include <policy/feerate.h>
 #include <random.h>
 #include <sync.h>
 #include <threadsafety.h>
 #include <uint256.h>
+#include <util/fs.h>
 
 #include <array>
 #include <map>

--- a/src/policy/fees_args.h
+++ b/src/policy/fees_args.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_POLICY_FEES_ARGS_H
 #define BITCOIN_POLICY_FEES_ARGS_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 class ArgsManager;
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -10,7 +10,6 @@
 #include <qt/bitcoin.h>
 
 #include <chainparams.h>
-#include <fs.h>
 #include <init.h>
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
@@ -32,6 +31,7 @@
 #include <qt/winshutdownmonitor.h>
 #include <stacktraces.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/threadnames.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -12,7 +12,6 @@
 
 #include <base58.h>
 #include <chainparams.h>
-#include <fs.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <policy/policy.h>
@@ -20,6 +19,8 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <script/standard.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/system.h>
 #include <util/time.h>
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -6,10 +6,10 @@
 #define BITCOIN_QT_GUIUTIL_H
 
 #include <consensus/amount.h>
-#include <fs.h>
 #include <net.h>
 #include <netaddress.h>
 #include <util/check.h>
+#include <util/fs.h>
 
 #include <qt/bitcoinunits.h>
 #include <qt/guiconstants.h>

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -8,15 +8,16 @@
 #endif
 
 #include <chainparams.h>
-#include <fs.h>
 #include <qt/intro.h>
 #include <qt/forms/ui_intro.h>
+#include <util/fs.h>
 
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 
 #include <interfaces/node.h>
+#include <util/fs_helpers.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -5,7 +5,6 @@
 #include <qt/psbtoperationsdialog.h>
 
 #include <core_io.h>
-#include <fs.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <node/psbt.h>
@@ -14,6 +13,7 @@
 #include <qt/forms/ui_psbtoperationsdialog.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 #include <fstream>

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -4,10 +4,8 @@
 
 #include <qt/walletframe.h>
 
-#include <fs.h>
 #include <node/interface_ui.h>
 #include <psbt.h>
-#include <util/system.h>
 
 #include <qt/guiutil.h>
 #include <qt/masternodelist.h>
@@ -16,6 +14,8 @@
 #include <qt/psbtoperationsdialog.h>
 #include <qt/walletmodel.h>
 #include <qt/walletview.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 
 #include <cassert>
 #include <fstream>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -17,7 +17,6 @@
 #include <deploymentinfo.h>
 #include <deploymentstatus.h>
 #include <evo/chainhelper.h>
-#include <fs.h>
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
 #include <index/timestampindex.h>
@@ -41,6 +40,7 @@
 #include <undo.h>
 #include <univalue.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -7,10 +7,10 @@
 
 #include <consensus/amount.h>
 #include <core_io.h>
-#include <fs.h>
 #include <kernel/coinstats.h>
 #include <streams.h>
 #include <sync.h>
+#include <util/fs.h>
 
 #include <cstdint>
 #include <functional>

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -9,7 +9,6 @@
 
 #include <chainparams.h>
 #include <core_io.h>
-#include <fs.h>
 #include <instantsend/instantsend.h>
 #include <llmq/context.h>
 #include <node/mempool_persist_args.h>
@@ -20,6 +19,7 @@
 #include <rpc/util.h>
 #include <txmempool.h>
 #include <univalue.h>
+#include <util/fs.h>
 #include <util/helpers.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -6,11 +6,13 @@
 
 #include <rpc/request.h>
 
-#include <fs.h>
+#include <util/fs.h>
+
 #include <random.h>
 #include <rpc/protocol.h>
-#include <util/system.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
+#include <util/system.h>
 
 #include <fstream>
 #include <stdexcept>

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -7,10 +7,10 @@
 #endif // HAVE_CONFIG_H
 
 #include <stacktraces.h>
-#include <fs.h>
 #include <logging.h>
 #include <streams.h>
 #include <threadsafety.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 #include <map>

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -2,14 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/system.h>
-#include <fs.h>
 #include <sync.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
 #include <test/util/str.h>
-#include <util/strencodings.h>
 #include <univalue.h>
+#include <util/fs.h>
+#include <util/strencodings.h>
+#include <util/system.h>
 
 #include <array>
 #include <optional>

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-#include <fs.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
-#include <util/system.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -3,14 +3,14 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <banman.h>
-#include <fs.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
-#include <util/readwritefile.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
+#include <util/readwritefile.h>
 #include <util/system.h>
 
 #include <cassert>

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -4,11 +4,11 @@
 
 #include <test/fuzz/fuzz.h>
 
-#include <fs.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/sock.h>
 #include <util/time.h>
 

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -10,6 +10,7 @@
 #include <test/fuzz/util.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -16,6 +16,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 #if defined(HAVE_CONSENSUS_LIB)

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -4,9 +4,9 @@
 
 #include <util/settings.h>
 
-#include <fs.h>
 #include <test/util/setup_common.h>
 #include <test/util/str.h>
+#include <util/fs.h>
 
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <streams.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -6,12 +6,12 @@
 #define BITCOIN_TEST_UTIL_CHAINSTATE_H
 
 #include <clientversion.h>
-#include <fs.h>
 #include <logging.h>
 #include <node/context.h>
 #include <node/utxo_snapshot.h>
 #include <rpc/blockchain.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <validation.h>
 
 #include <univalue.h>

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -7,7 +7,6 @@
 #define BITCOIN_TEST_UTIL_SETUP_COMMON_H
 
 #include <chainparamsbase.h>
-#include <fs.h>
 #include <key.h>
 #include <node/caches.h>
 #include <node/context.h> // IWYU pragma: export
@@ -15,6 +14,7 @@
 #include <pubkey.h>
 #include <random.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2,16 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/system.h>
-
 #include <clientversion.h>
-#include <fs.h>
 #include <hash.h> // For Hash()
 #include <key.h>  // For CKey
 #include <sync.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
 #include <util/message.h> // For MessageSign(), MessageVerify(), MESSAGE_MAGIC
 #include <util/moneystr.h>

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -8,8 +8,8 @@
 #ifndef BITCOIN_TORCONTROL_H
 #define BITCOIN_TORCONTROL_H
 
-#include <fs.h>
 #include <netaddress.h>
+#include <util/fs.h>
 
 #include <event2/util.h>
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -10,7 +10,7 @@
 #include <coins.h>
 #include <dbwrapper.h>
 #include <sync.h>
-#include <fs.h>
+#include <util/fs.h>
 
 #include <memory>
 #include <optional>

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -5,10 +5,10 @@
 #include <util/asmap.h>
 
 #include <clientversion.h>
-#include <fs.h>
 #include <logging.h>
 #include <serialize.h>
 #include <streams.h>
+#include <util/fs.h>
 
 #include <algorithm>
 #include <bit>

--- a/src/util/asmap.h
+++ b/src/util/asmap.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_ASMAP_H
 #define BITCOIN_UTIL_ASMAP_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/syserror.h>
 
 #ifndef WIN32

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_FS_H
-#define BITCOIN_FS_H
+#ifndef BITCOIN_UTIL_FS_H
+#define BITCOIN_UTIL_FS_H
 
 #include <tinyformat.h>
 
@@ -249,4 +249,4 @@ template<> inline void formatValue(std::ostream&, const char*, const char*, int,
 template<> inline void formatValue(std::ostream&, const char*, const char*, int, const fs::path&) = delete;
 } // namespace tinyformat
 
-#endif // BITCOIN_FS_H
+#endif // BITCOIN_UTIL_FS_H

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -1,0 +1,286 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/fs_helpers.h>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <logging.h>
+#include <sync.h>
+#include <tinyformat.h>
+#include <util/fs.h>
+#include <util/getuniquepath.h>
+#include <util/syserror.h>
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#ifndef WIN32
+// for posix_fallocate, in configure.ac we check if it is present after this
+#ifdef __linux__
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+
+#define _POSIX_C_SOURCE 200112L
+
+#endif // __linux__
+
+#include <fcntl.h>
+#include <sys/resource.h>
+#include <unistd.h>
+#else
+#include <io.h> /* For _get_osfhandle, _chsize */
+#include <shlobj.h> /* For SHGetSpecialFolderPathW */
+#endif // WIN32
+
+/** Mutex to protect dir_locks. */
+static GlobalMutex cs_dir_locks;
+/** A map that contains all the currently held directory locks. After
+ * successful locking, these will be held here until the global destructor
+ * cleans them up and thus automatically unlocks them, or ReleaseDirectoryLocks
+ * is called.
+ */
+static std::map<std::string, std::unique_ptr<fsbridge::FileLock>> dir_locks GUARDED_BY(cs_dir_locks);
+
+bool LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only)
+{
+    LOCK(cs_dir_locks);
+    fs::path pathLockFile = directory / lockfile_name;
+
+    // If a lock for this directory already exists in the map, don't try to re-lock it
+    if (dir_locks.count(fs::PathToString(pathLockFile))) {
+        return true;
+    }
+
+    // Create empty lock file if it doesn't exist.
+    FILE* file = fsbridge::fopen(pathLockFile, "a");
+    if (file) fclose(file);
+    auto lock = std::make_unique<fsbridge::FileLock>(pathLockFile);
+    if (!lock->TryLock()) {
+        LogPrintf("ERROR: %s\n", SafeStringFormat("Error while attempting to lock directory %s: %s", fs::PathToString(directory), lock->GetReason()));
+        return false;
+    }
+    if (!probe_only) {
+        // Lock successful and we're not just probing, put it into the map
+        dir_locks.emplace(fs::PathToString(pathLockFile), std::move(lock));
+    }
+    return true;
+}
+
+void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name)
+{
+    LOCK(cs_dir_locks);
+    dir_locks.erase(fs::PathToString(directory / lockfile_name));
+}
+
+void ReleaseDirectoryLocks()
+{
+    LOCK(cs_dir_locks);
+    dir_locks.clear();
+}
+
+bool DirIsWritable(const fs::path& directory)
+{
+    fs::path tmpFile = GetUniquePath(directory);
+
+    FILE* file = fsbridge::fopen(tmpFile, "a");
+    if (!file) return false;
+
+    fclose(file);
+    remove(tmpFile);
+
+    return true;
+}
+
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
+{
+    constexpr uint64_t min_disk_space = 52428800; // 50 MiB
+
+    uint64_t free_bytes_available = fs::space(dir).available;
+    return free_bytes_available >= min_disk_space + additional_bytes;
+}
+
+std::streampos GetFileSize(const char* path, std::streamsize max)
+{
+    std::ifstream file{path, std::ios::binary};
+    file.ignore(max);
+    return file.gcount();
+}
+
+bool FileCommit(FILE* file)
+{
+    if (fflush(file) != 0) { // harmless if redundantly called
+        LogPrintf("fflush failed: %s\n", SysErrorString(errno));
+        return false;
+    }
+#ifdef WIN32
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
+    if (FlushFileBuffers(hFile) == 0) {
+        LogPrintf("FlushFileBuffers failed: %s\n", Win32ErrorString(GetLastError()));
+        return false;
+    }
+#elif defined(MAC_OSX) && defined(F_FULLFSYNC)
+    if (fcntl(fileno(file), F_FULLFSYNC, 0) == -1) { // Manpage says "value other than -1" is returned on success
+        LogPrintf("fcntl F_FULLFSYNC failed: %s\n", SysErrorString(errno));
+        return false;
+    }
+#elif HAVE_FDATASYNC
+    if (fdatasync(fileno(file)) != 0 && errno != EINVAL) { // Ignore EINVAL for filesystems that don't support sync
+        LogPrintf("fdatasync failed: %s\n", SysErrorString(errno));
+        return false;
+    }
+#else
+    if (fsync(fileno(file)) != 0 && errno != EINVAL) {
+        LogPrintf("fsync failed: %s\n", SysErrorString(errno));
+        return false;
+    }
+#endif
+    return true;
+}
+
+void DirectoryCommit(const fs::path& dirname)
+{
+#ifndef WIN32
+    FILE* file = fsbridge::fopen(dirname, "r");
+    if (file) {
+        fsync(fileno(file));
+        fclose(file);
+    }
+#endif
+}
+
+bool TruncateFile(FILE* file, unsigned int length)
+{
+#if defined(WIN32)
+    return _chsize(_fileno(file), length) == 0;
+#else
+    return ftruncate(fileno(file), length) == 0;
+#endif
+}
+
+/**
+ * this function tries to raise the file descriptor limit to the requested number.
+ * It returns the actual file descriptor limit (which may be more or less than nMinFD)
+ */
+int RaiseFileDescriptorLimit(int nMinFD)
+{
+#if defined(WIN32)
+    return 2048;
+#else
+    struct rlimit limitFD;
+    if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
+        if (limitFD.rlim_cur < (rlim_t)nMinFD) {
+            limitFD.rlim_cur = nMinFD;
+            if (limitFD.rlim_cur > limitFD.rlim_max)
+                limitFD.rlim_cur = limitFD.rlim_max;
+            setrlimit(RLIMIT_NOFILE, &limitFD);
+            getrlimit(RLIMIT_NOFILE, &limitFD);
+        }
+        return limitFD.rlim_cur;
+    }
+    return nMinFD; // getrlimit failed, assume it's fine
+#endif
+}
+
+/**
+ * this function tries to make a particular range of a file allocated (corresponding to disk space)
+ * it is advisory, and the range specified in the arguments will never contain live data
+ */
+void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
+{
+#if defined(WIN32)
+    // Windows-specific version
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
+    LARGE_INTEGER nFileSize;
+    int64_t nEndPos = (int64_t)offset + length;
+    nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
+    nFileSize.u.HighPart = nEndPos >> 32;
+    SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
+    SetEndOfFile(hFile);
+#elif defined(MAC_OSX)
+    // OSX specific version
+    // NOTE: Contrary to other OS versions, the OSX version assumes that
+    // NOTE: offset is the size of the file.
+    fstore_t fst;
+    fst.fst_flags = F_ALLOCATECONTIG;
+    fst.fst_posmode = F_PEOFPOSMODE;
+    fst.fst_offset = 0;
+    fst.fst_length = length; // mac os fst_length takes the # of free bytes to allocate, not desired file size
+    fst.fst_bytesalloc = 0;
+    if (fcntl(fileno(file), F_PREALLOCATE, &fst) == -1) {
+        fst.fst_flags = F_ALLOCATEALL;
+        fcntl(fileno(file), F_PREALLOCATE, &fst);
+    }
+    ftruncate(fileno(file), static_cast<off_t>(offset) + length);
+#else
+#if defined(HAVE_POSIX_FALLOCATE)
+    // Version using posix_fallocate
+    off_t nEndPos = (off_t)offset + length;
+    if (0 == posix_fallocate(fileno(file), 0, nEndPos)) return;
+#endif
+    // Fallback version
+    // TODO: just write one byte per block
+    static const char buf[65536] = {};
+    if (fseek(file, offset, SEEK_SET)) {
+        return;
+    }
+    while (length > 0) {
+        unsigned int now = 65536;
+        if (length < now)
+            now = length;
+        fwrite(buf, 1, now, file); // allowed to fail; this function is advisory anyway
+        length -= now;
+    }
+#endif
+}
+
+#ifdef WIN32
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
+{
+    WCHAR pszPath[MAX_PATH] = L"";
+
+    if (SHGetSpecialFolderPathW(nullptr, pszPath, nFolder, fCreate)) {
+        return fs::path(pszPath);
+    }
+
+    LogPrintf("SHGetSpecialFolderPathW() failed, could not obtain requested path.\n");
+    return fs::path("");
+}
+#endif
+
+bool RenameOver(fs::path src, fs::path dest)
+{
+    std::error_code error;
+    fs::rename(src, dest, error);
+    return !error;
+}
+
+/**
+ * Ignores exceptions thrown by create_directories if the requested directory exists.
+ * Specifically handles case where path p exists, but it wasn't possible for the user to
+ * write to the parent directory.
+ */
+bool TryCreateDirectories(const fs::path& p)
+{
+    try {
+        return fs::create_directories(p);
+    } catch (const fs::filesystem_error&) {
+        if (!fs::exists(p) || !fs::is_directory(p))
+            throw;
+    }
+
+    // create_directories didn't create the directory, it had to have existed already
+    return false;
+}

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_FS_HELPERS_H
+#define BITCOIN_UTIL_FS_HELPERS_H
+
+#include <util/fs.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <iosfwd>
+#include <limits>
+
+/**
+ * Ensure file contents are fully committed to disk, using a platform-specific
+ * feature analogous to fsync().
+ */
+bool FileCommit(FILE* file);
+
+/**
+ * Sync directory contents. This is required on some environments to ensure that
+ * newly created files are committed to disk.
+ */
+void DirectoryCommit(const fs::path& dirname);
+
+bool TruncateFile(FILE* file, unsigned int length);
+int RaiseFileDescriptorLimit(int nMinFD);
+void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length);
+
+/**
+ * Rename src to dest.
+ * @return true if the rename was successful.
+ */
+[[nodiscard]] bool RenameOver(fs::path src, fs::path dest);
+
+bool LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only = false);
+void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name);
+bool DirIsWritable(const fs::path& directory);
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
+
+/** Get the size of a file by scanning it.
+ *
+ * @param[in] path The file path
+ * @param[in] max Stop seeking beyond this limit
+ * @return The file size or max
+ */
+std::streampos GetFileSize(const char* path, std::streamsize max = std::numeric_limits<std::streamsize>::max());
+
+/** Release all directory locks. This is used for unit testing only, at runtime
+ * the global destructor will take care of the locks.
+ */
+/** Dash: We also use this to release locks earlier when restarting the client */
+void ReleaseDirectoryLocks();
+
+bool TryCreateDirectories(const fs::path& p);
+fs::path GetDefaultDataDir();
+
+#ifdef WIN32
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
+#endif
+
+#endif // BITCOIN_UTIL_FS_HELPERS_H

--- a/src/util/getuniquepath.cpp
+++ b/src/util/getuniquepath.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <random.h>
-#include <fs.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 fs::path GetUniquePath(const fs::path& base)

--- a/src/util/getuniquepath.h
+++ b/src/util/getuniquepath.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_GETUNIQUEPATH_H
 #define BITCOIN_UTIL_GETUNIQUEPATH_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 /**
  * Helper function for getting a unique path

--- a/src/util/readwritefile.cpp
+++ b/src/util/readwritefile.cpp
@@ -5,7 +5,7 @@
 
 #include <util/readwritefile.h>
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <algorithm>
 #include <cstdio>

--- a/src/util/readwritefile.h
+++ b/src/util/readwritefile.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_READWRITEFILE_H
 #define BITCOIN_UTIL_READWRITEFILE_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <limits>
 #include <string>

--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/settings.h>
 
 #include <tinyformat.h>

--- a/src/util/settings.h
+++ b/src/util/settings.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_SETTINGS_H
 #define BITCOIN_UTIL_SETTINGS_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <map>
 #include <string>

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -10,10 +10,11 @@
 
 #include <chainparamsbase.h>
 #include <ctpl_stl.h>
-#include <fs.h>
 #include <stacktraces.h>
 #include <sync.h>
 #include <util/check.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -29,17 +30,6 @@
 #endif
 
 #ifndef WIN32
-// for posix_fallocate, in configure.ac we check if it is present after this
-#ifdef __linux__
-
-#ifdef _POSIX_C_SOURCE
-#undef _POSIX_C_SOURCE
-#endif
-
-#define _POSIX_C_SOURCE 200112L
-
-#endif // __linux__
-
 #include <algorithm>
 #include <atomic>
 #include <cassert>
@@ -52,7 +42,6 @@
 
 #include <codecvt>
 
-#include <io.h> /* for _commit */
 #include <shellapi.h>
 #include <shlobj.h>
 #endif
@@ -91,79 +80,6 @@ const char * const BITCOIN_CONF_FILENAME = "dash.conf";
 const char * const BITCOIN_SETTINGS_FILENAME = "settings.json";
 
 ArgsManager gArgs;
-
-/** Mutex to protect dir_locks. */
-static GlobalMutex cs_dir_locks;
-
-/** A map that contains all the currently held directory locks. After
- * successful locking, these will be held here until the global destructor
- * cleans them up and thus automatically unlocks them, or ReleaseDirectoryLocks
- * is called.
- */
-static std::map<std::string, std::unique_ptr<fsbridge::FileLock>> dir_locks GUARDED_BY(cs_dir_locks);
-
-bool LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only)
-{
-    LOCK(cs_dir_locks);
-    fs::path pathLockFile = directory / lockfile_name;
-
-    // If a lock for this directory already exists in the map, don't try to re-lock it
-    if (dir_locks.count(fs::PathToString(pathLockFile))) {
-        return true;
-    }
-
-    // Create empty lock file if it doesn't exist.
-    FILE* file = fsbridge::fopen(pathLockFile, "a");
-    if (file) fclose(file);
-    auto lock = std::make_unique<fsbridge::FileLock>(pathLockFile);
-    if (!lock->TryLock()) {
-        return error("Error while attempting to lock directory %s: %s", fs::PathToString(directory), lock->GetReason());
-    }
-    if (!probe_only) {
-        // Lock successful and we're not just probing, put it into the map
-        dir_locks.emplace(fs::PathToString(pathLockFile), std::move(lock));
-    }
-    return true;
-}
-
-void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name)
-{
-    LOCK(cs_dir_locks);
-    dir_locks.erase(fs::PathToString(directory / lockfile_name));
-}
-
-void ReleaseDirectoryLocks()
-{
-    LOCK(cs_dir_locks);
-    dir_locks.clear();
-}
-
-bool DirIsWritable(const fs::path& directory)
-{
-    fs::path tmpFile = GetUniquePath(directory);
-
-    FILE* file = fsbridge::fopen(tmpFile, "a");
-    if (!file) return false;
-
-    fclose(file);
-    remove(tmpFile);
-
-    return true;
-}
-
-bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
-{
-    constexpr uint64_t min_disk_space = 52428800; // 50 MiB
-
-    uint64_t free_bytes_available = fs::space(dir).available;
-    return free_bytes_available >= min_disk_space + additional_bytes;
-}
-
-std::streampos GetFileSize(const char* path, std::streamsize max) {
-    std::ifstream file{path, std::ios::binary};
-    file.ignore(max);
-    return file.gcount();
-}
 
 /**
  * Interpret a string argument as a boolean.
@@ -1226,171 +1142,6 @@ std::vector<util::SettingsValue> ArgsManager::GetSettingsList(const std::string&
     LOCK(cs_args);
     return util::GetSettingsList(m_settings, m_network, SettingName(arg), !UseDefaultSection(arg));
 }
-
-bool RenameOver(fs::path src, fs::path dest)
-{
-    std::error_code error;
-    fs::rename(src, dest, error);
-    return !error;
-}
-
-/**
- * Ignores exceptions thrown by create_directories if the requested directory exists.
- * Specifically handles case where path p exists, but it wasn't possible for the user to
- * write to the parent directory.
- */
-bool TryCreateDirectories(const fs::path& p)
-{
-    try
-    {
-        return fs::create_directories(p);
-    } catch (const fs::filesystem_error&) {
-        if (!fs::exists(p) || !fs::is_directory(p))
-            throw;
-    }
-
-    // create_directories didn't create the directory, it had to have existed already
-    return false;
-}
-
-bool FileCommit(FILE *file)
-{
-    if (fflush(file) != 0) { // harmless if redundantly called
-        LogPrintf("fflush failed: %s\n", SysErrorString(errno));
-        return false;
-    }
-#ifdef WIN32
-    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
-    if (FlushFileBuffers(hFile) == 0) {
-        LogPrintf("FlushFileBuffers failed: %s\n", Win32ErrorString(GetLastError()));
-        return false;
-    }
-#elif defined(MAC_OSX) && defined(F_FULLFSYNC)
-    if (fcntl(fileno(file), F_FULLFSYNC, 0) == -1) { // Manpage says "value other than -1" is returned on success
-        LogPrintf("fcntl F_FULLFSYNC failed: %s\n", SysErrorString(errno));
-        return false;
-    }
-#elif HAVE_FDATASYNC
-    if (fdatasync(fileno(file)) != 0 && errno != EINVAL) { // Ignore EINVAL for filesystems that don't support sync
-        LogPrintf("fdatasync failed: %d\n", SysErrorString(errno));
-        return false;
-    }
-#else
-    if (fsync(fileno(file)) != 0 && errno != EINVAL) {
-        LogPrintf("fsync failed: %d\n", SysErrorString(errno));
-        return false;
-    }
-#endif
-    return true;
-}
-
-void DirectoryCommit(const fs::path &dirname)
-{
-#ifndef WIN32
-    FILE* file = fsbridge::fopen(dirname, "r");
-    if (file) {
-        fsync(fileno(file));
-        fclose(file);
-    }
-#endif
-}
-
-bool TruncateFile(FILE *file, unsigned int length) {
-#if defined(WIN32)
-    return _chsize(_fileno(file), length) == 0;
-#else
-    return ftruncate(fileno(file), length) == 0;
-#endif
-}
-
-/**
- * this function tries to raise the file descriptor limit to the requested number.
- * It returns the actual file descriptor limit (which may be more or less than nMinFD)
- */
-int RaiseFileDescriptorLimit(int nMinFD) {
-#if defined(WIN32)
-    return 2048;
-#else
-    struct rlimit limitFD;
-    if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
-        if (limitFD.rlim_cur < (rlim_t)nMinFD) {
-            limitFD.rlim_cur = nMinFD;
-            if (limitFD.rlim_cur > limitFD.rlim_max)
-                limitFD.rlim_cur = limitFD.rlim_max;
-            setrlimit(RLIMIT_NOFILE, &limitFD);
-            getrlimit(RLIMIT_NOFILE, &limitFD);
-        }
-        return limitFD.rlim_cur;
-    }
-    return nMinFD; // getrlimit failed, assume it's fine
-#endif
-}
-
-/**
- * this function tries to make a particular range of a file allocated (corresponding to disk space)
- * it is advisory, and the range specified in the arguments will never contain live data
- */
-void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
-#if defined(WIN32)
-    // Windows-specific version
-    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
-    LARGE_INTEGER nFileSize;
-    int64_t nEndPos = (int64_t)offset + length;
-    nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
-    nFileSize.u.HighPart = nEndPos >> 32;
-    SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
-    SetEndOfFile(hFile);
-#elif defined(MAC_OSX)
-    // OSX specific version
-    // NOTE: Contrary to other OS versions, the OSX version assumes that
-    // NOTE: offset is the size of the file.
-    fstore_t fst;
-    fst.fst_flags = F_ALLOCATECONTIG;
-    fst.fst_posmode = F_PEOFPOSMODE;
-    fst.fst_offset = 0;
-    fst.fst_length = length; // mac os fst_length takes the # of free bytes to allocate, not desired file size
-    fst.fst_bytesalloc = 0;
-    if (fcntl(fileno(file), F_PREALLOCATE, &fst) == -1) {
-        fst.fst_flags = F_ALLOCATEALL;
-        fcntl(fileno(file), F_PREALLOCATE, &fst);
-    }
-    ftruncate(fileno(file), static_cast<off_t>(offset) + length);
-#else
-    #if defined(HAVE_POSIX_FALLOCATE)
-    // Version using posix_fallocate
-    off_t nEndPos = (off_t)offset + length;
-    if (0 == posix_fallocate(fileno(file), 0, nEndPos)) return;
-    #endif
-    // Fallback version
-    // TODO: just write one byte per block
-    static const char buf[65536] = {};
-    if (fseek(file, offset, SEEK_SET)) {
-        return;
-    }
-    while (length > 0) {
-        unsigned int now = 65536;
-        if (length < now)
-            now = length;
-        fwrite(buf, 1, now, file); // allowed to fail; this function is advisory anyway
-        length -= now;
-    }
-#endif
-}
-
-#ifdef WIN32
-fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
-{
-    WCHAR pszPath[MAX_PATH] = L"";
-
-    if(SHGetSpecialFolderPathW(nullptr, pszPath, nFolder, fCreate))
-    {
-        return fs::path(pszPath);
-    }
-
-    LogPrintf("SHGetSpecialFolderPathW() failed, could not obtain requested path.\n");
-    return fs::path("");
-}
-#endif
 
 #ifndef WIN32
 std::string ShellEscape(const std::string& arg)

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -18,9 +18,9 @@
 #include <compat/assumptions.h>
 #include <compat/compat.h>
 #include <consensus/amount.h>
-#include <fs.h>
 #include <logging.h>
 #include <sync.h>
+#include <util/fs.h>
 #include <util/settings.h>
 #include <util/time.h>
 
@@ -58,55 +58,9 @@ bool error(const char* fmt, const Args&... args)
 
 void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExceptionOrigin);
 
-/**
- * Ensure file contents are fully committed to disk, using a platform-specific
- * feature analogous to fsync().
- */
-bool FileCommit(FILE *file);
-
-/**
- * Sync directory contents. This is required on some environments to ensure that
- * newly created files are committed to disk.
- */
-void DirectoryCommit(const fs::path &dirname);
-
-bool TruncateFile(FILE *file, unsigned int length);
-int RaiseFileDescriptorLimit(int nMinFD);
-void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
-
-/**
- * Rename src to dest.
- * @return true if the rename was successful.
- */
-[[nodiscard]] bool RenameOver(fs::path src, fs::path dest);
-
-bool LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only=false);
-void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name);
-bool DirIsWritable(const fs::path& directory);
-bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
-
-/** Get the size of a file by scanning it.
- *
- * @param[in] path The file path
- * @param[in] max Stop seeking beyond this limit
- * @return The file size or max
- */
-std::streampos GetFileSize(const char* path, std::streamsize max = std::numeric_limits<std::streamsize>::max());
-
-/** Release all directory locks. This is used for unit testing only, at runtime
- * the global destructor will take care of the locks.
- */
-/** Dash: We also use this to release locks earlier when restarting the client */
-void ReleaseDirectoryLocks();
-
-bool TryCreateDirectories(const fs::path& p);
-fs::path GetDefaultDataDir();
 // Return true if -datadir option points to a valid directory or is not specified.
 bool CheckDataDirOption();
 fs::path GetConfigFile(const fs::path& configuration_file_path);
-#ifdef WIN32
-fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
-#endif
 #ifndef WIN32
 std::string ShellEscape(const std::string& arg);
 #endif

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -22,7 +22,6 @@
 #include <consensus/validation.h>
 #include <cuckoocache.h>
 #include <flatfile.h>
-#include <fs.h>
 #include <hash.h>
 #include <logging.h>
 #include <logging/timer.h>
@@ -43,6 +42,8 @@
 #include <uint256.h>
 #include <undo.h>
 #include <util/check.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/hasher.h>
 #include <util/strencodings.h>
 #include <util/time.h>

--- a/src/validation.h
+++ b/src/validation.h
@@ -18,7 +18,6 @@
 #include <kernel/chainstatemanager_opts.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
-#include <fs.h>
 #include <node/blockstorage.h>
 #include <policy/feerate.h>
 #include <policy/packages.h>
@@ -30,6 +29,7 @@
 #include <txmempool.h> // For CTxMemPool::cs
 #include <uint256.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/hasher.h>
 #include <util/translation.h>
 #include <versionbits.h>

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -4,10 +4,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compat/compat.h>
-#include <fs.h>
+#include <util/fs.h>
 #include <wallet/bdb.h>
 #include <wallet/db.h>
 
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
 

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -7,9 +7,9 @@
 #define BITCOIN_WALLET_BDB_H
 
 #include <clientversion.h>
-#include <fs.h>
 #include <serialize.h>
 #include <streams.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <wallet/db.h>
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -4,8 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <fs.h>
 #include <logging.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <wallet/db.h>
 

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -7,9 +7,9 @@
 #define BITCOIN_WALLET_DB_H
 
 #include <clientversion.h>
-#include <fs.h>
 #include <streams.h>
 #include <support/allocators/secure.h>
+#include <util/fs.h>
 
 #include <atomic>
 #include <memory>

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -4,7 +4,7 @@
 
 #include <wallet/dump.h>
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/translation.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_WALLET_DUMP_H
 #define BITCOIN_WALLET_DUMP_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <string>
 #include <vector>

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -7,11 +7,11 @@
 
 #include <coinjoin/client.h>
 #include <coinjoin/options.h>
-#include <fs.h>
 #include <net.h>
 #include <interfaces/chain.h>
 #include <scheduler.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -7,7 +7,6 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <core_io.h>
-#include <fs.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <merkleblock.h>
@@ -18,6 +17,7 @@
 #include <script/standard.h>
 #include <sync.h>
 #include <util/bip32.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <streams.h>
+#include <util/fs.h>
 #include <util/translation.h>
 #include <wallet/bdb.h>
 #include <wallet/salvage.h>

--- a/src/wallet/salvage.h
+++ b/src/wallet/salvage.h
@@ -6,8 +6,8 @@
 #ifndef BITCOIN_WALLET_SALVAGE_H
 #define BITCOIN_WALLET_SALVAGE_H
 
-#include <fs.h>
 #include <streams.h>
+#include <util/fs.h>
 
 class ArgsManager;
 struct bilingual_str;

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -8,8 +8,8 @@
 #include <crypto/common.h>
 #include <logging.h>
 #include <sync.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <wallet/db.h>
 

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -4,8 +4,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <fs.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <wallet/bdb.h>
 
 #include <fstream>

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <univalue.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/system.h>
 
 #include <fstream>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -13,7 +13,6 @@
 #include <consensus/consensus.h>
 #include <crypto/common.h>
 #include <external_signer.h>
-#include <fs.h>
 #include <interfaces/chain.h>
 #include <interfaces/wallet.h>
 #include <key.h>
@@ -31,6 +30,8 @@
 #include <txmempool.h>
 #include <util/check.h>
 #include <util/error.h>
+#include <util/fs.h>
+#include <util/fs_helpers.h>
 #include <util/moneystr.h>
 #include <util/string.h>
 #include <util/time.h>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -8,7 +8,6 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include <consensus/amount.h>
-#include <fs.h>
 #include <governance/common.h>
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
@@ -17,6 +16,7 @@
 #include <psbt.h>
 #include <saltedhasher.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/hasher.h>
 #include <util/message.h>
 #include <util/result.h>

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -6,12 +6,12 @@
 
 #include <wallet/walletdb.h>
 
-#include <key_io.h>
-#include <fs.h>
 #include <governance/common.h>
+#include <key_io.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -8,7 +8,7 @@
 
 #include <wallet/wallettool.h>
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/translation.h>
 #include <util/system.h>
 #include <wallet/dump.h>

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -5,9 +5,9 @@
 #ifndef BITCOIN_WALLET_WALLETUTIL_H
 #define BITCOIN_WALLET_WALLETUTIL_H
 
-#include <fs.h>
 #include <script/descriptor.h>
 #include <support/allocators/secure.h>
+#include <util/fs.h>
 
 #include <vector>
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Backports bitcoin/bitcoin#27254, the earliest remaining prerequisite in the bitcoin#29034 backport chain.

This PR previously bundled bitcoin#27254 and bitcoin#27419. It has been split back to one prerequisite at a time; bitcoin#27419 will follow separately.

## What was done?

- Moved filesystem helpers from `util/system` into `util/fs` and `util/fs_helpers`.
- Updated direct includes for the moved filesystem APIs, including Dash-specific callers.
- Audited all 97 touched files against the final four-commit bitcoin#27254 series and aligned the filesystem-header ordering in 33 include blocks.
- Completed omitted platform-specific extraction hunks and the direct `node/chainstate.cpp` include.
- Preserved Dash's existing descriptive `FileCommit()` errors and `RenameOver()` behavior.
- Removed an unrelated `util/bitdeque.h` include copied from later history and the unused inherited filesystem include from `src/net.h`.

The final change is scoped to bitcoin#27254 only: 97 files changed, 474 insertions, and 400 deletions.

The include audit found 84 upstream matches, 12 documented Dash-only deviations, and one file with no include change. `src/wallet/walletdb.cpp` now places `util/fs.h` in the same upstream-relative position between `sync.h` and `util/system.h`, while retaining the Dash-only governance include in canonical order.

## How Has This Been Tested?

On macOS:

```sh
python3 test/lint/lint-includes.py
python3 test/lint/lint-include-guards.py
git diff --check HEAD^ HEAD
make -j"$JOBS" src/dashd
make -C src -j"$JOBS" test/test_dash
./src/test/test_dash --run_test=fs_tests
git verify-commit HEAD
```

The include-only scope check confirmed that every review-addressing delta line is an include directive or include-block blank line. The non-GUI core and unit-test builds passed; local Qt development packages are unavailable, so fresh GitHub CI will provide the Qt build coverage.

Independent exact-head backport prerequisite gate: passed at `8e2288222a8e35d9f359c5121bb87a91a1715cb7` with no missing prerequisites or unexplained deviations.

## Breaking Changes

None expected. This is a filesystem-helper extraction with Dash-specific behavior preserved.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
