### PR TITLE
fix: fetch orphan-vote parents via the request tracker instead of broadcasting

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -163,6 +163,7 @@ BITCOIN_TESTS =\
   test/net_peer_eviction_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/orphan_vote_cache_tests.cpp \
   test/orphanage_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/cachemultimap.h
+++ b/src/cachemultimap.h
@@ -110,6 +110,15 @@ public:
         return (mapIndex.find(key) != mapIndex.end());
     }
 
+    bool HasEntry(const K& key, const V& value) const
+    {
+        map_cit mit = mapIndex.find(key);
+        if (mit == mapIndex.end()) {
+            return false;
+        }
+        return mit->second.count(value) > 0;
+    }
+
     bool Get(const K& key, V& value) const
     {
         map_cit it = mapIndex.find(key);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1020,7 +1020,6 @@ void GovernanceStore::Clear()
     mapObjects.clear();
     mapErasedGovernanceObjects.clear();
     cmmapOrphanVotes.Clear();
-    cmmapOrphanVotes.SetMaxSize(MAX_ORPHAN_VOTES);
     mapLastMasternodeObject.clear();
     lastMNListForVotingKeys = std::make_shared<CDeterministicMNList>();
 }

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -63,7 +63,7 @@ GovernanceStore::GovernanceStore() :
     cs_store(),
     mapObjects(),
     mapErasedGovernanceObjects(),
-    cmmapOrphanVotes(MAX_CACHE_SIZE),
+    cmmapOrphanVotes(MAX_ORPHAN_VOTES),
     mapLastMasternodeObject(),
     lastMNListForVotingKeys(std::make_shared<CDeterministicMNList>())
 {
@@ -405,6 +405,11 @@ void CGovernanceManager::CheckAndRemove()
     }
 
     ScopedLockBool guard(cs_store, fRateChecksEnabled, false);
+
+    // Drop orphan votes whose parent never arrived. Votes for an object that did arrive are
+    // consumed by CheckOrphanVotes() at that point, so anything still here is either waiting or
+    // dead; this is the only thing that removes the latter.
+    ExpireOrphanVotes();
 
     // Clean up any expired or invalid triggers
     m_superblocks.Clean(nCachedBlockHeight);
@@ -829,9 +834,12 @@ bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceExc
         // No penalty: the vote is signed by a masternode, it just arrived before its parent object,
         // which routinely happens during governance sync. Misbehaviour scores never decay.
         exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_WARNING);
-        if (cmmapOrphanVotes.Insert(nHashGovobj, governance::OrphanVote{vote, Now<NodeSeconds>() + GOVERNANCE_ORPHAN_EXPIRATION_TIME})) {
-            hashToRequest = nHashGovobj; // Caller should request this object
-        }
+        cmmapOrphanVotes.Insert(nHashGovobj, governance::OrphanVote{vote, Now<NodeSeconds>() + GOVERNANCE_ORPHAN_EXPIRATION_TIME});
+        // Ask for the parent whether or not the vote itself was new to us. A vote we already hold,
+        // relayed by a second peer, is fresh evidence that this peer has the parent -- and it is the
+        // only evidence we will get, since a peer relays a given vote once. Suppressing the request
+        // on a duplicate would strand the parent whenever the first peer we asked fails to deliver.
+        hashToRequest = nHashGovobj;
         LogPrint(BCLog::GOBJECT, "%s\n", msg);
         return false;
     }
@@ -1012,6 +1020,7 @@ void GovernanceStore::Clear()
     mapObjects.clear();
     mapErasedGovernanceObjects.clear();
     cmmapOrphanVotes.Clear();
+    cmmapOrphanVotes.SetMaxSize(MAX_ORPHAN_VOTES);
     mapLastMasternodeObject.clear();
     lastMNListForVotingKeys = std::make_shared<CDeterministicMNList>();
 }
@@ -1089,13 +1098,11 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex* pindex)
     m_superblocks.ExecuteBestSuperblock(m_dmnman.GetListAtChainTip(), pindex->nHeight);
 }
 
-std::vector<uint256> CGovernanceManager::GetOrphanVoteObjectHashes()
+void CGovernanceManager::ExpireOrphanVotes()
 {
-    LOCK(cs_store);
+    AssertLockHeld(cs_store);
 
     const auto now{Now<NodeSeconds>()};
-
-    // Clean up expired orphan votes
     const vote_cmm_t::list_t& items = cmmapOrphanVotes.GetItemList();
     for (auto it = items.begin(); it != items.end();) {
         auto prevIt = it;
@@ -1104,18 +1111,11 @@ std::vector<uint256> CGovernanceManager::GetOrphanVoteObjectHashes()
             cmmapOrphanVotes.Erase(prevIt->key, prevIt->value);
         }
     }
+}
 
-    // Get hashes of objects we don't have yet
-    std::vector<uint256> vecHashesFiltered;
-    std::vector<uint256> vecHashes;
-    cmmapOrphanVotes.GetKeys(vecHashes);
-    for (const uint256& nHash : vecHashes) {
-        if (mapObjects.find(nHash) == mapObjects.end()) {
-            vecHashesFiltered.push_back(nHash);
-        }
-    }
-
-    return vecHashesFiltered;
+size_t CGovernanceManager::GetOrphanVoteCount() const
+{
+    return WITH_LOCK(cs_store, return cmmapOrphanVotes.GetSize());
 }
 
 void CGovernanceManager::RemoveInvalidVotes()

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -63,7 +63,7 @@ GovernanceStore::GovernanceStore() :
     cs_store(),
     mapObjects(),
     mapErasedGovernanceObjects(),
-    cmmapOrphanVotes(MAX_ORPHAN_VOTES),
+    m_orphan_votes(MAX_ORPHAN_VOTES, MAX_ORPHAN_VOTES_PER_MN),
     mapLastMasternodeObject(),
     lastMNListForVotingKeys(std::make_shared<CDeterministicMNList>())
 {
@@ -279,7 +279,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj)
 
     uint256 nHash = govobj.GetHash();
     std::vector<governance::OrphanVote> orphan_votes;
-    cmmapOrphanVotes.GetAll(nHash, orphan_votes);
+    m_orphan_votes.GetAll(nHash, orphan_votes);
 
     ScopedLockBool guard(cs_store, fRateChecksEnabled, false);
 
@@ -296,7 +296,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj)
             fRemove = true;
         }
         if (fRemove) {
-            cmmapOrphanVotes.Erase(nHash, orphan_vote);
+            m_orphan_votes.Erase(nHash, orphan_vote);
         }
     }
 }
@@ -829,12 +829,24 @@ bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceExc
             exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
             return false;
         }
+        const auto insert_result = m_orphan_votes.Insert(
+            nHashGovobj, governance::OrphanVote{vote, Now<NodeSeconds>() + GOVERNANCE_ORPHAN_EXPIRATION_TIME});
+        if (insert_result == governance::OrphanVoteCache::InsertResult::MN_LIMIT) {
+            // This masternode already fills its share of the cache with votes for parents that
+            // never arrived; drop the vote and stop letting the key seed parent requests. Still no
+            // penalty: the sending peer may merely be relaying, and misbehaviour scores never decay.
+            std::string msg{strprintf("CGovernanceManager::%s -- Masternode %s is over its orphan-vote share, "
+                                      "dropping vote for unknown parent object %s",
+                __func__, vote.GetMasternodeOutpoint().ToStringShort(), nHashGovobj.ToString())};
+            exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_WARNING);
+            LogPrint(BCLog::GOBJECT, "%s\n", msg);
+            return false;
+        }
         std::string msg{strprintf("CGovernanceManager::%s -- Unknown parent object %s, MN outpoint = %s", __func__,
             nHashGovobj.ToString(), vote.GetMasternodeOutpoint().ToStringShort())};
         // No penalty: the vote is signed by a masternode, it just arrived before its parent object,
         // which routinely happens during governance sync. Misbehaviour scores never decay.
         exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_WARNING);
-        cmmapOrphanVotes.Insert(nHashGovobj, governance::OrphanVote{vote, Now<NodeSeconds>() + GOVERNANCE_ORPHAN_EXPIRATION_TIME});
         // Ask for the parent whether or not the vote itself was new to us. A vote we already hold,
         // relayed by a second peer, is fresh evidence that this peer has the parent -- and it is the
         // only evidence we will get, since a peer relays a given vote once. Suppressing the request
@@ -1019,7 +1031,7 @@ void GovernanceStore::Clear()
     LOCK(cs_store);
     mapObjects.clear();
     mapErasedGovernanceObjects.clear();
-    cmmapOrphanVotes.Clear();
+    m_orphan_votes.Clear();
     mapLastMasternodeObject.clear();
     lastMNListForVotingKeys = std::make_shared<CDeterministicMNList>();
 }
@@ -1102,19 +1114,19 @@ void CGovernanceManager::ExpireOrphanVotes()
     AssertLockHeld(cs_store);
 
     const auto now{Now<NodeSeconds>()};
-    const vote_cmm_t::list_t& items = cmmapOrphanVotes.GetItemList();
+    const auto& items = m_orphan_votes.GetItemList();
     for (auto it = items.begin(); it != items.end();) {
         auto prevIt = it;
         ++it;
         if (prevIt->value.expiration < now) {
-            cmmapOrphanVotes.Erase(prevIt->key, prevIt->value);
+            m_orphan_votes.Erase(prevIt->key, prevIt->value);
         }
     }
 }
 
 size_t CGovernanceManager::GetOrphanVoteCount() const
 {
-    return WITH_LOCK(cs_store, return cmmapOrphanVotes.GetSize());
+    return WITH_LOCK(cs_store, return m_orphan_votes.GetSize());
 }
 
 void CGovernanceManager::RemoveInvalidVotes()
@@ -1151,14 +1163,13 @@ void CGovernanceManager::RemoveInvalidVotes()
     for (const auto& outpoint : changedKeyMNs) {
         for (auto& [_, govobj] : mapObjects) {
             auto removed = Assert(govobj)->RemoveInvalidVotes(tip_mn_list, outpoint);
-            if (removed.empty()) {
-                continue;
-            }
             for (const auto& voteHash : removed) {
                 cmapVoteToObject.Erase(voteHash);
-                cmmapOrphanVotes.Erase(voteHash);
             }
         }
+        // Cached orphans from this masternode were signed with the replaced key and can no longer
+        // validate on replay.
+        m_orphan_votes.EraseAllForMasternode(outpoint);
     }
 
     // store current MN list for the next run so that we can determine which keys changed

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -238,7 +238,7 @@ public:
         // The historical format stores CacheMultiMap's capacity with its entries. Consume that
         // field to preserve the format, but keep both the stale orphan votes and their disk-supplied
         // capacity out of the live cache. Orphans are a ten-minute recovery window invalidated by
-        // the restart; the live capacity is node policy established by Clear().
+        // the restart; the live capacity is fixed at construction.
         vote_cmm_t discarded_orphan_votes;
 
         s   >> mapErasedGovernanceObjects

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -57,6 +57,109 @@ inline bool operator<(const OrphanVote& lhs, const OrphanVote& rhs)
 {
     return lhs.vote < rhs.vote;
 }
+
+/** Bounded holding area for votes whose parent object has not arrived yet. Entries are
+ *  peer-supplied and evicted oldest-first, so two bounds are enforced together: a global one that
+ *  caps memory, and a per-masternode one so that a single voting key cannot mint votes naming
+ *  invented parents and flush everyone else's orphans on demand. */
+class OrphanVoteCache
+{
+public:
+    using cache_t = CacheMultiMap<uint256, OrphanVote>;
+
+    enum class InsertResult {
+        OK,
+        DUPLICATE, //!< this (parent, vote) pair is already cached
+        MN_LIMIT,  //!< the vote's masternode already holds its full share of the cache
+    };
+
+    OrphanVoteCache(size_t max_total, size_t max_per_mn) :
+        m_max_total{max_total},
+        m_max_per_mn{max_per_mn},
+        // Eviction happens here, before the inner map is ever full, so its own self-pruning
+        // (which would bypass the per-masternode accounting) can never trigger.
+        m_cache{static_cast<cache_t::size_type>(max_total + 1)}
+    {
+    }
+
+    InsertResult Insert(const uint256& parent_hash, const OrphanVote& orphan_vote)
+    {
+        // A pair we already hold is reported as a duplicate even when its masternode is over its
+        // share: it costs no capacity, and the caller treats a repeat relay as fresh evidence that
+        // the sending peer has the missing parent.
+        if (m_cache.HasEntry(parent_hash, orphan_vote)) {
+            return InsertResult::DUPLICATE;
+        }
+        const COutPoint outpoint{orphan_vote.vote.GetMasternodeOutpoint()};
+        if (const auto it{m_counts.find(outpoint)}; it != m_counts.end() && it->second >= m_max_per_mn) {
+            return InsertResult::MN_LIMIT;
+        }
+        if (!m_cache.Insert(parent_hash, orphan_vote)) {
+            return InsertResult::DUPLICATE;
+        }
+        ++m_counts[outpoint];
+        if (m_cache.GetSize() > m_max_total) {
+            // Insert prepends, so the back is the oldest entry cache-wide and never the one just
+            // added. Copied, not referenced: Erase destroys the node.
+            const auto oldest{m_cache.GetItemList().back()};
+            Erase(oldest.key, oldest.value);
+        }
+        return InsertResult::OK;
+    }
+
+    void Erase(const uint256& parent_hash, const OrphanVote& orphan_vote)
+    {
+        // Callers may pass a reference into the cache's own item list (e.g. the expiry sweep),
+        // which the erase below invalidates; take what we need first.
+        const COutPoint outpoint{orphan_vote.vote.GetMasternodeOutpoint()};
+        const auto size_before{m_cache.GetSize()};
+        m_cache.Erase(parent_hash, orphan_vote);
+        if (m_cache.GetSize() == size_before) return;
+        if (const auto it{m_counts.find(outpoint)}; it != m_counts.end() && --it->second == 0) {
+            m_counts.erase(it);
+        }
+    }
+
+    //! Drop every cached vote from one masternode, e.g. because its keys changed and the votes
+    //! can no longer validate on replay. Returns how many were dropped.
+    size_t EraseAllForMasternode(const COutPoint& outpoint)
+    {
+        if (m_counts.find(outpoint) == m_counts.end()) return 0;
+        // Collect first: Erase destroys the nodes being iterated.
+        std::vector<std::pair<uint256, OrphanVote>> expelled;
+        for (const auto& item : m_cache.GetItemList()) {
+            if (item.value.vote.GetMasternodeOutpoint() == outpoint) {
+                expelled.emplace_back(item.key, item.value);
+            }
+        }
+        for (const auto& [parent_hash, orphan_vote] : expelled) {
+            Erase(parent_hash, orphan_vote);
+        }
+        return expelled.size();
+    }
+
+    bool GetAll(const uint256& parent_hash, std::vector<OrphanVote>& votes)
+    {
+        return m_cache.GetAll(parent_hash, votes);
+    }
+
+    void Clear()
+    {
+        m_cache.Clear();
+        m_counts.clear();
+    }
+
+    size_t GetSize() const { return m_cache.GetSize(); }
+    const cache_t::list_t& GetItemList() const { return m_cache.GetItemList(); }
+    //! The inner map, for writing the legacy on-disk field.
+    const cache_t& Store() const { return m_cache; }
+
+private:
+    const size_t m_max_total;
+    const size_t m_max_per_mn;
+    cache_t m_cache;
+    std::map<COutPoint, size_t> m_counts;
+};
 } // namespace governance
 
 static constexpr int RATE_BUFFER_SIZE = 5;
@@ -177,11 +280,15 @@ protected:
     using vote_cmm_t = CacheMultiMap<uint256, governance::OrphanVote>;
 
 public:
-    /** Bound for the orphan-vote cache, which is filled from the network by any peer with a parent
-     *  object we do not have. Orphans are short-lived recovery state for votes that outran their
-     *  object during relay, so this only has to cover objects genuinely in flight, not the whole
-     *  governance set. MAX_CACHE_SIZE would allow ~750 MB of peer-supplied data here. */
-    static constexpr int MAX_ORPHAN_VOTES = 1000;
+    /** Bounds for the orphan-vote cache, which is filled from the network by any peer with a
+     *  parent object we do not have. The per-masternode bound is the security control: eviction
+     *  is oldest-first, and every entry costs its sender a registered masternode voting key, so
+     *  one key can occupy at most its share instead of flushing the whole cache; the value is
+     *  far above the number of in-flight objects one masternode can plausibly have voted on.
+     *  The global bound caps memory: at roughly 400 bytes per entry this allows ~40 MB, and
+     *  filling it takes 200 distinct masternode keys. */
+    static constexpr size_t MAX_ORPHAN_VOTES = 100'000;
+    static constexpr size_t MAX_ORPHAN_VOTES_PER_MN = 500;
 
 protected:
     static constexpr int MAX_CACHE_SIZE = 1000000;
@@ -197,7 +304,7 @@ protected:
     //   key   - governance object's hash
     //   value - expiration time for deleted objects
     std::map<uint256, int64_t> mapErasedGovernanceObjects GUARDED_BY(cs_store);
-    vote_cmm_t cmmapOrphanVotes GUARDED_BY(cs_store);
+    governance::OrphanVoteCache m_orphan_votes GUARDED_BY(cs_store);
     txout_m_t mapLastMasternodeObject GUARDED_BY(cs_store);
     // used to check for changed voting keys
     std::shared_ptr<CDeterministicMNList> lastMNListForVotingKeys GUARDED_BY(cs_store);
@@ -215,7 +322,7 @@ public:
         s   << SERIALIZATION_VERSION_STRING
             << mapErasedGovernanceObjects
             << empty_invalid_votes
-            << cmmapOrphanVotes
+            << m_orphan_votes.Store()
             << mapObjects
             << mapLastMasternodeObject
             << *lastMNListForVotingKeys;

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -176,6 +176,13 @@ protected:
     using txout_m_t = std::map<COutPoint, last_object_rec>;
     using vote_cmm_t = CacheMultiMap<uint256, governance::OrphanVote>;
 
+public:
+    /** Bound for the orphan-vote cache, which is filled from the network by any peer with a parent
+     *  object we do not have. Orphans are short-lived recovery state for votes that outran their
+     *  object during relay, so this only has to cover objects genuinely in flight, not the whole
+     *  governance set. MAX_CACHE_SIZE would allow ~750 MB of peer-supplied data here. */
+    static constexpr int MAX_ORPHAN_VOTES = 1000;
+
 protected:
     static constexpr int MAX_CACHE_SIZE = 1000000;
     static const std::string SERIALIZATION_VERSION_STRING;
@@ -228,9 +235,15 @@ public:
 
         // TODO: Stop consuming the historical invalid-vote-cache field on the next disk-format version bump.
         CacheMap<uint256, CGovernanceVote> discarded_invalid_votes;
+        // The historical format stores CacheMultiMap's capacity with its entries. Consume that
+        // field to preserve the format, but keep both the stale orphan votes and their disk-supplied
+        // capacity out of the live cache. Orphans are a ten-minute recovery window invalidated by
+        // the restart; the live capacity is node policy established by Clear().
+        vote_cmm_t discarded_orphan_votes;
+
         s   >> mapErasedGovernanceObjects
             >> discarded_invalid_votes
-            >> cmmapOrphanVotes
+            >> discarded_orphan_votes
             >> mapObjects
             >> mapLastMasternodeObject
             >> *lastMNListForVotingKeys;
@@ -365,8 +378,8 @@ public:
     // Used by NetGovernance
     std::vector<CInv> FetchRelayInventory() EXCLUSIVE_LOCKS_REQUIRED(!cs_relay);
     void CheckAndRemove() EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
-    /** Get hashes of governance objects for which we have orphan votes. Also cleans up expired orphans. */
-    [[nodiscard]] std::vector<uint256> GetOrphanVoteObjectHashes() EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
+    /** Number of orphan votes currently held, so the MAX_ORPHAN_VOTES bound can be asserted. */
+    [[nodiscard]] size_t GetOrphanVoteCount() const EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
     std::pair<std::vector<uint256>, std::vector<uint256>> FetchGovernanceObjectVotes(
         size_t peers_per_hash_max, int64_t now, std::map<uint256, std::map<CService, int64_t>>& map_asked_recently) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
@@ -416,6 +429,10 @@ private:
 
     void CheckOrphanVotes(CGovernanceObject& govobj)
         EXCLUSIVE_LOCKS_REQUIRED(cs_store, !cs_relay);
+
+    /** Drop orphan votes whose parent object never arrived within GOVERNANCE_ORPHAN_EXPIRATION_TIME. */
+    void ExpireOrphanVotes()
+        EXCLUSIVE_LOCKS_REQUIRED(cs_store);
 
     void RebuildIndexes()
         EXCLUSIVE_LOCKS_REQUIRED(cs_store);

--- a/src/governance/net_governance.cpp
+++ b/src/governance/net_governance.cpp
@@ -45,23 +45,9 @@ void NetGovernance::Schedule(CScheduler& scheduler)
         [this]() -> void {
             if (!m_node_sync.IsSynced()) return;
 
-            // Request governance objects for orphan votes
-            auto vecOrphanHashes = m_gov_manager.GetOrphanVoteObjectHashes();
-            if (!vecOrphanHashes.empty()) {
-                LogPrint(BCLog::GOBJECT, "NetGovernance::Schedule -- requesting %d orphan objects\n",
-                         vecOrphanHashes.size());
-                const CConnman::NodesSnapshot snap{m_connman, CConnman::FullyConnectedOnly};
-                for (const uint256& nHash : vecOrphanHashes) {
-                    for (CNode* pnode : snap.Nodes()) {
-                        if (!pnode->CanRelay()) continue;
-                        CNetMsgMaker msgMaker(pnode->GetCommonVersion());
-                        CBloomFilter filter; // Empty filter - we want the object, not votes
-                        m_connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MNGOVERNANCESYNC, nHash, filter));
-                    }
-                }
-            }
-
             // CHECK AND REMOVE - REPROCESS GOVERNANCE OBJECTS
+            // Also expires orphan votes whose parent object never arrived. Fetching those parents
+            // is driven by the object request tracker from ProcessMessage(), not from here.
             m_gov_manager.CheckAndRemove();
         },
         std::chrono::minutes{5});
@@ -257,11 +243,13 @@ void NetGovernance::ProcessMessage(CNode& peer, const std::string& msg_type, CDa
             // m_peer_manager->PeerRelayInv(CInv{MSG_GOVERNANCE_OBJECT_VOTE, nHash});
         } else {
             LogPrint(BCLog::GOBJECT, "MNGOVERNANCEOBJECTVOTE -- Rejected vote, error = %s\n", exception.what());
-            if (hashToRequest != uint256()) {
-                // Orphan vote - request the missing governance object
-                CNetMsgMaker msgMaker(peer.GetCommonVersion());
-                CBloomFilter filter; // Empty filter - we just want the object, not votes
-                m_connman.PushMessage(&peer, msgMaker.Make(NetMsgType::MNGOVERNANCESYNC, hashToRequest, filter));
+            if (!hashToRequest.IsNull()) {
+                // Orphan vote: fetch the parent object through the request tracker, which owns
+                // GETDATA scheduling, per-peer in-flight limits, expiry and fallback to another
+                // peer. Register this peer explicitly -- holding a vote for the object is evidence
+                // it has the object, and it may never have announced the object to us.
+                m_peer_manager->PeerAskPeersForObject(CInv{MSG_GOVERNANCE_OBJECT, hashToRequest},
+                                                      peer.GetId());
             }
             if ((exception.GetNodePenalty() != 0) && m_node_sync.IsSynced()) {
                 m_peer_manager->PeerMisbehaving(peer.GetId(), exception.GetNodePenalty());

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -414,7 +414,7 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
         m_peer_manager->PeerRelayInvFiltered(inv, *tx);
     } else {
         m_peer_manager->PeerRelayInvFiltered(inv, islock->txid);
-        m_peer_manager->PeerAskPeersForTransaction(islock->txid);
+        m_peer_manager->PeerAskPeersForObject(CInv{MSG_TX, islock->txid});
     }
 }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -669,8 +669,11 @@ private:
     void RelayInvFiltered(const CInv& inv, const uint256& relatedTxHash) EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
 
     /** Register with m_object_request that an inv has been received from a peer, computing the
-     *  request delay from the peer's preferredness and in-flight load. */
-    void AddObjectAnnouncement(const CNode& node, const CInv& inv, std::chrono::microseconds current_time)
+     *  request delay from the peer's preferredness and in-flight load. force_preferred is for
+     *  announcements we synthesize because we want the object (see AskPeersForObject). Returns
+     *  whether the announcement passed the per-peer accounting. */
+    bool AddObjectAnnouncement(NodeId nodeid, const CInv& inv, std::chrono::microseconds current_time,
+                               bool force_preferred = false)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Delete all announcements of a transaction across all peers, under both inv types it may
@@ -1604,20 +1607,23 @@ bool IsGetDataOnlyObject(int invType)
     }
 }
 
-void PeerManagerImpl::AddObjectAnnouncement(const CNode& node, const CInv& inv, std::chrono::microseconds current_time)
+bool PeerManagerImpl::AddObjectAnnouncement(NodeId nodeid, const CInv& inv, std::chrono::microseconds current_time,
+                                            bool force_preferred)
 {
     AssertLockHeld(cs_main);
 
-    const CNodeState* state = State(node.GetId());
-    if (state == nullptr) return;
+    // nullptr if the peer disconnected; AskPeersForObject snapshots candidates outside cs_main.
+    const CNodeState* state = State(nodeid);
+    if (state == nullptr) return false;
 
-    if (m_object_request.Count(node.GetId()) >= MAX_PEER_OBJECT_ANNOUNCEMENTS) {
+    if (m_object_request.Count(nodeid) >= MAX_PEER_OBJECT_ANNOUNCEMENTS) {
         // Too many queued announcements from this peer
-        return;
+        return false;
     }
 
     // Decide the TxRequestTracker parameters for this announcement:
-    // - "preferred": if fPreferredDownload is set (= outbound, or PF_NOBAN permission)
+    // - "preferred": if fPreferredDownload is set (= outbound, or PF_NOBAN permission), or if the
+    //   caller forces it (an announcement we synthesized because we want the object)
     // - "reqtime": current time plus delays for:
     //   - NONPREF_PEER_TX_DELAY for MSG_TX announcements from non-preferred connections. Other
     //     object types -- including MSG_DSTX (used for the orphan-parent fetch, which wants the
@@ -1625,13 +1631,14 @@ void PeerManagerImpl::AddObjectAnnouncement(const CNode& node, const CInv& inv, 
     //     neither is anything in masternode mode. This matches the pre-txrequest Dash behavior.
     //   - OVERLOADED_PEER_OBJECT_DELAY for announcements from peers which have at least
     //     MAX_PEER_OBJECT_REQUEST_IN_FLIGHT requests in flight.
-    const bool preferred = state->fPreferredDownload;
+    const bool preferred = force_preferred || state->fPreferredDownload;
     auto delay{0us};
     if (inv.IsMsgTx() && !preferred && m_nodeman == nullptr) delay += NONPREF_PEER_TX_DELAY;
-    const bool overloaded = m_object_request.CountInFlight(node.GetId()) >= MAX_PEER_OBJECT_REQUEST_IN_FLIGHT;
+    const bool overloaded = m_object_request.CountInFlight(nodeid) >= MAX_PEER_OBJECT_REQUEST_IN_FLIGHT;
     if (overloaded) delay += OVERLOADED_PEER_OBJECT_DELAY;
 
-    m_object_request.ReceivedInv(node.GetId(), inv, preferred, current_time + delay);
+    m_object_request.ReceivedInv(nodeid, inv, preferred, current_time + delay);
+    return true;
 }
 
 void PeerManagerImpl::ForgetTx(const uint256& txid)
@@ -2397,6 +2404,9 @@ void PeerManagerImpl::SendPings()
 
 void PeerManagerImpl::AskPeersForObject(const CInv& inv, NodeId explicit_peer)
 {
+    // Every matching peer is collected, not just the first few: admission below needs cs_main,
+    // which cannot be taken under m_peer_mutex, so candidates that turn out to be disconnected or
+    // over their announcement cap are only discovered afterwards and must not consume the budget.
     std::vector<PeerRef> candidates;
     {
         READ_LOCK(m_peer_mutex);
@@ -2424,35 +2434,16 @@ void PeerManagerImpl::AskPeersForObject(const CInv& inv, NodeId explicit_peer)
     const auto current_time{GetTime<std::chrono::microseconds>()};
     size_t asked_count{0};
 
-    // Register a fresh, preferred announcement from each peer we intend to ask, so the object is
-    // requested ASAP. We deliberately do not forget existing announcements for this hash: any live
-    // candidate/request from another peer must survive as a fallback. If a peer here already has an
-    // announcement, ReceivedInv is a no-op and the existing one keeps its place.
-    auto try_ask_peer = [&](const PeerRef& peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
-        // The peer may have disconnected after the candidate snapshot. Recheck under cs_main so we
-        // cannot register an announcement after FinalizeNode has already cleaned up this peer.
-        if (State(peer->m_id) == nullptr) return false;
-        // Obey the same per-peer accounting AddObjectAnnouncement applies to announcements the peer
-        // sent us. A synthetic announcement is still an entry the peer's behaviour can cause us to
-        // create -- a peer that keeps naming objects we do not have would otherwise grow its tracker
-        // footprint without limit.
-        if (m_object_request.Count(peer->m_id) >= MAX_PEER_OBJECT_ANNOUNCEMENTS) return false;
-        const bool overloaded = m_object_request.CountInFlight(peer->m_id) >= MAX_PEER_OBJECT_REQUEST_IN_FLIGHT;
-        LogPrint(BCLog::NET, "PeerManagerImpl::%s -- %s: asking peer %d\n", __func__, inv.ToString(),
-                 peer->m_id);
-
-        // Preferred and otherwise undelayed: unlike a peer-initiated announcement, we asked for this
-        // one and want it as soon as the peer's in-flight budget allows.
-        m_object_request.ReceivedInv(peer->m_id, inv, /*preferred=*/true,
-                                     current_time + (overloaded ? OVERLOADED_PEER_OBJECT_DELAY : 0us));
-        return true;
-    };
-
+    // Synthesize an announcement from each peer we ask, forced preferred (we want this one ASAP)
+    // but through the same per-peer accounting as peer-sent announcements. Existing announcements
+    // for this hash are deliberately left alone: they must survive as fallbacks.
     for (const auto& peer : candidates) {
         if (asked_count >= MAX_PEERS_TO_ASK_FOR_OBJECT) {
             break;
         }
-        if (try_ask_peer(peer)) {
+        if (AddObjectAnnouncement(peer->m_id, inv, current_time, /*force_preferred=*/true)) {
+            LogPrint(BCLog::NET, "PeerManagerImpl::%s -- %s: asking peer %d\n", __func__, inv.ToString(),
+                     peer->m_id);
             ++asked_count;
         }
     }
@@ -4462,7 +4453,7 @@ void PeerManagerImpl::ProcessMessage(
                     }
                     bool allowWhileInIBD = allowWhileInIBDObjs.count(inv.type);
                     if (allowWhileInIBD || !m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
-                        AddObjectAnnouncement(pfrom, inv, current_time);
+                        AddObjectAnnouncement(pfrom.GetId(), inv, current_time);
                     }
                 }
             }
@@ -4867,7 +4858,7 @@ void PeerManagerImpl::ProcessMessage(
                     // parent fetched twice, as the tracker keys announcements on the full inv.
                     CInv _inv(MSG_DSTX, parent_txid);
                     AddKnownInv(*peer, _inv.hash);
-                    if (!AlreadyHave(_inv)) AddObjectAnnouncement(pfrom, _inv, current_time);
+                    if (!AlreadyHave(_inv)) AddObjectAnnouncement(pfrom.GetId(), _inv, current_time);
                 }
 
                 if (m_orphanage.AddTx(ptx, pfrom.GetId())) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -85,6 +85,10 @@ using node::fReindex;
 /** Maximum number of in-flight object requests from a peer. It is not a hard limit, but the
  *  threshold at which point the OVERLOADED_PEER_OBJECT_DELAY kicks in. */
 static constexpr int32_t MAX_PEER_OBJECT_REQUEST_IN_FLIGHT = 100;
+/** How many peers to ask for an object we want but were never offered (see AskPeersForObject).
+ *  Small on purpose: the request tracker retries and falls back to the next candidate on expiry, so
+ *  this is the width of the initial attempt, not the number of chances to obtain the object. */
+static constexpr size_t MAX_PEERS_TO_ASK_FOR_OBJECT = 4;
 /** Maximum number of announced objects from a peer.
  *  Unlike Bitcoin, this is not reduced to 5000: governance vote sync legitimately announces up to
  *  MAX_INV_SZ objects from a single peer (see CGovernanceManager). */
@@ -644,15 +648,16 @@ public:
     void PeerRelayDSQ(const CCoinJoinQueue& queue) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void PeerRelayTransaction(const uint256& txid) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void PeerRelayRecoveredSig(const llmq::CRecoveredSig& sig, bool proactive_relay) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
-    void PeerAskPeersForTransaction(const uint256& txid) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+    void PeerAskPeersForObject(const CInv& inv, NodeId explicit_peer) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !cs_main);
     size_t PeerGetRequestedObjectCount(NodeId nodeid) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, ::cs_main);
     void PeerPostProcessMessage(MessageProcessingResult&& ret) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
 
 private:
     void _RelayTransaction(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_peer_mutex);
 
-    /** Ask peers that have a transaction in their inventory to relay it to us. */
-    void AskPeersForTransaction(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+    /** Ask peers that have the object in their inventory to relay it to us, plus explicit_peer. */
+    void AskPeersForObject(const CInv& inv, NodeId explicit_peer) EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !cs_main);
 
     /** Relay inventories to peers that find it relevant */
     void RelayInvFiltered(const CInv& inv, const CTransaction& relatedTx) EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
@@ -2390,43 +2395,65 @@ void PeerManagerImpl::SendPings()
     for(auto& it : m_peer_map) it.second->m_ping_queued = true;
 }
 
-void PeerManagerImpl::AskPeersForTransaction(const uint256& txid)
+void PeerManagerImpl::AskPeersForObject(const CInv& inv, NodeId explicit_peer)
 {
-    std::vector<PeerRef> peersToAsk;
-    peersToAsk.reserve(4);
-
+    std::vector<PeerRef> candidates;
     {
         READ_LOCK(m_peer_mutex);
+        candidates.reserve(m_peer_map.size());
+
+        // A peer that holds the object without having announced it is not in any inventory filter,
+        // so it can only be reached by being named explicitly. Candidate selection order remains
+        // the request tracker's responsibility.
+        if (explicit_peer != -1) {
+            if (auto it = m_peer_map.find(explicit_peer); it != m_peer_map.end()) {
+                candidates.emplace_back(it->second);
+            }
+        }
+
         // TODO consider prioritizing MNs again, once that flag is moved into Peer
         for (const auto& [_, peer] : m_peer_map) {
-            if (peersToAsk.size() >= 4) {
-                break;
-            }
-            if (IsInvInFilter(*peer, txid)) {
-                peersToAsk.emplace_back(peer);
+            if (peer->m_id != explicit_peer && IsInvInFilter(*peer, inv.hash)) {
+                candidates.emplace_back(peer);
             }
         }
     }
-    {
-        LOCK(cs_main);
-        const auto current_time{GetTime<std::chrono::microseconds>()};
-        // Register a fresh, preferred (undelayed) MSG_TX announcement from each peer we intend to
-        // ask, so the transaction is requested ASAP. We deliberately do not forget existing
-        // announcements for this txid: any live candidate/request from another peer must survive as
-        // a fallback, and there is nothing to "unstick" -- the tracker deletes a txid's COMPLETED
-        // announcements automatically once no live one remains, so a completed entry only lingers
-        // while some peer is still being tried. If a peer here already has an announcement,
-        // ReceivedInv is a no-op and the existing one (in flight or queued) keeps its place.
-        for (PeerRef& peer : peersToAsk) {
-            // The peer may have been disconnected (and its tracker state wiped by DisconnectedPeer)
-            // after we collected it above but before we took cs_main. Registering an announcement
-            // for a gone peer would leave a candidate that is never requested and could block the
-            // live fallback peers, so skip it.
-            if (State(peer->m_id) == nullptr) continue;
-            LogPrintf("PeerManagerImpl::%s -- txid=%s: asking other peer %d for correct TX\n", __func__,
-                      txid.ToString(), peer->m_id);
 
-            m_object_request.ReceivedInv(peer->m_id, CInv(MSG_TX, txid), /*preferred=*/true, current_time);
+    LOCK(cs_main);
+
+    const auto current_time{GetTime<std::chrono::microseconds>()};
+    size_t asked_count{0};
+
+    // Register a fresh, preferred announcement from each peer we intend to ask, so the object is
+    // requested ASAP. We deliberately do not forget existing announcements for this hash: any live
+    // candidate/request from another peer must survive as a fallback. If a peer here already has an
+    // announcement, ReceivedInv is a no-op and the existing one keeps its place.
+    auto try_ask_peer = [&](const PeerRef& peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
+        // The peer may have disconnected after the candidate snapshot. Recheck under cs_main so we
+        // cannot register an announcement after FinalizeNode has already cleaned up this peer.
+        if (State(peer->m_id) == nullptr) return false;
+        // Obey the same per-peer accounting AddObjectAnnouncement applies to announcements the peer
+        // sent us. A synthetic announcement is still an entry the peer's behaviour can cause us to
+        // create -- a peer that keeps naming objects we do not have would otherwise grow its tracker
+        // footprint without limit.
+        if (m_object_request.Count(peer->m_id) >= MAX_PEER_OBJECT_ANNOUNCEMENTS) return false;
+        const bool overloaded = m_object_request.CountInFlight(peer->m_id) >= MAX_PEER_OBJECT_REQUEST_IN_FLIGHT;
+        LogPrint(BCLog::NET, "PeerManagerImpl::%s -- %s: asking peer %d\n", __func__, inv.ToString(),
+                 peer->m_id);
+
+        // Preferred and otherwise undelayed: unlike a peer-initiated announcement, we asked for this
+        // one and want it as soon as the peer's in-flight budget allows.
+        m_object_request.ReceivedInv(peer->m_id, inv, /*preferred=*/true,
+                                     current_time + (overloaded ? OVERLOADED_PEER_OBJECT_DELAY : 0us));
+        return true;
+    };
+
+    for (const auto& peer : candidates) {
+        if (asked_count >= MAX_PEERS_TO_ASK_FOR_OBJECT) {
+            break;
+        }
+        if (try_ask_peer(peer)) {
+            ++asked_count;
         }
     }
 }
@@ -6797,9 +6824,9 @@ void PeerManagerImpl::PeerRelayTransaction(const uint256& txid)
     RelayTransaction(txid);
 }
 
-void PeerManagerImpl::PeerAskPeersForTransaction(const uint256& txid)
+void PeerManagerImpl::PeerAskPeersForObject(const CInv& inv, NodeId explicit_peer)
 {
-    AskPeersForTransaction(txid);
+    AskPeersForObject(inv, explicit_peer);
 }
 
 size_t PeerManagerImpl::PeerGetRequestedObjectCount(NodeId nodeid) const

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -111,7 +111,19 @@ public:
     virtual void PeerRelayTransaction(const uint256& txid) = 0;
     virtual void PeerRelayDSQ(const CCoinJoinQueue& queue) = 0;
     virtual void PeerRelayRecoveredSig(const llmq::CRecoveredSig& sig, bool proactive_relay) = 0;
-    virtual void PeerAskPeersForTransaction(const uint256& txid) = 0;
+    /** Ask a few peers for an object we want but have not been offered, by registering a synthetic
+     *  announcement with the request tracker. The tracker then owns the fetch: GETDATA scheduling,
+     *  per-peer in-flight limits, expiry, and fallback to the next candidate.
+     *
+     *  Candidates are explicit_peer, if set, plus peers whose known-inventory filter already contains
+     *  the hash. That filter is only consulted for peers that enabled transaction relay, so for an
+     *  object type carried outside transaction relay -- and for any object nobody has announced to
+     *  us -- explicit_peer may be the only candidate. Pass it whenever a specific peer demonstrably
+     *  has the object without having announced it, such as one that sent a vote naming this parent.
+     *  The request tracker chooses among the candidates; explicit_peer does not imply request order.
+     *
+     *  Requires ::cs_main is NOT held. */
+    virtual void PeerAskPeersForObject(const CInv& inv, NodeId explicit_peer = -1) = 0;
     virtual size_t PeerGetRequestedObjectCount(NodeId nodeid) const = 0;
     virtual void PeerPostProcessMessage(MessageProcessingResult&& ret) = 0;
 };

--- a/src/test/governance_inv_tests.cpp
+++ b/src/test/governance_inv_tests.cpp
@@ -2,8 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <clientversion.h>
 #include <common/bloom.h>
 #include <evo/chainhelper.h>
+#include <evo/deterministicmns.h>
 #include <governance/governance.h>
 #include <governance/net_governance.h>
 #include <governance/object.h>
@@ -501,7 +503,7 @@ BOOST_AUTO_TEST_CASE(orphan_votes_require_a_valid_masternode_signature)
     connman.FlushSendBuffer(*peer);
     ProcessGovernanceVote(net_gov, *peer, vote);
 
-    BOOST_CHECK(m_node.govman->GetOrphanVoteObjectHashes().empty());
+    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), 0U);
     BOOST_CHECK_EQUAL(CountQueuedMessages(*peer, NetMsgType::MNGOVERNANCESYNC), 0U);
     AssertMisbehaviorScore(*m_node.peerman, *peer, 20);
 

--- a/src/test/governance_vote_processing_tests.cpp
+++ b/src/test/governance_vote_processing_tests.cpp
@@ -6,6 +6,7 @@
 #include <evo/chainhelper.h>
 #include <evo/deterministicmns.h>
 #include <governance/governance.h>
+#include <governance/net_governance.h>
 #include <governance/object.h>
 #include <governance/vote.h>
 #include <index/txindex.h>
@@ -15,6 +16,7 @@
 #include <masternode/meta.h>
 #include <masternode/sync.h>
 #include <messagesigner.h>
+#include <net_processing.h>
 #include <netfulfilledman.h>
 #include <primitives/transaction.h>
 #include <script/standard.h>
@@ -28,6 +30,7 @@
 
 #include <test/util/index.h>
 #include <test/util/masternode.h>
+#include <test/util/net.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
@@ -241,7 +244,7 @@ BOOST_AUTO_TEST_CASE(orphan_vote_is_cached_and_applied_when_parent_arrives)
     BOOST_CHECK_EQUAL(exception.GetNodePenalty(), 0);
     // The caller uses this to ask the sending peer for the missing object.
     BOOST_CHECK_EQUAL(hash_to_request, parent_hash);
-    BOOST_CHECK(govman.GetOrphanVoteObjectHashes() == std::vector<uint256>{parent_hash});
+    BOOST_CHECK_EQUAL(govman.GetOrphanVoteCount(), 1U);
 
     const uint256 collateral_hash{ConfirmProposalCollateral(parent_hash)};
     CGovernanceObject proposal{MakeProposal(collateral_hash)};
@@ -254,7 +257,7 @@ BOOST_AUTO_TEST_CASE(orphan_vote_is_cached_and_applied_when_parent_arrives)
     BOOST_REQUIRE(stored != nullptr);
     BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 1);
     BOOST_CHECK_EQUAL(govman.GetCurrentVotes(parent_hash, mn_collateral).size(), 1U);
-    BOOST_CHECK(govman.GetOrphanVoteObjectHashes().empty());
+    BOOST_CHECK_EQUAL(govman.GetOrphanVoteCount(), 0U);
     // Known gap, pinned here so a fix has to update this test: CheckOrphanVotes() applies the
     // vote to the object but never indexes it in cmapVoteToObject, so the vote inv it relays
     // during the replay cannot be served to a peer that requests it.
@@ -467,6 +470,158 @@ BOOST_AUTO_TEST_CASE(legacy_invalid_vote_cache_is_discarded)
     saved >> version >> erased_objects >> saved_invalid_votes;
     BOOST_CHECK_EQUAL(version, "CGovernanceManager-Version-16");
     BOOST_CHECK_EQUAL(saved_invalid_votes.GetSize(), 0U);
+}
+
+// The orphan cache is filled from the network by any peer, keyed by a parent hash we cannot verify
+// until the parent arrives, so its size must be bounded by us and not by the sender.
+BOOST_AUTO_TEST_CASE(orphan_vote_cache_is_bounded)
+{
+    constexpr size_t OVERSHOOT = 50;
+
+    for (size_t i = 0; i < CGovernanceManager::MAX_ORPHAN_VOTES + OVERSHOOT; ++i) {
+        // Distinct parent hash per vote, so each would occupy its own cache key.
+        CGovernanceVote vote{MakeVote(uint256S(strprintf("%x", i + 1)), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+        SignWithVotingKey(vote, mn_voting_key);
+        CGovernanceException exception;
+        uint256 hash_to_request;
+        BOOST_CHECK(!m_node.govman->ProcessVote(vote, exception, hash_to_request));
+    }
+
+    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(),
+                      static_cast<size_t>(CGovernanceManager::MAX_ORPHAN_VOTES));
+}
+
+// A peer relays a given vote once, so a second peer sending a vote we already hold is the only
+// evidence we will ever get that it has the parent. It has to become a fallback candidate: the peer
+// asked first may go away or never answer, and there is no periodic sweep to fall back on.
+BOOST_AUTO_TEST_CASE(orphan_vote_relayed_by_a_second_peer_adds_it_as_a_fallback)
+{
+    auto& govman = *m_node.govman;
+
+    const uint256 parent_hash{MakeProposal(uint256{}).GetHash()};
+    CGovernanceVote vote{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+    SignWithVotingKey(vote, mn_voting_key);
+
+    CGovernanceException exception1;
+    uint256 hash_to_request1;
+    BOOST_CHECK(!govman.ProcessVote(vote, exception1, hash_to_request1));
+    BOOST_CHECK_EQUAL(hash_to_request1, parent_hash);
+
+    // Same vote, second time. The orphan cache rejects the duplicate, but the parent hash to
+    // request must not be suppressed along with it.
+    CGovernanceException exception2;
+    uint256 hash_to_request2;
+    BOOST_CHECK(!govman.ProcessVote(vote, exception2, hash_to_request2));
+    BOOST_CHECK_EQUAL(hash_to_request2, parent_hash);
+
+    // The duplicate must still not be double-counted as orphan state.
+    BOOST_CHECK_EQUAL(govman.GetOrphanVoteCount(), 1U);
+}
+
+// Drive the same duplicate-relay case through NetGovernance: every peer that supplies the orphan
+// vote must become a candidate for fetching its parent, while an unrelated peer must not.
+BOOST_AUTO_TEST_CASE(orphan_vote_relayers_seed_parent_request_candidates)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    const uint256 parent_hash{MakeProposal(uint256{}).GetHash()};
+    CGovernanceVote vote{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+    SignWithVotingKey(vote, mn_voting_key);
+    BOOST_REQUIRE(vote.IsValid(tip_mn_list(), /*useVotingKey=*/true));
+
+    NetGovernance net_gov(m_node.peerman.get(), *m_node.govman, *m_node.mn_sync,
+                          *m_node.netfulfilledman, *m_node.connman);
+    auto first_relayer{MakeTestPeer(/*id=*/1)};
+    auto second_relayer{MakeTestPeer(/*id=*/2)};
+    auto unrelated_peer{MakeTestPeer(/*id=*/3)};
+    m_node.peerman->InitializeNode(*first_relayer, NODE_NETWORK);
+    m_node.peerman->InitializeNode(*second_relayer, NODE_NETWORK);
+    m_node.peerman->InitializeNode(*unrelated_peer, NODE_NETWORK);
+
+    const CInv vote_inv{MSG_GOVERNANCE_OBJECT_VOTE, vote.GetHash()};
+    auto relay_vote = [&](CNode& peer) EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex) {
+        AnnounceInv(*m_node.peerman, peer, vote_inv);
+        CDataStream vote_stream{SER_NETWORK, PROTOCOL_VERSION};
+        vote_stream << vote;
+        net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCEOBJECTVOTE, vote_stream);
+    };
+
+    relay_vote(*first_relayer);
+    relay_vote(*second_relayer);
+
+    const CInv parent_inv{MSG_GOVERNANCE_OBJECT, parent_hash};
+    BOOST_CHECK(WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeObjectRequest(
+                                              first_relayer->GetId(), parent_inv)));
+    BOOST_CHECK(WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeObjectRequest(
+                                              second_relayer->GetId(), parent_inv)));
+    BOOST_CHECK(!WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeObjectRequest(
+                                               unrelated_peer->GetId(), parent_inv)));
+
+    m_node.peerman->FinalizeNode(*first_relayer);
+    m_node.peerman->FinalizeNode(*second_relayer);
+    m_node.peerman->FinalizeNode(*unrelated_peer);
+}
+
+// CacheMultiMap serializes its own capacity, so loading a governance.dat written before
+// MAX_ORPHAN_VOTES existed would restore the old 1'000'000 and silently un-bound the cache for the
+// rest of the run -- leaving the bound in force on fresh nodes only, which is where it is least
+// needed. The on-disk format is unchanged, so this has to be reasserted on load rather than avoided
+// by a version bump.
+BOOST_AUTO_TEST_CASE(orphan_vote_bound_survives_loading_an_old_cache_file)
+{
+    // Stand in for a pre-existing governance.dat: the same field order GovernanceStore writes, with
+    // the orphan map carrying the historical capacity and an entry stored under it. The two maps
+    // whose value types are internal to GovernanceStore are written empty, which serializes as a
+    // count of zero without naming those types.
+    CDataStream ss{SER_DISK, CLIENT_VERSION};
+    CacheMultiMap<uint256, governance::OrphanVote> legacy_orphans{1'000'000};
+    legacy_orphans.Insert(uint256S("61"),
+                          governance::OrphanVote{MakeVote(uint256S("61"), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES), NodeSeconds{9999s}});
+    ss << std::string{"CGovernanceManager-Version-16"} << std::map<uint256, int64_t>{}
+       << CacheMap<uint256, CGovernanceVote>{1'000'000} << legacy_orphans
+       << std::map<uint256, uint8_t>{} << std::map<COutPoint, uint8_t>{} << CDeterministicMNList{};
+
+    BOOST_REQUIRE_NO_THROW(ss >> *m_node.govman);
+
+    // The file's orphan state is not retained.
+    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), 0U);
+
+    // And the bound is ours, not the file's. Without the reassert this holds 1'000'000 and keeps
+    // every one of the votes below.
+    for (size_t i = 0; i < CGovernanceManager::MAX_ORPHAN_VOTES + 25; ++i) {
+        CGovernanceVote vote{MakeVote(uint256S(strprintf("%x", i + 1)), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+        SignWithVotingKey(vote, mn_voting_key);
+        CGovernanceException exception;
+        uint256 hash_to_request;
+        BOOST_CHECK(!m_node.govman->ProcessVote(vote, exception, hash_to_request));
+    }
+    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(),
+                      static_cast<size_t>(CGovernanceManager::MAX_ORPHAN_VOTES));
+}
+
+// A load failure after the legacy orphan field must not leave its disk-supplied capacity behind.
+BOOST_AUTO_TEST_CASE(orphan_vote_bound_survives_a_failed_old_cache_load)
+{
+    CDataStream ss{SER_DISK, CLIENT_VERSION};
+    CacheMultiMap<uint256, governance::OrphanVote> legacy_orphans{1'000'000};
+    legacy_orphans.Insert(uint256S("71"),
+                          governance::OrphanVote{MakeVote(uint256S("71"), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES),
+                                                 NodeSeconds{9999s}});
+    // Stop after the legacy orphan field so the following map read throws.
+    ss << std::string{"CGovernanceManager-Version-16"} << std::map<uint256, int64_t>{}
+       << CacheMap<uint256, CGovernanceVote>{1'000'000} << legacy_orphans;
+
+    BOOST_CHECK_THROW(ss >> *m_node.govman, std::ios_base::failure);
+    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), 0U);
+
+    for (size_t i = 0; i < CGovernanceManager::MAX_ORPHAN_VOTES + 25; ++i) {
+        CGovernanceVote vote{MakeVote(uint256S(strprintf("%x", i + 1)), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+        SignWithVotingKey(vote, mn_voting_key);
+        CGovernanceException exception;
+        uint256 hash_to_request;
+        BOOST_CHECK(!m_node.govman->ProcessVote(vote, exception, hash_to_request));
+    }
+    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), static_cast<size_t>(CGovernanceManager::MAX_ORPHAN_VOTES));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/governance_vote_processing_tests.cpp
+++ b/src/test/governance_vote_processing_tests.cpp
@@ -216,6 +216,22 @@ struct TestGovernanceStore : GovernanceStore {
         return mapObjects.size();
     }
 };
+
+//! The legacy on-disk GovernanceStore layout, as written by every release so far. stop_after_orphans
+//! truncates the stream after the orphan field, so the read of the field after it throws mid-load.
+CDataStream MakeLegacyStore(const CacheMap<uint256, CGovernanceVote>& invalid_votes,
+                            const CacheMultiMap<uint256, governance::OrphanVote>& orphan_votes,
+                            const std::map<uint256, std::shared_ptr<CGovernanceObject>>& objects,
+                            bool stop_after_orphans = false)
+{
+    CDataStream ss{SER_DISK, CLIENT_VERSION};
+    ss << std::string{"CGovernanceManager-Version-16"} << std::map<uint256, int64_t>{} << invalid_votes
+       << orphan_votes;
+    if (!stop_after_orphans) {
+        ss << objects << std::map<COutPoint, TestGovernanceStore::last_object_rec>{} << CDeterministicMNList{};
+    }
+    return ss;
+}
 } // namespace
 
 BOOST_FIXTURE_TEST_SUITE(governance_vote_processing_tests, GovernanceVoteSetup)
@@ -449,14 +465,8 @@ BOOST_AUTO_TEST_CASE(legacy_invalid_vote_cache_is_discarded)
     legacy_invalid_votes.Insert(forged.GetHash(), forged);
     const auto proposal = std::make_shared<CGovernanceObject>(MakeProposal(uint256::ONE));
 
-    CDataStream stream{SER_DISK, CLIENT_VERSION};
-    stream << std::string{"CGovernanceManager-Version-16"}
-           << std::map<uint256, int64_t>{}
-           << legacy_invalid_votes
-           << CacheMultiMap<uint256, governance::OrphanVote>{3}
-           << std::map<uint256, std::shared_ptr<CGovernanceObject>>{{proposal->GetHash(), proposal}}
-           << std::map<COutPoint, TestGovernanceStore::last_object_rec>{}
-           << CDeterministicMNList{};
+    CDataStream stream{MakeLegacyStore(legacy_invalid_votes, CacheMultiMap<uint256, governance::OrphanVote>{3},
+                                       {{proposal->GetHash(), proposal}})};
 
     TestGovernanceStore store;
     store.Unserialize(stream);
@@ -562,66 +572,26 @@ BOOST_AUTO_TEST_CASE(orphan_vote_relayers_seed_parent_request_candidates)
     m_node.peerman->FinalizeNode(*unrelated_peer);
 }
 
-// CacheMultiMap serializes its own capacity, so loading a governance.dat written before
-// MAX_ORPHAN_VOTES existed would restore the old 1'000'000 and silently un-bound the cache for the
-// rest of the run -- leaving the bound in force on fresh nodes only, which is where it is least
-// needed. The on-disk format is unchanged, so this has to be reasserted on load rather than avoided
-// by a version bump.
-BOOST_AUTO_TEST_CASE(orphan_vote_bound_survives_loading_an_old_cache_file)
+// The legacy format stores the orphan cache -- entries and CacheMultiMap's own capacity, 1'000'000
+// in every release that wrote one -- with the store. Unserialize must drop both, whether the load
+// completes or throws mid-stream: orphans are a ten-minute recovery window invalidated by the
+// restart, and a stream that fed the live cache would let the file's capacity override
+// MAX_ORPHAN_VOTES.
+BOOST_AUTO_TEST_CASE(legacy_orphan_votes_are_discarded_on_load)
 {
-    // Stand in for a pre-existing governance.dat: the same field order GovernanceStore writes, with
-    // the orphan map carrying the historical capacity and an entry stored under it. The two maps
-    // whose value types are internal to GovernanceStore are written empty, which serializes as a
-    // count of zero without naming those types.
-    CDataStream ss{SER_DISK, CLIENT_VERSION};
     CacheMultiMap<uint256, governance::OrphanVote> legacy_orphans{1'000'000};
     legacy_orphans.Insert(uint256S("61"),
-                          governance::OrphanVote{MakeVote(uint256S("61"), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES), NodeSeconds{9999s}});
-    ss << std::string{"CGovernanceManager-Version-16"} << std::map<uint256, int64_t>{}
-       << CacheMap<uint256, CGovernanceVote>{1'000'000} << legacy_orphans
-       << std::map<uint256, uint8_t>{} << std::map<COutPoint, uint8_t>{} << CDeterministicMNList{};
-
-    BOOST_REQUIRE_NO_THROW(ss >> *m_node.govman);
-
-    // The file's orphan state is not retained.
-    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), 0U);
-
-    // And the bound is ours, not the file's. Without the reassert this holds 1'000'000 and keeps
-    // every one of the votes below.
-    for (size_t i = 0; i < CGovernanceManager::MAX_ORPHAN_VOTES + 25; ++i) {
-        CGovernanceVote vote{MakeVote(uint256S(strprintf("%x", i + 1)), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
-        SignWithVotingKey(vote, mn_voting_key);
-        CGovernanceException exception;
-        uint256 hash_to_request;
-        BOOST_CHECK(!m_node.govman->ProcessVote(vote, exception, hash_to_request));
-    }
-    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(),
-                      static_cast<size_t>(CGovernanceManager::MAX_ORPHAN_VOTES));
-}
-
-// A load failure after the legacy orphan field must not leave its disk-supplied capacity behind.
-BOOST_AUTO_TEST_CASE(orphan_vote_bound_survives_a_failed_old_cache_load)
-{
-    CDataStream ss{SER_DISK, CLIENT_VERSION};
-    CacheMultiMap<uint256, governance::OrphanVote> legacy_orphans{1'000'000};
-    legacy_orphans.Insert(uint256S("71"),
-                          governance::OrphanVote{MakeVote(uint256S("71"), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES),
+                          governance::OrphanVote{MakeVote(uint256S("61"), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES),
                                                  NodeSeconds{9999s}});
-    // Stop after the legacy orphan field so the following map read throws.
-    ss << std::string{"CGovernanceManager-Version-16"} << std::map<uint256, int64_t>{}
-       << CacheMap<uint256, CGovernanceVote>{1'000'000} << legacy_orphans;
 
-    BOOST_CHECK_THROW(ss >> *m_node.govman, std::ios_base::failure);
+    CDataStream loaded{MakeLegacyStore(CacheMap<uint256, CGovernanceVote>{1'000'000}, legacy_orphans, {})};
+    BOOST_REQUIRE_NO_THROW(loaded >> *m_node.govman);
     BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), 0U);
 
-    for (size_t i = 0; i < CGovernanceManager::MAX_ORPHAN_VOTES + 25; ++i) {
-        CGovernanceVote vote{MakeVote(uint256S(strprintf("%x", i + 1)), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
-        SignWithVotingKey(vote, mn_voting_key);
-        CGovernanceException exception;
-        uint256 hash_to_request;
-        BOOST_CHECK(!m_node.govman->ProcessVote(vote, exception, hash_to_request));
-    }
-    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), static_cast<size_t>(CGovernanceManager::MAX_ORPHAN_VOTES));
+    CDataStream truncated{MakeLegacyStore(CacheMap<uint256, CGovernanceVote>{1'000'000}, legacy_orphans, {},
+                                          /*stop_after_orphans=*/true)};
+    BOOST_CHECK_THROW(truncated >> *m_node.govman, std::ios_base::failure);
+    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), 0U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/governance_vote_processing_tests.cpp
+++ b/src/test/governance_vote_processing_tests.cpp
@@ -483,22 +483,28 @@ BOOST_AUTO_TEST_CASE(legacy_invalid_vote_cache_is_discarded)
 }
 
 // The orphan cache is filled from the network by any peer, keyed by a parent hash we cannot verify
-// until the parent arrives, so its size must be bounded by us and not by the sender.
-BOOST_AUTO_TEST_CASE(orphan_vote_cache_is_bounded)
+// until the parent arrives, so its size must be bounded by us and not by the sender -- and bounded
+// per voting key, or one masternode could keep flushing everyone else's orphans out of the shared
+// cache. Past its share, a key's votes are dropped and stop seeding parent requests.
+BOOST_AUTO_TEST_CASE(orphan_votes_per_masternode_are_bounded)
 {
-    constexpr size_t OVERSHOOT = 50;
+    constexpr size_t OVERSHOOT = 25;
 
-    for (size_t i = 0; i < CGovernanceManager::MAX_ORPHAN_VOTES + OVERSHOOT; ++i) {
+    for (size_t i = 0; i < CGovernanceManager::MAX_ORPHAN_VOTES_PER_MN + OVERSHOOT; ++i) {
         // Distinct parent hash per vote, so each would occupy its own cache key.
         CGovernanceVote vote{MakeVote(uint256S(strprintf("%x", i + 1)), VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
         SignWithVotingKey(vote, mn_voting_key);
         CGovernanceException exception;
         uint256 hash_to_request;
         BOOST_CHECK(!m_node.govman->ProcessVote(vote, exception, hash_to_request));
+        if (i < CGovernanceManager::MAX_ORPHAN_VOTES_PER_MN) {
+            BOOST_CHECK_EQUAL(hash_to_request, vote.GetParentHash());
+        } else {
+            BOOST_CHECK(hash_to_request.IsNull());
+        }
     }
 
-    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(),
-                      static_cast<size_t>(CGovernanceManager::MAX_ORPHAN_VOTES));
+    BOOST_CHECK_EQUAL(m_node.govman->GetOrphanVoteCount(), CGovernanceManager::MAX_ORPHAN_VOTES_PER_MN);
 }
 
 // A peer relays a given vote once, so a second peer sending a vote we already hold is the only

--- a/src/test/orphan_vote_cache_tests.cpp
+++ b/src/test/orphan_vote_cache_tests.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <governance/governance.h>
+#include <governance/vote.h>
+#include <primitives/transaction.h>
+#include <uint256.h>
+#include <util/time.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+governance::OrphanVote OrphanFor(const uint256& parent_hash, const COutPoint& mn_outpoint)
+{
+    return {CGovernanceVote{mn_outpoint, parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES}, NodeSeconds{9999s}};
+}
+} // namespace
+
+// OrphanVoteCache accounting, exercised directly: none of these paths verify signatures, and
+// small bounds keep the eviction cases readable.
+BOOST_FIXTURE_TEST_SUITE(orphan_vote_cache_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(per_masternode_share_is_enforced_and_freed_on_erase)
+{
+    using Result = governance::OrphanVoteCache::InsertResult;
+    governance::OrphanVoteCache cache{/*max_total=*/10, /*max_per_mn=*/2};
+    const COutPoint mn{uint256S("aa"), 0};
+    const COutPoint other_mn{uint256S("bb"), 0};
+
+    BOOST_CHECK(cache.Insert(uint256S("a1"), OrphanFor(uint256S("a1"), mn)) == Result::OK);
+    BOOST_CHECK(cache.Insert(uint256S("a1"), OrphanFor(uint256S("a1"), mn)) == Result::DUPLICATE);
+    BOOST_CHECK(cache.Insert(uint256S("a2"), OrphanFor(uint256S("a2"), mn)) == Result::OK);
+    BOOST_CHECK(cache.Insert(uint256S("a3"), OrphanFor(uint256S("a3"), mn)) == Result::MN_LIMIT);
+    // One masternode at its share must not affect another.
+    BOOST_CHECK(cache.Insert(uint256S("a3"), OrphanFor(uint256S("a3"), other_mn)) == Result::OK);
+    BOOST_CHECK_EQUAL(cache.GetSize(), 3U);
+
+    // Erasing one of the capped masternode's entries frees its slot; a duplicate insert must not
+    // have double-counted it.
+    cache.Erase(uint256S("a1"), OrphanFor(uint256S("a1"), mn));
+    BOOST_CHECK(cache.Insert(uint256S("a4"), OrphanFor(uint256S("a4"), mn)) == Result::OK);
+    BOOST_CHECK(cache.Insert(uint256S("a5"), OrphanFor(uint256S("a5"), mn)) == Result::MN_LIMIT);
+}
+
+// A vote we already hold costs no capacity, so a masternode at its share must still have repeats
+// reported as duplicates: the caller needs that answer to register the relaying peer as a source
+// for the missing parent, and MN_LIMIT would suppress it.
+BOOST_AUTO_TEST_CASE(duplicates_are_recognized_at_the_per_masternode_share)
+{
+    using Result = governance::OrphanVoteCache::InsertResult;
+    governance::OrphanVoteCache cache{/*max_total=*/10, /*max_per_mn=*/2};
+    const COutPoint mn{uint256S("ee"), 0};
+
+    BOOST_CHECK(cache.Insert(uint256S("d1"), OrphanFor(uint256S("d1"), mn)) == Result::OK);
+    BOOST_CHECK(cache.Insert(uint256S("d2"), OrphanFor(uint256S("d2"), mn)) == Result::OK);
+    // Exactly at its share now: a new parent is refused, but either cached vote repeats as one.
+    BOOST_CHECK(cache.Insert(uint256S("d3"), OrphanFor(uint256S("d3"), mn)) == Result::MN_LIMIT);
+    BOOST_CHECK(cache.Insert(uint256S("d1"), OrphanFor(uint256S("d1"), mn)) == Result::DUPLICATE);
+    BOOST_CHECK(cache.Insert(uint256S("d2"), OrphanFor(uint256S("d2"), mn)) == Result::DUPLICATE);
+    // The repeats changed nothing.
+    BOOST_CHECK_EQUAL(cache.GetSize(), 2U);
+}
+
+BOOST_AUTO_TEST_CASE(global_eviction_releases_the_evicted_masternodes_slot)
+{
+    using Result = governance::OrphanVoteCache::InsertResult;
+    governance::OrphanVoteCache cache{/*max_total=*/2, /*max_per_mn=*/2};
+    const COutPoint mn_a{uint256S("aa"), 0};
+    const COutPoint mn_b{uint256S("bb"), 0};
+
+    BOOST_CHECK(cache.Insert(uint256S("f1"), OrphanFor(uint256S("f1"), mn_a)) == Result::OK);
+    BOOST_CHECK(cache.Insert(uint256S("f2"), OrphanFor(uint256S("f2"), mn_a)) == Result::OK);
+    // The cache is full: the next insert evicts the oldest entry (f1), which must release mn_a's
+    // slot along with it.
+    BOOST_CHECK(cache.Insert(uint256S("f3"), OrphanFor(uint256S("f3"), mn_b)) == Result::OK);
+    BOOST_CHECK_EQUAL(cache.GetSize(), 2U);
+    std::vector<governance::OrphanVote> votes;
+    BOOST_CHECK(!cache.GetAll(uint256S("f1"), votes));
+    // mn_a was at its share; without the release this would be MN_LIMIT.
+    BOOST_CHECK(cache.Insert(uint256S("f4"), OrphanFor(uint256S("f4"), mn_a)) == Result::OK);
+}
+
+BOOST_AUTO_TEST_CASE(erase_all_for_masternode_and_clear_reset_the_accounting)
+{
+    using Result = governance::OrphanVoteCache::InsertResult;
+    governance::OrphanVoteCache cache{/*max_total=*/10, /*max_per_mn=*/2};
+    const COutPoint mn{uint256S("cc"), 0};
+    const COutPoint bystander{uint256S("dd"), 0};
+
+    BOOST_CHECK(cache.Insert(uint256S("e1"), OrphanFor(uint256S("e1"), mn)) == Result::OK);
+    BOOST_CHECK(cache.Insert(uint256S("e2"), OrphanFor(uint256S("e2"), mn)) == Result::OK);
+    BOOST_CHECK(cache.Insert(uint256S("e3"), OrphanFor(uint256S("e3"), bystander)) == Result::OK);
+
+    BOOST_CHECK_EQUAL(cache.EraseAllForMasternode(mn), 2U);
+    BOOST_CHECK_EQUAL(cache.GetSize(), 1U);
+    BOOST_CHECK_EQUAL(cache.EraseAllForMasternode(mn), 0U);
+    BOOST_CHECK(cache.Insert(uint256S("e4"), OrphanFor(uint256S("e4"), mn)) == Result::OK);
+
+    cache.Clear();
+    BOOST_CHECK_EQUAL(cache.GetSize(), 0U);
+    BOOST_CHECK(cache.Insert(uint256S("e5"), OrphanFor(uint256S("e5"), bystander)) == Result::OK);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/p2p_governance_orphan_vote.py
+++ b/test/functional/p2p_governance_orphan_vote.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test recovery of a governance vote that arrives before its parent object.
+
+A vote naming an object we do not have is held as an orphan, and the missing
+parent is fetched through the object request tracker from the peer that sent
+the vote: that peer demonstrably has the object but may never announce it.
+The node used to broadcast MNGOVERNANCESYNC for every orphan to every peer
+instead; that path is gone, so the tracker getdata to the vote's sender is
+what keeps the vote from being stranded until ordinary governance sync.
+"""
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.governance import prepare_object
+from test_framework.messages import (
+    CInv,
+    MSG_GOVERNANCE_OBJECT,
+    MSG_GOVERNANCE_OBJECT_VOTE,
+    msg_getdata,
+    msg_inv,
+)
+from test_framework.p2p import P2PInterface, p2p_lock
+from test_framework.test_framework import DashTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class GovernanceOrphanVoteTest(DashTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.set_dash_test_params(2, 1)
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        n0, n1 = self.nodes
+
+        # Without LLMQs the collateral tx can never receive an InstantSend lock, and the miner
+        # refuses to include an unlocked tx while InstantSend is enabled.
+        n0.sporkupdate("SPORK_2_INSTANTSEND_ENABLED", 4070908800)
+        self.wait_for_sporks_same()
+
+        self.log.info("Create a funded, voted-on proposal while node1 cannot see it")
+        self.disconnect_nodes(0, 1)
+        first_new_height = n0.getblockcount() + 1
+
+        proposal_time = self.mocktime
+        proposal = prepare_object(n0, 1, "%064x" % 0, proposal_time, 1, "orphan-vote-test", 1, n0.getnewaddress())
+        self.bump_mocktime(6)
+        self.generate(n0, 6, sync_fun=self.no_op)
+        # The collateral is looked up through the txindex, which processes the new blocks
+        # asynchronously; drain the validation queue so submit cannot race it.
+        n0.syncwithvalidationinterfacequeue()
+        proposal_hash = n0.gobject("submit", "0", 1, proposal_time, proposal["hex"], proposal["collateralHash"])
+        n0.gobject("vote-many", proposal_hash, "funding", "yes")
+        votes = n0.gobject("getcurrentvotes", proposal_hash)
+        assert_equal(len(votes), 1)
+        vote_hash = next(iter(votes))
+
+        self.log.info("Give node1 the blocks, so the collateral validates, but not the governance payloads")
+        for height in range(first_new_height, n0.getblockcount() + 1):
+            n1.submitblock(n0.getblock(n0.getblockhash(height), 0))
+        assert_equal(n1.getblockcount(), n0.getblockcount())
+        assert_raises_rpc_error(-8, "Unknown governance object", n1.gobject, "get", proposal_hash)
+
+        self.log.info("Capture the raw signed object and vote from node0")
+        obj_inv = CInv(MSG_GOVERNANCE_OBJECT, int(proposal_hash, 16))
+        vote_inv = CInv(MSG_GOVERNANCE_OBJECT_VOTE, int(vote_hash, 16))
+        source = n0.add_p2p_connection(P2PInterface())
+        source.send_message(msg_getdata([obj_inv, vote_inv]))
+        source.wait_until(lambda: "govobj" in source.last_message and "govobjvote" in source.last_message)
+        with p2p_lock:
+            obj_msg = source.last_message["govobj"]
+            vote_msg = source.last_message["govobjvote"]
+        assert_equal(vote_msg.vote.nParentHash, int(proposal_hash, 16))
+
+        self.log.info("An orphan vote makes node1 request the missing parent from the vote's sender")
+        peer = n1.add_p2p_connection(P2PInterface())
+        peer.send_message(msg_inv([vote_inv]))
+        peer.wait_for_getdata([vote_inv.hash])
+        peer.send_message(vote_msg)
+        # The parent object was never announced to node1, so this getdata can only come from the
+        # vote sender being registered with the object request tracker.
+        peer.wait_for_getdata([obj_inv.hash])
+        with p2p_lock:
+            assert "govsync" not in peer.last_message
+
+        self.log.info("Serving the object replays the orphan vote")
+        peer.send_message(obj_msg)
+
+        def vote_replayed():
+            try:
+                return len(n1.gobject("getcurrentvotes", proposal_hash)) == 1
+            except JSONRPCException:  # the object itself has not been processed yet
+                return False
+        self.wait_until(vote_replayed)
+        assert_equal(n1.gobject("get", proposal_hash)["FundingResult"]["YesCount"], 1)
+
+        self.connect_nodes(0, 1)
+
+
+if __name__ == '__main__':
+    GovernanceOrphanVoteTest().main()

--- a/test/functional/p2p_governance_orphan_vote.py
+++ b/test/functional/p2p_governance_orphan_vote.py
@@ -65,6 +65,10 @@ class GovernanceOrphanVoteTest(DashTestFramework):
         for height in range(first_new_height, n0.getblockcount() + 1):
             n1.submitblock(n0.getblock(n0.getblockhash(height), 0))
         assert_equal(n1.getblockcount(), n0.getblockcount())
+        # As with the submit above: node1 validates the collateral through its txindex when the
+        # object arrives, and a txindex miss is a hard reject with no retry. Drain the queue so
+        # serving the object cannot race the index.
+        n1.syncwithvalidationinterfacequeue()
         assert_raises_rpc_error(-8, "Unknown governance object", n1.gobject, "get", proposal_hash)
 
         self.log.info("Capture the raw signed object and vote from node0")

--- a/test/functional/p2p_govsync_bloom.py
+++ b/test/functional/p2p_govsync_bloom.py
@@ -11,9 +11,7 @@ bounds, so an unbounded value would force an enormous amount of work while the m
 processing mutex is held. The handler must reject any filter that is not within the
 standard size constraints (vData <= 36000 bytes, nHashFuncs <= 50), matching filterload.
 """
-import struct
-
-from test_framework.messages import msg_generic, ser_compact_size, ser_string, ser_uint256
+from test_framework.messages import msg_generic, msg_govsync, ser_compact_size, ser_uint256
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import force_finish_mnsync
@@ -23,29 +21,6 @@ MAX_HASH_FUNCS = 50
 # serialize.h MAX_SIZE: the largest count ReadCompactSize() accepts, so a declared
 # vData length of this value reaches the vData cap, not the compact-size guard.
 MAX_SIZE = 0x02000000
-
-
-class msg_govsync:
-    """MNGOVERNANCESYNC: a governance-object hash followed by a CBloomFilter."""
-    msgtype = b"govsync"
-
-    def __init__(self, nprop=0, data=b"", n_hash_funcs=0, n_tweak=0, n_flags=0):
-        self.nprop = nprop
-        self.data = data
-        self.n_hash_funcs = n_hash_funcs
-        self.n_tweak = n_tweak
-        self.n_flags = n_flags
-
-    def serialize(self):
-        r = ser_uint256(self.nprop)
-        r += ser_string(self.data)  # CBloomFilter.vData
-        r += struct.pack("<I", self.n_hash_funcs)
-        r += struct.pack("<I", self.n_tweak)
-        r += struct.pack("<B", self.n_flags)
-        return r
-
-    def __repr__(self):
-        return f"msg_govsync(n_hash_funcs={self.n_hash_funcs})"
 
 
 class GovsyncBloomCapTest(BitcoinTestFramework):
@@ -58,14 +33,14 @@ class GovsyncBloomCapTest(BitcoinTestFramework):
 
         self.log.info("A govsync request with a well-formed bloom filter is accepted (no false positive)")
         good_peer = node.add_p2p_connection(P2PInterface())
-        good_peer.send_message(msg_govsync(n_hash_funcs=MAX_HASH_FUNCS))
+        good_peer.send_message(msg_govsync(nHashFuncs=MAX_HASH_FUNCS))
         good_peer.sync_with_ping()
         assert good_peer.is_connected
         node.disconnect_p2ps()
 
         self.log.info("A govsync request with an out-of-bounds bloom filter (nHashFuncs > 50) is rejected and the peer disconnected")
         bad_peer = node.add_p2p_connection(P2PInterface())
-        bad_peer.send_message(msg_govsync(n_hash_funcs=0xFFFFFFFF))
+        bad_peer.send_message(msg_govsync(nHashFuncs=0xFFFFFFFF))
         bad_peer.wait_for_disconnect()
 
         self.log.info("A govsync request declaring an oversized filter vData length with the bytes omitted is rejected before allocation")

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1464,10 +1464,10 @@ class CGovernanceObject:
         self.nRevision = 0
         self.nTime = 0
         self.nCollateralHash = 0
-        self.vchData = []
+        self.vchData = b""
         self.nObjectType = 0
         self.masternodeOutpoint = COutPoint()
-        self.vchSig = []
+        self.vchSig = b""
 
     def deserialize(self, f):
         self.nHashParent = deser_uint256(f)
@@ -1485,15 +1485,15 @@ class CGovernanceObject:
 
     def serialize(self):
         r = b""
-        r += ser_uint256(self.nParentHash)
+        r += ser_uint256(self.nHashParent)
         r += struct.pack("<i", self.nRevision)
         r += struct.pack("<q", self.nTime)
-        r += deser_uint256(self.nCollateralHash)
-        r += deser_compact_size(len(self.vchData))
+        r += ser_uint256(self.nCollateralHash)
+        r += ser_compact_size(len(self.vchData))
         r += self.vchData
         r += struct.pack("<i", self.nObjectType)
         r += self.masternodeOutpoint.serialize()
-        r += deser_compact_size(len(self.vchSig))
+        r += ser_compact_size(len(self.vchSig))
         r += self.vchSig
         return r
 
@@ -1507,7 +1507,7 @@ class CGovernanceVote:
         self.nVoteOutcome = 0
         self.nVoteSignal = 0
         self.nTime = 0
-        self.vchSig = []
+        self.vchSig = b""
 
     def deserialize(self, f):
         self.masternodeOutpoint.deserialize(f)
@@ -2406,6 +2406,73 @@ class msg_clsig:
 
     def __repr__(self):
         return "msg_clsig(height=%d, blockHash=%064x)" % (self.height, self.blockHash)
+
+
+class msg_govobj:
+    __slots__ = ("obj",)
+    msgtype = b"govobj"
+
+    def __init__(self, obj=None):
+        self.obj = obj if obj is not None else CGovernanceObject()
+
+    def deserialize(self, f):
+        self.obj.deserialize(f)
+
+    def serialize(self):
+        return self.obj.serialize()
+
+    def __repr__(self):
+        return "msg_govobj(nHashParent=%064x, nObjectType=%d)" % (self.obj.nHashParent, self.obj.nObjectType)
+
+
+class msg_govobjvote:
+    __slots__ = ("vote",)
+    msgtype = b"govobjvote"
+
+    def __init__(self, vote=None):
+        self.vote = vote if vote is not None else CGovernanceVote()
+
+    def deserialize(self, f):
+        self.vote.deserialize(f)
+
+    def serialize(self):
+        return self.vote.serialize()
+
+    def __repr__(self):
+        return "msg_govobjvote(nParentHash=%064x, nVoteSignal=%d, nVoteOutcome=%d)" % \
+               (self.vote.nParentHash, self.vote.nVoteSignal, self.vote.nVoteOutcome)
+
+
+class msg_govsync:
+    """MNGOVERNANCESYNC: a governance object hash plus a bloom filter, kept as raw fields."""
+    __slots__ = ("nHash", "vData", "nHashFuncs", "nTweak", "nFlags")
+    msgtype = b"govsync"
+
+    def __init__(self, nHash=0, vData=b"", nHashFuncs=0, nTweak=0, nFlags=0):
+        self.nHash = nHash
+        self.vData = vData
+        self.nHashFuncs = nHashFuncs
+        self.nTweak = nTweak
+        self.nFlags = nFlags
+
+    def deserialize(self, f):
+        self.nHash = deser_uint256(f)
+        self.vData = deser_string(f)
+        self.nHashFuncs = struct.unpack("<I", f.read(4))[0]
+        self.nTweak = struct.unpack("<I", f.read(4))[0]
+        self.nFlags = struct.unpack("<B", f.read(1))[0]
+
+    def serialize(self):
+        r = b""
+        r += ser_uint256(self.nHash)
+        r += ser_string(self.vData)
+        r += struct.pack("<I", self.nHashFuncs)
+        r += struct.pack("<I", self.nTweak)
+        r += struct.pack("<B", self.nFlags)
+        return r
+
+    def __repr__(self):
+        return "msg_govsync(nHash=%064x, nHashFuncs=%d)" % (self.nHash, self.nHashFuncs)
 
 
 class msg_isdlock:

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -57,6 +57,9 @@ from test_framework.messages import (
     msg_getheaders,
     msg_getheaders2,
     msg_getmnlistd,
+    msg_govobj,
+    msg_govobjvote,
+    msg_govsync,
     msg_headers,
     msg_headers2,
     msg_inv,
@@ -160,9 +163,9 @@ MESSAGEMAP = {
     b"getmnlistd": msg_getmnlistd,
     b"getqrinfo": None,
     b"getsporks": None,
-    b"govobj": None,
-    b"govobjvote": None,
-    b"govsync": None,
+    b"govobj": msg_govobj,
+    b"govobjvote": msg_govobjvote,
+    b"govsync": msg_govsync,
     b"headers2": msg_headers2,
     b"isdlock": msg_isdlock,
     b"mnauth": None,
@@ -617,6 +620,9 @@ class P2PInterface(P2PConnection):
 
     def on_mnlistdiff(self, message): pass
     def on_clsig(self, message): pass
+    def on_govobj(self, message): pass
+    def on_govobjvote(self, message): pass
+    def on_govsync(self, message): pass
     def on_islock(self, message): pass
     def on_isdlock(self, message): pass
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -131,6 +131,7 @@ BASE_SCRIPTS = [
     'feature_masternode_params.py', # NOTE: needs dash_hash to pass
     'feature_governance.py --descriptors',
     'feature_governance_cl.py --descriptors',
+    'p2p_governance_orphan_vote.py',
     'rpc_verifyislock.py',
     'feature_notifications.py',
     # vv Tests less than 60s vv


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CGovernanceManager` holds votes whose parent governance object has not arrived yet ("orphan votes") in `cmmapOrphanVotes`, keyed by the parent hash carried in the vote. Any unauthenticated peer can put entries there: the only gate is the standard announce-then-request tracker.

Two things then scale with that peer-controlled input.

**Fan-out.** `NetGovernance::Schedule()` ran a 5-minute sweep that sent one `MNGOVERNANCESYNC` per orphan parent hash **per connected peer**, uncapped. That is `O(orphans x peers)` outbound messages every 5 minutes, for as long as the orphans live. With ~30k orphans and 50 peers that is ~1.5M messages per tick — roughly 180 MB of `vSendMsg` allocated in a burst plus ~100 MB of egress, repeating. `CSerializedNetMsg` is appended by `PushMessage` regardless of `fPauseSend` (that flag only throttles *reading* from a peer), so the per-peer `-maxsendbuffer` ceiling of 1 MB does not stop it.

**Cache size.** `cmmapOrphanVotes` was constructed with `MAX_CACHE_SIZE = 1'000'000`. Each retained entry costs roughly 750 bytes: `CacheMultiMap` stores the value twice — once in `listItems`, once as the key of the inner `std::map<V, list_it>` — and each copy of `CGovernanceVote` carries a heap-allocated signature. Reaching the full ceiling is throttled by the fetch path, so the realistic figure is tens of MB rather than the ~750 MB the bound permits; it is still not a bound this node chose.

The fan-out is the larger of the two, in bandwidth and in memory.

Worth noting what the sweep was actually doing. On the serving side, `MNGOVERNANCESYNC` with a non-zero `nProp` and an empty bloom filter is special-cased (`object_fetch` in `net_governance.cpp`) to reply with a plain `INV{MSG_GOVERNANCE_OBJECT, nProp}` — which then flows into the ordinary object request tracker. So the sweep was an unbounded broadcast whose only purpose was to induce an announcement that the tracker would act on. It also had to be exempted from the `HasFulfilledRequest` anti-spam accounting to work at all.

This is resource exhaustion only. Orphan votes never reach consensus, and the worst functional outcome is dropped governance votes that re-sync.

## What was done?

**Fetch orphan parents through the object request tracker instead of broadcasting.**

`PeerManagerImpl::AskPeersForTransaction(txid)` already implemented the right pattern for exactly this problem — fetching a parent you know you want but were never offered — for orphan transactions. It is generalized to `AskPeersForObject(const CInv&, NodeId explicit_peer)` and exposed as `PeerAskPeersForObject`. It registers a preferred announcement with `m_object_request` for a small number of peers and lets the tracker own the fetch: GETDATA scheduling, `MAX_PEER_OBJECT_REQUEST_IN_FLIGHT`, `OVERLOADED_PEER_OBJECT_DELAY`, expiry-driven fallback to the next candidate, and `AlreadyHave()` dedup once the object turns up from any source. The synthetic announcements go through the same per-peer admission accounting (`AddObjectAnnouncement`) as peer-sent ones.

`explicit_peer` is new. A peer that holds an object without having announced it appears in no inventory filter, so the existing filter-based candidate search cannot reach it. The peer that sent us an orphan vote is registered explicitly alongside peers whose known-inventory filter contains the parent hash; the request tracker chooses among those candidates and handles timeout-driven fallback.

The orphan branch in `NetGovernance::ProcessMessage` now calls this instead of pushing `MNGOVERNANCESYNC`, and the 5-minute sweep plus `GetOrphanVoteObjectHashes()` are deleted. Each evidence-bearing relay can register its sender as a candidate, while per-peer tracker accounting bounds retained announcements and the tracker deduplicates repeated peer/object pairs. One round trip is also saved, since the tracker is seeded directly rather than via an induced INV.

**Keep expiring orphans.** Expiry lived inside `GetOrphanVoteObjectHashes()`. It moves to `ExpireOrphanVotes()`, called from `CheckAndRemove()` — the same 5-minute tick, one gate looser (`IsBlockchainSynced` rather than `IsSynced`).

**Bound the cache, globally and per masternode.** `cmmapOrphanVotes` becomes `governance::OrphanVoteCache`, which enforces two bounds together: a per-masternode share (`MAX_ORPHAN_VOTES_PER_MN = 500`) and a global cap (`MAX_ORPHAN_VOTES = 100'000`, ~40 MB worst case, replacing the ~750 MB `MAX_CACHE_SIZE` ceiling). Eviction is oldest-first cache-wide, so with only a global bound one voting key could mint votes naming invented parents and keep flushing everyone else's orphans out of the cache; with the per-key share, a key past its slice has further votes dropped without seeding parent requests, and filling the cache at all takes 200 distinct masternode keys. The wrapper owns the eviction accounting, and the inner map's capacity sits one above the global cap so its own pruning can never bypass the per-masternode counts. `RemoveInvalidVotes` now also drops a changed-key or removed masternode's cached orphans, which could no longer validate on replay — replacing an erase that was keyed by vote hash into a parent-hash-keyed map and so never matched anything.

We still serve `object_fetch` requests from older peers; only the sending side changes.

### Deliberately not done

The orphan branch stays at penalty 0. Reaching it is a routine relay race for honest peers, misbehavior scoring is suppressed while `!IsSynced()` — precisely when orphans are common — and the sending peer may merely be relaying someone else's votes. A valid MN signature is also not treated as scarce: `nParentHash` is covered by the signature, but nothing ties it to an object that exists, so any one masternode key can sign unlimited votes naming invented parents. The per-masternode share is the response to that — rather than punishing peers, each voting key is limited to its slice of the cache.

## How Has This Been Tested?

Built and tested locally on aarch64-apple-darwin (`--enable-debug`), full `make` clean.

New unit tests in `src/test/governance_vote_processing_tests.cpp`:

- `orphan_votes_per_masternode_are_bounded` verifies one voting key's orphans are capped at `MAX_ORPHAN_VOTES_PER_MN` and that votes past the share stop seeding parent requests.
- `orphan_vote_relayed_by_a_second_peer_adds_it_as_a_fallback` verifies duplicate relays still expose the missing parent for tracker registration.
- `orphan_vote_relayers_seed_parent_request_candidates` verifies the full network path registers both relayers, but not an unrelated peer, as parent-fetch candidates.
- `legacy_orphan_votes_are_discarded_on_load` verifies a legacy cache file's orphan entries and serialized capacity are dropped, both on a clean load and when the load fails mid-stream.
- A standalone `orphan_vote_cache_tests` suite exercises `OrphanVoteCache` accounting directly with small bounds: per-key share enforcement and release on erase, global eviction releasing the evicted key's slot, `EraseAllForMasternode`, and `Clear`.

Unit: `governance_inv_tests`, `governance_superblock_tests`, `governance_validators_tests`, `governance_vote_wire_tests`, `denialofservice_tests`, `net_tests`, `net_peer_eviction_tests`, `peerman_tests` — all pass.

New functional test `test/functional/p2p_governance_orphan_vote.py` covers the path end to end at the wire level, which the unit tests stop short of: a P2P peer delivers a vote whose parent object the node lacks, the node responds with a tracker-driven `getdata` for the parent **to that same peer** (which never announced the object, so nothing else could request it), no `MNGOVERNANCESYNC` is sent, and serving the object replays the orphan vote. Against a pre-change `dashd` the test fails waiting for the parent `getdata`, confirming it pins the new behavior. Supporting framework work: `govobj`/`govobjvote`/`govsync` message classes (previously known-but-ignored types), and a fix for `CGovernanceObject.serialize()` in `messages.py`, which was broken (wrong attribute name, `deser_*` used for writing) and had never been usable. Passes 14 consecutive parallel-load runs locally.

Functional: `feature_governance.py`, `feature_governance_cl.py`, `feature_governance_objects.py`, `p2p_govsync_bloom.py` pass with the framework changes; `p2p_instantsend.py` and `rpc_verifyislock.py` pass for the InstantSend caller that was updated.

Rebased on develop after #7569 (invalid-vote cache removal) landed; `Unserialize` now discards both legacy fields while preserving the on-disk field order.

Lint: `lint-whitespace.py`, `lint-circular-dependencies.py` clean.

## Breaking Changes

None. No message format changes, no `governance.dat` format change, no consensus or P2P protocol change. Purely a change in what this node sends.

One behavioral note for reviewers, called out explicitly because it is a deliberate narrowing rather than a strict improvement. The old sweep re-asked every connected peer every 5 minutes for an orphan's full 10-minute life. The new path registers only peers that give us evidence they have the parent: the peer that relayed the vote, plus any that already announced that specific object hash. So the set of peers asked is driven by who actually relays to us rather than by who happens to be connected.

Every relay of a vote for a still-missing parent adds its sender as a candidate, including a relay of a vote we already hold, so fallbacks accumulate as the vote propagates rather than being fixed at the first sender. The tracker retries and moves to the next candidate on expiry. If every registered candidate fails, recovery for a synced node comes from ordinary flood relay — any peer that accepts the object announces it to us — not from governance sync, which only runs during initial sync; a restarting node is covered by that initial sync. The accepted trade is that the old persistence *was* the amplification: it cannot be kept without keeping the `O(orphans x peers)` term.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
