### PR TITLE
fix: conflict ProRegTx collateral reuse with in-mempool masternode updates

### DIFF
--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -1513,6 +1513,14 @@ void FuncTestMempoolProRegReplacementUpdateConflict(TestChainSetup& setup)
         testPool.addUnchecked(entry.FromTx(tx_up_serv));
         BOOST_CHECK_EQUAL(testPool.size(), 1U);
         BOOST_CHECK(testPool.existsProviderTxConflict(CTransaction(tx_reg_replace)));
+
+        // existsProviderTxConflict only gates our own acceptance; it cannot stop a miner from
+        // confirming the replacement. Once that block arrives, removeForBlock must evict the
+        // now-unmineable update, otherwise it lingers and stalls our own block assembly.
+        std::vector<CTransactionRef> connected{MakeTransactionRef(CMutableTransaction()),
+                                               MakeTransactionRef(tx_reg_replace)};
+        testPool.removeForBlock(connected, tip_height() + 1);
+        BOOST_CHECK_EQUAL(testPool.size(), 0U);
     }
 }
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -1418,6 +1418,104 @@ void FuncTestMempoolDualProregtx(TestChainSetup& setup)
     BOOST_CHECK(testPool.existsProviderTxConflict(CTransaction(tx_reg2)));
 }
 
+// A ProRegTx that reuses a confirmed external collateral replaces the live MN at block
+// connect time. An update (ProUpServ/ProUpReg/ProUpRev) for the replaced proTxHash is still
+// mempool-valid against the pre-block tip list, so fee-ordered packaging can put the replacement
+// ProRegTx before the update and make BuildNewListFromBlock return bad-protx-hash, aborting
+// CreateNewBlock/getblocktemplate. The mempool must treat them as conflicts.
+void FuncTestMempoolProRegReplacementUpdateConflict(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto tip_height = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Height()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    int nHeight = tip_height();
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+
+    CKey ownerKey;
+    CKey payoutKey;
+    CKey collateralKey;
+    CBLSSecretKey operatorKey;
+    ownerKey.MakeNewKey(true);
+    payoutKey.MakeNewKey(true);
+    collateralKey.MakeNewKey(true);
+    operatorKey.MakeNewKey();
+
+    auto scriptPayout = GetScriptForDestination(PKHash(payoutKey.GetPubKey()));
+    auto scriptCollateral = GetScriptForDestination(PKHash(collateralKey.GetPubKey()));
+
+    // Fund and mine an external collateral, then register MN X against it.
+    auto tx_collateral = CreateSpendTx(chainman, utxos, scriptCollateral, dmn_types::Regular.collat_amount, setup.coinbaseKey);
+    auto block = std::make_shared<CBlock>(setup.CreateBlock({tx_collateral}, coinbase_pk, chainman.ActiveChainstate()));
+    BOOST_REQUIRE(chainman.ProcessNewBlock(block, true, nullptr));
+    sync_dmn_tip();
+    BOOST_CHECK_EQUAL(tip_height(), nHeight + 1);
+
+    const auto collateralOutpoint = GetCollateralOutpoint(tx_collateral);
+    auto tx_reg = CreateProRegTxExternalCollateral(chainman, utxos, /*port=*/1, collateralOutpoint, scriptPayout,
+                                                    ownerKey, operatorKey, collateralKey, setup.coinbaseKey);
+    const uint256 proTxHash = tx_reg.GetHash();
+    block = std::make_shared<CBlock>(setup.CreateBlock({tx_reg}, coinbase_pk, chainman.ActiveChainstate()));
+    BOOST_REQUIRE(chainman.ProcessNewBlock(block, true, nullptr));
+    sync_dmn_tip();
+    BOOST_CHECK_EQUAL(tip_height(), nHeight + 2);
+    BOOST_REQUIRE(dmnman.GetListAtChainTip().HasMN(proTxHash));
+    BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMNByCollateral(collateralOutpoint) != nullptr);
+    BOOST_CHECK_EQUAL(dmnman.GetListAtChainTip().GetMNByCollateral(collateralOutpoint)->proTxHash.ToString(),
+                      proTxHash.ToString());
+
+    // Replacement ProRegTx reusing the same external collateral with fresh keys/address.
+    CKey ownerKey2;
+    CKey payoutKey2;
+    CBLSSecretKey operatorKey2;
+    ownerKey2.MakeNewKey(true);
+    payoutKey2.MakeNewKey(true);
+    operatorKey2.MakeNewKey();
+    auto scriptPayout2 = GetScriptForDestination(PKHash(payoutKey2.GetPubKey()));
+    auto tx_reg_replace = CreateProRegTxExternalCollateral(chainman, utxos, /*port=*/3, collateralOutpoint, scriptPayout2,
+                                                            ownerKey2, operatorKey2, collateralKey, setup.coinbaseKey);
+
+    // Same-block-style update for the MN that the replacement would delete.
+    auto tx_up_serv = CreateProUpServTx(chainman, utxos, proTxHash, operatorKey, /*port=*/2, CScript(), setup.coinbaseKey);
+
+    // Prove the in-block hazard itself: replacement first, then update of the deleted proTxHash.
+    {
+        LOCK(cs_main);
+        CBlock hazard_block;
+        hazard_block.vtx.emplace_back(MakeTransactionRef(CMutableTransaction())); // dummy coinbase slot
+        hazard_block.vtx.emplace_back(MakeTransactionRef(tx_reg_replace));
+        hazard_block.vtx.emplace_back(MakeTransactionRef(tx_up_serv));
+
+        BlockValidationState state;
+        CDeterministicMNList mn_list;
+        BOOST_CHECK(!chainman.ActiveChainstate().ChainHelper().special_tx->BuildNewListFromBlock(
+            hazard_block, tip_index(), chainman.ActiveChainstate().CoinsTip(), /*debugLogs=*/false, state, mn_list));
+        BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-hash");
+    }
+
+    // Mempool acceptance must refuse the second of these once one is present.
+    CTxMemPool testPool{MemPoolOptionsForTest(setup.m_node)};
+    TestMemPoolEntryHelper entry;
+
+    {
+        LOCK2(cs_main, testPool.cs);
+        // Replacement already in mempool => update for the MN it replaces is a conflict.
+        testPool.addUnchecked(entry.FromTx(tx_reg_replace));
+        BOOST_CHECK_EQUAL(testPool.size(), 1U);
+        BOOST_CHECK(testPool.existsProviderTxConflict(CTransaction(tx_up_serv)));
+        testPool.removeRecursive(CTransaction(tx_reg_replace), MemPoolRemovalReason::MANUAL);
+        BOOST_CHECK_EQUAL(testPool.size(), 0U);
+
+        // Update already in mempool => replacement ProRegTx reusing that MN's collateral conflicts.
+        testPool.addUnchecked(entry.FromTx(tx_up_serv));
+        BOOST_CHECK_EQUAL(testPool.size(), 1U);
+        BOOST_CHECK(testPool.existsProviderTxConflict(CTransaction(tx_reg_replace)));
+    }
+}
+
 void FuncVerifyDB(TestChainSetup& setup)
 {
     auto& chainman = *Assert(setup.m_node.chainman.get());
@@ -3142,6 +3240,12 @@ BOOST_AUTO_TEST_CASE(test_mempool_dual_proregtx_basic)
 {
     TestChainV19Setup setup;
     FuncTestMempoolDualProregtx(setup);
+}
+
+BOOST_AUTO_TEST_CASE(test_mempool_proreg_replacement_update_conflict)
+{
+    TestChainV19Setup setup;
+    FuncTestMempoolProRegReplacementUpdateConflict(setup);
 }
 
 //This one can be started only with legacy scheme, since inside undo block will switch it back to legacy resulting into an inconsistency

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1027,6 +1027,24 @@ void CTxMemPool::removeProTxConflicts(const CTransaction &tx)
         }
         if (!proTx.collateralOutpoint.hash.IsNull()) {
             removeProTxCollateralConflicts(tx, proTx.collateralOutpoint);
+            // Replacement of a live MN via external-collateral reuse: drop any
+            // mempool updates that still target the proTxHash being replaced.
+            // removeProTxSpentCollateralConflicts only covers spends, not reuse.
+            if (auto dmn = m_dmnman.GetListAtChainTip().GetMNByCollateral(proTx.collateralOutpoint)) {
+                // Can't use equal_range + erase loop: removeRecursive may invalidate iterators.
+                while (true) {
+                    auto it = mapProTxRefs.find(dmn->proTxHash);
+                    if (it == mapProTxRefs.end()) {
+                        break;
+                    }
+                    auto conflictIt = mapTx.find(it->second);
+                    if (conflictIt != mapTx.end()) {
+                        removeRecursive(conflictIt->GetTx(), MemPoolRemovalReason::CONFLICT);
+                    } else {
+                        mapProTxRefs.erase(it);
+                    }
+                }
+            }
         } else {
             removeProTxCollateralConflicts(tx, COutPoint(tx_hash, proTx.collateralOutpoint.n));
         }
@@ -1450,6 +1468,14 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
                 // there is another tx that spends the collateral
                 return true;
             }
+            // A replacement ProRegTx deletes the live MN backed by this collateral. Any
+            // in-mempool update that still targets that MN's proTxHash would then fail
+            // BuildNewListFromBlock with bad-protx-hash if both were mined in one block.
+            if (auto dmn = m_dmnman.GetListAtChainTip().GetMNByCollateral(proTx.collateralOutpoint)) {
+                if (mapProTxRefs.find(dmn->proTxHash) != mapProTxRefs.end()) {
+                    return true;
+                }
+            }
         }
         return false;
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
@@ -1470,6 +1496,12 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
                 return true;
             }
         }
+        // Conflict with a replacement ProRegTx that reuses this MN's external collateral.
+        if (auto dmn = m_dmnman.GetListAtChainTip().GetMN(opt_proTx->proTxHash)) {
+            if (mapProTxCollaterals.count(dmn->collateralOutpoint)) {
+                return true;
+            }
+        }
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_REGISTRAR) {
         const auto opt_proTx = GetTxPayload<CProUpRegTx>(tx);
         if (!opt_proTx) {
@@ -1483,6 +1515,10 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         if (!dmn) {
             LogPrint(BCLog::MEMPOOL, "%s: ERROR: Masternode is not in the list, proTxHash: %s\n", __func__, proTx.proTxHash.ToString());
             return true; // i.e. failed to find validated ProTx == conflict
+        }
+        // Conflict with a replacement ProRegTx that reuses this MN's external collateral.
+        if (mapProTxCollaterals.count(dmn->collateralOutpoint)) {
+            return true;
         }
         // only allow one operator key change in the mempool
         if (dmn->pdmnState->pubKeyOperator != proTx.pubKeyOperator) {
@@ -1505,6 +1541,10 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         if (!dmn) {
             LogPrint(BCLog::MEMPOOL, "%s: ERROR: Masternode is not in the list, proTxHash: %s\n", __func__, proTx.proTxHash.ToString());
             return true; // i.e. failed to find validated ProTx == conflict
+        }
+        // Conflict with a replacement ProRegTx that reuses this MN's external collateral.
+        if (mapProTxCollaterals.count(dmn->collateralOutpoint)) {
+            return true;
         }
         // only allow one operator key change in the mempool
         if (dmn->pdmnState->pubKeyOperator.Get() != CBLSPublicKey()) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -937,39 +937,41 @@ void CTxMemPool::removeProTxCollateralConflicts(const CTransaction &tx, const CO
     }
 }
 
+void CTxMemPool::removeProTxReferences(const uint256& proTxHash)
+{
+    // Can't use equal_range here as every call to removeRecursive might invalidate iterators
+    AssertLockHeld(cs);
+    while (true) {
+        auto it = mapProTxRefs.find(proTxHash);
+        if (it == mapProTxRefs.end()) {
+            break;
+        }
+        auto conflictIt = mapTx.find(it->second);
+        if (conflictIt != mapTx.end()) {
+            removeRecursive(conflictIt->GetTx(), MemPoolRemovalReason::CONFLICT);
+        } else {
+            // Should not happen as we track referencing TXs in addUnchecked/removeUnchecked.
+            // But lets be on the safe side and not run into an endless loop...
+            LogPrint(BCLog::MEMPOOL, "%s: ERROR: found invalid TX ref in mapProTxRefs, proTxHash=%s, txHash=%s\n", __func__, proTxHash.ToString(), it->second.ToString());
+            mapProTxRefs.erase(it);
+        }
+    }
+}
+
 void CTxMemPool::removeProTxSpentCollateralConflicts(const CTransaction &tx)
 {
     // Remove TXs that refer to a MN for which the collateral was spent
-    auto removeSpentCollateralConflict = [&](const uint256& proTxHash) EXCLUSIVE_LOCKS_REQUIRED(cs) {
-        // Can't use equal_range here as every call to removeRecursive might invalidate iterators
-        AssertLockHeld(cs);
-        while (true) {
-            auto it = mapProTxRefs.find(proTxHash);
-            if (it == mapProTxRefs.end()) {
-                break;
-            }
-            auto conflictIt = mapTx.find(it->second);
-            if (conflictIt != mapTx.end()) {
-                removeRecursive(conflictIt->GetTx(), MemPoolRemovalReason::CONFLICT);
-            } else {
-                // Should not happen as we track referencing TXs in addUnchecked/removeUnchecked.
-                // But lets be on the safe side and not run into an endless loop...
-                LogPrint(BCLog::MEMPOOL, "%s: ERROR: found invalid TX ref in mapProTxRefs, proTxHash=%s, txHash=%s\n", __func__, proTxHash.ToString(), it->second.ToString());
-                mapProTxRefs.erase(it);
-            }
-        }
-    };
     auto mnList = m_dmnman.GetListAtChainTip();
     for (const auto& in : tx.vin) {
         auto collateralIt = mapProTxCollaterals.find(in.prevout);
         if (collateralIt != mapProTxCollaterals.end()) {
             // These are not yet mined ProRegTxs
-            removeSpentCollateralConflict(collateralIt->second);
+            removeProTxReferences(collateralIt->second);
         }
         auto dmn = mnList.GetMNByCollateral(in.prevout);
         if (dmn) {
             // These are updates referring to a mined ProRegTx
-            removeSpentCollateralConflict(dmn->proTxHash);
+            removeProTxReferences(dmn->proTxHash);
         }
     }
 }
@@ -1027,23 +1029,12 @@ void CTxMemPool::removeProTxConflicts(const CTransaction &tx)
         }
         if (!proTx.collateralOutpoint.hash.IsNull()) {
             removeProTxCollateralConflicts(tx, proTx.collateralOutpoint);
-            // Replacement of a live MN via external-collateral reuse: drop any
-            // mempool updates that still target the proTxHash being replaced.
-            // removeProTxSpentCollateralConflicts only covers spends, not reuse.
+            // A ProRegTx reusing an external collateral replaces the MN that collateral
+            // currently backs, so that MN ceases to exist. Drop any mempool update that
+            // still targets its proTxHash; such an update can never be mined afterwards.
+            // removeProTxSpentCollateralConflicts only covers collateral *spends*, not reuse.
             if (auto dmn = m_dmnman.GetListAtChainTip().GetMNByCollateral(proTx.collateralOutpoint)) {
-                // Can't use equal_range + erase loop: removeRecursive may invalidate iterators.
-                while (true) {
-                    auto it = mapProTxRefs.find(dmn->proTxHash);
-                    if (it == mapProTxRefs.end()) {
-                        break;
-                    }
-                    auto conflictIt = mapTx.find(it->second);
-                    if (conflictIt != mapTx.end()) {
-                        removeRecursive(conflictIt->GetTx(), MemPoolRemovalReason::CONFLICT);
-                    } else {
-                        mapProTxRefs.erase(it);
-                    }
-                }
+                removeProTxReferences(dmn->proTxHash);
             }
         } else {
             removeProTxCollateralConflicts(tx, COutPoint(tx_hash, proTx.collateralOutpoint.n));

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -650,6 +650,10 @@ public:
     void removeProTxPubKeyConflicts(const CTransaction &tx, const CBLSLazyPublicKey &pubKey) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeProTxPlatformNodeIDConflicts(const CTransaction &tx, const uint160 &platformNodeID) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeProTxCollateralConflicts(const CTransaction &tx, const COutPoint &collateralOutpoint) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    /** Remove every mempool TX that refers to proTxHash. Used when the MN it names ceases to exist
+     *  (collateral spent, or collateral reused by a replacement ProRegTx), since such TXs can never
+     *  be mined afterwards and would abort block assembly with "bad-protx-hash". */
+    void removeProTxReferences(const uint256& proTxHash) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeProTxSpentCollateralConflicts(const CTransaction &tx) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeProTxKeyChangedConflicts(const CTransaction &tx, const uint256& proTxHash, const uint256& newKeyHash) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeProTxConflicts(const CTransaction &tx) EXCLUSIVE_LOCKS_REQUIRED(cs);


### PR DESCRIPTION
## Issue being fixed or feature implemented

A ProRegTx that reuses an external collateral *replaces* the masternode that collateral
currently backs — the old masternode ceases to exist and its `proTxHash` becomes unknown.

The mempool does not model that. It tracks collateral *spends*
(`removeProTxSpentCollateralConflicts`), but reuse is not a spend, so:

- A replacement ProRegTx and an update (ProUpServTx / ProUpRegTx / ProUpRevTx) targeting the
  masternode being replaced can sit in the mempool at the same time.
- If both are selected into one block, `BuildNewListFromBlock()` deletes the masternode when
  it applies the ProRegTx, then fails `bad-protx-hash` on the update.
- That aborts block assembly in the miner.

The same hazard exists when the replacement ProRegTx arrives in a block rather than through
the mempool: the stale update is left behind and can never be mined.

## What was done?

Three commits.

**1. Mempool admission (`existsProviderTxConflict`)** — the two directions are now
symmetric:

- A ProRegTx reusing an external collateral conflicts if any mempool transaction still
  references the incumbent masternode's `proTxHash`.
- A ProUpServTx / ProUpRegTx / ProUpRevTx conflicts if a pending ProRegTx already claims its
  masternode's collateral outpoint.

This is first-in-wins with no RBF-style tiebreak. That is a deliberate policy choice: both
transactions are individually valid, and the only requirement is that they not coexist.
Preferring the incumbent would mean evicting an already-accepted transaction on arrival of a
new one, which is a bigger policy change than this problem warrants.

**2. Eviction on block connect (`removeProTxConflicts`)** — when a collateral-reusing
ProRegTx is mined, any mempool transaction still targeting the replaced masternode is
removed. This covers the case where the ProRegTx never passed through this node's mempool,
so the admission check above never ran.

**3. Refactor** — the removal loop inside `removeProTxSpentCollateralConflicts` is extracted
as `CTxMemPool::removeProTxReferences()` and reused by both call sites. No behaviour change;
it just avoids a second copy of the iterator-invalidation-safe loop.

### One thing reviewers should look at

The eviction in (2) calls `dmnman->GetListAtChainTip()` and needs it to resolve to the list
at the *previous* tip, so `GetMNByCollateral()` returns the masternode being replaced rather
than its replacement. That holds because `CDeterministicMNManager::tipIndex` is assigned in
`UpdatedBlockTip()`, which fires from `ActivateBestChain()` (`validation.cpp:3339-3340`) —
after `ConnectTip()` calls `removeForBlock()` (`validation.cpp:3025`).

`removeProTxSpentCollateralConflicts()` already depends on this ordering, so the new code is
consistent with the file. The difference is that there it is an optimisation, whereas here it
is load-bearing: if the ordering changed, `GetMNByCollateral()` would return the replacement
masternode and the eviction would silently become a no-op. I have noted the dependency in a
comment, but flagging it explicitly since it is the least obvious part of the change.

## How Has This Been Tested?

`test_mempool_proreg_replacement_update_conflict` in
`src/test/evo_deterministicmns_tests.cpp`, added in the commit *preceding* the fix. It
covers both paths:

- admission, via `existsProviderTxConflict()` in both directions;
- eviction, via `removeForBlock()` with a block containing the replacement ProRegTx.

Without the fix the admission assertions fail (2 failures) — the conflicting pair is
accepted. With the fix, `evo_dip3_activation_tests` passes (19 cases).

Built and run on macOS/arm64 against current `develop`.

## Breaking Changes

Mempool policy only; no consensus rules change. Some transaction pairs that were previously
accepted together are now mutually exclusive in the mempool. Neither could have been mined
together, so nothing that was previously minable is rejected.

## Known follow-up

Coverage is C++ unit level only. A functional test exercising the miner path end to end
would strengthen this; happy to add one in this PR if reviewers would prefer it before merge.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
