### PR TITLE
backport: wallet coin selection prerequisites for #7400

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -93,6 +93,7 @@ if ENABLE_WALLET
 bench_bench_dash_SOURCES += bench/coin_selection.cpp
 bench_bench_dash_SOURCES += bench/wallet_balance.cpp
 bench_bench_dash_SOURCES += bench/wallet_create.cpp
+bench_bench_dash_SOURCES += bench/wallet_create_tx.cpp
 bench_bench_dash_SOURCES += bench/wallet_loading.cpp
 bench_bench_dash_LDADD += $(BDB_LIBS) $(SQLITE_LIBS)
 endif

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -102,7 +102,7 @@ static void WalletCreateTx(benchmark::Bench& bench, bool allow_other_inputs, std
     }
 
     // Check available balance
-    auto bal = wallet::GetAvailableBalance(wallet); // Cache
+    auto bal = WITH_LOCK(wallet.cs_wallet, return wallet::AvailableCoins(wallet).total_amount); // Cache
     assert(bal == 50 * COIN * (chain_size - COINBASE_MATURITY));
 
     wallet::CCoinControl coin_control;

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <chainparams.h>
+#include <wallet/coincontrol.h>
+#include <consensus/merkle.h>
+#include <kernel/chain.h>
+#include <node/context.h>
+#include <test/util/setup_common.h>
+#include <test/util/wallet.h>
+#include <validation.h>
+#include <wallet/spend.h>
+#include <wallet/wallet.h>
+
+using wallet::CWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::DBErrors;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+
+struct TipBlock
+{
+    uint256 prev_block_hash;
+    int64_t prev_block_time;
+    int tip_height;
+};
+
+TipBlock getTip(const CChainParams& params, const node::NodeContext& context)
+{
+    auto tip = WITH_LOCK(::cs_main, return context.chainman->ActiveTip());
+    return (tip) ? TipBlock{tip->GetBlockHash(), tip->GetBlockTime(), tip->nHeight} :
+           TipBlock{params.GenesisBlock().GetHash(), params.GenesisBlock().GetBlockTime(), 0};
+}
+
+void generateFakeBlock(const CChainParams& params,
+                       const node::NodeContext& context,
+                       CWallet& wallet,
+                       const CScript& coinbase_out_script)
+{
+    TipBlock tip{getTip(params, context)};
+
+    // Create block
+    CBlock block;
+    CMutableTransaction coinbase_tx;
+    coinbase_tx.vin.resize(1);
+    coinbase_tx.vin[0].prevout.SetNull();
+    coinbase_tx.vout.resize(2);
+    coinbase_tx.vout[0].scriptPubKey = coinbase_out_script;
+    coinbase_tx.vout[0].nValue = 49 * COIN;
+    coinbase_tx.vin[0].scriptSig = CScript() << ++tip.tip_height << OP_0;
+    coinbase_tx.vout[1].scriptPubKey = coinbase_out_script; // extra output
+    coinbase_tx.vout[1].nValue = 1 * COIN;
+    block.vtx = {MakeTransactionRef(std::move(coinbase_tx))};
+
+    block.nVersion = VERSIONBITS_LAST_OLD_BLOCK_VERSION;
+    block.hashPrevBlock = tip.prev_block_hash;
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    block.nTime = ++tip.prev_block_time;
+    block.nBits = params.GenesisBlock().nBits;
+    block.nNonce = 0;
+
+    {
+        LOCK(::cs_main);
+        // Add it to the index
+        CBlockIndex* pindex{context.chainman->m_blockman.AddToBlockIndex(block, block.GetHash(), context.chainman->m_best_header)};
+        // add it to the chain
+        context.chainman->ActiveChain().SetTip(*pindex);
+    }
+
+    // notify wallet
+    const auto& pindex = WITH_LOCK(::cs_main, return context.chainman->ActiveChain().Tip());
+    wallet.blockConnected(kernel::MakeBlockInfo(pindex, &block));
+}
+
+struct PreSelectInputs {
+    // How many coins from the wallet the process should select
+    int num_of_internal_inputs;
+    // future: this could have external inputs as well.
+};
+
+static void WalletCreateTx(benchmark::Bench& bench, bool allow_other_inputs, std::optional<PreSelectInputs> preset_inputs)
+{
+    const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
+
+    CWallet wallet{test_setup->m_node.chain.get(), test_setup->m_node.coinjoin_loader.get(), "", gArgs, CreateMockWalletDatabase()};
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        wallet.SetupDescriptorScriptPubKeyMans("", "");
+        if (wallet.LoadWallet() != DBErrors::LOAD_OK) assert(false);
+    }
+
+    // Generate destinations
+    CScript dest = GetScriptForDestination(getNewDestination(wallet));
+
+    // Generate chain; each coinbase will have two outputs to fill-up the wallet
+    const auto& params = Params();
+    unsigned int chain_size = 5000; // 5k blocks means 10k UTXO for the wallet (minus 200 due COINBASE_MATURITY)
+    for (unsigned int i = 0; i < chain_size; ++i) {
+        generateFakeBlock(params, test_setup->m_node, wallet, dest);
+    }
+
+    // Check available balance
+    auto bal = wallet::GetAvailableBalance(wallet); // Cache
+    assert(bal == 50 * COIN * (chain_size - COINBASE_MATURITY));
+
+    wallet::CCoinControl coin_control;
+    coin_control.m_allow_other_inputs = allow_other_inputs;
+
+    CAmount target = 0;
+    if (preset_inputs) {
+        // Select inputs, each has 49 DASH
+        const auto& res = WITH_LOCK(wallet.cs_wallet,
+                                    return wallet::AvailableCoins(wallet, nullptr, std::nullopt, 1, MAX_MONEY,
+                                                                  MAX_MONEY, preset_inputs->num_of_internal_inputs));
+        for (int i = 0; i < preset_inputs->num_of_internal_inputs; i++) {
+            const auto& coin{res.legacy[i]};
+            target += coin.txout.nValue;
+            coin_control.Select(coin.outpoint);
+        }
+    }
+
+    // If automatic coin selection is enabled, add the value of another UTXO to the target
+    if (coin_control.m_allow_other_inputs) target += 50 * COIN;
+    std::vector<wallet::CRecipient> recipients = {{dest, target, true}};
+
+    bench.epochIterations(5).run([&] {
+        LOCK(wallet.cs_wallet);
+        const auto& tx_res = CreateTransaction(wallet, recipients, wallet::RANDOM_CHANGE_POSITION, coin_control);
+        assert(tx_res);
+    });
+}
+
+static void WalletCreateTxUseOnlyPresetInputs(benchmark::Bench& bench) { WalletCreateTx(bench, /*allow_other_inputs=*/false,
+                                                                                        {{/*num_of_internal_inputs=*/4}}); }
+
+static void WalletCreateTxUsePresetInputsAndCoinSelection(benchmark::Bench& bench) { WalletCreateTx(bench, /*allow_other_inputs=*/true,
+                                                                                                    {{/*num_of_internal_inputs=*/4}}); }
+
+BENCHMARK(WalletCreateTxUseOnlyPresetInputs, benchmark::PriorityLevel::LOW)
+BENCHMARK(WalletCreateTxUsePresetInputsAndCoinSelection, benchmark::PriorityLevel::LOW)

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -324,7 +324,9 @@ bool SendCoinsDialog::send(const QList<SendCoinsRecipient>& recipients, QString&
 
     updateCoinControlState();
 
-    prepareStatus = model->prepareTransaction(*m_current_transaction, *m_coin_control);
+    CCoinControl coin_control = *m_coin_control;
+    coin_control.m_allow_other_inputs = !coin_control.HasSelected(); // future, could introduce a checkbox to customize this value.
+    prepareStatus = model->prepareTransaction(*m_current_transaction, coin_control);
 
     // process prepareStatus and on error generate message shown to user
     processSendCoinsReturn(prepareStatus,

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -507,7 +507,7 @@ void SendCoinsDialog::presentPSBT(PartiallySignedTransaction& psbtx)
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << psbtx;
     GUIUtil::setClipboard(EncodeBase64(ssTx.str()).c_str());
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     msgBox.setText("Unsigned Transaction");
     msgBox.setInformativeText("The PSBT has been copied to the clipboard. You can also save it.");
     msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Discard);
@@ -897,8 +897,13 @@ void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
     // Include watch-only for wallets without private key
     m_coin_control->fAllowWatchOnly = model->wallet().privateKeysDisabled() && !model->wallet().hasExternalSigner();
 
+    // Same behavior as send: if we have selected coins, only obtain their available balance.
+    // Copy to avoid modifying the member's data.
+    CCoinControl coin_control = *m_coin_control;
+    coin_control.m_allow_other_inputs = !coin_control.HasSelected();
+
     // Calculate available amount to send.
-    CAmount amount = model->wallet().getAvailableBalance(*m_coin_control);
+    CAmount amount = model->wallet().getAvailableBalance(coin_control);
     for (int i = 0; i < ui->entries->count(); ++i) {
         SendCoinsEntry* e = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
         if (e && !e->isHidden() && e != entry) {

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -50,6 +50,9 @@ public:
     void pasteEntry(const SendCoinsRecipient &rv);
     bool handlePaymentRequest(const SendCoinsRecipient &recipient);
 
+    // Only used for testing-purposes
+    wallet::CCoinControl* getCoinControl() { return m_coin_control.get(); }
+
 public Q_SLOTS:
     void clear();
     void reject() override;

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -18,9 +18,13 @@
 #include <qt/transactionview.h>
 #include <qt/walletmodel.h>
 #include <key_io.h>
+#include <outputtype.h>
+#include <psbt.h>
 #include <test/util/setup_common.h>
+#include <util/strencodings.h>
 #include <util/system.h>
 #include <validation.h>
+#include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 #include <qt/overviewpage.h>
 #include <qt/receivecoinsdialog.h>
@@ -34,8 +38,11 @@
 #include <QAction>
 #include <QApplication>
 #include <QCheckBox>
+#include <QClipboard>
 #include <QDialogButtonBox>
+#include <QLabel>
 #include <QListView>
+#include <QObject>
 #include <QPushButton>
 #include <QTableView>
 #include <QTextEdit>
@@ -47,21 +54,22 @@ using wallet::CWallet;
 using wallet::CreateMockWalletDatabase;
 using wallet::RemoveWallet;
 using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WALLET_FLAG_DISABLE_PRIVATE_KEYS;
 using wallet::WalletContext;
 using wallet::WalletDescriptor;
 using wallet::WalletRescanReserver;
 
 namespace
 {
-//! Press "Yes" or "Cancel" buttons in modal send confirmation dialog.
-void ConfirmSend(QString* text = nullptr, bool cancel = false)
+//! Press "Yes", "Save", or "Cancel" buttons in modal send confirmation dialog.
+void ConfirmSend(QString* text = nullptr, QMessageBox::StandardButton confirm_type = QMessageBox::Yes)
 {
-    QTimer::singleShot(0, [text, cancel]() {
+    QTimer::singleShot(0, [text, confirm_type]() {
         for (QWidget* widget : QApplication::topLevelWidgets()) {
             if (widget->inherits("SendConfirmationDialog")) {
                 SendConfirmationDialog* dialog = qobject_cast<SendConfirmationDialog*>(widget);
                 if (text) *text = dialog->text();
-                QAbstractButton* button = dialog->button(cancel ? QMessageBox::Cancel : QMessageBox::Yes);
+                QAbstractButton* button = dialog->button(confirm_type);
                 button->setEnabled(true);
                 button->click();
             }
@@ -70,7 +78,8 @@ void ConfirmSend(QString* text = nullptr, bool cancel = false)
 }
 
 //! Send coins to address and return txid.
-uint256 SendCoins(CWallet& wallet, SendCoinsDialog& sendCoinsDialog, const CTxDestination& address, CAmount amount)
+uint256 SendCoins(CWallet& wallet, SendCoinsDialog& sendCoinsDialog, const CTxDestination& address, CAmount amount,
+                  QMessageBox::StandardButton confirm_type = QMessageBox::Yes)
 {
     QVBoxLayout* entries = sendCoinsDialog.findChild<QVBoxLayout*>("entries");
     SendCoinsEntry* entry = qobject_cast<SendCoinsEntry*>(entries->itemAt(0)->widget());
@@ -80,7 +89,7 @@ uint256 SendCoins(CWallet& wallet, SendCoinsDialog& sendCoinsDialog, const CTxDe
     boost::signals2::scoped_connection c(wallet.NotifyTransactionChanged.connect([&txid](const uint256& hash, ChangeType status) {
         if (status == CT_NEW) txid = hash;
     }));
-    ConfirmSend();
+    ConfirmSend(/*text=*/nullptr, confirm_type);
     bool invoked = QMetaObject::invokeMethod(&sendCoinsDialog, "sendButtonClicked", Q_ARG(bool, false));
     assert(invoked);
     return txid;
@@ -98,6 +107,71 @@ QModelIndex FindTx(const QAbstractItemModel& model, const uint256& txid)
         }
     }
     return {};
+}
+
+// Verify the 'useAvailableBalance' functionality. With and without manually selected coins.
+// Case 1: No coin control selected coins.
+// 'useAvailableBalance' should fill the amount edit box with the total available balance
+// Case 2: With coin control selected coins.
+// 'useAvailableBalance' should fill the amount edit box with the sum of the selected coins values.
+void VerifyUseAvailableBalance(SendCoinsDialog& sendCoinsDialog, const WalletModel& walletModel)
+{
+    // Verify first entry amount and "useAvailableBalance" button
+    QVBoxLayout* entries = sendCoinsDialog.findChild<QVBoxLayout*>("entries");
+    QVERIFY(entries->count() == 1); // only one entry
+    SendCoinsEntry* send_entry = qobject_cast<SendCoinsEntry*>(entries->itemAt(0)->widget());
+    QVERIFY(send_entry->getValue().amount == 0);
+    // Now click "useAvailableBalance", check updated balance (the entire wallet balance should be set)
+    Q_EMIT send_entry->useAvailableBalance(send_entry);
+    QVERIFY(send_entry->getValue().amount == walletModel.wallet().getBalance());
+
+    // Now manually select two coins and click on "useAvailableBalance". Then check updated balance
+    // (only the sum of the selected coins should be set).
+    int COINS_TO_SELECT = 2;
+    auto coins = walletModel.wallet().listCoins();
+    CAmount sum_selected_coins = 0;
+    int selected = 0;
+    QVERIFY(coins.size() == 1); // context check, coins received only on one destination
+    for (const auto& [outpoint, tx_out] : coins.begin()->second) {
+        sendCoinsDialog.getCoinControl()->Select(outpoint);
+        sum_selected_coins += tx_out.txout.nValue;
+        if (++selected == COINS_TO_SELECT) break;
+    }
+    QVERIFY(selected == COINS_TO_SELECT);
+
+    // Now that we have 2 coins selected, "useAvailableBalance" should update the balance label only with
+    // the sum of them.
+    Q_EMIT send_entry->useAvailableBalance(send_entry);
+    QVERIFY(send_entry->getValue().amount == sum_selected_coins);
+}
+
+void SyncUpWallet(const std::shared_ptr<CWallet>& wallet, interfaces::Node& node)
+{
+    WalletRescanReserver reserver(*wallet);
+    reserver.reserve();
+    CWallet::ScanResult result = wallet->ScanForWalletTransactions(Params().GetConsensus().hashGenesisBlock, /*start_height=*/0, /*max_height=*/{}, reserver, /*fUpdate=*/true, /*save_progress=*/false);
+    QCOMPARE(result.status, CWallet::ScanResult::SUCCESS);
+    QCOMPARE(result.last_scanned_block, WITH_LOCK(node.context()->chainman->GetMutex(), return node.context()->chainman->ActiveChain().Tip()->GetBlockHash()));
+    QVERIFY(result.last_failed_block.IsNull());
+}
+
+std::shared_ptr<CWallet> SetupLegacyWatchOnlyWallet(interfaces::Node& node, TestChain100Setup& test)
+{
+    // Dash wallets require the CoinJoin loader; pass the test node loader through.
+    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(node.context()->chain.get(), node.context()->coinjoin_loader.get(), "", gArgs, CreateMockWalletDatabase());
+    wallet->LoadWallet();
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->SetWalletFlag(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
+        wallet->SetupLegacyScriptPubKeyMan();
+        // Add watched key
+        CPubKey pubKey = test.coinbaseKey.GetPubKey();
+        bool import_keys = wallet->ImportPubKeys({pubKey.GetID()}, {{pubKey.GetID(), pubKey}}, /*key_origins=*/{}, /*add_keypool=*/false, /*internal=*/false, /*timestamp=*/1);
+        assert(import_keys);
+        wallet->SetLastBlockProcessed(105, WITH_LOCK(node.context()->chainman->GetMutex(), return node.context()->chainman->ActiveChain().Tip()->GetBlockHash()));
+    }
+    SyncUpWallet(wallet, node);
+    return wallet;
 }
 
 //! Simple qt wallet tests.
@@ -141,14 +215,7 @@ void TestGUI(interfaces::Node& node)
         wallet->SetAddressBook(dest, "", "receive");
         wallet->SetLastBlockProcessed(105, WITH_LOCK(node.context()->chainman->GetMutex(), return node.context()->chainman->ActiveChain().Tip()->GetBlockHash()));
     }
-    {
-        WalletRescanReserver reserver(*wallet);
-        reserver.reserve();
-        CWallet::ScanResult result = wallet->ScanForWalletTransactions(Params().GetConsensus().hashGenesisBlock, /*start_height=*/0, /*max_height=*/{}, reserver, /*fUpdate=*/true, /*save_progress=*/false);
-        QCOMPARE(result.status, CWallet::ScanResult::SUCCESS);
-        QCOMPARE(result.last_scanned_block, WITH_LOCK(node.context()->chainman->GetMutex(), return node.context()->chainman->ActiveChain().Tip()->GetBlockHash()));
-        QVERIFY(result.last_failed_block.IsNull());
-    }
+    SyncUpWallet(wallet, node);
     wallet->SetBroadcastTransactions(true);
 
     // Create widgets for sending coins and listing transactions.
@@ -171,6 +238,9 @@ void TestGUI(interfaces::Node& node)
         QString balanceComparison = BitcoinUnits::formatWithUnit(unit, balance, false /*, BitcoinUnits::SeparatorStyle::ALWAYS*/);
         QCOMPARE(balanceText, balanceComparison);
     }
+
+    // Check 'UseAvailableBalance' functionality
+    VerifyUseAvailableBalance(sendCoinsDialog, walletModel);
 
     // Send two transactions, and verify they are added to transaction list.
     TransactionTableModel* transactionTableModel = walletModel.getTransactionTableModel();
@@ -302,6 +372,79 @@ void TestGUI(interfaces::Node& node)
     QCOMPARE(walletModel.wallet().getAddressReceiveRequests().size(), size_t{0});
 }
 
+//! Verify PSBT creation on a legacy watch-only wallet (Create Unsigned path).
+//
+// Dash does not use WalletModel::getAvailableBalance with a cached-balance path
+// (bitcoin-core/gui#598 / bitcoin#26687). Watch-only coins are spendable for
+// selection through wallet().getAvailableBalance / AvailableCoins when
+// fAllowWatchOnly is set in updateCoinControlState / useAvailableBalance.
+// This test covers the user-visible watch-only PSBT flow that remains relevant
+// in Dash: private-keys-disabled legacy wallet, watch-only balance display, and
+// "Create Unsigned" producing a clipboard PSBT.
+void TestGUIWatchOnly(interfaces::Node& node)
+{
+    TestChain100Setup test;
+    for (int i = 0; i < 5; ++i) {
+        test.CreateAndProcessBlock({}, GetScriptForRawPubKey(test.coinbaseKey.GetPubKey()));
+    }
+    node.setContext(&test.m_node);
+    WalletContext& context = *node.walletLoader().context();
+
+    const std::shared_ptr<CWallet> wallet = SetupLegacyWatchOnlyWallet(node, test);
+    AddWallet(context, wallet);
+
+    SendCoinsDialog sendCoinsDialog;
+    OptionsModel optionsModel(node);
+    bilingual_str error;
+    QVERIFY(optionsModel.Init(error));
+    ClientModel clientModel(node, &optionsModel);
+    WalletModel walletModel(interfaces::MakeWallet(context, wallet), clientModel);
+    sendCoinsDialog.setModel(&walletModel);
+
+    // Update cached balance and check the send dialog shows the watch-only balance.
+    walletModel.pollBalanceChanged();
+    {
+        QLabel* balanceLabel = sendCoinsDialog.findChild<QLabel*>("labelBalance");
+        BitcoinUnit unit = walletModel.getOptionsModel()->getDisplayUnit();
+        CAmount watch_only_balance = walletModel.wallet().getBalances().watch_only_balance;
+        QVERIFY(watch_only_balance > 0);
+        QString balanceComparison = BitcoinUnits::formatWithUnit(unit, watch_only_balance, false);
+        QCOMPARE(balanceLabel->text(), balanceComparison);
+    }
+
+    // Set change address so createTransaction can complete without a keypool change key.
+    sendCoinsDialog.getCoinControl()->destChange = GetDestinationForKey(test.coinbaseKey.GetPubKey(), OutputType::LEGACY);
+
+    // Dismiss the "PSBT has been copied" dialog that presentPSBT opens after Save.
+    QTimer timer;
+    timer.setInterval(500);
+    QObject::connect(&timer, &QTimer::timeout, [&]() {
+        for (QWidget* widget : QApplication::topLevelWidgets()) {
+            if (widget->inherits("QMessageBox")) {
+                QMessageBox* dialog = qobject_cast<QMessageBox*>(widget);
+                QAbstractButton* button = dialog->button(QMessageBox::Discard);
+                if (!button) continue;
+                button->setEnabled(true);
+                button->click();
+                timer.stop();
+                break;
+            }
+        }
+    });
+    timer.start(500);
+
+    // Create unsigned PSBT and verify it was copied to the clipboard.
+    SendCoins(*wallet.get(), sendCoinsDialog, PKHash(), 5 * COIN, QMessageBox::Save);
+    const std::string& psbt_string = QApplication::clipboard()->text().toStdString();
+    QVERIFY(!psbt_string.empty());
+
+    PartiallySignedTransaction psbt;
+    std::string err;
+    QVERIFY(DecodeBase64PSBT(psbt, psbt_string, err));
+
+    RemoveWallet(context, wallet, /*load_on_start=*/std::nullopt);
+}
+
 } // namespace
 
 void WalletTests::walletTests()
@@ -318,4 +461,5 @@ void WalletTests::walletTests()
     }
 #endif
     TestGUI(m_node);
+    TestGUIWatchOnly(m_node);
 }

--- a/src/test/util/wallet.cpp
+++ b/src/test/util/wallet.cpp
@@ -25,7 +25,12 @@ const std::string ADDRESS_BCRT1_UNSPENDABLE = "bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqq
 #ifdef ENABLE_WALLET
 std::string getnewaddress(CWallet& w)
 {
-    return EncodeDestination(*Assert(w.GetNewDestination("")));
+    return EncodeDestination(getNewDestination(w));
+}
+
+CTxDestination getNewDestination(CWallet& w)
+{
+    return *Assert(w.GetNewDestination(""));
 }
 
 // void importaddress(CWallet& wallet, const std::string& address)

--- a/src/test/util/wallet.h
+++ b/src/test/util/wallet.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_TEST_UTIL_WALLET_H
 #define BITCOIN_TEST_UTIL_WALLET_H
 
+#include <script/standard.h>
+
 #include <string>
 
 namespace wallet {
@@ -20,8 +22,10 @@ extern const std::string ADDRESS_BCRT1_UNSPENDABLE;
 
 /** Import the address to the wallet */
 void importaddress(wallet::CWallet& wallet, const std::string& address);
-/** Returns a new address from the wallet */
+/** Returns a new encoded destination from the wallet */
 std::string getnewaddress(wallet::CWallet& w);
+/** Returns a new destination from the wallet. Dash only supports OutputType::LEGACY. */
+CTxDestination getNewDestination(wallet::CWallet& w);
 
 
 #endif // BITCOIN_TEST_UTIL_WALLET_H

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -48,7 +48,7 @@ public:
     bool m_include_unsafe_inputs = false;
     //! If true, the selection process can add extra unselected inputs from the wallet
     //! while requires all selected inputs be used
-    bool m_allow_other_inputs = false;
+    bool m_allow_other_inputs = true;
     //! If false, only include as many inputs as necessary to fulfill a coin selection request. Only usable together with m_allow_other_inputs
     bool fRequireAllInputs = true;
     //! Includes watch only addresses which are solvable

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -587,6 +587,12 @@ void SelectionResult::AddInput(const OutputGroup& group)
     m_use_effective = !group.m_subtract_fee_outputs;
 }
 
+void SelectionResult::AddInputs(const std::set<COutput>& inputs, bool subtract_fee_outputs)
+{
+    util::insert(m_selected_inputs, inputs);
+    m_use_effective = !subtract_fee_outputs;
+}
+
 void SelectionResult::Merge(const SelectionResult& other)
 {
     m_target += other.m_target;

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -307,6 +307,7 @@ public:
     void Clear();
 
     void AddInput(const OutputGroup& group);
+    void AddInputs(const std::set<COutput>& inputs, bool subtract_fee_outputs);
 
     /** Calculates and stores the waste for this selection via GetSelectionWaste */
     void ComputeAndSetWaste(const CAmount min_viable_change, const CAmount change_cost, const CAmount change_fee);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -467,6 +467,8 @@ public:
 
         CCoinControl coin_control;
         coin_control.destChange = fund_destination;
+        // Fund from the given address only, spending no more of its coins than necessary.
+        coin_control.m_allow_other_inputs = false;
         coin_control.fRequireAllInputs = false;
         for (const auto& output : AvailableCoinsListUnspent(*m_wallet).all()) {
             CTxDestination destination;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -23,6 +23,7 @@
 #include <util/translation.h>
 #include <util/ui_change_type.h>
 #include <validation.h>
+#include <wallet/coincontrol.h>
 #include <wallet/coinjoin.h>
 #include <wallet/context.h>
 #include <wallet/fees.h>
@@ -655,9 +656,26 @@ public:
     {
         if (coin_control.IsUsingCoinJoin()) {
             return GetBalanceAnonymized(*m_wallet, coin_control);
-        } else {
-            return GetAvailableBalance(*m_wallet, &coin_control);
         }
+
+        LOCK(m_wallet->cs_wallet);
+        CAmount total_amount = 0;
+        // Fetch selected coins total amount
+        if (coin_control.HasSelected()) {
+            FastRandomContext rng{};
+            CoinSelectionParams params(rng);
+            // Note: for now, swallow any error.
+            if (auto res = FetchSelectedInputs(*m_wallet, coin_control, params)) {
+                total_amount += res->total_amount;
+            }
+        }
+
+        // And fetch the wallet available coins
+        if (coin_control.m_allow_other_inputs) {
+            total_amount += AvailableCoins(*m_wallet, &coin_control).total_amount;
+        }
+
+        return total_amount;
     }
     wallet::isminetype txinIsMine(const CTxIn& txin) override
     {

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -326,18 +326,6 @@ CoinsResult AvailableCoinsListUnspent(const CWallet& wallet, const CCoinControl*
     return AvailableCoins(wallet, coinControl, /*feerate=*/ std::nullopt, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, /*only_spendable=*/false);
 }
 
-CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl)
-{
-    LOCK(wallet.cs_wallet);
-    return AvailableCoins(wallet, coinControl,
-            /*feerate=*/ std::nullopt,
-            /*nMinimumAmount=*/ 1,
-            /*nMaximumAmount=*/ MAX_MONEY,
-            /*nMinimumSumAmount=*/ MAX_MONEY,
-            /*nMaximumCount=*/ 0
-    ).total_amount;
-}
-
 const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const CTransaction& tx, int output)
 {
     AssertLockHeld(wallet.cs_wallet);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -960,16 +960,33 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
                                          0);           /*nMaximumCount*/
     }
 
-    // Choose coins to use
-    std::optional<SelectionResult> result = SelectCoins(wallet, available_coins, preset_inputs, /*nTargetValue=*/selection_target, coin_control, coin_selection_params);
-    if (!result) {
-        if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
-            return util::Error{_("Unable to locate enough non-denominated funds for this transaction.")};
-        } else if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
-            return util::Error{_("Unable to locate enough mixed funds for this transaction.") +
-                               Untranslated(" ") + strprintf(_("%s uses exact denominated amounts to send funds, you might simply need to mix some more coins."), gCoinJoinName)};
+    // Choose coins to use. Coin selection estimates CompactSize prefixes before the final input
+    // and output counts are known. If either count crosses a boundary, retry with the exact prefix
+    // fees included in the target.
+    std::optional<SelectionResult> result;
+    while (true) {
+        result = SelectCoins(wallet, available_coins, preset_inputs, /*nTargetValue=*/selection_target, coin_control, coin_selection_params);
+        if (!result) {
+            if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
+                return util::Error{_("Unable to locate enough non-denominated funds for this transaction.")};
+            } else if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
+                return util::Error{_("Unable to locate enough mixed funds for this transaction.") +
+                                   Untranslated(" ") + strprintf(_("%s uses exact denominated amounts to send funds, you might simply need to mix some more coins."), gCoinJoinName)};
+            }
+            return util::Error{_("Insufficient funds.")};
         }
-        return util::Error{_("Insufficient funds.")};
+        if (coin_selection_params.m_subtract_fee_outputs) break;
+
+        const size_t vin_count_delta = GetSizeOfCompactSize(result->GetInputSet().size()) - 1;
+        const CAmount change_amount = coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED
+                                          ? 0
+                                          : result->GetChange(coin_selection_params.min_viable_change, coin_selection_params.m_change_fee);
+        const size_t vout_count_delta = GetSizeOfCompactSize(vecSend.size() + (change_amount > 0)) -
+                                        GetSizeOfCompactSize(vecSend.size());
+        const CAmount adjusted_target = recipients_sum + coin_selection_params.m_effective_feerate.GetFee(
+            coin_selection_params.tx_noinputs_size + vin_count_delta + vout_count_delta);
+        if (adjusted_target <= selection_target) break;
+        selection_target = adjusted_target;
     }
     TRACE5(coin_selection, selected_coins, wallet.GetName().c_str(), GetAlgorithmName(result->GetAlgo()).c_str(), result->GetTarget(), result->GetWaste(), result->GetSelectedValue());
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -100,6 +100,57 @@ void CoinsResult::clear()
     other.clear();
 }
 
+// Fetch and validate the coin control selected inputs.
+// Coins could be internal (from the wallet) or external.
+util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const CCoinControl& coin_control,
+                                            const CoinSelectionParams& coin_selection_params) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    PreSelectedInputs result;
+    for (const COutPoint& outpoint : coin_control.ListSelected()) {
+        int input_bytes = -1;
+        CTxOut txout;
+        if (auto ptr_wtx = wallet.GetWalletTx(outpoint.hash)) {
+            // Clearly invalid input, fail
+            if (ptr_wtx->tx->vout.size() <= outpoint.n) {
+                return util::Error{strprintf(_("Invalid pre-selected input %s"), outpoint.ToString())};
+            }
+            txout = ptr_wtx->tx->vout.at(outpoint.n);
+            input_bytes = CalculateMaximumSignedInputSize(txout, &wallet, &coin_control);
+        } else {
+            // The input is external. We did not find the tx in mapWallet.
+            const auto out{coin_control.GetExternalOutput(outpoint)};
+            if (!out) {
+                return util::Error{strprintf(_("Not found pre-selected input %s"), outpoint.ToString())};
+            }
+            txout = *out;
+        }
+
+        if (input_bytes == -1) {
+            input_bytes = CalculateMaximumSignedInputSize(txout, outpoint, &coin_control.m_external_provider, &coin_control);
+        }
+
+        if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
+            // Make sure to include mixed preset inputs only,
+            // even if some non-mixed inputs were manually selected via CoinControl
+            if (!wallet.IsFullyMixed(outpoint)) continue;
+        }
+
+        // If available, override calculated size with coin control specified size
+        if (coin_control.HasInputWeight(outpoint)) {
+            input_bytes = GetVirtualTransactionSize(coin_control.GetInputWeight(outpoint), 0, 0);
+        }
+
+        if (input_bytes == -1) {
+            return util::Error{strprintf(_("Not solvable pre-selected input %s"), outpoint.ToString())}; // Not solvable, can't estimate size for fee
+        }
+
+        /* Set some defaults for depth, spendable, solvable, safe, time, and from_me as these don't matter for preset inputs since no selection is being done. */
+        COutput output(outpoint, txout, /*depth=*/ 0, input_bytes, /*spendable=*/ true, /*solvable=*/ true, /*safe=*/ true, /*time=*/ 0, /*from_me=*/ false, coin_selection_params.m_effective_feerate);
+        result.Insert(output, coin_selection_params.m_subtract_fee_outputs);
+    }
+    return result;
+}
+
 CoinsResult AvailableCoins(const CWallet& wallet,
                            const CCoinControl* coinControl,
                            std::optional<CFeeRate> feerate,
@@ -188,7 +239,8 @@ CoinsResult AvailableCoins(const CWallet& wallet,
             if (output.nValue < nMinimumAmount || output.nValue > nMaximumAmount)
                 continue;
 
-            if (coinControl && coinControl->HasSelected() && !coinControl->m_allow_other_inputs && !coinControl->IsSelected(outpoint))
+            // Skip manually selected coins (the caller can fetch them directly)
+            if (coinControl && coinControl->HasSelected() && coinControl->IsSelected(outpoint))
                 continue;
 
             if (wallet.IsLockedCoin(outpoint) && nCoinType != CoinType::ONLY_MASTERNODE_COLLATERAL)
@@ -503,109 +555,71 @@ std::optional<SelectionResult> ChooseSelectionResult(const CWallet& wallet, cons
     return *std::min_element(results.begin(), results.end());
 }
 
-std::optional<SelectionResult> SelectCoins(const CWallet& wallet, CoinsResult& available_coins, const CAmount& nTargetValue, const CCoinControl& coin_control, const CoinSelectionParams& coin_selection_params)
+/**
+ * Dash: walk the pre-selected inputs in outpoint order and stop as soon as their selection
+ * amount covers nTargetValue. Used when coin control requests that only as many of the
+ * manually selected inputs as are actually needed be spent, rather than all of them
+ * (see CCoinControl::fRequireAllInputs). Note this does not minimise the input count or the
+ * selected value; it only avoids sweeping every selected coin.
+ */
+static PreSelectedInputs TrimPreSelectedInputs(const PreSelectedInputs& pre_set_inputs, const CAmount& nTargetValue, bool subtract_fee_outputs)
+{
+    PreSelectedInputs trimmed;
+    for (const COutput& output : pre_set_inputs.coins) {
+        // Insert before testing, so a non-empty input set always contributes at least one coin
+        // even when nTargetValue is 0. An empty selection would trip the non-empty assert in
+        // GetSelectionWaste().
+        trimmed.Insert(output, subtract_fee_outputs);
+        if (trimmed.total_amount >= nTargetValue) break;
+    }
+    return trimmed;
+}
+
+std::optional<SelectionResult> SelectCoins(const CWallet& wallet, CoinsResult& available_coins, const PreSelectedInputs& pre_set_inputs,
+                                           const CAmount& nTargetValue, const CCoinControl& coin_control,
+                                           const CoinSelectionParams& coin_selection_params)
 {
     // Note: this function should never be used for "always free" tx types like dstx
-    CoinType nCoinType = coin_control.nCoinType;
-    CAmount value_to_select = nTargetValue;
 
-    OutputGroup preset_inputs(coin_selection_params);
+    // Deduct preset inputs amount from the search target
+    CAmount selection_target = nTargetValue - pre_set_inputs.total_amount;
 
-    // calculate value from preset inputs and store them
-    std::set<COutPoint> preset_coins;
+    // Return if automatic coin selection is disabled, and we don't cover the selection target
+    if (!coin_control.m_allow_other_inputs && selection_target > 0) return std::nullopt;
 
-    for (const COutPoint& outpoint : coin_control.ListSelected()) {
-        int input_bytes = -1;
-        CTxOut txout;
-        auto ptr_wtx = wallet.GetWalletTx(outpoint.hash);
-        if (ptr_wtx) {
-            // Clearly invalid input, fail
-            if (ptr_wtx->tx->vout.size() <= outpoint.n) {
-                return std::nullopt;
-            }
-            txout = ptr_wtx->tx->vout.at(outpoint.n);
-            input_bytes = CalculateMaximumSignedInputSize(txout, &wallet, &coin_control);
-        } else {
-            // The input is external. We did not find the tx in mapWallet.
-            const auto out{coin_control.GetExternalOutput(outpoint)};
-            if (!out) {
-                return std::nullopt;
-            }
-            txout = *out;
-        }
-
-        if (input_bytes == -1) {
-            input_bytes = CalculateMaximumSignedInputSize(txout, outpoint, &coin_control.m_external_provider, &coin_control);
-        }
-        if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
-            // Make sure to include mixed preset inputs only,
-            // even if some non-mixed inputs were manually selected via CoinControl
-            if (!wallet.IsFullyMixed(outpoint)) continue;
-        }
-        // If available, override calculated size with coin control specified size
-        if (coin_control.HasInputWeight(outpoint)) {
-            input_bytes = GetVirtualTransactionSize(coin_control.GetInputWeight(outpoint), 0, 0);
-        }
-
-        if (input_bytes == -1) {
-            return std::nullopt; // Not solvable, can't estimate size for fee
-        }
-
-        /* Set some defaults for depth, spendable, solvable, safe, time, and from_me as these don't matter for preset inputs since no selection is being done. */
-        COutput output(outpoint, txout, /*depth=*/ 0, input_bytes, /*spendable=*/ true, /*solvable=*/ true, /*safe=*/ true, /*time=*/ 0, /*from_me=*/ false, coin_selection_params.m_effective_feerate);
-        if (coin_selection_params.m_subtract_fee_outputs) {
-            value_to_select -= output.txout.nValue;
-        } else {
-            value_to_select -= output.GetEffectiveValue();
-        }
-        preset_coins.insert(outpoint);
-        /* Set ancestors and descendants to 0 as they don't matter for preset inputs since no actual selection is being done.
-         * positive_only is set to false because we want to include all preset inputs, even if they are dust.
-         */
-        preset_inputs.Insert(output, /*ancestors=*/ 0, /*descendants=*/ 0, /*positive_only=*/ false);
-    }
-
-    // coin control -> return all selected outputs (we want all selected to go into the transaction for sure)
-    if (coin_control.HasSelected() && !coin_control.m_allow_other_inputs) {
+    // Return if we can cover the target only with the preset inputs
+    if (selection_target <= 0) {
         SelectionResult result(nTargetValue, SelectionAlgorithm::MANUAL);
-        bool all_inputs{coin_control.fRequireAllInputs};
-        if (!all_inputs) {
-            // Calculate the smallest set of inputs required to meet nTargetValue from available_coins
-            bool success{false};
-            OutputGroup preset_candidates(coin_selection_params);
-            for (const COutput& out : available_coins.all()) {
-                if (!out.spendable) continue;
-                if (preset_coins.count(out.outpoint)) {
-                    preset_candidates.Insert(out, /*ancestors=*/0, /*descendants=*/0, /*positive_only=*/false);
-                }
-                if (preset_candidates.GetSelectionAmount() >= nTargetValue) {
-                    result.AddInput(preset_candidates);
-                    success = true;
-                    break;
-                }
-            }
-            // Couldn't meet target, add all inputs
-            if (!success) all_inputs = true;
+        if (coin_control.fRequireAllInputs) {
+            result.AddInputs(pre_set_inputs.coins, coin_selection_params.m_subtract_fee_outputs);
+        } else {
+            // Dash: spend only as many of the manually selected inputs as are needed to cover the target
+            const PreSelectedInputs trimmed{TrimPreSelectedInputs(pre_set_inputs, nTargetValue, coin_selection_params.m_subtract_fee_outputs)};
+            result.AddInputs(trimmed.coins, coin_selection_params.m_subtract_fee_outputs);
         }
-        if (all_inputs) {
-            result.AddInput(preset_inputs);
-        }
-
-        if (!coin_selection_params.m_subtract_fee_outputs && result.GetSelectedEffectiveValue() < nTargetValue) {
-            return std::nullopt;
-        } else if (result.GetSelectedValue() < nTargetValue) {
-            return std::nullopt;
-        }
-
         result.ComputeAndSetWaste(coin_selection_params.min_viable_change, coin_selection_params.m_cost_of_change, coin_selection_params.m_change_fee);
         return result;
     }
 
-    // remove preset inputs from coins so that Coin Selection doesn't pick them.
-    if (coin_control.HasSelected()) {
-        available_coins.legacy.erase(remove_if(available_coins.legacy.begin(), available_coins.legacy.end(), [&](const COutput& c) { return preset_coins.count(c.outpoint); }), available_coins.legacy.end());
-        available_coins.other.erase(remove_if(available_coins.other.begin(), available_coins.other.end(), [&](const COutput& c) { return preset_coins.count(c.outpoint); }), available_coins.other.end());
+    // Start wallet Coin Selection procedure
+    auto op_selection_result = AutomaticCoinSelection(wallet, available_coins, selection_target, coin_control, coin_selection_params);
+    if (!op_selection_result) return op_selection_result;
+
+    // If needed, add preset inputs to the automatic coin selection result
+    if (!pre_set_inputs.coins.empty()) {
+        SelectionResult preselected(pre_set_inputs.total_amount, SelectionAlgorithm::MANUAL);
+        preselected.AddInputs(pre_set_inputs.coins, coin_selection_params.m_subtract_fee_outputs);
+        op_selection_result->Merge(preselected);
+        op_selection_result->ComputeAndSetWaste(coin_selection_params.min_viable_change,
+                                                coin_selection_params.m_cost_of_change,
+                                                coin_selection_params.m_change_fee);
     }
+    return op_selection_result;
+}
+
+std::optional<SelectionResult> AutomaticCoinSelection(const CWallet& wallet, CoinsResult& available_coins, const CAmount& value_to_select, const CCoinControl& coin_control, const CoinSelectionParams& coin_selection_params)
+{
+    CoinType nCoinType = coin_control.nCoinType;
 
     unsigned int limit_ancestor_count = 0;
     unsigned int limit_descendant_count = 0;
@@ -624,16 +638,10 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, CoinsResult& a
         Shuffle(available_coins.other.begin(), available_coins.other.end(), coin_selection_params.rng_fast);
     }
 
-    SelectionResult preselected(preset_inputs.GetSelectionAmount(), SelectionAlgorithm::MANUAL);
-    preselected.AddInput(preset_inputs);
-
     // Coin Selection attempts to select inputs from a pool of eligible UTXOs to fund the
     // transaction at a target feerate. If an attempt fails, more attempts may be made using a more
     // permissive CoinEligibilityFilter.
     std::optional<SelectionResult> res = [&] {
-        // Pre-selected inputs already cover the target amount.
-        if (value_to_select <= 0) return std::make_optional(SelectionResult(value_to_select, SelectionAlgorithm::MANUAL));
-
         // If possible, fund the transaction with confirmed UTXOs only. Prefer at least six
         // confirmations on outputs received from other wallets and only spend confirmed change.
         if (auto r1{AttemptSelection(wallet, value_to_select, CoinEligibilityFilter(1, 6, 0), available_coins, coin_selection_params, /*allow_mixed_output_types=*/false, nCoinType)}) return r1;
@@ -682,14 +690,6 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, CoinsResult& a
         // Coin Selection failed.
         return std::optional<SelectionResult>();
     }();
-
-    if (!res) return std::nullopt;
-
-    // Add preset inputs to result
-    res->Merge(preselected);
-    if (res->GetAlgo() == SelectionAlgorithm::MANUAL) {
-        res->ComputeAndSetWaste(coin_selection_params.min_viable_change, coin_selection_params.m_cost_of_change, coin_selection_params.m_change_fee);
-    }
 
     return res;
 }
@@ -951,17 +951,29 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         return util::Error{_("Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input")};
     }
 
-    // Get available coins
-    auto available_coins = AvailableCoins(wallet,
-                                              &coin_control,
-                                              coin_selection_params.m_effective_feerate,
-                                              1,            /*nMinimumAmount*/
-                                              MAX_MONEY,    /*nMaximumAmount*/
-                                              MAX_MONEY,    /*nMinimumSumAmount*/
-                                              0);           /*nMaximumCount*/
+    // Fetch manually selected coins
+    PreSelectedInputs preset_inputs;
+    if (coin_control.HasSelected()) {
+        auto res_fetch_inputs = FetchSelectedInputs(wallet, coin_control, coin_selection_params);
+        if (!res_fetch_inputs) return util::Error{util::ErrorString(res_fetch_inputs)};
+        preset_inputs = *res_fetch_inputs;
+    }
+
+    // Fetch wallet available coins if "other inputs" are
+    // allowed (coins automatically selected by the wallet)
+    CoinsResult available_coins;
+    if (coin_control.m_allow_other_inputs) {
+        available_coins = AvailableCoins(wallet,
+                                         &coin_control,
+                                         coin_selection_params.m_effective_feerate,
+                                         1,            /*nMinimumAmount*/
+                                         MAX_MONEY,    /*nMaximumAmount*/
+                                         MAX_MONEY,    /*nMinimumSumAmount*/
+                                         0);           /*nMaximumCount*/
+    }
 
     // Choose coins to use
-    std::optional<SelectionResult> result = SelectCoins(wallet, available_coins, /*nTargetValue=*/selection_target, coin_control, coin_selection_params);
+    std::optional<SelectionResult> result = SelectCoins(wallet, available_coins, preset_inputs, /*nTargetValue=*/selection_target, coin_control, coin_selection_params);
     if (!result) {
         if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
             return util::Error{_("Unable to locate enough non-denominated funds for this transaction.")};
@@ -1277,6 +1289,8 @@ bool GenBudgetSystemCollateralTx(CWallet& wallet, CTransactionRef& tx, uint256 h
 
     CCoinControl coinControl;
     if (!outpoint.IsNull()) {
+        // Fund the collateral from the given outpoint only.
+        coinControl.m_allow_other_inputs = false;
         coinControl.Select(outpoint);
     }
 

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -73,8 +73,6 @@ CoinsResult AvailableCoins(const CWallet& wallet,
  */
 CoinsResult AvailableCoinsListUnspent(const CWallet& wallet, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
-CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl = nullptr);
-
 /**
  * Find non-change parent output.
  */

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -122,9 +122,35 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
 std::optional<SelectionResult> ChooseSelectionResult(const CWallet& wallet, const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, const std::vector<COutput>& available_coins,
                                                      const CoinSelectionParams& coin_selection_params, CoinType nCoinType = CoinType::ALL_COINS);
 
+// User manually selected inputs that must be part of the transaction
+struct PreSelectedInputs
+{
+    std::set<COutput> coins;
+    // If subtract fee from outputs is disabled, the 'total_amount'
+    // will be the sum of each output effective value
+    // instead of the sum of the outputs amount
+    CAmount total_amount{0};
+
+    void Insert(const COutput& output, bool subtract_fee_outputs)
+    {
+        if (subtract_fee_outputs) {
+            total_amount += output.txout.nValue;
+        } else {
+            total_amount += output.GetEffectiveValue();
+        }
+        coins.insert(output);
+    }
+};
+
 /**
- * Select a set of coins such that nTargetValue is met and at least
- * all coins from coin_control are selected; never select unconfirmed coins if they are not ours
+ * Fetch and validate coin control selected inputs.
+ * Coins could be internal (from the wallet) or external.
+*/
+util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const CCoinControl& coin_control,
+                                                    const CoinSelectionParams& coin_selection_params) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+
+/**
+ * Select a set of coins such that nTargetValue is met; never select unconfirmed coins if they are not ours
  * param@[in]   wallet                 The wallet which provides data necessary to spend the selected coins
  * param@[in]   available_coins        The struct of coins, organized by OutputType, available for selection prior to filtering
  * param@[in]   nTargetValue           The target value
@@ -133,8 +159,16 @@ std::optional<SelectionResult> ChooseSelectionResult(const CWallet& wallet, cons
  * returns                             If successful, a SelectionResult containing the selected coins
  *                                     If failed, a nullopt.
  */
-std::optional<SelectionResult> SelectCoins(const CWallet& wallet, CoinsResult& available_coins, const CAmount& nTargetValue, const CCoinControl& coin_control,
+std::optional<SelectionResult> AutomaticCoinSelection(const CWallet& wallet, CoinsResult& available_coins, const CAmount& nTargetValue, const CCoinControl& coin_control,
                  const CoinSelectionParams& coin_selection_params) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+
+/**
+ * Select all coins from coin_control, and if coin_control 'm_allow_other_inputs=true', call 'AutomaticCoinSelection' to
+ * select a set of coins such that nTargetValue - pre_set_inputs.total_amount is met.
+ */
+std::optional<SelectionResult> SelectCoins(const CWallet& wallet, CoinsResult& available_coins, const PreSelectedInputs& pre_set_inputs,
+                                           const CAmount& nTargetValue, const CCoinControl& coin_control,
+                                           const CoinSelectionParams& coin_selection_params) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 struct CreatedTransactionResult
 {

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -349,9 +349,13 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         add_coin(available_coins, *wallet, 2 * CENT, coin_selection_params_bnb.m_effective_feerate, 6 * 24, false, 0, true);
         CCoinControl coin_control;
         coin_control.m_allow_other_inputs = true;
-        coin_control.Select(available_coins.all().at(0).outpoint);
+        COutput select_coin = available_coins.all().at(0);
+        coin_control.Select(select_coin.outpoint);
+        PreSelectedInputs selected_input;
+        selected_input.Insert(select_coin, coin_selection_params_bnb.m_subtract_fee_outputs);
+        available_coins.legacy.erase(available_coins.legacy.begin());
         coin_selection_params_bnb.m_effective_feerate = CFeeRate(0);
-        const auto result10 = SelectCoins(*wallet, available_coins, 10 * CENT, coin_control, coin_selection_params_bnb);
+        const auto result10 = SelectCoins(*wallet, available_coins, selected_input, 10 * CENT, coin_control, coin_selection_params_bnb);
         BOOST_CHECK(result10);
     }
     {
@@ -374,7 +378,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         expected_result.Clear();
         add_coin(10 * CENT, 2, expected_result);
         CCoinControl coin_control;
-        const auto result11 = SelectCoins(*wallet, available_coins, 10 * CENT, coin_control, coin_selection_params_bnb);
+        const auto result11 = SelectCoins(*wallet, available_coins, /*pre_set_inputs=*/{}, 10 * CENT, coin_control, coin_selection_params_bnb);
         BOOST_CHECK(EquivalentResult(expected_result, *result11));
         available_coins.clear();
 
@@ -389,7 +393,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         expected_result.Clear();
         add_coin(9 * CENT, 2, expected_result);
         add_coin(1 * CENT, 2, expected_result);
-        const auto result12 = SelectCoins(*wallet, available_coins, 10 * CENT, coin_control, coin_selection_params_bnb);
+        const auto result12 = SelectCoins(*wallet, available_coins, /*pre_set_inputs=*/{}, 10 * CENT, coin_control, coin_selection_params_bnb);
         // NOTE: Dash does not use BnB and therefore, this check will fail
         // BOOST_CHECK(EquivalentResult(expected_result, *result12));
         available_coins.clear();
@@ -406,8 +410,12 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         add_coin(9 * CENT, 2, expected_result);
         add_coin(1 * CENT, 2, expected_result);
         coin_control.m_allow_other_inputs = true;
-        coin_control.Select(available_coins.all().at(1).outpoint); // pre select 9 coin
-        const auto result13 = SelectCoins(*wallet, available_coins, 10 * CENT, coin_control, coin_selection_params_bnb);
+        COutput select_coin = available_coins.all().at(1); // pre select 9 coin
+        coin_control.Select(select_coin.outpoint);
+        PreSelectedInputs selected_input;
+        selected_input.Insert(select_coin, coin_selection_params_bnb.m_subtract_fee_outputs);
+        available_coins.legacy.erase(++available_coins.legacy.begin());
+        const auto result13 = SelectCoins(*wallet, available_coins, selected_input, 10 * CENT, coin_control, coin_selection_params_bnb);
         BOOST_CHECK(EquivalentResult(expected_result, *result13));
     }
 }
@@ -795,7 +803,7 @@ BOOST_AUTO_TEST_CASE(SelectCoins_test)
         cs_params.m_cost_of_change = 1;
         cs_params.min_viable_change = 1;
         CCoinControl cc;
-        const auto result = SelectCoins(*wallet, available_coins, target, cc, cs_params);
+        const auto result = SelectCoins(*wallet, available_coins, /*pre_set_inputs=*/{}, target, cc, cs_params);
         BOOST_CHECK(result);
         BOOST_CHECK_GE(result->GetSelectedValue(), target);
     }
@@ -977,7 +985,10 @@ BOOST_AUTO_TEST_CASE(SelectCoins_effective_value_test)
     cc.SetInputWeight(output.outpoint, 148);
     cc.SelectExternal(output.outpoint, output.txout);
 
-    const auto result = SelectCoins(*wallet, available_coins, target, cc, cs_params);
+    const auto preset_inputs = *Assert(FetchSelectedInputs(*wallet, cc, cs_params));
+    available_coins.legacy.erase(available_coins.legacy.begin());
+
+    const auto result = SelectCoins(*wallet, available_coins, preset_inputs, target, cc, cs_params);
     BOOST_CHECK(!result);
 }
 
@@ -1064,7 +1075,7 @@ static std::optional<SelectionResult> select_coins(const CAmount& target, const 
     wallet->SetupDescriptorScriptPubKeyMans("", "");
 
     auto available_coins = coin_setup(*wallet);
-    auto result = SelectCoins(*wallet, available_coins, target, cc, cs_params);
+    auto result = SelectCoins(*wallet, available_coins, /*pre_set_inputs=*/{}, target, cc, cs_params);
     if (result) {
         BOOST_CHECK_LE(static_cast<int>(cs_params.tx_noinputs_size) + GetSelectionWeight(*result), MAX_STANDARD_TX_SIZE);
         BOOST_CHECK_GE(result->GetSelectedValue(), target);
@@ -1178,12 +1189,15 @@ BOOST_AUTO_TEST_CASE(minimum_inputs_test)
         /*tx_noinputs_size=*/0,
         /*avoid_partial=*/false,
     };
-    auto result = SelectCoins(*wallet, available_coins, target, coin_control, coin_selection_params);
+    const auto pre_set_inputs = *Assert(FetchSelectedInputs(*wallet, coin_control, coin_selection_params));
+    auto result = SelectCoins(*wallet, available_coins, pre_set_inputs, target, coin_control, coin_selection_params);
     BOOST_REQUIRE(result);
 
-    // Should consume only the first two coins (9 + 16) >= 25 and account correctly
+    // Should consume only two of the three coins: no single coin covers the 25 target, and any
+    // two of them do. Which two are picked depends on the pre-selected inputs ordering, so only
+    // assert on the input count and that the target is actually covered.
     BOOST_CHECK_EQUAL(result->GetInputSet().size(), 2);
-    BOOST_CHECK_EQUAL(result->GetSelectedValue(), 25 * COIN);
+    BOOST_CHECK_GE(result->GetSelectedValue(), target);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/fees.h>
+#include <test/util/wallet.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/spend.h>
@@ -56,6 +57,142 @@ BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
     // -123). This overpays the recipient instead of overpaying the miner more
     // than double the neccesary fee.
     BOOST_CHECK_EQUAL(fee, check_tx(fee + 123));
+}
+
+// Regression test for a Dash-specific bug: CreateTransactionInternal() estimates the
+// non-input part of the transaction size (used to size coin selection's target and, via
+// SelectionResult::m_target, the change amount) assuming the vin-count CompactSize prefix
+// is always 1 byte. Once the final input count reaches 253 or more, the real prefix is 3
+// bytes, so the fee actually collected falls a couple of duffs short of the fee needed for
+// the accurately-measured final size, and CreateTransactionInternal() used to bail out with
+// "Fee needed > fee paid" (see spend.cpp's tx_noinputs_size and the STR_INTERNAL_BUG check).
+//
+// Funds a wallet with `input_count` confirmed CENT UTXOs, then requires all of them as
+// inputs (via CCoinControl::fRequireAllInputs) and checks transaction creation with either a
+// change output or an exact no-change target.
+//
+// UTXOs are funded in chunks of at most 100 per transaction (well under the CompactSize
+// boundary being tested) so that setup itself never has to cross a CompactSize boundary on
+// the *output* side, which would otherwise obscure the input-count regression under test.
+static void CheckManyRequiredInputs(TestChain100Setup& setup, size_t input_count, bool exact_no_change = false)
+{
+    setup.CreateAndProcessBlock({}, GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey()));
+    auto wallet = CreateSyncedWallet(*setup.m_node.chain, *setup.m_node.coinjoin_loader, *Assert(setup.m_node.chainman), setup.m_args, setup.coinbaseKey);
+
+    std::vector<COutPoint> outpoints;
+    outpoints.reserve(input_count);
+    static constexpr size_t CHUNK_SIZE{100};
+    for (size_t funded = 0; funded < input_count; funded += CHUNK_SIZE) {
+        const size_t chunk = std::min(CHUNK_SIZE, input_count - funded);
+
+        CCoinControl fund_control;
+        fund_control.m_feerate.emplace(10000);
+        fund_control.fOverrideFeeRate = true;
+        std::vector<CRecipient> recipients;
+        recipients.reserve(chunk);
+        for (size_t i = 0; i < chunk; ++i) {
+            recipients.push_back({GetScriptForDestination(getNewDestination(*wallet)), CENT, /*subtract fee=*/false});
+        }
+        auto fund_res = CreateTransaction(*wallet, recipients, RANDOM_CHANGE_POSITION, fund_control);
+        BOOST_REQUIRE(fund_res);
+        const CTransactionRef fund_tx = fund_res->tx;
+
+        // Confirm the funding transaction, mirroring CreateTransactionTestSetup::GetCoins()
+        // in wallet_tests.cpp: CreateSyncedWallet() does not register the wallet for chain
+        // notifications, so the confirmation has to be reflected into mapWallet manually.
+        wallet->CommitTransaction(fund_tx, {}, {});
+        setup.CreateAndProcessBlock({CMutableTransaction(*fund_tx)}, GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey()));
+        const CBlockIndex* tip{WITH_LOCK(Assert(setup.m_node.chainman)->GetMutex(), return setup.m_node.chainman->ActiveChain().Tip())};
+        {
+            LOCK(wallet->cs_wallet);
+            wallet->SetLastBlockProcessed(tip->nHeight, tip->GetBlockHash());
+            auto it = wallet->mapWallet.find(fund_tx->GetHash());
+            BOOST_REQUIRE(it != wallet->mapWallet.end());
+            it->second.m_state = TxStateConfirmed{tip->GetBlockHash(), tip->nHeight, /*index=*/1};
+        }
+
+        {
+            LOCK(wallet->cs_wallet);
+            for (size_t i = 0; i < chunk; ++i) {
+                outpoints.emplace_back(fund_tx->GetHash(), i);
+                wallet->LockCoin(outpoints.back());
+            }
+        }
+    }
+
+    CCoinControl coin_control;
+    coin_control.m_feerate.emplace(10000);
+    coin_control.fOverrideFeeRate = true;
+    coin_control.fRequireAllInputs = true;
+    coin_control.m_allow_other_inputs = false;
+    for (const auto& outpoint : outpoints) coin_control.Select(outpoint);
+
+    const CAmount total{CAmount(input_count) * CENT};
+    const CScript recipient_script{GetScriptForDestination(getNewDestination(*wallet))};
+    CAmount recipient_amount{total - CENT};
+    if (exact_no_change) {
+        CAmount selected_effective_value{0};
+        {
+            LOCK(wallet->cs_wallet);
+            for (const auto& outpoint : outpoints) {
+                const CWalletTx* wtx{wallet->GetWalletTx(outpoint.hash)};
+                BOOST_REQUIRE(wtx);
+                const CTxOut& txout{wtx->tx->vout.at(outpoint.n)};
+                const int64_t input_size{CalculateMaximumSignedInputSize(txout, wallet.get(), &coin_control)};
+                BOOST_REQUIRE_NE(input_size, -1);
+                selected_effective_value += txout.nValue - coin_control.m_feerate->GetFee(input_size);
+            }
+        }
+        const CTxOut recipient_out{/*nValueIn=*/0, recipient_script};
+        const size_t noinputs_size{9 + GetSizeOfCompactSize(/*nSize=*/1) +
+                                   GetSerializeSize(recipient_out) + GetSizeOfCompactSize(input_count) - 1};
+        recipient_amount = selected_effective_value - coin_control.m_feerate->GetFee(noinputs_size);
+    }
+
+    CRecipient recipient{recipient_script, recipient_amount, /*subtract fee=*/false};
+    auto res = CreateTransaction(*wallet, {recipient}, RANDOM_CHANGE_POSITION, coin_control);
+    BOOST_REQUIRE(res);
+    BOOST_CHECK_EQUAL(res->tx->vout.size(), exact_no_change ? 1 : 2);
+}
+
+// Below the CompactSize boundary: the vin-count prefix really is 1 byte, so this must always
+// succeed, with or without the fix.
+BOOST_FIXTURE_TEST_CASE(CompactSizeInputCountBelowBoundary, TestChain100Setup)
+{
+    CheckManyRequiredInputs(*this, 252);
+}
+
+// At the CompactSize boundary: 253 inputs need a 3-byte vin-count prefix. This is the case
+// that used to fail with "Fee needed > fee paid".
+BOOST_FIXTURE_TEST_CASE(CompactSizeInputCountAtBoundary, TestChain100Setup)
+{
+    CheckManyRequiredInputs(*this, 253);
+}
+
+// The exact-target path has no change output to absorb a fee shortfall, so coin selection must
+// include the wider vin-count prefix in its target before finalizing the input set.
+BOOST_FIXTURE_TEST_CASE(CompactSizeInputCountAtBoundaryNoChange, TestChain100Setup)
+{
+    CheckManyRequiredInputs(*this, 253, /*exact_no_change=*/true);
+}
+
+// Adding change to 252 recipient outputs crosses the vout-count CompactSize boundary. Coin
+// selection must include the wider prefix in its target before finalizing the transaction.
+BOOST_FIXTURE_TEST_CASE(CompactSizeOutputCountAtBoundary, TestChain100Setup)
+{
+    CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+    auto wallet = CreateSyncedWallet(*m_node.chain, *m_node.coinjoin_loader, *Assert(m_node.chainman), m_args, coinbaseKey);
+
+    const CScript recipient_script{GetScriptForDestination(getNewDestination(*wallet))};
+    const CRecipient recipient{recipient_script, CENT, /*subtract fee=*/false};
+    const std::vector<CRecipient> recipients(/*count=*/252, recipient);
+
+    CCoinControl coin_control;
+    coin_control.m_feerate.emplace(10000);
+    coin_control.fOverrideFeeRate = true;
+    auto res = CreateTransaction(*wallet, recipients, RANDOM_CHANGE_POSITION, coin_control);
+    BOOST_REQUIRE(res);
+    BOOST_CHECK_EQUAL(res->tx->vout.size(), 253);
 }
 
 static void TestFillInputToWeight(int64_t additional_weight, int64_t expected_scriptsig_size)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -1304,6 +1304,8 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
     // First run the tests with only one input containing 100k duffs
     {
         coinControl = CCoinControl();
+        // Spend the selected coins only, do not let the wallet add any of its own
+        coinControl.m_allow_other_inputs = false;
         coinControl.Select(GetCoins({{100000, false}})[0]);
 
         // Start with fallback feerate
@@ -1344,6 +1346,8 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
     // Now use 4 different inputs with a total of 100k duff
     {
         coinControl = CCoinControl();
+        // Spend the selected coins only, do not let the wallet add any of its own
+        coinControl.m_allow_other_inputs = false;
         auto setCoins = GetCoins({{1000, false}, {5000, false}, {10000, false}, {84000, false}});
         for (auto coin : setCoins) {
             coinControl.Select(coin);
@@ -1388,6 +1392,8 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
     // Last use 10 equal inputs with a total of 100k duff
     {
         coinControl = CCoinControl();
+        // Spend the selected coins only, do not let the wallet add any of its own
+        coinControl.m_allow_other_inputs = false;
         auto setCoins = GetCoins({{10000, false}, {10000, false}, {10000, false}, {10000, false}, {10000, false},
                                   {10000, false}, {10000, false}, {10000, false}, {10000, false}, {10000, false}});
 
@@ -1481,6 +1487,8 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
     {
         coinControl = CCoinControl();
         coinControl.m_feerate = CFeeRate(fallbackFee);
+        // Spend the selected coins only, do not let the wallet add any of its own
+        coinControl.m_allow_other_inputs = false;
         coinControl.Select(GetCoins({{100000, false}})[0]);
 
         BOOST_CHECK(CreateTransaction({{25000, false}, {25000, false}, {25000, false}}, {}, 0, true, ChangeTest::ChangeExpected));
@@ -1527,6 +1535,8 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
 
         coinControl = CCoinControl();
         coinControl.m_feerate = CFeeRate(fallbackFee);
+        // Spend the selected coins only, do not let the wallet add any of its own
+        coinControl.m_allow_other_inputs = false;
         coinControl.Select(GetCoins({{100 * COIN, false}})[0]);
 
         BOOST_CHECK(CreateTransaction({{-5000, false}}, strAmountNotNegative, false));

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -722,7 +722,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 1U);
 
     // Check initial balance from one mature coinbase transaction.
-    BOOST_CHECK_EQUAL(500 * COIN, GetAvailableBalance(*wallet));
+    BOOST_CHECK_EQUAL(500 * COIN, WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).total_amount));
 
     // Add a transaction creating a change address, and confirm ListCoins still
     // returns the coin associated with the change address underneath the
@@ -1567,7 +1567,7 @@ BOOST_FIXTURE_TEST_CASE(CreateTransactionTest, CreateTransactionTestSetup)
 BOOST_FIXTURE_TEST_CASE(select_coins_grouped_by_addresses, ListCoinsTestingSetup)
 {
     // Check initial balance from one mature coinbase transaction.
-    BOOST_CHECK_EQUAL(GetAvailableBalance(*wallet), 500 * COIN);
+    BOOST_CHECK_EQUAL(WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).total_amount), 500 * COIN);
 
     {
         std::vector<CompactTallyItem> vecTally = wallet->SelectCoinsGroupedByAddresses(/*fSkipDenominated=*/false,
@@ -1590,7 +1590,7 @@ BOOST_FIXTURE_TEST_CASE(select_coins_grouped_by_addresses, ListCoinsTestingSetup
     BOOST_CHECK(ret2);
     const auto& txr2 = ret2->tx;
     wallet->CommitTransaction(txr1, {}, {});
-    BOOST_CHECK_EQUAL(GetAvailableBalance(*wallet), 0);
+    BOOST_CHECK_EQUAL(WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).total_amount), 0);
     CreateAndProcessBlock({CMutableTransaction(*txr2)}, GetScriptForRawPubKey({}));
     struct ChainInfo {
         const CBlockIndex* tip;
@@ -1627,7 +1627,7 @@ BOOST_FIXTURE_TEST_CASE(select_coins_grouped_by_addresses, ListCoinsTestingSetup
     BOOST_CHECK_EQUAL(vecTally.at(0).outpoints.size(), 1);
     BOOST_CHECK_EQUAL(vecTally.at(1).outpoints.size(), 1);
     BOOST_CHECK_EQUAL(vecTally.at(0).nAmount + vecTally.at(1).nAmount, (500 + 499) * COIN);
-    BOOST_CHECK_EQUAL(GetAvailableBalance(*wallet), (500 + 499) * COIN);
+    BOOST_CHECK_EQUAL(WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).total_amount), (500 + 499) * COIN);
 }
 
 

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -506,7 +506,7 @@ class PSBTTest(BitcoinTestFramework):
         ext_utxo = self.nodes[0].listunspent(addresses=[addr])[0]
 
         # An external input without solving data should result in an error
-        assert_raises_rpc_error(-4, "Insufficient funds", wallet.walletcreatefundedpsbt, [ext_utxo], {self.nodes[0].getnewaddress(): 15})
+        assert_raises_rpc_error(-4, "Not solvable pre-selected input COutPoint(%s, %s)" % (ext_utxo["txid"], ext_utxo["vout"]), wallet.walletcreatefundedpsbt, [ext_utxo], {self.nodes[0].getnewaddress(): 15})
 
         # But funding should work when the solving data is provided
         psbt = wallet.walletcreatefundedpsbt([ext_utxo], {self.nodes[0].getnewaddress(): 15}, 0, {"add_inputs": True, "solving_data": {"pubkeys": [addr_info['pubkey']], "scripts": [addr_info["embedded"]["scriptPubKey"]]}})

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -378,7 +378,9 @@ class RawTransactionsTest(BitcoinTestFramework):
 
     def test_invalid_input(self):
         self.log.info("Test fundrawtxn with an invalid vin")
-        inputs  = [ {'txid' : "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1", 'vout' : 0} ] #invalid vin!
+        txid = "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1"
+        vout = 0
+        inputs  = [ {'txid' : txid, 'vout' : vout} ] #invalid vin!
         outputs = { self.nodes[0].getnewaddress() : 10}
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         assert_raises_rpc_error(-4, "Unable to find UTXO for external input", self.nodes[2].fundrawtransaction, rawtx)
@@ -960,7 +962,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # An external input without solving data should result in an error
         raw_tx = wallet.createrawtransaction([ext_utxo], {self.nodes[0].getnewaddress(): ext_utxo["amount"] / 2})
-        assert_raises_rpc_error(-4, "Insufficient funds", wallet.fundrawtransaction, raw_tx)
+        assert_raises_rpc_error(-4, "Not solvable pre-selected input COutPoint(%s, %s)" % (ext_utxo["txid"], ext_utxo["vout"]), wallet.fundrawtransaction, raw_tx)
 
         # Error conditions
         assert_raises_rpc_error(-5, "'not a pubkey' is not hex", wallet.fundrawtransaction, raw_tx, {"solving_data": {"pubkeys":["not a pubkey"]}})
@@ -1043,6 +1045,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         #       Expect: only preset inputs are used.
         # 5. Explicit add_inputs=true, no preset inputs (same as (1) but with an explicit set):
         #       Expect: include inputs from the wallet.
+        # 6. Explicit add_inputs=false, no preset inputs:
+        #       Expect: failure as we did not provide inputs and the process cannot automatically select coins.
 
         # Case (1), 'send' command
         # 'add_inputs' value is true unless "inputs" are specified, in such case, add_inputs=false.
@@ -1094,6 +1098,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         tx = wallet.send(outputs=[{addr1: 8}], options=options)
         assert tx["complete"]
 
+        # 6. Explicit add_inputs=false, no preset inputs:
+        options = {"add_inputs": False}
+        assert_raises_rpc_error(-4, "Insufficient funds", wallet.send, outputs=[{addr1: 3}], options=options)
+
         ################################################
 
         # Case (1), 'walletcreatefundedpsbt' command
@@ -1134,6 +1142,10 @@ class RawTransactionsTest(BitcoinTestFramework):
             "add_inputs": True
         }
         assert "psbt" in wallet.walletcreatefundedpsbt(inputs=[], outputs=outputs, options=options)
+
+        # Case (6). Explicit add_inputs=false, no preset inputs:
+        options = {"add_inputs": False}
+        assert_raises_rpc_error(-4, "Insufficient funds", wallet.walletcreatefundedpsbt, inputs=[], outputs=outputs, options=options)
 
         self.nodes[2].unloadwallet("test_preset_inputs")
     def test_include_unsafe(self):

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -491,7 +491,7 @@ class WalletSendTest(BitcoinTestFramework):
         ext_utxo = ext_fund.listunspent(addresses=[addr])[0]
 
         # An external input without solving data should result in an error
-        self.test_send(from_wallet=ext_wallet, to_wallet=self.nodes[0], amount=15, inputs=[ext_utxo], add_inputs=True, psbt=True, include_watching=True, expect_error=(-4, "Insufficient funds"))
+        self.test_send(from_wallet=ext_wallet, to_wallet=self.nodes[0], amount=15, inputs=[ext_utxo], add_inputs=True, psbt=True, include_watching=True, expect_error=(-4, "Not solvable pre-selected input COutPoint(%s, %s)" % (ext_utxo["txid"], ext_utxo["vout"])))
 
         # But funding should work when the solving data is provided
         res = self.test_send(from_wallet=ext_wallet, to_wallet=self.nodes[0], amount=15, inputs=[ext_utxo], add_inputs=True, psbt=True, include_watching=True, solving_data={"pubkeys": [addr_info['pubkey']], "scripts": [addr_info["embedded"]["scriptPubKey"]]})


### PR DESCRIPTION
## Issue being fixed or feature implemented

Dash PR #7400 currently combines its target wallet changes with a longer Bitcoin Core prerequisite chain. This extracts the first independently mergeable prerequisite batch so the backports can be reviewed and landed in smaller units.

This branch was rebased onto `upstream/develop` at `e25f9925df4f0bafaf5f6d13ac34e14bdc8eecc9` (pre-rebase backup `refs/heads/backup/pr7479-pre-develop-rebase-a8c5f714`; pre-provenance-fix backup `refs/heads/backup/7479-pre-provenance-fixes-182745cf`). It contains four logical Bitcoin Core backports plus one Dash CompactSize adaptation, within the requested limit of at most five commits per prerequisite PR. It does not modify or replace #7400; that PR must remain unchanged until the prerequisite PRs merge.

## What was done?

Backported:

- bitcoin/bitcoin#25647 — return change from `SelectionResult`
- bitcoin/bitcoin#26203 — use the correct effective value when checking the selection target
- bitcoin/bitcoin#25685 — move preselected-input fetching out of coin selection and speed up selected-input-only transaction creation
- bitcoin/bitcoin#26699 (**partial**) — include manually selected coins in the GUI available balance after #25685, plus the applicable GUI/test follow-ups (see partial note below)

#26699 intentionally travels with #25685 because omitting it makes manual coin-control balance checks exclude the selected coins.

### Partial backport: bitcoin/bitcoin#26699

**Subject form:** `partial Merge bitcoin/bitcoin#26699` (Dash convention).

**Included (adapted to Dash):**

| Upstream commit | Summary |
|---|---|
| `dc1cc1c3599` | bugfix: `getAvailableBalance` includes selected coins after #25685 |
| `74eac3a82fc` | test: `useAvailableBalance` coverage |
| `2f76ac03839` / `306aab5bb47` | test helpers (SyncUpWallet / SetupLegacyWatchOnlyWallet; MiniGUI not ported wholesale — Dash constructors differ) |
| `68eed5df865` | presentPSBT `QMessageBox(this)`; ConfirmSend `StandardButton`; legacy watch-only PSBT GUI test |

**Intentionally omitted:**

| Upstream commit | Why |
|---|---|
| `cd98b717398` gui: `getAvailableBalance`, include watch-only balance | Upstream #26687 fixed `WalletModel::getAvailableBalance` so the **cached-balance path** from bitcoin-core/gui#598 adds `watch_only_balance` when private keys are disabled. **Dash never landed that `WalletModel::getAvailableBalance` API.** `prepareTransaction` and `useAvailableBalance` both call `wallet().getAvailableBalance(coin_control)` after `fAllowWatchOnly` is set for private-keys-disabled wallets; `AvailableCoins` already includes solvable watch-only outputs under that flag; `SendCoinsDialog::setBalance` already shows `watch_only_balance` for legacy private-keys-disabled wallets. Porting `cd98b717` would require introducing the model-level cache API only to re-express behavior Dash already has on the wallet-interface path — out of scope for this prerequisite batch. Still valid on current develop. |

**Watch-only PSBT test:**

An adapted `TestGUIWatchOnly` is included. It builds a private-keys-disabled legacy wallet via `ImportPubKeys`, asserts the send dialog displays `watch_only_balance`, drives **Create Unsigned** (`QMessageBox::Save`), and decodes the clipboard PSBT with `DecodeBase64PSBT`. Dash adaptations: `CWallet` requires the CoinJoin loader; no `PlatformStyle` constructors; no full MiniGUI port.

After rebase onto develop, `src/qt/test/wallettests.cpp` also retains develop’s CoinJoin autobackup-failure tooltip regression coverage (`nWalletBackups` 0/-1/-2) from #7479’s new base; both includes (`util/strencodings.h` + `util/system.h`) are kept.

### Dash-specific adaptations

- Preserve Dash's CoinJoin coin types and fully mixed no-change behavior.
- Preserve `FundSpecialTx` selected-input handling in `rpc/evo.cpp` (`m_allow_other_inputs = false`).
- **#25685 benchmark/test API adaptations (folded into the #25685 merge commit for bisectability):** account for Dash's CoinJoin-loader wallet constructor, mnemonic/passphrase descriptor setup, legacy-only destination helper, explicit block-hash `AddToBlockIndex` argument, `CoinsResult::legacy` layout, and `wallet::RANDOM_CHANGE_POSITION`. Upstream already used `kernel::MakeBlockInfo(pindex, &block)`; that line is unchanged.
- Preserve Dash's `CCoinControl::fRequireAllInputs=false` behavior with `TrimPreSelectedInputs`. Before this backport the subset was accumulated in `AvailableCoins`/wallet order; it is now accumulated from `PreSelectedInputs::coins`, a `std::set<COutput>` ordered by outpoint. The particular sufficient subset may therefore change, while the preserved invariant is that it still covers the target. The sole production caller using this mode is `FundSpecialTx`.
- Correct fee targeting when the final vin CompactSize prefix widens at 253 inputs, or when adding change widens the vout CompactSize prefix at 253 outputs. Regression coverage for 252/253-input transactions, exact no-change selection, and 252 recipients plus change.
- `#25685` still flips `CCoinControl::m_allow_other_inputs` default from develop’s `false` (bitcoin#25118) to `true` (upstream #25685). Field already existed on develop; default change is intentional and retained.

### Commit map (post develop rebase)

| Commit | Subject |
|---|---|
| `512571f3597` | Merge bitcoin/bitcoin#25647 |
| `b1a545f183d` | Merge bitcoin/bitcoin#26203 |
| `7ca4e430d2b` | Merge bitcoin/bitcoin#25685 (+ folded Dash benchmark/input-selection adaptations) |
| `2ffd8e52194` | **partial** Merge bitcoin/bitcoin#26699 |
| `66d72b4aa17` | Dash adaptations for bitcoin#25647 (CompactSize fee accounting) |

Old→new (pre-rebase review-rewrite head → current post-rebase/review-reconciliation head):

- `56439297b8f` → `512571f3597`
- `db880c91dd3` → `b1a545f183d`
- `126566523f8` → `7ca4e430d2b`
- `d0b79b12c0f` → `2ffd8e52194`
- `a8c5f714bab` → `66d72b4aa17`

Later sequencing, after this PR merges:

1. Open a second prerequisite PR with bitcoin/bitcoin#26021, #26532, #26560, #26661, and #25806, including the associated Dash cursor-close and test-utility adaptations.
2. After both prerequisite PRs merge, rebase #7400 and retain its reduced target stack: bitcoin/bitcoin#25796, #26715, #27665, and #27666.

No later prerequisite PR has been opened yet.

## How Has This Been Tested?

Tested on macOS arm64 using the repository's autotools build configured against the existing Dash depends prefix.

Build targets at final head `66d72b4aa17`:

- `test/test_dash`
- `bench/bench_dash`
- `qt/test/test_dash-qt`

**Commit-level buildability:**

- At rewritten #25685 (`7ca4e430d2b`), `make -C src bench/bench_dash test/test_dash` succeeded. The benchmark's `kernel::MakeBlockInfo` call matches upstream; the folded changes are the documented Dash API and selected-input adaptations.

Unit and benchmark coverage at final head (rerun after review reconciliation):

- `./src/test/test_dash --run_test=coinselector_tests,spend_tests,wallet_tests` — 34 test cases, no errors
- `./src/bench/bench_dash -filter='WalletCreateTx.*'` — both `WalletCreateTxUseOnlyPresetInputs` and `WalletCreateTxUsePresetInputsAndCoinSelection` ran successfully

Qt:

- `./src/qt/test/test_dash-qt -platform minimal` — all suites passed; on macOS `minimal`, `WalletTests` / `AddressBookTests` / `AppTests` bodies skip due to known Qt cocoa/`minimal` limitations (pre-existing). The new `TestGUIWatchOnly` is under that same guard and is intended to run on Linux CI / non-minimal platforms.

Additional checks:

- `git diff --check` clean on `e25f9925df4..HEAD`
- All five commits have valid GPG signatures (`git verify-commit` Good signature from thepastaclaw)
- `git merge-tree --write-tree --name-only HEAD upstream/develop` clean after rebase
- Rebase conflict resolution in `src/qt/test/wallettests.cpp` keeps develop CoinJoin tooltip coverage and the adapted watch-only Create Unsigned/clipboard PSBT path

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation (not applicable)
- [ ] I have assigned this pull request to a milestone

