### PR TITLE
fix: data races and check-then-act races in the CoinJoin server

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1229,8 +1229,9 @@ bool CCoinJoinClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, 
         SetState(POOL_STATE_QUEUE);
         nTimeLastSuccessfulStep = GetTime();
         WalletCJLogPrint(m_wallet, /* Continued */
-                         "CCoinJoinClientSession::JoinExistingQueue -- pending connection, masternode=%s, nSessionDenom=%d (%s)\n",
-                         dmn->proTxHash.ToString(), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+                         "CCoinJoinClientSession::JoinExistingQueue -- pending connection, masternode=%s, "
+                         "nSessionDenom=%d (%s)\n",
+                         dmn->proTxHash.ToString(), nSessionDenom.load(), CoinJoin::DenominationToString(nSessionDenom));
         strAutoDenomResult = _("Trying to connect…");
         return true;
     }
@@ -1310,9 +1311,11 @@ bool CCoinJoinClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, CCon
         pendingDsaRequest = CPendingDsaRequest(dmn->proTxHash, CCoinJoinAccept(nSessionDenom, txMyCollateral));
         SetState(POOL_STATE_QUEUE);
         nTimeLastSuccessfulStep = GetTime();
-        WalletCJLogPrint( /* Continued */
-            m_wallet, "CCoinJoinClientSession::StartNewQueue -- pending connection, masternode=%s, nSessionDenom=%d (%s)\n",
-            dmn->proTxHash.ToString(), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+        WalletCJLogPrint(/* Continued */
+                         m_wallet,
+                         "CCoinJoinClientSession::StartNewQueue -- pending connection, masternode=%s, nSessionDenom=%d "
+                         "(%s)\n",
+                         dmn->proTxHash.ToString(), nSessionDenom.load(), CoinJoin::DenominationToString(nSessionDenom));
         strAutoDenomResult = _("Trying to connect…");
         return true;
     }
@@ -1424,7 +1427,7 @@ bool CCoinJoinClientSession::SubmitDenominate(CConnman& connman)
         return a.second > b.second || (a.second == b.second && a.first < b.first);
     });
 
-    WalletCJLogPrint(m_wallet, "vecInputsByRounds for denom %d\n", nSessionDenom);
+    WalletCJLogPrint(m_wallet, "vecInputsByRounds for denom %d\n", nSessionDenom.load());
     for (const auto& pair : vecInputsByRounds) {
         WalletCJLogPrint(m_wallet, "vecInputsByRounds: rounds: %d, inputs: %d\n", pair.first, pair.second);
     }

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -475,7 +475,7 @@ bool CCoinJoinClientSession::SignFinalTransaction(CNode& peer, Chainstate& activ
     // Make sure all inputs/outputs are valid
     PoolMessage nMessageID{MSG_NOERR};
     if (!IsValidInOuts(active_chainstate, m_isman, mempool, finalMutableTransaction.vin, finalMutableTransaction.vout,
-                       nMessageID, nullptr)) {
+                       nSessionDenom.load(), nMessageID, nullptr)) {
         WalletCJLogPrint(m_wallet, "CCoinJoinClientSession::%s -- ERROR! IsValidInOuts() failed: %s\n", __func__, CoinJoin::GetMessageByID(nMessageID).translated);
         UnlockCoins();
         keyHolderStorage.ReturnAll();
@@ -2004,4 +2004,3 @@ UniValue CCoinJoinClientManager::getJsonInfo() const
     obj.pushKV("sessions", arrSessions);
     return obj;
 }
-

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -206,8 +206,8 @@ std::string CCoinJoinBaseSession::GetStateString() const
 
 bool CCoinJoinBaseSession::IsValidInOuts(Chainstate& active_chainstate, const llmq::CInstantSendManager& isman,
                                          const CTxMemPool& mempool, const std::vector<CTxIn>& vin,
-                                         const std::vector<CTxOut>& vout, PoolMessage& nMessageIDRet,
-                                         bool* fConsumeCollateralRet) const
+                                         const std::vector<CTxOut>& vout, int session_denom,
+                                         PoolMessage& nMessageIDRet, bool* fConsumeCollateralRet)
 {
     std::set<CScript> setScripPubKeys;
     nMessageIDRet = MSG_NOERR;
@@ -221,9 +221,10 @@ bool CCoinJoinBaseSession::IsValidInOuts(Chainstate& active_chainstate, const ll
     }
 
     auto checkTxOut = [&](const CTxOut& txout) {
-        if (int nDenom = CoinJoin::AmountToDenomination(txout.nValue); nDenom != nSessionDenom) {
+        if (int nDenom = CoinJoin::AmountToDenomination(txout.nValue); nDenom != session_denom) {
             LogPrint(BCLog::COINJOIN, "CCoinJoinBaseSession::IsValidInOuts -- ERROR: incompatible denom %d (%s) != nSessionDenom %d (%s)\n",
-                    nDenom, CoinJoin::DenominationToString(nDenom), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+                    nDenom, CoinJoin::DenominationToString(nDenom), session_denom,
+                    CoinJoin::DenominationToString(session_denom));
             nMessageIDRet = ERR_DENOM;
             if (fConsumeCollateralRet) *fConsumeCollateralRet = true;
             return false;

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -342,7 +342,9 @@ protected:
                        PoolMessage& nMessageIDRet, bool* fConsumeCollateralRet) const;
 
 public:
-    int nSessionDenom{0}; // Users must submit a denom matching this
+    // Atomic because the message-handling and scheduler threads write it while those threads and
+    // RPC callers also read it without holding cs_coinjoin.
+    std::atomic<int> nSessionDenom{0};
 
     CCoinJoinBaseSession() = default;
     virtual ~CCoinJoinBaseSession() = default;

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -337,9 +337,10 @@ protected:
 
     virtual void SetNull() EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
-    bool IsValidInOuts(Chainstate& active_chainstate, const llmq::CInstantSendManager& isman,
-                       const CTxMemPool& mempool, const std::vector<CTxIn>& vin, const std::vector<CTxOut>& vout,
-                       PoolMessage& nMessageIDRet, bool* fConsumeCollateralRet) const;
+    static bool IsValidInOuts(Chainstate& active_chainstate, const llmq::CInstantSendManager& isman,
+                              const CTxMemPool& mempool, const std::vector<CTxIn>& vin,
+                              const std::vector<CTxOut>& vout, int session_denom, PoolMessage& nMessageIDRet,
+                              bool* fConsumeCollateralRet);
 
 public:
     // Atomic because the message-handling and scheduler threads write it while those threads and

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -405,6 +405,8 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
     AssertLockNotHeld(cs_coinjoin);
 
     CTransactionRef finalTransaction;
+    std::vector<CService> participants;
+    std::vector<CTransactionRef> collaterals;
     {
         LOCK(cs_coinjoin);
         // Committing a session that is already gone would push a cleared finalMutableTransaction
@@ -415,6 +417,9 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
             return;
         }
         finalTransaction = MakeTransactionRef(finalMutableTransaction);
+        participants.reserve(vecEntries.size());
+        std::ranges::transform(vecEntries, std::back_inserter(participants), [](const auto& entry) { return entry.addr; });
+        collaterals = m_session_collaterals.txs();
     }
     uint256 hashTx = finalTransaction->GetHash();
 
@@ -428,9 +433,9 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
         if (!lockMain || !ATMPIfSaneFee(m_chainman, finalTransaction)) {
             LogPrint(BCLog::COINJOIN, /* Continued */
                      "CCoinJoinServer::CommitFinalTransaction -- ATMPIfSaneFee() error: Transaction not valid\n");
-            WITH_LOCK(cs_coinjoin, SetNull());
             // not much we can do in this case, just notify clients
-            RelayCompletedTransaction(ERR_INVALID_TX);
+            RelayCompletedTransaction(session_id, participants, ERR_INVALID_TX);
+            ResetSigningSessionIfCurrent(session_id);
             return;
         }
     }
@@ -451,14 +456,14 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
     m_peer_manager->PeerRelayInv(inv);
 
     // Tell the clients it was successful
-    RelayCompletedTransaction(MSG_SUCCESS);
+    RelayCompletedTransaction(session_id, participants, MSG_SUCCESS);
 
     // Randomly charge clients
-    ChargeRandomFees();
+    ChargeRandomFees(collaterals);
 
     // Reset
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- COMPLETED -- RESETTING\n");
-    WITH_LOCK(cs_coinjoin, SetNull());
+    ResetSigningSessionIfCurrent(session_id);
 }
 
 //
@@ -548,17 +553,11 @@ CTransactionRef CCoinJoinServer::SelectCollateralToCharge() const
     stop these kinds of attacks 1 in 10 successful transactions are charged. This
     adds up to a cost of 0.001DRK per transaction on average.
 */
-void CCoinJoinServer::ChargeRandomFees() const
+void CCoinJoinServer::ChargeRandomFees(const std::vector<CTransactionRef>& collaterals) const
 {
     AssertLockNotHeld(cs_coinjoin);
 
-    std::vector<CTransactionRef> session_collaterals;
-    {
-        LOCK(cs_coinjoin);
-        session_collaterals = m_session_collaterals.txs();
-    }
-
-    for (const auto& txCollateral : session_collaterals) {
+    for (const auto& txCollateral : collaterals) {
         if (GetRand<int>(/*nMax=*/100) > 10) return;
         LogPrint(BCLog::COINJOIN, /* Continued */
                  "CCoinJoinServer::ChargeRandomFees -- charging random fees, txCollateral=%s", txCollateral->ToString());
@@ -1098,26 +1097,34 @@ void CCoinJoinServer::RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nM
     }
 }
 
-void CCoinJoinServer::RelayCompletedTransaction(PoolMessage nMessageID)
+void CCoinJoinServer::RelayCompletedTransaction(int session_id, const std::vector<CService>& participants,
+                                                PoolMessage nMessageID)
 {
     AssertLockNotHeld(cs_coinjoin);
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- nSessionID: %d  nSessionDenom: %d (%s)\n",
-        __func__, nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- nSessionID: %d\n", __func__, session_id);
 
-    // final mixing tx with empty signatures should be relayed to mixing participants only
-    LOCK(cs_coinjoin);
-    for (const auto& entry : vecEntries) {
-        bool fOk = connman.ForNode(entry.addr, [&nMessageID, this](CNode* pnode) {
+    for (const auto& addr : participants) {
+        const bool fOk = connman.ForNode(addr, [&nMessageID, session_id, this](CNode* pnode) {
             CNetMsgMaker msgMaker(pnode->GetCommonVersion());
-            connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSCOMPLETE, nSessionID.load(), nMessageID));
+            connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSCOMPLETE, session_id, nMessageID));
             return true;
         });
         if (!fOk) {
-            // no such node? maybe client disconnected or our own connection went down
-            RelayStatus(STATUS_REJECTED);
-            break;
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- participant disconnected before completion\n", __func__);
         }
     }
+}
+
+void CCoinJoinServer::ResetSigningSessionIfCurrent(int session_id)
+{
+    AssertLockNotHeld(cs_coinjoin);
+    LOCK(cs_coinjoin);
+    if (nSessionID != session_id || nState != POOL_STATE_SIGNING) {
+        LogPrint(BCLog::COINJOIN, /* Continued */
+                 "CCoinJoinServer::%s -- signing session %d is no longer current, not resetting\n", __func__, session_id);
+        return;
+    }
+    SetNull();
 }
 
 void CCoinJoinServer::SetState(PoolState nStateNew)

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -41,7 +41,6 @@ CCoinJoinServer::CCoinJoinServer(PeerManagerInternal* peer_manager, ChainstateMa
     m_mn_activeman{mn_activeman},
     m_mn_sync{mn_sync},
     m_isman{isman},
-    vecSessionCollaterals{},
     fUnitTest{false}
 {
 }
@@ -86,7 +85,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
         return;
     }
 
-    if (WITH_LOCK(cs_coinjoin, return vecSessionCollaterals.empty())) {
+    if (WITH_LOCK(cs_coinjoin, return m_session_collaterals.empty())) {
         {
             const auto hasQueue = m_queueman.TryHasQueueFromMasternode(m_mn_activeman.GetOutPoint());
             if (!hasQueue.has_value()) return;
@@ -282,8 +281,7 @@ void CCoinJoinServer::SetNull()
 {
     AssertLockHeld(cs_coinjoin);
     // MN side
-    vecSessionCollaterals.clear();
-    setSessionCollateralPrevouts.clear();
+    m_session_collaterals.Clear();
 
     CCoinJoinBaseSession::SetNull();
     m_queueman.SetNull();
@@ -323,7 +321,7 @@ void CCoinJoinServer::CheckPool()
             LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- entries count %lu\n", entries);
         }
         if (nState == POOL_STATE_ACCEPTING_ENTRIES) {
-            if (static_cast<size_t>(entries) == vecSessionCollaterals.size()) {
+            if (static_cast<size_t>(entries) == m_session_collaterals.size()) {
                 // We have an entry for each collateral
                 action = Action::Finalize;
             } else if (CCoinJoinServer::HasTimedOut() && entries >= CoinJoin::GetMinPoolParticipants()) {
@@ -482,10 +480,10 @@ void CCoinJoinServer::ChargeFees() const
         // and then charge and log them as "didn't sign", or pick offenders from a session the
         // state no longer describes.
         state = nState;
-        nSessionCollaterals = vecSessionCollaterals.size();
+        nSessionCollaterals = m_session_collaterals.size();
 
         if (state == POOL_STATE_ACCEPTING_ENTRIES) {
-            for (const auto& txCollateral : vecSessionCollaterals) {
+            for (const auto& txCollateral : m_session_collaterals.txs()) {
                 bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
                     return *entry.txCollateral == *txCollateral;
                 });
@@ -550,7 +548,7 @@ void CCoinJoinServer::ChargeRandomFees() const
     std::vector<CTransactionRef> session_collaterals;
     {
         LOCK(cs_coinjoin);
-        session_collaterals = vecSessionCollaterals;
+        session_collaterals = m_session_collaterals.txs();
     }
 
     for (const auto& txCollateral : session_collaterals) {
@@ -614,7 +612,7 @@ void CCoinJoinServer::CheckForCompleteQueue()
 
         SetState(POOL_STATE_ACCEPTING_ENTRIES);
         session_denom = nSessionDenom;
-        participants = vecSessionCollaterals.size();
+        participants = m_session_collaterals.size();
     }
 
     CCoinJoinQueue dsq(session_denom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(), GetAdjustedTime(), true);
@@ -677,7 +675,7 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
 {
     AssertLockNotHeld(cs_coinjoin);
 
-    if (size_t(GetEntriesCount()) >= vecSessionCollaterals.size()) {
+    if (WITH_LOCK(cs_coinjoin, return size_t(GetEntriesCountLocked()) >= m_session_collaterals.size())) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
         nMessageIDRet = ERR_ENTRIES_FULL;
         return false;
@@ -692,10 +690,11 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
         CTransactionRef txCollateralToConsume;
         {
             LOCK(cs_coinjoin);
-            const auto it = std::ranges::find_if(vecSessionCollaterals, [&entry](const auto& txCollateral) {
+            const auto& txs = m_session_collaterals.txs();
+            const auto it = std::ranges::find_if(txs, [&entry](const auto& txCollateral) {
                 return *entry.txCollateral == *txCollateral;
             });
-            if (it != vecSessionCollaterals.end()) {
+            if (it != txs.end()) {
                 txCollateralToConsume = *it;
             }
         }
@@ -814,15 +813,6 @@ bool CCoinJoinServer::IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& n
     return true;
 }
 
-void CCoinJoinServer::CommitSessionCollateral(const CMutableTransaction& txCollateral)
-{
-    AssertLockHeld(cs_coinjoin);
-    vecSessionCollaterals.push_back(MakeTransactionRef(txCollateral));
-    for (const auto& txin : txCollateral.vin) {
-        setSessionCollateralPrevouts.insert(txin.prevout);
-    }
-}
-
 bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet)
 {
     if (nSessionID != 0) return false;
@@ -838,6 +828,8 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
         return false;
     }
 
+    int nDenom{0};
+    size_t nParticipants{0};
     {
         LOCK(cs_coinjoin);
 
@@ -856,21 +848,25 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
 
         SetState(POOL_STATE_QUEUE);
 
-        CommitSessionCollateral(dsa.txCollateral);
+        m_session_collaterals.Add(dsa.txCollateral);
+        nDenom = nSessionDenom;
+        nParticipants = m_session_collaterals.size();
     }
 
     if (!fUnitTest) {
         //broadcast that I'm accepting entries, only if it's the first entry through
-        CCoinJoinQueue dsq(nSessionDenom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(),
-                           GetAdjustedTime(), false);
+        CCoinJoinQueue dsq(nDenom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(), GetAdjustedTime(), false);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- signing and relaying new queue: %s\n", dsq.ToString());
         dsq.vchSig = m_mn_activeman.SignBasic(dsq.GetSignatureHash());
         m_peer_manager->PeerRelayDSQ(dsq);
         m_queueman.AddQueue(std::move(dsq));
     }
 
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- new session created, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
-        nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), vecSessionCollaterals.size(), CoinJoin::GetMaxPoolParticipants());
+    LogPrint(BCLog::COINJOIN, /* Continued */
+             "CCoinJoinServer::CreateNewSession -- new session created, nSessionID: %d  nSessionDenom: %d (%s)  "
+             "participants: %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
+             nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), nParticipants,
+             CoinJoin::GetMaxPoolParticipants());
 
     return true;
 }
@@ -916,25 +912,26 @@ bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolM
         return false;
     }
 
-    // Session collaterals are only ever test-accepted, never added to the mempool, so nothing
-    // pins their identity: the same UTXO can be re-signed into arbitrarily many distinct txids.
-    // Match on input prevouts so a resent or replayed dsa cannot be counted as a new participant.
-    for (const auto& txin : dsa.txCollateral.vin) {
-        if (setSessionCollateralPrevouts.contains(txin.prevout)) {
-            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- collateral %s spends prevout %s already committed to this session\n",
-                dsa.txCollateral.GetHash().ToString(), txin.prevout.ToStringShort());
-            nMessageIDRet = ERR_ALREADY_HAVE;
-            return false;
-        }
+    // A resent or replayed dsa must not be counted as a new participant; see SessionCollaterals.
+    if (const auto prevout = m_session_collaterals.FindCommittedPrevout(dsa.txCollateral)) {
+        LogPrint(BCLog::COINJOIN, /* Continued */
+                 "CCoinJoinServer::AddUserToExistingSession -- collateral %s spends prevout %s already committed to "
+                 "this session\n",
+                 dsa.txCollateral.GetHash().ToString(), prevout->ToStringShort());
+        nMessageIDRet = ERR_ALREADY_HAVE;
+        return false;
     }
 
     // count new user as accepted to an existing session
 
     nMessageIDRet = MSG_NOERR;
-    CommitSessionCollateral(dsa.txCollateral);
+    m_session_collaterals.Add(dsa.txCollateral);
 
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- new user accepted, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
-        nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), vecSessionCollaterals.size(), CoinJoin::GetMaxPoolParticipants());
+    LogPrint(BCLog::COINJOIN, /* Continued */
+             "CCoinJoinServer::AddUserToExistingSession -- new user accepted, nSessionID: %d  nSessionDenom: %d (%s)  "
+             "participants: %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
+             nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), m_session_collaterals.size(),
+             CoinJoin::GetMaxPoolParticipants());
 
     return true;
 }
@@ -945,10 +942,10 @@ bool CCoinJoinServer::IsSessionReady() const
     AssertLockHeld(cs_coinjoin);
 
     if (nState == POOL_STATE_QUEUE) {
-        if ((int)vecSessionCollaterals.size() >= CoinJoin::GetMaxPoolParticipants()) {
+        if ((int)m_session_collaterals.size() >= CoinJoin::GetMaxPoolParticipants()) {
             return true;
         }
-        if (CCoinJoinServer::HasTimedOut() && (int)vecSessionCollaterals.size() >= CoinJoin::GetMinPoolParticipants()) {
+        if (CCoinJoinServer::HasTimedOut() && (int)m_session_collaterals.size() >= CoinJoin::GetMinPoolParticipants()) {
             return true;
         }
     }

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -606,6 +606,20 @@ void CCoinJoinServer::CheckTimeout()
         // closing the session form one atomic cutoff for late entries and signatures.
         if (!CCoinJoinServer::HasTimedOut()) return;
 
+        // CheckForCompleteQueue() and CheckPool() run before this method on the scheduler thread,
+        // but a final collateral, entry, or signature can arrive after their snapshots. The
+        // message-handling thread then skips its own CheckPool() if this scheduler tick still holds
+        // cs_check_pool. Give a session that can now advance priority over resetting it; the next
+        // scheduler tick will perform the transition, finalization, or commit.
+        const int entries{GetEntriesCountLocked()};
+        const bool can_advance{
+            (nState == POOL_STATE_QUEUE && IsSessionReady()) ||
+            (nState == POOL_STATE_ACCEPTING_ENTRIES &&
+             (static_cast<size_t>(entries) == m_session_collaterals.size() ||
+              entries >= CoinJoin::GetMinPoolParticipants())) ||
+            (nState == POOL_STATE_SIGNING && IsSignaturesComplete())};
+        if (can_advance) return;
+
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
                  (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
         collateral_to_charge = SelectCollateralToCharge();

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -675,7 +675,12 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
 {
     AssertLockNotHeld(cs_coinjoin);
 
-    if (WITH_LOCK(cs_coinjoin, return size_t(GetEntriesCountLocked()) >= m_session_collaterals.size())) {
+    // Remember which session we are admitting this entry to. The validation below releases
+    // cs_coinjoin and takes cs_main, so the session can be reset underneath us before we commit.
+    const int session_id{nSessionID};
+
+    // Cheap gate before the cs_main work below; the authoritative check is at commit time.
+    if (WITH_LOCK(cs_coinjoin, return static_cast<size_t>(GetEntriesCountLocked()) >= m_session_collaterals.size())) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
         nMessageIDRet = ERR_ENTRIES_FULL;
         return false;
@@ -711,21 +716,24 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
     }
 
     std::vector<CTxIn> vin;
-    for (const auto& txin : entry.vecTxDSIn) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- txin=%s\n", __func__, txin.ToString());
+    {
         LOCK(cs_coinjoin);
-        for (const auto& inner_entry : vecEntries) {
-            if (std::ranges::any_of(inner_entry.vecTxDSIn,
-                                    [&txin](const auto& txdsin) { return txdsin.prevout == txin.prevout; })) {
-                LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: already have this txin in entries\n", __func__);
-                nMessageIDRet = ERR_ALREADY_HAVE;
-                // Two peers sent the same input? Can't really say who is the malicious one here,
-                // could be that someone is picking someone else's inputs randomly trying to force
-                // collateral consumption. Do not punish.
-                return false;
+        for (const auto& txin : entry.vecTxDSIn) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- txin=%s\n", __func__, txin.ToString());
+            for (const auto& inner_entry : vecEntries) {
+                if (std::ranges::any_of(inner_entry.vecTxDSIn,
+                                        [&txin](const auto& txdsin) { return txdsin.prevout == txin.prevout; })) {
+                    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: already have this txin in entries\n",
+                             __func__);
+                    nMessageIDRet = ERR_ALREADY_HAVE;
+                    // Two peers sent the same input? Can't really say who is the malicious one here,
+                    // could be that someone is picking someone else's inputs randomly trying to force
+                    // collateral consumption. Do not punish.
+                    return false;
+                }
             }
+            vin.emplace_back(txin);
         }
-        vin.emplace_back(txin);
     }
 
     bool fConsumeCollateral{false};
@@ -738,9 +746,32 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
         return false;
     }
 
-    WITH_LOCK(cs_coinjoin, vecEntries.push_back(entry));
+    int nEntries{0};
+    {
+        LOCK(cs_coinjoin);
 
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- adding entry %d of %d required\n", __func__, GetEntriesCount(), CoinJoin::GetMaxPoolParticipants());
+        // IsCollateralValid() and IsValidInOuts() above take cs_main and can block for a long
+        // time behind block validation, so a scheduler-thread timeout can reset the session in
+        // that window. Committing then would leave an entry of a dead session in vecEntries: the
+        // next session inherits it, counts it towards its own participants, and finalizes a
+        // transaction containing an input nobody present is going to sign.
+        if (nSessionID != session_id) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: session %d is gone!\n", __func__, session_id);
+            nMessageIDRet = ERR_SESSION;
+            return false;
+        }
+        if (static_cast<size_t>(GetEntriesCountLocked()) >= m_session_collaterals.size()) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
+            nMessageIDRet = ERR_ENTRIES_FULL;
+            return false;
+        }
+
+        vecEntries.push_back(entry);
+        nEntries = GetEntriesCountLocked();
+    }
+
+    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- adding entry %d of %d required\n", __func__, nEntries,
+             CoinJoin::GetMaxPoolParticipants());
     nMessageIDRet = MSG_ENTRIES_ADDED;
 
     return true;

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -200,7 +200,7 @@ void CCoinJoinServer::ProcessDSQUEUE(NodeId from, CDataStream& vRecv)
 void CCoinJoinServer::ProcessDSVIN(CNode& peer, CDataStream& vRecv)
 {
     //do we have enough users in the current session?
-    if (!IsSessionReady()) {
+    if (!WITH_LOCK(cs_coinjoin, return IsSessionReady())) {
         LogPrint(BCLog::COINJOIN, "DSVIN -- session not complete!\n");
         PushStatus(peer, STATUS_REJECTED, ERR_SESSION);
         return;
@@ -294,41 +294,78 @@ void CCoinJoinServer::SetNull()
 //
 void CCoinJoinServer::CheckPool()
 {
-    if (int entries = GetEntriesCount(); entries != 0)
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- entries count %lu\n", entries);
+    AssertLockNotHeld(cs_coinjoin);
 
-    // If we have an entry for each collateral, then create final tx
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES && size_t(GetEntriesCount()) == vecSessionCollaterals.size()) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- FINALIZE TRANSACTIONS\n");
-        CreateFinalTransaction();
-        return;
+    // Both the scheduler thread and the message-handling thread get here. Skip the round if the
+    // other one is already in it rather than blocking msghand behind its mempool work: whichever
+    // thread holds the lock is performing the same check we would.
+    TRY_LOCK(cs_check_pool, lock_check_pool);
+    if (!lock_check_pool) return;
+
+    // Decide what to do from a single consistent snapshot. Sampling nState, the entry count and
+    // the collateral count under separate lock acquisitions let a concurrent SetNull() land
+    // between them, so an already-reset session could be read as "0 entries == 0 collaterals"
+    // and finalized: an empty final transaction, a dead session put back into SIGNING, and no
+    // new session accepted until that timed out.
+    enum class Action : uint8_t {
+        None,
+        Finalize,
+        ChargeAndFinalize,
+        Commit
+    };
+    Action action{Action::None};
+    int session_id{0};
+    {
+        LOCK(cs_coinjoin);
+        session_id = nSessionID;
+        const int entries{GetEntriesCountLocked()};
+        if (entries != 0) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- entries count %lu\n", entries);
+        }
+        if (nState == POOL_STATE_ACCEPTING_ENTRIES) {
+            if (static_cast<size_t>(entries) == vecSessionCollaterals.size()) {
+                // We have an entry for each collateral
+                action = Action::Finalize;
+            } else if (CCoinJoinServer::HasTimedOut() && entries >= CoinJoin::GetMinPoolParticipants()) {
+                // We timed out while accepting entries but still have more than the minimum, so
+                // punish the misbehaving participants and complete the session without them
+                action = Action::ChargeAndFinalize;
+            }
+        } else if (nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
+            action = Action::Commit;
+        }
     }
 
-    // Check for Time Out
-    // If we timed out while accepting entries, then if we have more than minimum, create final tx
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES && CCoinJoinServer::HasTimedOut() &&
-        GetEntriesCount() >= CoinJoin::GetMinPoolParticipants()) {
-        // Punish misbehaving participants
+    switch (action) {
+    case Action::None:
+        return;
+    case Action::ChargeAndFinalize:
         ChargeFees();
-        // Try to complete this session ignoring the misbehaving ones
-        CreateFinalTransaction();
+        [[fallthrough]];
+    case Action::Finalize:
+        CreateFinalTransaction(session_id);
         return;
-    }
-
-    // If we have all the signatures, try to compile the transaction
-    if (nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
+    case Action::Commit:
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- SIGNING\n");
-        CommitFinalTransaction();
+        CommitFinalTransaction(session_id);
         return;
     }
 }
 
-void CCoinJoinServer::CreateFinalTransaction()
+void CCoinJoinServer::CreateFinalTransaction(int session_id)
 {
     AssertLockNotHeld(cs_coinjoin);
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- FINALIZE TRANSACTIONS\n");
 
     LOCK(cs_coinjoin);
+
+    // Finalizing a session that is already gone would put it back into SIGNING and reject every
+    // new one until that timed out.
+    if (nSessionID != session_id) {
+        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- session %d is gone, not finalizing\n",
+                 session_id);
+        return;
+    }
 
     CMutableTransaction txNew;
 
@@ -354,11 +391,22 @@ void CCoinJoinServer::CreateFinalTransaction()
     RelayFinalTransaction(CTransaction(finalMutableTransaction));
 }
 
-void CCoinJoinServer::CommitFinalTransaction()
+void CCoinJoinServer::CommitFinalTransaction(int session_id)
 {
     AssertLockNotHeld(cs_coinjoin);
 
-    CTransactionRef finalTransaction = WITH_LOCK(cs_coinjoin, return MakeTransactionRef(finalMutableTransaction));
+    CTransactionRef finalTransaction;
+    {
+        LOCK(cs_coinjoin);
+        // Committing a session that is already gone would push a cleared finalMutableTransaction
+        // through ATMP and notify the participants of a failure that never happened.
+        if (nSessionID != session_id) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- session %d is gone, not committing\n",
+                     session_id);
+            return;
+        }
+        finalTransaction = MakeTransactionRef(finalMutableTransaction);
+    }
     uint256 hashTx = finalTransaction->GetHash();
 
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- finalTransaction=%s", /* Continued */
@@ -424,33 +472,42 @@ void CCoinJoinServer::ChargeFees() const
     if (GetRand<int>(/*nMax=*/100) > 33) return;
 
     std::vector<CTransactionRef> vecOffendersCollaterals;
+    size_t nSessionCollaterals{0};
+    PoolState state{POOL_STATE_IDLE};
 
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES) {
+    {
         LOCK(cs_coinjoin);
-        for (const auto& txCollateral : vecSessionCollaterals) {
-            bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
-                return *entry.txCollateral == *txCollateral;
-            });
+        // Sample the state under the lock, together with the data it describes. Reading nState
+        // separately per branch let a concurrent transition select the "didn't send" offenders
+        // and then charge and log them as "didn't sign", or pick offenders from a session the
+        // state no longer describes.
+        state = nState;
+        nSessionCollaterals = vecSessionCollaterals.size();
 
-            // This queue entry didn't send us the promised transaction
-            if (!fFound) {
-                LogPrint(BCLog::COINJOIN, /* Continued */
-                         "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't send transaction), found "
-                         "offence\n");
-                vecOffendersCollaterals.push_back(txCollateral);
-            }
-        }
-    }
+        if (state == POOL_STATE_ACCEPTING_ENTRIES) {
+            for (const auto& txCollateral : vecSessionCollaterals) {
+                bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
+                    return *entry.txCollateral == *txCollateral;
+                });
 
-    if (nState == POOL_STATE_SIGNING) {
-        // who didn't sign?
-        LOCK(cs_coinjoin);
-        for (const auto& entry : vecEntries) {
-            for (const auto& txdsin : entry.vecTxDSIn) {
-                if (!txdsin.fHasSig) {
+                // This queue entry didn't send us the promised transaction
+                if (!fFound) {
                     LogPrint(BCLog::COINJOIN, /* Continued */
-                             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't sign), found offence\n");
-                    vecOffendersCollaterals.push_back(entry.txCollateral);
+                             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't send transaction), found "
+                             "offence\n");
+                    vecOffendersCollaterals.push_back(txCollateral);
+                }
+            }
+        } else if (state == POOL_STATE_SIGNING) {
+            // who didn't sign?
+            for (const auto& entry : vecEntries) {
+                for (const auto& txdsin : entry.vecTxDSIn) {
+                    if (!txdsin.fHasSig) {
+                        LogPrint(BCLog::COINJOIN, /* Continued */
+                                 "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't sign), found "
+                                 "offence\n");
+                        vecOffendersCollaterals.push_back(entry.txCollateral);
+                    }
                 }
             }
         }
@@ -460,20 +517,18 @@ void CCoinJoinServer::ChargeFees() const
     if (vecOffendersCollaterals.empty()) return;
 
     //mostly offending? Charge sometimes
-    if (vecOffendersCollaterals.size() >= vecSessionCollaterals.size() - 1 && GetRand<int>(/*nMax=*/100) > 33) return;
+    if (vecOffendersCollaterals.size() >= nSessionCollaterals - 1 && GetRand<int>(/*nMax=*/100) > 33) return;
 
     //everyone is an offender? That's not right
-    if (vecOffendersCollaterals.size() >= vecSessionCollaterals.size()) return;
+    if (vecOffendersCollaterals.size() >= nSessionCollaterals) return;
 
     //charge one of the offenders randomly
     Shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end(), FastRandomContext());
 
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_SIGNING) {
-        LogPrint(BCLog::COINJOIN, /* Continued */
-                 "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s",
-                 (nState == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
-        ConsumeCollateral(vecOffendersCollaterals[0]);
-    }
+    LogPrint(BCLog::COINJOIN, /* Continued */
+             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s",
+             (state == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
+    ConsumeCollateral(vecOffendersCollaterals[0]);
 }
 
 /*
@@ -549,6 +604,8 @@ void CCoinJoinServer::CheckTimeout()
 */
 void CCoinJoinServer::CheckForCompleteQueue()
 {
+    AssertLockNotHeld(cs_coinjoin);
+
     int session_denom;
     size_t participants;
     {
@@ -731,8 +788,7 @@ bool CCoinJoinServer::AddScriptSig(const CTxIn& txinNew)
 // Check to make sure everything is signed
 bool CCoinJoinServer::IsSignaturesComplete() const
 {
-    AssertLockNotHeld(cs_coinjoin);
-    LOCK(cs_coinjoin);
+    AssertLockHeld(cs_coinjoin);
 
     return std::ranges::all_of(vecEntries, [](const auto& entry) {
         return std::ranges::all_of(entry.vecTxDSIn, [](const auto& txdsin) { return txdsin.fHasSig; });
@@ -886,6 +942,8 @@ bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolM
 // Returns true if either max size has been reached or if the mix timed out and min size was reached
 bool CCoinJoinServer::IsSessionReady() const
 {
+    AssertLockHeld(cs_coinjoin);
+
     if (nState == POOL_STATE_QUEUE) {
         if ((int)vecSessionCollaterals.size() >= CoinJoin::GetMaxPoolParticipants()) {
             return true;
@@ -988,6 +1046,8 @@ void CCoinJoinServer::RelayCompletedTransaction(PoolMessage nMessageID)
 
 void CCoinJoinServer::SetState(PoolState nStateNew)
 {
+    AssertLockHeld(cs_coinjoin);
+
     if (nStateNew == POOL_STATE_ERROR) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::SetState -- Can't set state to ERROR as a Masternode. \n");
         return;

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -338,10 +338,8 @@ void CCoinJoinServer::CheckPool()
     case Action::None:
         return;
     case Action::ChargeAndFinalize:
-        ChargeFees();
-        [[fallthrough]];
     case Action::Finalize:
-        CreateFinalTransaction(session_id);
+        CreateFinalTransaction(session_id, action == Action::ChargeAndFinalize);
         return;
     case Action::Commit:
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- SIGNING\n");
@@ -350,43 +348,56 @@ void CCoinJoinServer::CheckPool()
     }
 }
 
-void CCoinJoinServer::CreateFinalTransaction(int session_id)
+void CCoinJoinServer::CreateFinalTransaction(int session_id, bool charge_fees)
 {
     AssertLockNotHeld(cs_coinjoin);
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- FINALIZE TRANSACTIONS\n");
 
-    LOCK(cs_coinjoin);
+    CTransactionRef collateral_to_charge;
+    {
+        LOCK(cs_coinjoin);
 
-    // Finalizing a session that is already gone would put it back into SIGNING and reject every
-    // new one until that timed out.
-    if (nSessionID != session_id) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- session %d is gone, not finalizing\n",
-                 session_id);
-        return;
+        // Finalizing a session that is already gone would put it back into SIGNING and reject every
+        // new one until that timed out. Requiring the accepting state also makes selecting an
+        // offender and closing entry admission one atomic operation.
+        if (nSessionID != session_id || nState != POOL_STATE_ACCEPTING_ENTRIES) {
+            LogPrint(BCLog::COINJOIN, /* Continued */
+                     "CCoinJoinServer::CreateFinalTransaction -- session %d is gone or no longer accepting entries\n",
+                     session_id);
+            return;
+        }
+
+        if (charge_fees) {
+            collateral_to_charge = SelectCollateralToCharge();
+        }
+
+        CMutableTransaction txNew;
+
+        // make our new transaction
+        for (const auto& entry : vecEntries) {
+            for (const auto& txout : entry.vecTxOut) {
+                txNew.vout.push_back(txout);
+            }
+            for (const auto& txdsin : entry.vecTxDSIn) {
+                txNew.vin.push_back(txdsin);
+            }
+        }
+
+        sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());
+        sort(txNew.vout.begin(), txNew.vout.end(), CompareOutputBIP69());
+
+        finalMutableTransaction = txNew;
+        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- finalMutableTransaction=%s", /* Continued */
+                 txNew.ToString());
+
+        // request signatures from clients
+        SetState(POOL_STATE_SIGNING);
+        RelayFinalTransaction(CTransaction(finalMutableTransaction));
     }
 
-    CMutableTransaction txNew;
-
-    // make our new transaction
-    for (const auto& entry : vecEntries) {
-        for (const auto& txout : entry.vecTxOut) {
-            txNew.vout.push_back(txout);
-        }
-        for (const auto& txdsin : entry.vecTxDSIn) {
-            txNew.vin.push_back(txdsin);
-        }
+    if (collateral_to_charge) {
+        ConsumeCollateral(collateral_to_charge);
     }
-
-    sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());
-    sort(txNew.vout.begin(), txNew.vout.end(), CompareOutputBIP69());
-
-    finalMutableTransaction = txNew;
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- finalMutableTransaction=%s", /* Continued */
-             txNew.ToString());
-
-    // request signatures from clients
-    SetState(POOL_STATE_SIGNING);
-    RelayFinalTransaction(CTransaction(finalMutableTransaction));
 }
 
 void CCoinJoinServer::CommitFinalTransaction(int session_id)
@@ -462,71 +473,67 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
 // transaction for the client to be able to enter the pool. This transaction is kept by the Masternode
 // until the transaction is either complete or fails.
 //
-void CCoinJoinServer::ChargeFees() const
+/*
+ * Select one offender while cs_coinjoin still binds the state, entries and collaterals to the
+ * same session. The caller must close the relevant admission path before releasing the lock and
+ * consuming the returned collateral, so a late entry or signature cannot make the snapshot stale.
+ */
+CTransactionRef CCoinJoinServer::SelectCollateralToCharge() const
 {
-    AssertLockNotHeld(cs_coinjoin);
+    AssertLockHeld(cs_coinjoin);
 
     //we don't need to charge collateral for every offence.
-    if (GetRand<int>(/*nMax=*/100) > 33) return;
+    if (GetRand<int>(/*nMax=*/100) > 33) return {};
 
     std::vector<CTransactionRef> vecOffendersCollaterals;
-    size_t nSessionCollaterals{0};
-    PoolState state{POOL_STATE_IDLE};
+    const PoolState state{nState};
+    const size_t nSessionCollaterals{m_session_collaterals.size()};
 
-    {
-        LOCK(cs_coinjoin);
-        // Sample the state under the lock, together with the data it describes. Reading nState
-        // separately per branch let a concurrent transition select the "didn't send" offenders
-        // and then charge and log them as "didn't sign", or pick offenders from a session the
-        // state no longer describes.
-        state = nState;
-        nSessionCollaterals = m_session_collaterals.size();
+    if (state == POOL_STATE_ACCEPTING_ENTRIES) {
+        for (const auto& txCollateral : m_session_collaterals.txs()) {
+            bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
+                return *entry.txCollateral == *txCollateral;
+            });
 
-        if (state == POOL_STATE_ACCEPTING_ENTRIES) {
-            for (const auto& txCollateral : m_session_collaterals.txs()) {
-                bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
-                    return *entry.txCollateral == *txCollateral;
-                });
-
-                // This queue entry didn't send us the promised transaction
-                if (!fFound) {
-                    LogPrint(BCLog::COINJOIN, /* Continued */
-                             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't send transaction), found "
-                             "offence\n");
-                    vecOffendersCollaterals.push_back(txCollateral);
-                }
+            // This queue entry didn't send us the promised transaction
+            if (!fFound) {
+                LogPrint(BCLog::COINJOIN, /* Continued */
+                         "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't send "
+                         "transaction), found offence\n");
+                vecOffendersCollaterals.push_back(txCollateral);
             }
-        } else if (state == POOL_STATE_SIGNING) {
-            // who didn't sign?
-            for (const auto& entry : vecEntries) {
-                for (const auto& txdsin : entry.vecTxDSIn) {
-                    if (!txdsin.fHasSig) {
-                        LogPrint(BCLog::COINJOIN, /* Continued */
-                                 "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't sign), found "
-                                 "offence\n");
-                        vecOffendersCollaterals.push_back(entry.txCollateral);
-                    }
+        }
+    } else if (state == POOL_STATE_SIGNING) {
+        // who didn't sign?
+        for (const auto& entry : vecEntries) {
+            for (const auto& txdsin : entry.vecTxDSIn) {
+                if (!txdsin.fHasSig) {
+                    LogPrint(BCLog::COINJOIN, /* Continued */
+                             "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't sign), "
+                             "found offence\n");
+                    vecOffendersCollaterals.push_back(entry.txCollateral);
                 }
             }
         }
     }
 
     // no offences found
-    if (vecOffendersCollaterals.empty()) return;
+    if (vecOffendersCollaterals.empty()) return {};
 
     //mostly offending? Charge sometimes
-    if (vecOffendersCollaterals.size() >= nSessionCollaterals - 1 && GetRand<int>(/*nMax=*/100) > 33) return;
+    if (vecOffendersCollaterals.size() >= nSessionCollaterals - 1 && GetRand<int>(/*nMax=*/100) > 33) return {};
 
     //everyone is an offender? That's not right
-    if (vecOffendersCollaterals.size() >= nSessionCollaterals) return;
+    if (vecOffendersCollaterals.size() >= nSessionCollaterals) return {};
 
     //charge one of the offenders randomly
     Shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end(), FastRandomContext());
 
     LogPrint(BCLog::COINJOIN, /* Continued */
-             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s",
+             "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't %s transaction), charging "
+             "fees: %s",
              (state == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
-    ConsumeCollateral(vecOffendersCollaterals[0]);
+    return vecOffendersCollaterals[0];
 }
 
 /*
@@ -586,13 +593,28 @@ void CCoinJoinServer::CheckTimeout()
 {
     m_queueman.CheckQueue();
 
-    // Too early to do anything
-    if (!CCoinJoinServer::HasTimedOut()) return;
+    // CheckPool can be finalizing or committing on the message-handling thread. Skipping this tick
+    // keeps timeout reset and finalization/commit single-flight without blocking the scheduler.
+    TRY_LOCK(cs_check_pool, lock_check_pool);
+    if (!lock_check_pool) return;
 
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
-        (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
-    ChargeFees();
-    WITH_LOCK(cs_coinjoin, SetNull());
+    CTransactionRef collateral_to_charge;
+    {
+        LOCK(cs_coinjoin);
+
+        // Too early to do anything. Recheck while holding the lock so selecting an offender and
+        // closing the session form one atomic cutoff for late entries and signatures.
+        if (!CCoinJoinServer::HasTimedOut()) return;
+
+        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
+                 (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
+        collateral_to_charge = SelectCollateralToCharge();
+        SetNull();
+    }
+
+    if (collateral_to_charge) {
+        ConsumeCollateral(collateral_to_charge);
+    }
 }
 
 /*
@@ -755,7 +777,7 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
         // that window. Committing then would leave an entry of a dead session in vecEntries: the
         // next session inherits it, counts it towards its own participants, and finalizes a
         // transaction containing an input nobody present is going to sign.
-        if (nSessionID != session_id) {
+        if (nSessionID != session_id || nState != POOL_STATE_ACCEPTING_ENTRIES) {
             LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: session %d is gone!\n", __func__, session_id);
             nMessageIDRet = ERR_SESSION;
             return false;

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -699,13 +699,25 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
 
     // Remember which session we are admitting this entry to. The validation below releases
     // cs_coinjoin and takes cs_main, so the session can be reset underneath us before we commit.
-    const int session_id{nSessionID};
+    int session_id{0};
+    int session_denom{0};
+    {
+        LOCK(cs_coinjoin);
+        session_id = nSessionID;
+        session_denom = nSessionDenom;
 
-    // Cheap gate before the cs_main work below; the authoritative check is at commit time.
-    if (WITH_LOCK(cs_coinjoin, return static_cast<size_t>(GetEntriesCountLocked()) >= m_session_collaterals.size())) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
-        nMessageIDRet = ERR_ENTRIES_FULL;
-        return false;
+        if (nState != POOL_STATE_ACCEPTING_ENTRIES) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: session is not accepting entries!\n", __func__);
+            nMessageIDRet = ERR_SESSION;
+            return false;
+        }
+
+        // Cheap gate before the cs_main work below; the authoritative check is at commit time.
+        if (static_cast<size_t>(GetEntriesCountLocked()) >= m_session_collaterals.size()) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
+            nMessageIDRet = ERR_ENTRIES_FULL;
+            return false;
+        }
     }
 
     if (entry.vecTxDSIn.size() > COINJOIN_ENTRY_MAX_SIZE || entry.vecTxOut.size() > COINJOIN_ENTRY_MAX_SIZE) {
@@ -759,8 +771,8 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
     }
 
     bool fConsumeCollateral{false};
-    if (!IsValidInOuts(m_chainman.ActiveChainstate(), m_isman, mempool, vin, entry.vecTxOut, nMessageIDRet,
-                       &fConsumeCollateral)) {
+    if (!IsValidInOuts(m_chainman.ActiveChainstate(), m_isman, mempool, vin, entry.vecTxOut, session_denom,
+                       nMessageIDRet, &fConsumeCollateral)) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR! IsValidInOuts() failed: %s\n", __func__, CoinJoin::GetMessageByID(nMessageIDRet).translated);
         if (fConsumeCollateral) {
             ConsumeCollateral(entry.txCollateral);

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -26,11 +26,16 @@ class CNode;
 class CTxMemPool;
 
 class UniValue;
+namespace coinjoin_inouts_tests {
+class TestableCoinJoinServer;
+}
 
 /** Used to keep track of current status of mixing pool
  */
 class CCoinJoinServer : public CCoinJoinBaseSession, public NetHandler
 {
+    friend class coinjoin_inouts_tests::TestableCoinJoinServer;
+
 private:
     CoinJoinQueueManager m_queueman;
 
@@ -88,11 +93,12 @@ private:
 
     bool fUnitTest;
 
-    /// Serializes CheckPool() against itself. CheckPool() runs both on the scheduler thread and
-    /// on the message-handling thread, and its finalize and commit steps have to be single-shot:
-    /// relaying DSFINALTX twice makes every client sign twice, and the duplicate signatures then
-    /// abort the session for all of them. Always acquired with TRY_LOCK and never taken by any
-    /// other code path, so a contended caller skips the round rather than blocking msghand.
+    /// Serializes CheckPool() against itself and against CheckTimeout(). CheckPool() runs both on
+    /// the scheduler thread and on the message-handling thread, and its finalize and commit steps
+    /// have to be single-shot: relaying DSFINALTX twice makes every client sign twice, and the
+    /// duplicate signatures then abort the session for all of them. CheckTimeout() uses the same
+    /// guard so it cannot reset a session during finalization or commit. Production paths always
+    /// acquire it with TRY_LOCK, so a contended caller skips the round rather than blocking msghand.
     Mutex cs_check_pool;
 
     /// Add a clients entry to the pool
@@ -100,8 +106,8 @@ private:
     /// Add signature to a txin
     bool AddScriptSig(const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
-    /// Charge fees to bad actors (Charge clients a fee if they're abusive)
-    void ChargeFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    /// Choose one bad actor whose collateral should be consumed, if any.
+    CTransactionRef SelectCollateralToCharge() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     /// Rarely charge fees to pay miners
     void ChargeRandomFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Consume collateral in cases when peer misbehaved
@@ -110,7 +116,7 @@ private:
     /// Check for process
     void CheckPool() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
 
-    void CreateFinalTransaction(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CreateFinalTransaction(int session_id, bool charge_fees) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     void CommitFinalTransaction(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     /// Is this nDenom and txCollateral acceptable?
@@ -161,7 +167,7 @@ public:
     void Schedule(CScheduler& scheduler) override;
 
     bool HasTimedOut() const;
-    void CheckTimeout() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CheckTimeout() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
     void CheckForCompleteQueue() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     void GetJsonInfo(UniValue& obj) const;

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -52,6 +52,13 @@ private:
 
     bool fUnitTest;
 
+    /// Serializes CheckPool() against itself. CheckPool() runs both on the scheduler thread and
+    /// on the message-handling thread, and its finalize and commit steps have to be single-shot:
+    /// relaying DSFINALTX twice makes every client sign twice, and the duplicate signatures then
+    /// abort the session for all of them. Always acquired with TRY_LOCK and never taken by any
+    /// other code path, so a contended caller skips the round rather than blocking msghand.
+    Mutex cs_check_pool;
+
     /// Add a clients entry to the pool
     bool AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Add signature to a txin
@@ -65,10 +72,10 @@ private:
     void ConsumeCollateral(const CTransactionRef& txref) const;
 
     /// Check for process
-    void CheckPool();
+    void CheckPool() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
 
-    void CreateFinalTransaction() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
-    void CommitFinalTransaction() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CreateFinalTransaction(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CommitFinalTransaction(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     /// Is this nDenom and txCollateral acceptable?
     bool IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) const;
@@ -77,15 +84,18 @@ private:
     bool CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     bool AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Do we have enough users to take entries?
-    bool IsSessionReady() const;
+    bool IsSessionReady() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
     /// Check that all inputs are signed. (Are all inputs signed?)
-    bool IsSignaturesComplete() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    bool IsSignaturesComplete() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     /// Check to make sure a given input matches an input in the pool and its scriptSig is valid
     bool IsInputScriptSigValid(const CTxIn& txin) const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
-    // Set the 'state' value, with some logging and capturing when the state changed
-    void SetState(PoolState nStateNew);
+    // Set the 'state' value, with some logging and capturing when the state changed.
+    // Requires cs_coinjoin so that a transition and the session data it describes are always
+    // observed together: code that revalidates nState under the lock must not have it changed
+    // out from under it by a concurrent transition.
+    void SetState(PoolState nStateNew) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
     /// Relay mixing Messages
     void RelayFinalTransaction(const CTransaction& txFinal) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
@@ -95,8 +105,8 @@ private:
 
     void ProcessDSACCEPT(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     void ProcessDSQUEUE(NodeId from, CDataStream& vRecv);
-    void ProcessDSVIN(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
-    void ProcessDSSIGNFINALTX(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void ProcessDSVIN(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
+    void ProcessDSSIGNFINALTX(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
 
     void SetNull() override EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
@@ -110,14 +120,15 @@ public:
                              const CMasternodeSync& mn_sync, const llmq::CInstantSendManager& isman);
     ~CCoinJoinServer() override;
 
-    void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv) override;
+    void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv) override
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
     bool ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker) override;
     bool AlreadyHave(const CInv& inv) override;
     void Schedule(CScheduler& scheduler) override;
 
     bool HasTimedOut() const;
-    void CheckTimeout();
-    void CheckForCompleteQueue();
+    void CheckTimeout() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CheckForCompleteQueue() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     void GetJsonInfo(UniValue& obj) const;
 };

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -12,6 +12,7 @@
 #include <protocol.h>
 #include <util/hasher.h>
 
+#include <optional>
 #include <unordered_set>
 
 class CActiveMasternodeManager;
@@ -43,12 +44,47 @@ private:
     const CMasternodeSync& m_mn_sync;
     const llmq::CInstantSendManager& m_isman;
 
-    // Mixing uses collateral transactions to trust parties entering the pool
-    // to behave honestly. If they don't it takes their money.
-    std::vector<CTransactionRef> vecSessionCollaterals;
-    // Input prevouts of every transaction in vecSessionCollaterals, so a dsa whose collateral
-    // reuses one of them can be rejected without rescanning them all.
-    std::unordered_set<COutPoint, SaltedOutpointHasher> setSessionCollateralPrevouts GUARDED_BY(cs_coinjoin);
+    /// The collateral transactions of every peer admitted to the current session.
+    ///
+    /// Mixing uses collateral transactions to trust parties entering the pool to behave
+    /// honestly. If they don't it takes their money.
+    ///
+    /// Session collaterals are only ever test-accepted, never added to the mempool, so nothing
+    /// pins their identity: the same UTXO can be re-signed into arbitrarily many distinct txids.
+    /// Matching on input prevouts is what makes a resent or replayed dsa recognisable as the
+    /// same participant.
+    class SessionCollaterals
+    {
+    public:
+        void Add(const CMutableTransaction& txCollateral)
+        {
+            m_txs.push_back(MakeTransactionRef(txCollateral));
+            for (const auto& txin : txCollateral.vin) {
+                m_prevouts.insert(txin.prevout);
+            }
+        }
+        void Clear()
+        {
+            m_txs.clear();
+            m_prevouts.clear();
+        }
+        //! The first input of txCollateral that an already admitted collateral also spends, if any.
+        std::optional<COutPoint> FindCommittedPrevout(const CMutableTransaction& txCollateral) const
+        {
+            for (const auto& txin : txCollateral.vin) {
+                if (m_prevouts.contains(txin.prevout)) return txin.prevout;
+            }
+            return std::nullopt;
+        }
+        const std::vector<CTransactionRef>& txs() const { return m_txs; }
+        size_t size() const { return m_txs.size(); }
+        bool empty() const { return m_txs.empty(); }
+
+    private:
+        std::vector<CTransactionRef> m_txs;
+        std::unordered_set<COutPoint, SaltedOutpointHasher> m_prevouts;
+    };
+    SessionCollaterals m_session_collaterals GUARDED_BY(cs_coinjoin);
 
     bool fUnitTest;
 
@@ -79,8 +115,6 @@ private:
 
     /// Is this nDenom and txCollateral acceptable?
     bool IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) const;
-    /// Record an accepted collateral and index its input prevouts
-    void CommitSessionCollateral(const CMutableTransaction& txCollateral) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     bool CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     bool AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Do we have enough users to take entries?

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -109,7 +109,7 @@ private:
     /// Choose one bad actor whose collateral should be consumed, if any.
     CTransactionRef SelectCollateralToCharge() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     /// Rarely charge fees to pay miners
-    void ChargeRandomFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void ChargeRandomFees(const std::vector<CTransactionRef>& collaterals) const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Consume collateral in cases when peer misbehaved
     void ConsumeCollateral(const CTransactionRef& txref) const;
 
@@ -141,7 +141,9 @@ private:
     void RelayFinalTransaction(const CTransaction& txFinal) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     void PushStatus(CNode& peer, PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID) const;
     void RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID = MSG_NOERR) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
-    void RelayCompletedTransaction(PoolMessage nMessageID) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void RelayCompletedTransaction(int session_id, const std::vector<CService>& participants, PoolMessage nMessageID)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void ResetSigningSessionIfCurrent(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     void ProcessDSACCEPT(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     void ProcessDSQUEUE(NodeId from, CDataStream& vRecv);

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -20,6 +20,7 @@
 #include <uint256.h>
 #include <util/check.h>
 #include <util/time.h>
+#include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -205,6 +206,13 @@ public:
         locked.count_down();
         release.wait();
     }
+
+    bool ValidateInOuts(const std::vector<CTxIn>& vin, const std::vector<CTxOut>& vout, int session_denom,
+                        PoolMessage& message, bool& consume_collateral)
+    {
+        return IsValidInOuts(m_chainman.ActiveChainstate(), m_isman, mempool, vin, vout, session_denom, message,
+                             &consume_collateral);
+    }
 };
 
 static std::unique_ptr<CNode> MakePeer(NodeId id, uint32_t ipv4)
@@ -326,6 +334,28 @@ BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)
 
     server.CheckTimeout();
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+}
+
+BOOST_AUTO_TEST_CASE(server_validation_uses_session_denom_snapshot)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+
+    const int session_denom{CoinJoin::AmountToDenomination(CoinJoin::GetSmallestDenomination())};
+    const std::vector<CTxIn> vin{CTxIn{COutPoint{uint256::ONE, 0}}};
+    const std::vector<CTxOut> vout{CTxOut{CoinJoin::GetSmallestDenomination(), P2PKHScript()}};
+    PoolMessage message{MSG_NOERR};
+    bool consume_collateral{false};
+
+    // The live session denomination is zero, as it is after a concurrent SetNull(). Validation
+    // must use the denomination captured before the reset instead of treating this as a punishable
+    // denomination mismatch. The deliberately absent input makes validation stop with ERR_MISSING_TX.
+    BOOST_CHECK(!server.ValidateInOuts(vin, vout, session_denom, message, consume_collateral));
+    BOOST_CHECK_EQUAL(message, ERR_MISSING_TX);
+    BOOST_CHECK(!consume_collateral);
 }
 
 BOOST_AUTO_TEST_CASE(entry_deserializes_vectors_through_wire_cap)

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -192,6 +192,27 @@ public:
         vecEntries.push_back(std::move(entry));
     }
 
+    void SeedCompletionSession(int session_id, const CService& addr, PoolState state = POOL_STATE_SIGNING)
+    {
+        LOCK(cs_coinjoin);
+        SetNull();
+        nSessionID = session_id;
+        nState = state;
+
+        if (state == POOL_STATE_SIGNING) {
+            CCoinJoinEntry entry;
+            entry.addr = addr;
+            vecEntries.push_back(std::move(entry));
+        }
+    }
+
+    void RelayCompletion(int session_id, const CService& addr)
+    {
+        RelayCompletedTransaction(session_id, {addr}, MSG_SUCCESS);
+    }
+
+    void ResetForSession(int session_id) { ResetSigningSessionIfCurrent(session_id); }
+
     void SeedTimedOutSession()
     {
         LOCK(cs_coinjoin);
@@ -344,6 +365,31 @@ BOOST_AUTO_TEST_CASE(server_signfinaltx_participant_oversized_count_is_rejected_
                       std::ios_base::failure);
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
     BOOST_CHECK_EQUAL(server.GetEntriesCount(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(server_completion_does_not_reset_an_unreachable_or_replacement_session)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+
+    auto participant = MakePeer(/*id=*/7, /*ipv4=*/0x0a000001);
+    server.SeedCompletionSession(/*session_id=*/1, participant->addr);
+
+    // The participant is deliberately absent from connman. Failing to deliver DSCOMPLETE must not
+    // reset live session data; only CommitFinalTransaction owns the completion reset.
+    server.RelayCompletion(/*session_id=*/1, participant->addr);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
+    BOOST_CHECK_EQUAL(server.GetEntriesCount(), 1);
+
+    // A delayed tail operation from session 1 must never clear a replacement queue, even if the
+    // random wire session ID happens to be reused.
+    server.SeedCompletionSession(/*session_id=*/1, participant->addr, POOL_STATE_QUEUE);
+    server.ResetForSession(/*session_id=*/1);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_QUEUE});
+    BOOST_CHECK_EQUAL(server.GetEntriesCount(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -198,6 +198,40 @@ public:
         nSessionID = 1;
         nState = POOL_STATE_ACCEPTING_ENTRIES;
         nTimeLastSuccessfulStep = GetTime() - COINJOIN_QUEUE_TIMEOUT;
+        for (int i = 0; i < CoinJoin::GetMinPoolParticipants(); ++i) {
+            CMutableTransaction collateral;
+            collateral.vin.emplace_back(COutPoint{uint256::ONE, static_cast<uint32_t>(i)});
+            m_session_collaterals.Add(collateral);
+        }
+    }
+
+    void SeedTimedOutActionableSession(PoolState state, bool has_missing_entry = false)
+    {
+        LOCK(cs_coinjoin);
+        SetNull();
+
+        nSessionID = 1;
+        nState = state;
+        nTimeLastSuccessfulStep = GetTime() -
+                                  (state == POOL_STATE_SIGNING ? COINJOIN_SIGNING_TIMEOUT : COINJOIN_QUEUE_TIMEOUT);
+
+        for (int i = 0; i < CoinJoin::GetMinPoolParticipants(); ++i) {
+            CMutableTransaction collateral;
+            collateral.vin.emplace_back(COutPoint{uint256::ONE, static_cast<uint32_t>(i)});
+            m_session_collaterals.Add(collateral);
+
+            if (state == POOL_STATE_QUEUE) continue;
+
+            CTxDSIn txdsin{CTxIn{COutPoint{uint256::TWO, static_cast<uint32_t>(i)}}, P2PKHScript(), 0};
+            txdsin.fHasSig = state == POOL_STATE_SIGNING;
+            vecEntries.emplace_back(std::vector<CTxDSIn>{txdsin}, std::vector<CTxOut>{}, CTransaction{collateral});
+        }
+
+        if (has_missing_entry) {
+            CMutableTransaction collateral;
+            collateral.vin.emplace_back(COutPoint{uint256::ONE, static_cast<uint32_t>(CoinJoin::GetMinPoolParticipants())});
+            m_session_collaterals.Add(collateral);
+        }
     }
 
     void HoldPoolCheck(std::latch& locked, std::latch& release)
@@ -334,6 +368,28 @@ BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)
 
     server.CheckTimeout();
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+}
+
+BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_actionable_session)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+
+    for (const auto state : {POOL_STATE_QUEUE, POOL_STATE_ACCEPTING_ENTRIES, POOL_STATE_SIGNING}) {
+        BOOST_TEST_CONTEXT("state=" << state)
+        {
+            server.SeedTimedOutActionableSession(state);
+            server.CheckTimeout();
+            BOOST_CHECK_EQUAL(server.GetState(), int{state});
+        }
+    }
+
+    server.SeedTimedOutActionableSession(POOL_STATE_ACCEPTING_ENTRIES, /*has_missing_entry=*/true);
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_ACCEPTING_ENTRIES});
 }
 
 BOOST_AUTO_TEST_CASE(server_validation_uses_session_denom_snapshot)

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -26,7 +26,9 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <latch>
 #include <memory>
+#include <thread>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(coinjoin_inouts_tests, TestingSetup)
@@ -171,9 +173,9 @@ BOOST_AUTO_TEST_CASE(entry_addscriptsig_matches_and_rejects)
     }
 }
 
-// Test-only subclass exposing the minimal seams needed to observe how
-// ProcessDSSIGNFINALTX treats messages from participants vs. non-participants
-// without standing up a full DKG-backed signing session.
+// Test-only subclass exposing the minimal seams needed to exercise server lifecycle behavior
+// without standing up a full DKG-backed signing session. The helpers only establish preconditions
+// and invoke the production paths; the behavior under test is not reproduced here.
 class TestableCoinJoinServer : public CCoinJoinServer
 {
 public:
@@ -187,6 +189,21 @@ public:
         entry.addr = addr;
         LOCK(cs_coinjoin);
         vecEntries.push_back(std::move(entry));
+    }
+
+    void SeedTimedOutSession()
+    {
+        LOCK(cs_coinjoin);
+        nSessionID = 1;
+        nState = POOL_STATE_ACCEPTING_ENTRIES;
+        nTimeLastSuccessfulStep = GetTime() - COINJOIN_QUEUE_TIMEOUT;
+    }
+
+    void HoldPoolCheck(std::latch& locked, std::latch& release)
+    {
+        LOCK(cs_check_pool);
+        locked.count_down();
+        release.wait();
     }
 };
 
@@ -285,6 +302,30 @@ BOOST_AUTO_TEST_CASE(server_signfinaltx_participant_oversized_count_is_rejected_
                       std::ios_base::failure);
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
     BOOST_CHECK_EQUAL(server.GetEntriesCount(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+    server.SeedTimedOutSession();
+
+    std::latch locked{1};
+    std::latch release{1};
+    std::thread pool_check{[&] { server.HoldPoolCheck(locked, release); }};
+    locked.wait();
+
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_ACCEPTING_ENTRIES});
+
+    release.count_down();
+    pool_check.join();
+
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
 }
 
 BOOST_AUTO_TEST_CASE(entry_deserializes_vectors_through_wire_cap)


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CCoinJoinServer` state is touched by two threads: `msghand` (single-threaded, via `ProcessDS*`) and the 1s scheduler tick (`CheckForCompleteQueue` / `CheckPool` / `CheckTimeout`), plus RPC threads in `GetJsonInfo()`. Note that `CheckPool()` runs on **both** — the scheduler tick *and* `msghand` via `ProcessDSVIN` / `ProcessDSSIGNFINALTX`.

`vecSessionCollaterals` was mutated only under `cs_coinjoin` but read without any lock from seven places across both threads, and several decisions sampled `nState`, the entry count and the collateral count under separate lock acquisitions before acting on the result. #7507 fixed the write side of the collateral race; this PR is the follow-up that closes the read side and the check-then-act paths around it.

These are the concrete, reachable failures, not just TSan-visible UB:

1. **Use-after-free in `ChargeRandomFees()`.** It iterated `vecSessionCollaterals` **by reference** while calling `ConsumeCollateral()` — a `cs_main` mempool submission — for each element. A concurrent `SetNull()` destroys the `CTransactionRef`s the loop is walking.

2. **A reset session could be finalized.** `CheckPool()` sampled `nState`, then took and released `cs_coinjoin` for `GetEntriesCount()`, then read `vecSessionCollaterals.size()` unlocked. A `SetNull()` between the samples makes an already-reset session read as `0 entries == 0 collaterals` → finalize. That builds an empty final transaction and puts a dead session back into `POOL_STATE_SIGNING`, so every new `dsa` is rejected with `ERR_MODE` until the 15s signing timeout clears it.

3. **A session could be finalized twice.** Because `CheckPool()` runs on both threads, two concurrent calls could both take the finalize path. Clients then receive `DSFINALTX` twice and sign twice; the duplicate signatures make `AddScriptSig()` fail, which relays `STATUS_REJECTED` and aborts the session for every participant.

4. **`AddEntry()` could commit into a dead session, and the damage outlived the window.** The bound was checked, then `IsCollateralValid()` and `IsValidInOuts()` ran (both take `cs_main`, both can block behind block validation), and only then was `cs_coinjoin` re-taken to `push_back`. A `CheckTimeout()` in that window resets the session, leaving an orphaned entry in `vecEntries` while `vecSessionCollaterals` is empty — so the *next* session starts one entry ahead of its own participant count, `CheckPool()`'s `entries == collaterals` test fires early, and it finalizes a transaction containing an input nobody present will sign. That session then stalls to its signing timeout and `ChargeFees()` charges its honest participants.

5. **`ChargeFees()` sampled `nState` three times**, so a transition in between could select the "didn't send" offenders and then charge and log them as "didn't sign".

6. **`nSessionDenom` was a plain `int`** written by both threads and read unlocked by both plus RPC threads — the one `CCoinJoinBaseSession` field that was neither atomic nor guarded. Benign on supported hardware, but UB and TSan-reportable.

## What was done?

Eight commits, each standalone:

**`fix: make CoinJoin nSessionDenom atomic`** — `std::atomic<int>`, matching its siblings `nState`, `nSessionID` and `nTimeLastSuccessfulStep`. `WalletCJLogPrint()` takes its arguments by value, so the three client-side log sites need an explicit `.load()`; `LogPrint()` takes by const reference and does not.

**`fix: decide CoinJoin server state transitions under cs_coinjoin`** — addresses 2, 3 and 5.
- `CheckPool()` decides from a single locked snapshot, then acts with the lock released. `CreateFinalTransaction()` / `CommitFinalTransaction()` take the session id the decision was made for and revalidate it, since the lock is dropped in between.
- A new `cs_check_pool`, acquired **only** via `TRY_LOCK` by `CheckPool()` and `CheckTimeout()`, makes finalization, commit and timeout reset single-shot. It is strictly outermost and never contended-blocking, so `msghand` is never made to wait on the scheduler thread; a contended caller just skips to the next tick.
- `SetState()` and `IsSessionReady()` now require `cs_coinjoin`. This is what makes the existing revalidation blocks in `CreateNewSession()` / `AddUserToExistingSession()` actually effective — previously `nState` could be flipped by a concurrent `SetState()` immediately after they revalidated it.
- `CheckForCompleteQueue()` performs its transition under the lock and moves BLS signing and the `dsq` relay **outside** it — a shorter hold than before, not a longer one.
- `ChargeFees()` samples `nState` once, under the lock, together with the data it describes.

**`fix: guard the CoinJoin session collaterals with cs_coinjoin`** — addresses 1.
- `vecSessionCollaterals` and `setSessionCollateralPrevouts` become a single `SessionCollaterals` member marked `GUARDED_BY(cs_coinjoin)`. Folding them together means one annotation covers both and they cannot drift or be annotated inconsistently again — which is exactly what went wrong before, where one was guarded and the other was not.
- Every read site is fixed. `ChargeRandomFees()` now works from a copy taken under the lock, which fixes the use-after-free and also keeps `cs_coinjoin` from being held across `cs_main`.
- The copy goes through `CopyTxs()`, which returns by value on purpose: `WITH_LOCK` expands to a lambda returning `decltype(auto)`, so returning a `const&` accessor through it would hand back a reference and perform the copy *after* the lock was released.

**`fix: revalidate the CoinJoin session before committing an entry`** — addresses 4. The bound check and the `push_back` now share one lock scope, and the session identity captured before validation is rechecked inside it. The duplicate-input scan is also hoisted out of the per-input loop so it is atomic across the whole entry instead of re-locking up to nine times.

**`fix: serialize CoinJoin timeout transitions`** — makes `CheckTimeout()` use the same `cs_check_pool` guard as `CheckPool()`. Offender selection and session reset happen together under `cs_coinjoin`; collateral consumption happens after releasing it. A timeout can no longer invalidate a finalization or commit already in progress.

**`fix(coinjoin): validate entries against session snapshot`** — passes the denomination captured with the session identity into `IsValidInOuts()`. A concurrent reset can therefore reject the stale commit without first misclassifying the old entry as a punishable denomination mismatch.

**`fix(coinjoin): prioritize progress over timeout reset`** — rechecks queue readiness, finalizability and signature completeness under `cs_coinjoin` immediately before a timeout reset. If the last collateral, entry or signature arrived after the scheduler's earlier snapshot, actionable work wins and is handled on the next tick.

**`fix(coinjoin): bind completion tail to session snapshot`** — captures the final transaction, participants and collaterals under `cs_coinjoin`, makes completion notification side-effect-free, and resets only the matching signing session. Delayed relay or fee work can no longer charge or clear a replacement session.

The load-bearing part is the `GUARDED_BY`: reintroducing an unlocked read of the session collaterals is now a compile error under `-Wthread-safety` rather than something a reviewer has to catch.

### Lock discipline

No new `cs_coinjoin`-across-`cs_main`, `cs_coinjoin`-across-network-send, or `cs_coinjoin`-across-BLS-signing edge is introduced; `CheckForCompleteQueue()` and `ChargeRandomFees()` end up with strictly shorter holds than on develop. `cs_check_pool` is `TRY_LOCK`-only, taken only by `CheckPool()` and `CheckTimeout()` while holding nothing else, so the order `cs_check_pool` → `cs_coinjoin` is unidirectional and no ABBA cycle is possible.

## How Has This Been Tested?

macOS arm64, `--enable-debug`, depends build.

- Clean build.
- `clang -Wthread-safety` clean on every TU that includes `coinjoin/server.h` (`server.cpp`, `rpc/coinjoin.cpp`, `init.cpp`, `test/coinjoin_inouts_tests.cpp`) plus `coinjoin.cpp` and `client.cpp`. The baseline before these changes was also clean, so nothing is being suppressed.
- Each of the eight commits compiles on its own.
- Full unit suite passes. Targeted `coinjoin_inouts_tests` (12 cases) and wallet `coinjoin_tests` (12 cases) pass.
- `test/functional/rpc_coinjoin.py` and `test/functional/p2p_dstx.py` pass.
- CI's exact `clang-format-diff` invocation returns no output.

Four targeted regression tests were added:

- `server_timeout_does_not_reset_during_pool_check` drives `cs_check_pool` from two threads and proves a contended timeout tick cannot reset an in-flight pool check.
- `server_timeout_does_not_reset_actionable_session` covers queue-ready, finalizable and fully signed sessions at their timeout boundary.
- `server_validation_uses_session_denom_snapshot` proves validation uses the captured denomination after a concurrent reset.
- `server_completion_does_not_reset_an_unreachable_or_replacement_session` proves completion relay is side-effect-free and a delayed reset cannot clear a replacement queue.

These tests deterministically cover the newly exposed concurrency seams. Broader end-to-end scheduling coverage would still benefit from a dedicated multi-threaded CoinJoin server harness.

## Breaking Changes

None. No protocol, serialization or RPC change. Two debug log lines have `vecSessionCollaterals.size():` renamed to `participants:` since the member no longer exists under that name.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
