### PR TITLE
refactor: route per-LLMQ-type caches through PerLlmqTypeCache

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -295,6 +295,7 @@ BITCOIN_CORE_H = \
   key_io.h \
   limitedmap.h \
   llmq/blockprocessor.h \
+  llmq/cache.h \
   llmq/commitment.h \
   llmq/context.h \
   llmq/debug.h \

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -83,7 +83,7 @@ CQuorumBlockProcessor::CQuorumBlockProcessor(ChainstateManager& chainman, CDeter
     m_evoDb{evoDb},
     m_qsnapman{qsnapman}
 {
-    utils::InitQuorumsCache(mapMinedCommitmentBlockCache, m_chainman.GetConsensus());
+    mapMinedCommitmentBlockCache.Init(m_chainman.GetConsensus());
     LogPrintf("BLS verification uses %d additional threads\n", bls_threads);
     m_bls_queue.StartWorkerThreads(bls_threads);
 }
@@ -427,7 +427,7 @@ bool CQuorumBlockProcessor::ProcessCommitment(Chainstate& chainstate, int nHeigh
 
     {
         LOCK(minableCommitmentsCs);
-        mapMinedCommitmentBlockCache[qc.llmqType].erase(qc.quorumHash);
+        mapMinedCommitmentBlockCache.erase(qc.llmqType, qc.quorumHash);
         minableCommitmentsByQuorum.erase(cacheKey);
         minableCommitments.erase(::SerializeHash(qc));
     }
@@ -444,11 +444,7 @@ void CQuorumBlockProcessor::DropQcHashesCache()
     m_quorums_cached.clear();
     m_qc_hashes_cached.clear();
     m_qc_indexed_hashes_cached.clear();
-    // Clear per-type LRU contents but keep the map entries so InitQuorumsCache is not
-    // required on every subsequent miss.
-    for (auto& [_, cache] : m_qc_hashes_lru) {
-        cache.clear();
-    }
+    m_qc_hashes_lru.clear();
 }
 
 std::optional<std::pair<QcHashMap, QcIndexedHashMap>> CQuorumBlockProcessor::GetQcHashes(const CBlockIndex* pindexPrev) const
@@ -464,8 +460,8 @@ std::optional<std::pair<QcHashMap, QcIndexedHashMap>> CQuorumBlockProcessor::Get
     m_quorums_cached.clear();
     m_qc_hashes_cached.clear();
     m_qc_indexed_hashes_cached.clear();
-    if (m_qc_hashes_lru.empty()) {
-        utils::InitQuorumsCache(m_qc_hashes_lru, Params().GetConsensus());
+    if (!m_qc_hashes_lru.IsInitialized()) {
+        m_qc_hashes_lru.Init(Params().GetConsensus());
     }
 
     for (const auto& [llmqType, vecBlockIndexes] : quorums) {
@@ -479,7 +475,7 @@ std::optional<std::pair<QcHashMap, QcIndexedHashMap>> CQuorumBlockProcessor::Get
             uint256 block_hash{blockIndex->GetBlockHash()};
 
             std::pair<uint256, int> qc_hash;
-            if (!m_qc_hashes_lru[llmqType].get(block_hash, qc_hash)) {
+            if (!m_qc_hashes_lru.get(llmqType, block_hash, qc_hash)) {
                 auto [pqc, dummy_hash] = GetMinedCommitment(llmqType, block_hash);
                 if (dummy_hash == uint256::ZERO) {
                     // this should never happen
@@ -487,7 +483,7 @@ std::optional<std::pair<QcHashMap, QcIndexedHashMap>> CQuorumBlockProcessor::Get
                 }
                 qc_hash.first = ::SerializeHash(pqc);
                 qc_hash.second = rotation_enabled ? pqc.quorumIndex : 0;
-                m_qc_hashes_lru[llmqType].insert(block_hash, qc_hash);
+                m_qc_hashes_lru.insert(llmqType, block_hash, qc_hash);
             }
             if (rotation_enabled) {
                 map_indexed_hashes[qc_hash.second] = qc_hash.first;
@@ -534,7 +530,7 @@ bool CQuorumBlockProcessor::UndoBlock(const Chainstate& chainstate, const CBlock
         // Only once this commitment's state change is complete; see ProcessCommitment.
         DropQcHashesCache();
 
-        WITH_LOCK(minableCommitmentsCs, mapMinedCommitmentBlockCache[qc.llmqType].erase(qc.quorumHash));
+        WITH_LOCK(minableCommitmentsCs, mapMinedCommitmentBlockCache.erase(qc.llmqType, qc.quorumHash));
 
         // if a reorg happened, we should allow to mine this commitment later
         AddMineableCommitment(qc);
@@ -639,16 +635,8 @@ bool CQuorumBlockProcessor::HasMinedCommitment(Consensus::LLMQType llmqType, con
     uint256 mined_block_hash;
     bool cached;
     {
-        // Defence-in-depth: this map is only pre-seeded by InitQuorumsCache() with the LLMQ types
-        // from the chain's consensus params. operator[] with any other type would insert a
-        // default-constructed, zero-capacity cache and abort in its constructor, so treat an
-        // unregistered type as "no mined commitment" rather than indexing the map.
         LOCK(minableCommitmentsCs);
-        auto it = mapMinedCommitmentBlockCache.find(llmqType);
-        if (it == mapMinedCommitmentBlockCache.end()) {
-            return false;
-        }
-        cached = it->second.get(quorumHash, mined_block_hash);
+        cached = mapMinedCommitmentBlockCache.get(llmqType, quorumHash, mined_block_hash);
     }
     if (!cached) {
         mined_block_hash = GetMinedCommitment(llmqType, quorumHash).second;
@@ -656,11 +644,7 @@ bool CQuorumBlockProcessor::HasMinedCommitment(Consensus::LLMQType llmqType, con
         // outside ProcessCommitment's normal cache-invalidation path.
         if (!mined_block_hash.IsNull()) {
             LOCK(minableCommitmentsCs);
-            // The key set is fixed at construction, so this can only miss if the type was
-            // unregistered, which the check above already returned on.
-            if (auto it = mapMinedCommitmentBlockCache.find(llmqType); it != mapMinedCommitmentBlockCache.end()) {
-                it->second.insert(quorumHash, mined_block_hash);
-            }
+            mapMinedCommitmentBlockCache.insert(llmqType, quorumHash, mined_block_hash);
         }
     }
 

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -6,10 +6,10 @@
 #define BITCOIN_LLMQ_BLOCKPROCESSOR_H
 
 #include <bls/bls.h>
+#include <llmq/cache.h>
 #include <llmq/params.h>
 #include <llmq/utils.h>
 #include <msg_result.h>
-#include <unordered_lru_cache.h>
 
 #include <checkqueue.h>
 #include <protocol.h>
@@ -67,7 +67,7 @@ private:
 
     // Cache the block in which a commitment was mined. Membership in a
     // particular chain is checked on every call so reorgs need no cache flush.
-    mutable std::map<Consensus::LLMQType, Uint256LruHashMap<uint256>> mapMinedCommitmentBlockCache GUARDED_BY(minableCommitmentsCs);
+    mutable PerLlmqTypeCache<uint256> mapMinedCommitmentBlockCache GUARDED_BY(minableCommitmentsCs);
 
     // Memoizes GetQcHashes(). The whole-result cache is keyed on the set of active
     // quorum base blocks, the LRU on those base-block hashes; neither key identifies
@@ -77,7 +77,7 @@ private:
     // block index whose CBlockIndex* the outer cache stores.
     mutable Mutex m_qc_hashes_cache_mutex;
     mutable std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> m_quorums_cached GUARDED_BY(m_qc_hashes_cache_mutex);
-    mutable std::map<Consensus::LLMQType, Uint256LruHashMap<std::pair<uint256, int>>> m_qc_hashes_lru GUARDED_BY(m_qc_hashes_cache_mutex);
+    mutable PerLlmqTypeCache<std::pair<uint256, int>> m_qc_hashes_lru GUARDED_BY(m_qc_hashes_cache_mutex);
     mutable QcHashMap m_qc_hashes_cached GUARDED_BY(m_qc_hashes_cache_mutex);
     mutable QcIndexedHashMap m_qc_indexed_hashes_cached GUARDED_BY(m_qc_hashes_cache_mutex);
 

--- a/src/llmq/cache.h
+++ b/src/llmq/cache.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_LLMQ_CACHE_H
+#define BITCOIN_LLMQ_CACHE_H
+
+#include <consensus/params.h>
+#include <llmq/params.h>
+#include <saltedhasher.h>
+#include <uint256.h>
+#include <unordered_lru_cache.h>
+
+#include <map>
+#include <utility>
+
+namespace llmq {
+
+//! A separate LRU cache per LLMQ type, sized from that type's consensus parameters.
+//!
+//! Only the types registered for the active chain get a cache. Consensus::LLMQType is a
+//! uint8_t enum that arrives over the wire, so callers may pass a type this chain does not
+//! use: those lookups miss and those writes are dropped, which is the same answer a cache
+//! that has never held such an entry would give.
+template <typename Value, typename Key = uint256>
+class PerLlmqTypeCache
+{
+private:
+    using CacheType = unordered_lru_cache<Key, Value, StaticSaltedHasher>;
+
+    std::map<Consensus::LLMQType, CacheType> m_caches;
+
+public:
+    //! Creates a cache per registered type, sized by size_fn. Must be called before use;
+    //! until then every type reads as absent.
+    template <typename SizeFn>
+    void Init(const Consensus::Params& consensus_params, SizeFn size_fn)
+    {
+        for (const auto& llmq : consensus_params.llmqs) {
+            m_caches.emplace(std::piecewise_construct, std::forward_as_tuple(llmq.type),
+                             std::forward_as_tuple(size_fn(llmq)));
+        }
+    }
+
+    void Init(const Consensus::Params& consensus_params, bool limit_by_connections = true)
+    {
+        Init(consensus_params, [limit_by_connections](const Consensus::LLMQParams& llmq) {
+            return limit_by_connections ? llmq.keepOldConnections : llmq.keepOldKeys;
+        });
+    }
+
+    bool IsInitialized() const { return !m_caches.empty(); }
+
+    bool get(Consensus::LLMQType llmqType, const Key& key, Value& value)
+    {
+        auto it = m_caches.find(llmqType);
+        return it != m_caches.end() && it->second.get(key, value);
+    }
+
+    void insert(Consensus::LLMQType llmqType, const Key& key, const Value& value)
+    {
+        if (auto it = m_caches.find(llmqType); it != m_caches.end()) {
+            it->second.insert(key, value);
+        }
+    }
+
+    void emplace(Consensus::LLMQType llmqType, const Key& key, Value&& value)
+    {
+        if (auto it = m_caches.find(llmqType); it != m_caches.end()) {
+            it->second.emplace(key, std::move(value));
+        }
+    }
+
+    void erase(Consensus::LLMQType llmqType, const Key& key)
+    {
+        if (auto it = m_caches.find(llmqType); it != m_caches.end()) {
+            it->second.erase(key);
+        }
+    }
+
+    //! Drops cached entries but keeps the per-type caches, so Init is not needed again.
+    void clear()
+    {
+        for (auto& [_, cache] : m_caches) {
+            cache.clear();
+        }
+    }
+
+    void clear(Consensus::LLMQType llmqType)
+    {
+        if (auto it = m_caches.find(llmqType); it != m_caches.end()) {
+            it->second.clear();
+        }
+    }
+
+    //! Capacity of a type's cache, or 0 if this chain does not use it.
+    size_t max_size(Consensus::LLMQType llmqType) const
+    {
+        auto it = m_caches.find(llmqType);
+        return it != m_caches.end() ? it->second.max_size() : 0;
+    }
+};
+
+} // namespace llmq
+
+#endif // BITCOIN_LLMQ_CACHE_H

--- a/src/llmq/net_dkg.cpp
+++ b/src/llmq/net_dkg.cpp
@@ -420,10 +420,10 @@ void NetDKG::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStre
     int quorumIndex{-1};
     {
         LOCK(cs_indexed_quorums_cache);
-        if (indexed_quorums_cache.empty()) {
-            utils::InitQuorumsCache(indexed_quorums_cache, m_chainman.GetConsensus());
+        if (!indexed_quorums_cache.IsInitialized()) {
+            indexed_quorums_cache.Init(m_chainman.GetConsensus());
         }
-        indexed_quorums_cache[llmqType].get(quorumHash, quorumIndex);
+        indexed_quorums_cache.get(llmqType, quorumHash, quorumIndex);
     }
 
     if (quorumIndex == -1) {
@@ -532,7 +532,7 @@ void NetDKG::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStre
         return;
     }
 
-    WITH_LOCK(cs_indexed_quorums_cache, indexed_quorums_cache[llmqType].insert(quorumHash, quorumIndex));
+    WITH_LOCK(cs_indexed_quorums_cache, indexed_quorums_cache.insert(llmqType, quorumHash, quorumIndex));
 }
 
 bool NetDKG::AlreadyHave(const CInv& inv)

--- a/src/llmq/net_dkg.h
+++ b/src/llmq/net_dkg.h
@@ -6,10 +6,10 @@
 #define BITCOIN_LLMQ_NET_DKG_H
 
 #include <consensus/params.h>
+#include <llmq/cache.h>
 #include <net_processing.h>
 #include <sync.h>
 #include <uint256.h>
-#include <unordered_lru_cache.h>
 
 #include <map>
 #include <memory>
@@ -100,7 +100,7 @@ private:
 
     /** Cache: quorum hash → quorum index, populated lazily by ProcessMessage. */
     mutable Mutex cs_indexed_quorums_cache;
-    mutable std::map<Consensus::LLMQType, Uint256LruHashMap<int>> indexed_quorums_cache GUARDED_BY(cs_indexed_quorums_cache);
+    mutable PerLlmqTypeCache<int> indexed_quorums_cache GUARDED_BY(cs_indexed_quorums_cache);
 
     std::vector<std::thread> m_phase_threads;
 };

--- a/src/llmq/net_quorum.cpp
+++ b/src/llmq/net_quorum.cpp
@@ -688,20 +688,19 @@ void NetQuorum::StartCleanupOldQuorumDataThread(gsl::not_null<const CBlockIndex*
     workerPool.push([pIndex, t, this](int threadId) {
         Uint256HashSet dbKeysToSkip;
 
-        if (LOCK(cs_cleanup); cleanupQuorumsCache.empty()) {
-            utils::InitQuorumsCache(cleanupQuorumsCache, m_chainman.GetConsensus(), /*limit_by_connections=*/false);
+        if (LOCK(cs_cleanup); !cleanupQuorumsCache.IsInitialized()) {
+            cleanupQuorumsCache.Init(m_chainman.GetConsensus(), /*limit_by_connections=*/false);
         }
         for (const auto& params : Params().GetConsensus().llmqs) {
             if (quorumThreadInterrupt) {
                 break;
             }
             LOCK(cs_cleanup);
-            auto& cache = cleanupQuorumsCache[params.type];
             const CBlockIndex* pindex_loop{pIndex};
             Uint256HashSet quorum_keys;
             while (pindex_loop != nullptr && pIndex->nHeight - pindex_loop->nHeight < params.max_store_depth()) {
                 uint256 quorum_key;
-                if (cache.get(pindex_loop->GetBlockHash(), quorum_key)) {
+                if (cleanupQuorumsCache.get(params.type, pindex_loop->GetBlockHash(), quorum_key)) {
                     quorum_keys.insert(quorum_key);
                     if (quorum_keys.size() >= static_cast<size_t>(params.keepOldKeys)) break; // extra safety belt
                 }
@@ -710,7 +709,8 @@ void NetQuorum::StartCleanupOldQuorumDataThread(gsl::not_null<const CBlockIndex*
             for (const auto& pQuorum : m_qman.ScanQuorums(params.type, pIndex, params.keepOldKeys - quorum_keys.size())) {
                 const uint256 quorum_key = MakeQuorumKey(*pQuorum);
                 quorum_keys.insert(quorum_key);
-                cache.insert(pQuorum->m_quorum_base_block_index->GetBlockHash(), quorum_key);
+                cleanupQuorumsCache.insert(params.type, pQuorum->m_quorum_base_block_index->GetBlockHash(),
+                                           quorum_key);
             }
             dbKeysToSkip.merge(quorum_keys);
         }

--- a/src/llmq/net_quorum.h
+++ b/src/llmq/net_quorum.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_LLMQ_NET_QUORUM_H
 #define BITCOIN_LLMQ_NET_QUORUM_H
 
+#include <llmq/cache.h>
 #include <llmq/options.h>
 #include <llmq/quorums.h>
 #include <net_processing.h>
 #include <sync.h>
-#include <unordered_lru_cache.h>
 #include <util/threadinterrupt.h>
 #include <validationinterface.h>
 
@@ -117,7 +117,7 @@ private:
     const bool m_quorums_recovery;
 
     mutable Mutex cs_cleanup;
-    mutable std::map<Consensus::LLMQType, Uint256LruHashMap<uint256>> cleanupQuorumsCache
+    mutable PerLlmqTypeCache<uint256> cleanupQuorumsCache
         GUARDED_BY(cs_cleanup);
 
     mutable ctpl::thread_pool workerPool;

--- a/src/llmq/quorumsman.cpp
+++ b/src/llmq/quorumsman.cpp
@@ -38,7 +38,7 @@ CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CDeterministicMNManager& 
     m_chainman{chainman},
     db{util::MakeDbWrapper({db_params.path / "llmq" / "quorumdb", db_params.memory, db_params.wipe, /*cache_size=*/1 << 20})}
 {
-    utils::InitQuorumsCache(mapQuorumsCache, m_chainman.GetConsensus(), /*limit_by_connections=*/false);
+    mapQuorumsCache.Init(m_chainman.GetConsensus(), /*limit_by_connections=*/false);
     m_cache_interrupt.reset();
     m_cache_thread = std::thread(&util::TraceThread, "q-cache", [this] { CacheWarmingThreadMain(); });
     MigrateOldQuorumDB(_evoDb);
@@ -81,7 +81,7 @@ CQuorumPtr CQuorumManager::BuildQuorumFromCommitment(const Consensus::LLMQType l
         std::make_unique<CFinalCommitment>(std::move(qc)), pQuorumBaseBlockIndex, minedBlockHash, members);
 
     if (populate_cache && llmq_params_opt->size == 1) {
-        WITH_LOCK(m_cs_maps, mapQuorumsCache[llmqType].insert(quorumHash, quorum));
+        WITH_LOCK(m_cs_maps, mapQuorumsCache.insert(llmqType, quorumHash, quorum));
 
         return quorum;
     }
@@ -105,7 +105,7 @@ CQuorumPtr CQuorumManager::BuildQuorumFromCommitment(const Consensus::LLMQType l
         QueueQuorumForWarming(quorum);
     }
 
-    WITH_LOCK(m_cs_maps, mapQuorumsCache[llmqType].insert(quorumHash, quorum));
+    WITH_LOCK(m_cs_maps, mapQuorumsCache.insert(llmqType, quorumHash, quorum));
 
     return quorum;
 }
@@ -209,18 +209,17 @@ std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(Consensus::LLMQType llmqTyp
 
     if (chain == nullptr) {
         LOCK(m_cs_maps);
-        if (scanQuorumsCache.empty()) {
-            for (const auto& llmq : Params().GetConsensus().llmqs) {
-                // NOTE: We store it for each block hash in the DKG mining phase here
-                // and not for a single quorum hash per quorum like we do for other caches.
-                // And we only do this for max_cycles() of the most recent quorums
-                // because signing by old quorums requires the exact quorum hash to be specified
-                // and quorum scanning isn't needed there.
-                scanQuorumsCache.try_emplace(llmq.type, llmq.max_cycles(llmq.keepOldConnections) * (llmq.dkgMiningWindowEnd - llmq.dkgMiningWindowStart));
-            }
+        if (!scanQuorumsCache.IsInitialized()) {
+            // NOTE: We store it for each block hash in the DKG mining phase here
+            // and not for a single quorum hash per quorum like we do for other caches.
+            // And we only do this for max_cycles() of the most recent quorums
+            // because signing by old quorums requires the exact quorum hash to be specified
+            // and quorum scanning isn't needed there.
+            scanQuorumsCache.Init(Params().GetConsensus(), [](const Consensus::LLMQParams& llmq) {
+                return llmq.max_cycles(llmq.keepOldConnections) * (llmq.dkgMiningWindowEnd - llmq.dkgMiningWindowStart);
+            });
         }
-        auto& cache = scanQuorumsCache[llmqType];
-        bool fCacheExists = cache.get(pindexStore->GetBlockHash(), vecResultQuorums);
+        bool fCacheExists = scanQuorumsCache.get(llmqType, pindexStore->GetBlockHash(), vecResultQuorums);
         if (fCacheExists) {
             // We have exactly what requested so just return it
             if (vecResultQuorums.size() == nCountRequested) {
@@ -284,9 +283,9 @@ std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(Consensus::LLMQType llmqTyp
         // Don't cache more than keepOldConnections elements
         // because signing by old quorums requires the exact quorum hash
         // to be specified and quorum scanning isn't needed there.
-        auto& cache = scanQuorumsCache[llmqType];
         const size_t nCacheEndIndex = std::min(nCountResult, static_cast<size_t>(llmq_params_opt->keepOldConnections));
-        cache.emplace(pindexStore->GetBlockHash(), {vecResultQuorums.begin(), vecResultQuorums.begin() + nCacheEndIndex});
+        scanQuorumsCache.emplace(llmqType, pindexStore->GetBlockHash(),
+                                 {vecResultQuorums.begin(), vecResultQuorums.begin() + nCacheEndIndex});
     }
     // Don't return more than nCountRequested elements
     const size_t nResultEndIndex = std::min(nCountResult, nCountRequested);
@@ -400,13 +399,8 @@ CQuorumCPtr CQuorumManager::GetQuorum(Consensus::LLMQType llmqType, gsl::not_nul
 
     CQuorumPtr pQuorum;
     {
-        // Defence-in-depth: mapQuorumsCache only holds the LLMQ types InitQuorumsCache() seeded
-        // from the chain's consensus params. operator[] on any other type would insert a
-        // default-constructed, zero-capacity cache and abort in its constructor, so look up
-        // without inserting and fall through for unknown types.
         LOCK(m_cs_maps);
-        auto it = mapQuorumsCache.find(llmqType);
-        if (it != mapQuorumsCache.end() && it->second.get(quorumHash, pQuorum)) {
+        if (mapQuorumsCache.get(llmqType, quorumHash, pQuorum)) {
             return pQuorum;
         }
     }
@@ -426,7 +420,7 @@ CQuorumCPtr CQuorumManager::GetQuorum(Consensus::LLMQType llmqType,
     }
 
     CQuorumPtr pQuorum;
-    if (LOCK(m_cs_maps); mapQuorumsCache[llmqType].get(quorumHash, pQuorum)) {
+    if (LOCK(m_cs_maps); mapQuorumsCache.get(llmqType, quorumHash, pQuorum)) {
         return pQuorum;
     }
 
@@ -469,11 +463,8 @@ CQuorumManager::DataResponseValidation CQuorumManager::ValidateDataResponse(
 CQuorumPtr CQuorumManager::GetCachedMutableQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash) const
 {
     CQuorumPtr pQuorum;
-    // See GetQuorum(): never operator[] this map with a wire-supplied LLMQ type.
     LOCK(m_cs_maps);
-    if (auto it = mapQuorumsCache.find(llmqType); it != mapQuorumsCache.end()) {
-        it->second.get(quorumHash, pQuorum);
-    }
+    mapQuorumsCache.get(llmqType, quorumHash, pQuorum);
     return pQuorum;
 }
 

--- a/src/llmq/quorumsman.h
+++ b/src/llmq/quorumsman.h
@@ -7,6 +7,7 @@
 
 #include <bls/bls_ies.h>
 #include <evo/types.h>
+#include <llmq/cache.h>
 #include <llmq/params.h>
 #include <llmq/quorums.h>
 #include <llmq/types.h>
@@ -72,10 +73,8 @@ private:
         GUARDED_BY(cs_data_requests);
 
     mutable Mutex m_cs_maps;
-    mutable std::map<Consensus::LLMQType, Uint256LruHashMap<CQuorumPtr>> mapQuorumsCache
-        GUARDED_BY(m_cs_maps);
-    mutable std::map<Consensus::LLMQType, Uint256LruHashMap<std::vector<CQuorumCPtr>>> scanQuorumsCache
-        GUARDED_BY(m_cs_maps);
+    mutable PerLlmqTypeCache<CQuorumPtr> mapQuorumsCache GUARDED_BY(m_cs_maps);
+    mutable PerLlmqTypeCache<std::vector<CQuorumCPtr>> scanQuorumsCache GUARDED_BY(m_cs_maps);
 
     // On mainnet, we have around 62 quorums active at any point; let's cache a little more than double that to be safe.
     // it maps `quorum_hash` to `pindex`

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -6,6 +6,7 @@
 
 #include <bls/bls.h>
 #include <evo/deterministicmns.h>
+#include <llmq/cache.h>
 #include <llmq/options.h>
 #include <llmq/snapshot.h>
 #include <llmq/types.h>
@@ -633,9 +634,9 @@ std::optional<std::vector<CDeterministicMNCPtr>> ComputeQuorumMembersFromWorkBlo
 QuorumMembers GetAllQuorumMembers(Consensus::LLMQType llmqType, const UtilParameters& util_params, bool reset_cache)
 {
     static RecursiveMutex cs_members;
-    static std::map<Consensus::LLMQType, Uint256LruHashMap<QuorumMembers>> mapQuorumMembers GUARDED_BY(cs_members);
+    static PerLlmqTypeCache<QuorumMembers> mapQuorumMembers GUARDED_BY(cs_members);
     static RecursiveMutex cs_indexed_members;
-    static std::map<Consensus::LLMQType, unordered_lru_cache<std::pair<uint256, int>, QuorumMembers, StaticSaltedHasher>> mapIndexedQuorumMembers GUARDED_BY(cs_indexed_members);
+    static PerLlmqTypeCache<QuorumMembers, std::pair<uint256, int>> mapIndexedQuorumMembers GUARDED_BY(cs_indexed_members);
 
     // A parentless base index (genesis) can never host a quorum. IsQuorumTypeEnabled() handles the
     // null, but say so explicitly here: this is reached with an attacker-supplied quorumHash via
@@ -648,12 +649,12 @@ QuorumMembers GetAllQuorumMembers(Consensus::LLMQType llmqType, const UtilParame
     std::vector<CDeterministicMNCPtr> quorumMembers;
     {
         LOCK(cs_members);
-        if (mapQuorumMembers.empty()) {
-            InitQuorumsCache(mapQuorumMembers, util_params.m_chainman.GetConsensus());
+        if (!mapQuorumMembers.IsInitialized()) {
+            mapQuorumMembers.Init(util_params.m_chainman.GetConsensus());
         }
         if (reset_cache) {
-            mapQuorumMembers[llmqType].clear();
-        } else if (mapQuorumMembers[llmqType].get(util_params.m_base_index->GetBlockHash(), quorumMembers)) {
+            mapQuorumMembers.clear(llmqType);
+        } else if (mapQuorumMembers.get(llmqType, util_params.m_base_index->GetBlockHash(), quorumMembers)) {
             return quorumMembers;
         }
     }
@@ -663,8 +664,8 @@ QuorumMembers GetAllQuorumMembers(Consensus::LLMQType llmqType, const UtilParame
     const auto& llmq_params = llmq_params_opt.value();
 
     if (IsQuorumRotationEnabled(llmq_params, util_params.m_base_index)) {
-        if (LOCK(cs_indexed_members); mapIndexedQuorumMembers.empty()) {
-            InitQuorumsCache(mapIndexedQuorumMembers, util_params.m_chainman.GetConsensus());
+        if (LOCK(cs_indexed_members); !mapIndexedQuorumMembers.IsInitialized()) {
+            mapIndexedQuorumMembers.Init(util_params.m_chainman.GetConsensus());
         }
         /*
          * Quorums created with rotation are now created in a different way. All signingActiveQuorumCount are created
@@ -689,11 +690,11 @@ QuorumMembers GetAllQuorumMembers(Consensus::LLMQType llmqType, const UtilParame
          */
         if (reset_cache) {
             LOCK(cs_indexed_members);
-            mapIndexedQuorumMembers[llmqType].clear();
-        } else if (LOCK(cs_indexed_members); mapIndexedQuorumMembers[llmqType].get(
-                       std::pair(pCycleQuorumBaseBlockIndex->GetBlockHash(), quorumIndex), quorumMembers)) {
+            mapIndexedQuorumMembers.clear(llmqType);
+        } else if (LOCK(cs_indexed_members); mapIndexedQuorumMembers.get(
+                       llmqType, std::pair(pCycleQuorumBaseBlockIndex->GetBlockHash(), quorumIndex), quorumMembers)) {
             LOCK(cs_members);
-            mapQuorumMembers[llmqType].insert(util_params.m_base_index->GetBlockHash(), quorumMembers);
+            mapQuorumMembers.insert(llmqType, util_params.m_base_index->GetBlockHash(), quorumMembers);
             return quorumMembers;
         }
 
@@ -708,8 +709,8 @@ QuorumMembers GetAllQuorumMembers(Consensus::LLMQType llmqType, const UtilParame
 
         LOCK(cs_indexed_members);
         for (const size_t i : util::irange(q.size())) {
-            mapIndexedQuorumMembers[llmqType].emplace(std::make_pair(pCycleQuorumBaseBlockIndex->GetBlockHash(), i),
-                                                      std::move(q[i]));
+            mapIndexedQuorumMembers.emplace(llmqType, std::make_pair(pCycleQuorumBaseBlockIndex->GetBlockHash(), i),
+                                            std::move(q[i]));
         }
     } else {
         const CBlockIndex* pWorkBlockIndex = DeploymentActiveAfter(util_params.m_base_index,
@@ -724,7 +725,7 @@ QuorumMembers GetAllQuorumMembers(Consensus::LLMQType llmqType, const UtilParame
     }
 
     LOCK(cs_members);
-    mapQuorumMembers[llmqType].insert(util_params.m_base_index->GetBlockHash(), quorumMembers);
+    mapQuorumMembers.insert(llmqType, util_params.m_base_index->GetBlockHash(), quorumMembers);
     return quorumMembers;
 }
 

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -81,15 +81,6 @@ Uint256HashSet GetQuorumConnections(const Consensus::LLMQParams& llmqParams, con
 
 Uint256HashSet GetQuorumRelayMembers(const Consensus::LLMQParams& llmqParams, const UtilParameters& util_params,
                                      const uint256& forMember, bool onlyOutbound);
-
-template <typename CacheType>
-inline void InitQuorumsCache(CacheType& cache, const Consensus::Params& consensus_params, bool limit_by_connections = true)
-{
-    for (const auto& llmq : consensus_params.llmqs) {
-        cache.emplace(std::piecewise_construct, std::forward_as_tuple(llmq.type),
-                      std::forward_as_tuple(limit_by_connections ? llmq.keepOldConnections : llmq.keepOldKeys));
-    }
-}
 } // namespace utils
 } // namespace llmq
 

--- a/src/test/llmq_invalid_type_tests.cpp
+++ b/src/test/llmq_invalid_type_tests.cpp
@@ -6,81 +6,97 @@
 
 #include <chainparams.h>
 #include <llmq/blockprocessor.h>
+#include <llmq/cache.h>
 #include <llmq/context.h>
 #include <llmq/params.h>
 #include <llmq/quorumsman.h>
-#include <llmq/utils.h>
-#include <saltedhasher.h>
-#include <sync.h>
 #include <uint256.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
-#include <map>
-
-// An LLMQ type arriving in a P2P QSIGSHARE message is an unvalidated uint8_t. It used to reach
-// CQuorumManager::GetQuorum() -> CQuorumBlockProcessor::HasMinedCommitment(), where indexing
-// mapHasMinedCommitmentCache with std::map::operator[] inserted a default-constructed
-// Uint256LruHashMap. Its default MaxSize is 0, and unordered_lru_cache's constructor asserts
-// maxSize != 0, so any of the ~250 unregistered type values aborted the node.
+// Consensus::LLMQType is a uint8_t enum serialized verbatim over the wire, so a peer can name
+// either an unknown enum value or a known type that this chain does not use. PerLlmqTypeCache
+// holds a cache only for the types registered on the active chain and answers for the rest as
+// misses; before it existed these were plain std::map<LLMQType, ...>, and operator[] on an
+// unregistered key default-constructed a zero-capacity LRU whose constructor asserts.
 //
-// These caches are only ever seeded by InitQuorumsCache() with the LLMQ types in the active
-// chain's consensus params, so every lookup keyed by untrusted input must use find() rather than
-// operator[]. The message handler now rejects unregistered types up front as well.
+// These tests cover the cache contract itself plus the two lookup paths a wire-supplied type
+// reaches: HasMinedCommitment directly, and GetQuorum, which funnels into it via HasQuorum.
 
 BOOST_AUTO_TEST_SUITE(llmq_invalid_type_tests)
 
 // Not a named enumerator, and never present in any chain's consensus params.
 static constexpr Consensus::LLMQType UNKNOWN_LLMQ_TYPE{static_cast<Consensus::LLMQType>(0)};
-// LLMQ_25_67. A real enumerator, but registered on testnet only, so it is unknown under regtest.
+// A real enumerator registered on testnet but not regtest.
 static constexpr Consensus::LLMQType UNREGISTERED_LLMQ_TYPE{Consensus::LLMQType::LLMQ_25_67};
 
-BOOST_FIXTURE_TEST_CASE(init_quorums_cache_does_not_seed_unknown_types, BasicTestingSetup)
+BOOST_FIXTURE_TEST_CASE(per_llmq_type_cache_ignores_unknown_types, BasicTestingSetup)
 {
-    std::map<Consensus::LLMQType, Uint256LruHashMap<bool>> cache;
-    llmq::utils::InitQuorumsCache(cache, Params().GetConsensus());
-    BOOST_REQUIRE(!cache.empty());
+    llmq::PerLlmqTypeCache<bool> cache;
+    BOOST_CHECK(!cache.IsInitialized());
+    cache.Init(Params().GetConsensus());
+    BOOST_REQUIRE(cache.IsInitialized());
 
     BOOST_REQUIRE(!Params().GetLLMQ(UNKNOWN_LLMQ_TYPE).has_value());
-    BOOST_CHECK(cache.find(UNKNOWN_LLMQ_TYPE) == cache.end());
+    BOOST_CHECK_EQUAL(cache.max_size(UNKNOWN_LLMQ_TYPE), 0U);
 
-    // Every seeded type has a non-zero capacity; anything else would have to be
-    // default-constructed, which is exactly what aborts.
+    // Writes for an unregistered type are dropped rather than sized into existence, and reads
+    // stay misses -- the value below must be left alone.
+    bool value{true};
+    cache.insert(UNKNOWN_LLMQ_TYPE, uint256::ONE, false);
+    BOOST_CHECK(!cache.get(UNKNOWN_LLMQ_TYPE, uint256::ONE, value));
+    BOOST_CHECK(value);
+    cache.erase(UNKNOWN_LLMQ_TYPE, uint256::ONE);
+    cache.clear(UNKNOWN_LLMQ_TYPE);
+    BOOST_CHECK_EQUAL(cache.max_size(UNKNOWN_LLMQ_TYPE), 0U);
+
     for (const auto& llmq : Params().GetConsensus().llmqs) {
-        auto it = cache.find(llmq.type);
-        BOOST_REQUIRE(it != cache.end());
-        BOOST_CHECK_GT(it->second.max_size(), 0U);
+        BOOST_CHECK_GT(cache.max_size(llmq.type), 0U);
+
+        value = false;
+        cache.insert(llmq.type, uint256::ONE, true);
+        BOOST_CHECK(cache.get(llmq.type, uint256::ONE, value));
+        BOOST_CHECK(value);
+
+        cache.erase(llmq.type, uint256::ONE);
+        BOOST_CHECK(!cache.get(llmq.type, uint256::ONE, value));
     }
 }
 
-// Crash site. Pre-fix this aborted with `Assertion failed: (_maxSize != 0)`; it must report that
-// there is no mined commitment instead.
+// The crash site itself: an unregistered type must answer false, not abort.
 BOOST_FIXTURE_TEST_CASE(has_mined_commitment_unknown_llmq_type_is_safe, RegTestingSetup)
 {
-    const auto& qbp = *Assert(Assert(m_node.llmq_ctx)->quorum_block_processor);
-    const uint256 tip_hash = WITH_LOCK(::cs_main, return Assert(m_node.chainman->ActiveTip())->GetBlockHash());
+    auto& qbp = *Assert(m_node.llmq_ctx)->quorum_block_processor;
+    const uint256 hash = WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip()->GetBlockHash());
 
     BOOST_REQUIRE(!Params().GetLLMQ(UNKNOWN_LLMQ_TYPE).has_value());
     BOOST_REQUIRE(!Params().GetLLMQ(UNREGISTERED_LLMQ_TYPE).has_value());
 
-    BOOST_CHECK(!qbp.HasMinedCommitment(UNKNOWN_LLMQ_TYPE, tip_hash));
-    BOOST_CHECK(!qbp.HasMinedCommitment(UNREGISTERED_LLMQ_TYPE, tip_hash));
+    BOOST_CHECK(!qbp.HasMinedCommitment(UNKNOWN_LLMQ_TYPE, hash));
+    BOOST_CHECK(!qbp.HasMinedCommitment(UNREGISTERED_LLMQ_TYPE, hash));
+
+    for (const auto& llmq : Params().GetConsensus().llmqs) {
+        BOOST_CHECK(!qbp.HasMinedCommitment(llmq.type, hash));
+    }
 }
 
-// The exact call ProcessMessageSigShare() makes with wire-supplied values: LookupBlockIndex()
-// succeeds for a real block hash, so HasQuorum() -> HasMinedCommitment() runs with the
-// attacker-chosen LLMQ type. Pre-fix this aborted; it must return nullptr instead.
+// The path a wire-supplied type actually travels: GetQuorum resolves the block index from the
+// hash, then consults HasQuorum -> HasMinedCommitment. Must return nullptr, not abort.
 BOOST_FIXTURE_TEST_CASE(get_quorum_unknown_llmq_type_is_safe, RegTestingSetup)
 {
-    const auto& qman = *Assert(Assert(m_node.llmq_ctx)->qman);
-    const uint256 tip_hash = WITH_LOCK(::cs_main, return Assert(m_node.chainman->ActiveTip())->GetBlockHash());
+    auto& qman = *Assert(m_node.llmq_ctx)->qman;
+    const uint256 tip_hash = WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip()->GetBlockHash());
 
     BOOST_REQUIRE(!Params().GetLLMQ(UNKNOWN_LLMQ_TYPE).has_value());
     BOOST_REQUIRE(!Params().GetLLMQ(UNREGISTERED_LLMQ_TYPE).has_value());
 
     BOOST_CHECK(qman.GetQuorum(UNKNOWN_LLMQ_TYPE, tip_hash) == nullptr);
     BOOST_CHECK(qman.GetQuorum(UNREGISTERED_LLMQ_TYPE, tip_hash) == nullptr);
+
+    // Same map, reached by the QDATA handler with a wire-supplied type.
+    BOOST_CHECK(qman.GetCachedMutableQuorum(UNKNOWN_LLMQ_TYPE, tip_hash) == nullptr);
+    BOOST_CHECK(qman.GetCachedMutableQuorum(UNREGISTERED_LLMQ_TYPE, tip_hash) == nullptr);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/llmq_utils_tests.cpp
+++ b/src/test/llmq_utils_tests.cpp
@@ -308,9 +308,6 @@ BOOST_AUTO_TEST_CASE(deterministic_outbound_connection_edge_cases_test)
 // Note: CalcDeterministicWatchConnections requires CBlockIndex which is complex to mock
 // Testing is deferred to functional tests
 
-// Note: InitQuorumsCache requires specific cache types with LLMQ consensus parameters
-// Testing is deferred to integration tests
-
 BOOST_AUTO_TEST_CASE(deterministic_connection_symmetry_test)
 {
     // Test interesting properties of DeterministicOutboundConnection


### PR DESCRIPTION
## Issue being fixed or feature implemented

**Note on scope after rebase:** this PR originally carried the QSIGSHARE fix itself. That fix shipped independently in v23.1.8 (`a801d3f3b72`) and reached `develop` through the master back-merge in #7534, so the handler gate and the two `find()`-guarded lookups are already present. What remains here is the structural follow-up, retitled accordingly.

`Consensus::LLMQType` is a `uint8_t` enum serialized verbatim over the wire with no range check. The LLMQ LRU caches keyed by it are `std::map<LLMQType, unordered_lru_cache<...>>`, seeded only with the types registered for the active chain. `operator[]` on an unregistered key default-constructs the cache with `MaxSize = 0`, and `unordered_lru_cache`'s constructor runs `assert(_maxSize != 0)`. Since `src/util/check.h` makes compiling with `NDEBUG` a hard `#error`, that assert is live in release builds — so any such `operator[]` is a deterministic abort waiting for a caller that has not validated the type.

The v23.1.8 fix closed the reported vector by gating the QSIGSHARE handler and switching the two lookups a `QSIGSHARE` could reach (`HasMinedCommitment`, `GetQuorum`/`GetCachedMutableQuorum`) to `find()`. The remaining caches still use `operator[]`, and nothing in the type system stops a future caller from reaching one with an unvalidated type.

## What was done?

Remove the hazard structurally rather than gating each lookup. A new `PerLlmqTypeCache<Value, Key>` (`src/llmq/cache.h`) owns the map, holds one LRU per registered type, and answers for any other type as a miss with writes dropped — so no caller can size a zero-capacity cache into existence.

All eight caches are converted (`mapHasMinedCommitmentCache`, `m_qc_hashes_lru`, `mapQuorumsCache`, `scanQuorumsCache`, `mapQuorumMembers`, `mapIndexedQuorumMembers`, `indexed_quorums_cache`, `cleanupQuorumsCache`), the ad-hoc `find()` guards added in v23.1.8 are folded into it, and `InitQuorumsCache` is deleted.

Per-type cache capacities, lock scopes, `GUARDED_BY` annotations and the lazy `if (empty()) Init(...)` seeding are preserved at every converted site.

One deliberate behaviour change worth calling out: `HasMinedCommitment` on an unregistered type now falls through to the EvoDB probe and returns false, where `develop` currently returns false before touching the DB. That probe is the same one any cache miss performs, and the handlers reject unregistered types before reaching it, so this is not remotely reachable — but it is a step back from the early return and is easy to restore if reviewers prefer.

`llmq_invalid_type_tests` is extended to pin the `PerLlmqTypeCache` contract itself (unregistered types read as misses, writes dropped, capacity 0) alongside the existing `HasMinedCommitment` / `GetQuorum` / `GetCachedMutableQuorum` coverage. An earlier revision also carried a unit test for the QSIGSHARE handler ban with its own peer/stream scaffolding; it was dropped per review feedback — comprehensive `NetSigning` regression coverage is better done as its own effort than by pinning one corner case here.

## How Has This Been Tested?

- Full local build clean on macOS/arm64.
- `src/test/test_dash --run_test=llmq_invalid_type_tests,llmq_utils_tests`: 18 test cases, no errors — also exercised by the CI unit-test jobs (linux64, tsan, sqlite, multiprocess), all green on this tree.
- The current head is a commit-message-only amend of the CI-tested commit (identical tree).

## Breaking Changes

None. Only lookups naming an LLMQ type that is not registered for the active chain are affected, and those were never valid.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
