### PR TITLE
fix: charge collateral when a CoinJoin session aborts

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1229,8 +1229,9 @@ bool CCoinJoinClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, 
         SetState(POOL_STATE_QUEUE);
         nTimeLastSuccessfulStep = GetTime();
         WalletCJLogPrint(m_wallet, /* Continued */
-                         "CCoinJoinClientSession::JoinExistingQueue -- pending connection, masternode=%s, nSessionDenom=%d (%s)\n",
-                         dmn->proTxHash.ToString(), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+                         "CCoinJoinClientSession::JoinExistingQueue -- pending connection, masternode=%s, "
+                         "nSessionDenom=%d (%s)\n",
+                         dmn->proTxHash.ToString(), nSessionDenom.load(), CoinJoin::DenominationToString(nSessionDenom));
         strAutoDenomResult = _("Trying to connect…");
         return true;
     }
@@ -1310,9 +1311,11 @@ bool CCoinJoinClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, CCon
         pendingDsaRequest = CPendingDsaRequest(dmn->proTxHash, CCoinJoinAccept(nSessionDenom, txMyCollateral));
         SetState(POOL_STATE_QUEUE);
         nTimeLastSuccessfulStep = GetTime();
-        WalletCJLogPrint( /* Continued */
-            m_wallet, "CCoinJoinClientSession::StartNewQueue -- pending connection, masternode=%s, nSessionDenom=%d (%s)\n",
-            dmn->proTxHash.ToString(), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+        WalletCJLogPrint(/* Continued */
+                         m_wallet,
+                         "CCoinJoinClientSession::StartNewQueue -- pending connection, masternode=%s, nSessionDenom=%d "
+                         "(%s)\n",
+                         dmn->proTxHash.ToString(), nSessionDenom.load(), CoinJoin::DenominationToString(nSessionDenom));
         strAutoDenomResult = _("Trying to connect…");
         return true;
     }
@@ -1424,7 +1427,7 @@ bool CCoinJoinClientSession::SubmitDenominate(CConnman& connman)
         return a.second > b.second || (a.second == b.second && a.first < b.first);
     });
 
-    WalletCJLogPrint(m_wallet, "vecInputsByRounds for denom %d\n", nSessionDenom);
+    WalletCJLogPrint(m_wallet, "vecInputsByRounds for denom %d\n", nSessionDenom.load());
     for (const auto& pair : vecInputsByRounds) {
         WalletCJLogPrint(m_wallet, "vecInputsByRounds: rounds: %d, inputs: %d\n", pair.first, pair.second);
     }

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -475,7 +475,7 @@ bool CCoinJoinClientSession::SignFinalTransaction(CNode& peer, Chainstate& activ
     // Make sure all inputs/outputs are valid
     PoolMessage nMessageID{MSG_NOERR};
     if (!IsValidInOuts(active_chainstate, m_isman, mempool, finalMutableTransaction.vin, finalMutableTransaction.vout,
-                       nMessageID, nullptr)) {
+                       nSessionDenom.load(), nMessageID, nullptr)) {
         WalletCJLogPrint(m_wallet, "CCoinJoinClientSession::%s -- ERROR! IsValidInOuts() failed: %s\n", __func__, CoinJoin::GetMessageByID(nMessageID).translated);
         UnlockCoins();
         keyHolderStorage.ReturnAll();
@@ -2004,4 +2004,3 @@ UniValue CCoinJoinClientManager::getJsonInfo() const
     obj.pushKV("sessions", arrSessions);
     return obj;
 }
-

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -206,8 +206,8 @@ std::string CCoinJoinBaseSession::GetStateString() const
 
 bool CCoinJoinBaseSession::IsValidInOuts(Chainstate& active_chainstate, const llmq::CInstantSendManager& isman,
                                          const CTxMemPool& mempool, const std::vector<CTxIn>& vin,
-                                         const std::vector<CTxOut>& vout, PoolMessage& nMessageIDRet,
-                                         bool* fConsumeCollateralRet) const
+                                         const std::vector<CTxOut>& vout, int session_denom,
+                                         PoolMessage& nMessageIDRet, bool* fConsumeCollateralRet)
 {
     std::set<CScript> setScripPubKeys;
     nMessageIDRet = MSG_NOERR;
@@ -221,9 +221,10 @@ bool CCoinJoinBaseSession::IsValidInOuts(Chainstate& active_chainstate, const ll
     }
 
     auto checkTxOut = [&](const CTxOut& txout) {
-        if (int nDenom = CoinJoin::AmountToDenomination(txout.nValue); nDenom != nSessionDenom) {
+        if (int nDenom = CoinJoin::AmountToDenomination(txout.nValue); nDenom != session_denom) {
             LogPrint(BCLog::COINJOIN, "CCoinJoinBaseSession::IsValidInOuts -- ERROR: incompatible denom %d (%s) != nSessionDenom %d (%s)\n",
-                    nDenom, CoinJoin::DenominationToString(nDenom), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+                    nDenom, CoinJoin::DenominationToString(nDenom), session_denom,
+                    CoinJoin::DenominationToString(session_denom));
             nMessageIDRet = ERR_DENOM;
             if (fConsumeCollateralRet) *fConsumeCollateralRet = true;
             return false;

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -342,7 +342,9 @@ protected:
                        PoolMessage& nMessageIDRet, bool* fConsumeCollateralRet) const;
 
 public:
-    int nSessionDenom{0}; // Users must submit a denom matching this
+    // Atomic because the message-handling and scheduler threads write it while those threads and
+    // RPC callers also read it without holding cs_coinjoin.
+    std::atomic<int> nSessionDenom{0};
 
     CCoinJoinBaseSession() = default;
     virtual ~CCoinJoinBaseSession() = default;

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -337,9 +337,10 @@ protected:
 
     virtual void SetNull() EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
-    bool IsValidInOuts(Chainstate& active_chainstate, const llmq::CInstantSendManager& isman,
-                       const CTxMemPool& mempool, const std::vector<CTxIn>& vin, const std::vector<CTxOut>& vout,
-                       PoolMessage& nMessageIDRet, bool* fConsumeCollateralRet) const;
+    static bool IsValidInOuts(Chainstate& active_chainstate, const llmq::CInstantSendManager& isman,
+                              const CTxMemPool& mempool, const std::vector<CTxIn>& vin,
+                              const std::vector<CTxOut>& vout, int session_denom, PoolMessage& nMessageIDRet,
+                              bool* fConsumeCollateralRet);
 
 public:
     // Atomic because the message-handling and scheduler threads write it while those threads and

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -708,13 +708,25 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
 
     // Remember which session we are admitting this entry to. The validation below releases
     // cs_coinjoin and takes cs_main, so the session can be reset underneath us before we commit.
-    const int session_id{nSessionID};
+    int session_id{0};
+    int session_denom{0};
+    {
+        LOCK(cs_coinjoin);
+        session_id = nSessionID;
+        session_denom = nSessionDenom;
 
-    // Cheap gate before the cs_main work below; the authoritative check is at commit time.
-    if (WITH_LOCK(cs_coinjoin, return static_cast<size_t>(GetEntriesCountLocked()) >= m_session_collaterals.size())) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
-        nMessageIDRet = ERR_ENTRIES_FULL;
-        return false;
+        if (nState != POOL_STATE_ACCEPTING_ENTRIES) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: session is not accepting entries!\n", __func__);
+            nMessageIDRet = ERR_SESSION;
+            return false;
+        }
+
+        // Cheap gate before the cs_main work below; the authoritative check is at commit time.
+        if (static_cast<size_t>(GetEntriesCountLocked()) >= m_session_collaterals.size()) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
+            nMessageIDRet = ERR_ENTRIES_FULL;
+            return false;
+        }
     }
 
     if (entry.vecTxDSIn.size() > COINJOIN_ENTRY_MAX_SIZE || entry.vecTxOut.size() > COINJOIN_ENTRY_MAX_SIZE) {
@@ -768,8 +780,8 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
     }
 
     bool fConsumeCollateral{false};
-    if (!IsValidInOuts(m_chainman.ActiveChainstate(), m_isman, mempool, vin, entry.vecTxOut, nMessageIDRet,
-                       &fConsumeCollateral)) {
+    if (!IsValidInOuts(m_chainman.ActiveChainstate(), m_isman, mempool, vin, entry.vecTxOut, session_denom,
+                       nMessageIDRet, &fConsumeCollateral)) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR! IsValidInOuts() failed: %s\n", __func__, CoinJoin::GetMessageByID(nMessageIDRet).translated);
         if (fConsumeCollateral) {
             ConsumeCollateral(entry.txCollateral);

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -41,7 +41,6 @@ CCoinJoinServer::CCoinJoinServer(PeerManagerInternal* peer_manager, ChainstateMa
     m_mn_activeman{mn_activeman},
     m_mn_sync{mn_sync},
     m_isman{isman},
-    vecSessionCollaterals{},
     fUnitTest{false}
 {
 }
@@ -86,7 +85,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
         return;
     }
 
-    if (vecSessionCollaterals.empty()) {
+    if (WITH_LOCK(cs_coinjoin, return m_session_collaterals.empty())) {
         {
             const auto hasQueue = m_queueman.TryHasQueueFromMasternode(m_mn_activeman.GetOutPoint());
             if (!hasQueue.has_value()) return;
@@ -282,8 +281,7 @@ void CCoinJoinServer::SetNull()
 {
     AssertLockHeld(cs_coinjoin);
     // MN side
-    vecSessionCollaterals.clear();
-    setSessionCollateralPrevouts.clear();
+    m_session_collaterals.Clear();
 
     CCoinJoinBaseSession::SetNull();
     m_queueman.SetNull();
@@ -323,7 +321,7 @@ void CCoinJoinServer::CheckPool()
             LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- entries count %lu\n", entries);
         }
         if (nState == POOL_STATE_ACCEPTING_ENTRIES) {
-            if (static_cast<size_t>(entries) == vecSessionCollaterals.size()) {
+            if (static_cast<size_t>(entries) == m_session_collaterals.size()) {
                 // We have an entry for each collateral
                 action = Action::Finalize;
             } else if (CCoinJoinServer::HasTimedOut() && entries >= CoinJoin::GetMinPoolParticipants()) {
@@ -482,10 +480,10 @@ void CCoinJoinServer::ChargeFees() const
         // and then charge and log them as "didn't sign", or pick offenders from a session the
         // state no longer describes.
         state = nState;
-        nSessionCollaterals = vecSessionCollaterals.size();
+        nSessionCollaterals = m_session_collaterals.size();
 
         if (state == POOL_STATE_ACCEPTING_ENTRIES) {
-            for (const auto& txCollateral : vecSessionCollaterals) {
+            for (const auto& txCollateral : m_session_collaterals.txs()) {
                 bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
                     return *entry.txCollateral == *txCollateral;
                 });
@@ -545,7 +543,15 @@ void CCoinJoinServer::ChargeFees() const
 */
 void CCoinJoinServer::ChargeRandomFees() const
 {
-    for (const auto& txCollateral : vecSessionCollaterals) {
+    AssertLockNotHeld(cs_coinjoin);
+
+    // Copy the collaterals out before consuming any: ConsumeCollateral() takes cs_main, which
+    // must not be held under cs_coinjoin, and iterating the member directly meant a concurrent
+    // SetNull() destroyed the transactions this loop was walking.
+    std::vector<CTransactionRef> collaterals;
+    WITH_LOCK(cs_coinjoin, collaterals = m_session_collaterals.txs());
+
+    for (const auto& txCollateral : collaterals) {
         if (GetRand<int>(/*nMax=*/100) > 10) return;
         LogPrint(BCLog::COINJOIN, /* Continued */
                  "CCoinJoinServer::ChargeRandomFees -- charging random fees, txCollateral=%s", txCollateral->ToString());
@@ -611,7 +617,7 @@ void CCoinJoinServer::CheckForCompleteQueue()
 
         SetState(POOL_STATE_ACCEPTING_ENTRIES);
         nDenom = nSessionDenom;
-        nParticipants = vecSessionCollaterals.size();
+        nParticipants = m_session_collaterals.size();
     }
 
     // Signing and relaying happen with cs_coinjoin released: BLS signing and network sends have
@@ -678,7 +684,7 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
 {
     AssertLockNotHeld(cs_coinjoin);
 
-    if (size_t(GetEntriesCount()) >= vecSessionCollaterals.size()) {
+    if (WITH_LOCK(cs_coinjoin, return size_t(GetEntriesCountLocked()) >= m_session_collaterals.size())) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
         nMessageIDRet = ERR_ENTRIES_FULL;
         return false;
@@ -693,10 +699,11 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
         CTransactionRef txCollateralToConsume;
         {
             LOCK(cs_coinjoin);
-            const auto it = std::ranges::find_if(vecSessionCollaterals, [&entry](const auto& txCollateral) {
+            const auto& txs = m_session_collaterals.txs();
+            const auto it = std::ranges::find_if(txs, [&entry](const auto& txCollateral) {
                 return *entry.txCollateral == *txCollateral;
             });
-            if (it != vecSessionCollaterals.end()) {
+            if (it != txs.end()) {
                 txCollateralToConsume = *it;
             }
         }
@@ -815,15 +822,6 @@ bool CCoinJoinServer::IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& n
     return true;
 }
 
-void CCoinJoinServer::CommitSessionCollateral(const CMutableTransaction& txCollateral)
-{
-    AssertLockHeld(cs_coinjoin);
-    vecSessionCollaterals.push_back(MakeTransactionRef(txCollateral));
-    for (const auto& txin : txCollateral.vin) {
-        setSessionCollateralPrevouts.insert(txin.prevout);
-    }
-}
-
 bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet)
 {
     if (nSessionID != 0) return false;
@@ -839,6 +837,8 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
         return false;
     }
 
+    int nDenom{0};
+    size_t nParticipants{0};
     {
         LOCK(cs_coinjoin);
 
@@ -857,21 +857,25 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
 
         SetState(POOL_STATE_QUEUE);
 
-        CommitSessionCollateral(dsa.txCollateral);
+        m_session_collaterals.Add(dsa.txCollateral);
+        nDenom = nSessionDenom;
+        nParticipants = m_session_collaterals.size();
     }
 
     if (!fUnitTest) {
         //broadcast that I'm accepting entries, only if it's the first entry through
-        CCoinJoinQueue dsq(nSessionDenom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(),
-                           GetAdjustedTime(), false);
+        CCoinJoinQueue dsq(nDenom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(), GetAdjustedTime(), false);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- signing and relaying new queue: %s\n", dsq.ToString());
         dsq.vchSig = m_mn_activeman.SignBasic(dsq.GetSignatureHash());
         m_peer_manager->PeerRelayDSQ(dsq);
         m_queueman.AddQueue(std::move(dsq));
     }
 
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- new session created, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
-        nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), vecSessionCollaterals.size(), CoinJoin::GetMaxPoolParticipants());
+    LogPrint(BCLog::COINJOIN, /* Continued */
+             "CCoinJoinServer::CreateNewSession -- new session created, nSessionID: %d  nSessionDenom: %d (%s)  "
+             "participants: %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
+             nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), nParticipants,
+             CoinJoin::GetMaxPoolParticipants());
 
     return true;
 }
@@ -905,30 +909,31 @@ bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolM
     // A scheduler-thread timeout can reset the session via SetNull() between the checks above
     // and taking cs_coinjoin, so revalidate: a collateral must never be committed to a session
     // that no longer exists.
-    if (nSessionID == 0 || nState != POOL_STATE_QUEUE) {
+    if (nSessionID == 0 || nState != POOL_STATE_QUEUE || IsSessionReady()) {
         nMessageIDRet = ERR_MODE;
         return false;
     }
 
-    // Session collaterals are only ever test-accepted, never added to the mempool, so nothing
-    // pins their identity: the same UTXO can be re-signed into arbitrarily many distinct txids.
-    // Match on input prevouts so a resent or replayed dsa cannot be counted as a new participant.
-    for (const auto& txin : dsa.txCollateral.vin) {
-        if (setSessionCollateralPrevouts.contains(txin.prevout)) {
-            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- collateral %s spends prevout %s already committed to this session\n",
-                dsa.txCollateral.GetHash().ToString(), txin.prevout.ToStringShort());
-            nMessageIDRet = ERR_ALREADY_HAVE;
-            return false;
-        }
+    // A resent or replayed dsa must not be counted as a new participant; see SessionCollaterals.
+    if (const auto prevout = m_session_collaterals.FindCommittedPrevout(dsa.txCollateral)) {
+        LogPrint(BCLog::COINJOIN, /* Continued */
+                 "CCoinJoinServer::AddUserToExistingSession -- collateral %s spends prevout %s already committed to "
+                 "this session\n",
+                 dsa.txCollateral.GetHash().ToString(), prevout->ToStringShort());
+        nMessageIDRet = ERR_ALREADY_HAVE;
+        return false;
     }
 
     // count new user as accepted to an existing session
 
     nMessageIDRet = MSG_NOERR;
-    CommitSessionCollateral(dsa.txCollateral);
+    m_session_collaterals.Add(dsa.txCollateral);
 
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- new user accepted, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
-        nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), vecSessionCollaterals.size(), CoinJoin::GetMaxPoolParticipants());
+    LogPrint(BCLog::COINJOIN, /* Continued */
+             "CCoinJoinServer::AddUserToExistingSession -- new user accepted, nSessionID: %d  nSessionDenom: %d (%s)  "
+             "participants: %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
+             nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), m_session_collaterals.size(),
+             CoinJoin::GetMaxPoolParticipants());
 
     return true;
 }
@@ -939,10 +944,10 @@ bool CCoinJoinServer::IsSessionReady() const
     AssertLockHeld(cs_coinjoin);
 
     if (nState == POOL_STATE_QUEUE) {
-        if ((int)vecSessionCollaterals.size() >= CoinJoin::GetMaxPoolParticipants()) {
+        if ((int)m_session_collaterals.size() >= CoinJoin::GetMaxPoolParticipants()) {
             return true;
         }
-        if (CCoinJoinServer::HasTimedOut() && (int)vecSessionCollaterals.size() >= CoinJoin::GetMinPoolParticipants()) {
+        if (CCoinJoinServer::HasTimedOut() && (int)m_session_collaterals.size() >= CoinJoin::GetMinPoolParticipants()) {
             return true;
         }
     }

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -67,7 +67,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
 {
     assert(m_mn_metaman.IsValid());
 
-    if (IsSessionReady()) {
+    if (WITH_LOCK(cs_coinjoin, return IsSessionReady())) {
         // too many users in this session already, reject new ones
         LogPrint(BCLog::COINJOIN, "DSACCEPT -- queue is already full!\n");
         PushStatus(peer, STATUS_REJECTED, ERR_QUEUE_FULL);
@@ -200,7 +200,7 @@ void CCoinJoinServer::ProcessDSQUEUE(NodeId from, CDataStream& vRecv)
 void CCoinJoinServer::ProcessDSVIN(CNode& peer, CDataStream& vRecv)
 {
     //do we have enough users in the current session?
-    if (!IsSessionReady()) {
+    if (!WITH_LOCK(cs_coinjoin, return IsSessionReady())) {
         LogPrint(BCLog::COINJOIN, "DSVIN -- session not complete!\n");
         PushStatus(peer, STATUS_REJECTED, ERR_SESSION);
         return;
@@ -294,41 +294,78 @@ void CCoinJoinServer::SetNull()
 //
 void CCoinJoinServer::CheckPool()
 {
-    if (int entries = GetEntriesCount(); entries != 0)
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- entries count %lu\n", entries);
+    AssertLockNotHeld(cs_coinjoin);
 
-    // If we have an entry for each collateral, then create final tx
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES && size_t(GetEntriesCount()) == vecSessionCollaterals.size()) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- FINALIZE TRANSACTIONS\n");
-        CreateFinalTransaction();
-        return;
+    // Both the scheduler thread and the message-handling thread get here. Skip the round if the
+    // other one is already in it rather than blocking msghand behind its mempool work: whichever
+    // thread holds the lock is performing the same check we would.
+    TRY_LOCK(cs_check_pool, lock_check_pool);
+    if (!lock_check_pool) return;
+
+    // Decide what to do from a single consistent snapshot. Sampling nState, the entry count and
+    // the collateral count under separate lock acquisitions let a concurrent SetNull() land
+    // between them, so an already-reset session could be read as "0 entries == 0 collaterals"
+    // and finalized: an empty final transaction, a dead session put back into SIGNING, and no
+    // new session accepted until that timed out.
+    enum class Action : uint8_t {
+        None,
+        Finalize,
+        ChargeAndFinalize,
+        Commit
+    };
+    Action action{Action::None};
+    int session_id{0};
+    {
+        LOCK(cs_coinjoin);
+        session_id = nSessionID;
+        const int entries{GetEntriesCountLocked()};
+        if (entries != 0) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- entries count %lu\n", entries);
+        }
+        if (nState == POOL_STATE_ACCEPTING_ENTRIES) {
+            if (static_cast<size_t>(entries) == vecSessionCollaterals.size()) {
+                // We have an entry for each collateral
+                action = Action::Finalize;
+            } else if (CCoinJoinServer::HasTimedOut() && entries >= CoinJoin::GetMinPoolParticipants()) {
+                // We timed out while accepting entries but still have more than the minimum, so
+                // punish the misbehaving participants and complete the session without them
+                action = Action::ChargeAndFinalize;
+            }
+        } else if (nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
+            action = Action::Commit;
+        }
     }
 
-    // Check for Time Out
-    // If we timed out while accepting entries, then if we have more than minimum, create final tx
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES && CCoinJoinServer::HasTimedOut() &&
-        GetEntriesCount() >= CoinJoin::GetMinPoolParticipants()) {
-        // Punish misbehaving participants
+    switch (action) {
+    case Action::None:
+        return;
+    case Action::ChargeAndFinalize:
         ChargeFees();
-        // Try to complete this session ignoring the misbehaving ones
-        CreateFinalTransaction();
+        [[fallthrough]];
+    case Action::Finalize:
+        CreateFinalTransaction(session_id);
         return;
-    }
-
-    // If we have all the signatures, try to compile the transaction
-    if (nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
+    case Action::Commit:
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- SIGNING\n");
-        CommitFinalTransaction();
+        CommitFinalTransaction(session_id);
         return;
     }
 }
 
-void CCoinJoinServer::CreateFinalTransaction()
+void CCoinJoinServer::CreateFinalTransaction(int session_id)
 {
     AssertLockNotHeld(cs_coinjoin);
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- FINALIZE TRANSACTIONS\n");
 
     LOCK(cs_coinjoin);
+
+    // Finalizing a session that is already gone would put it back into SIGNING and reject every
+    // new one until that timed out.
+    if (nSessionID != session_id) {
+        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- session %d is gone, not finalizing\n",
+                 session_id);
+        return;
+    }
 
     CMutableTransaction txNew;
 
@@ -354,11 +391,22 @@ void CCoinJoinServer::CreateFinalTransaction()
     RelayFinalTransaction(CTransaction(finalMutableTransaction));
 }
 
-void CCoinJoinServer::CommitFinalTransaction()
+void CCoinJoinServer::CommitFinalTransaction(int session_id)
 {
     AssertLockNotHeld(cs_coinjoin);
 
-    CTransactionRef finalTransaction = WITH_LOCK(cs_coinjoin, return MakeTransactionRef(finalMutableTransaction));
+    CTransactionRef finalTransaction;
+    {
+        LOCK(cs_coinjoin);
+        // Committing a session that is already gone would push a cleared finalMutableTransaction
+        // through ATMP and notify the participants of a failure that never happened.
+        if (nSessionID != session_id) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- session %d is gone, not committing\n",
+                     session_id);
+            return;
+        }
+        finalTransaction = MakeTransactionRef(finalMutableTransaction);
+    }
     uint256 hashTx = finalTransaction->GetHash();
 
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- finalTransaction=%s", /* Continued */
@@ -424,33 +472,42 @@ void CCoinJoinServer::ChargeFees() const
     if (GetRand<int>(/*nMax=*/100) > 33) return;
 
     std::vector<CTransactionRef> vecOffendersCollaterals;
+    size_t nSessionCollaterals{0};
+    PoolState state{POOL_STATE_IDLE};
 
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES) {
+    {
         LOCK(cs_coinjoin);
-        for (const auto& txCollateral : vecSessionCollaterals) {
-            bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
-                return *entry.txCollateral == *txCollateral;
-            });
+        // Sample the state under the lock, together with the data it describes. Reading nState
+        // separately per branch let a concurrent transition select the "didn't send" offenders
+        // and then charge and log them as "didn't sign", or pick offenders from a session the
+        // state no longer describes.
+        state = nState;
+        nSessionCollaterals = vecSessionCollaterals.size();
 
-            // This queue entry didn't send us the promised transaction
-            if (!fFound) {
-                LogPrint(BCLog::COINJOIN, /* Continued */
-                         "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't send transaction), found "
-                         "offence\n");
-                vecOffendersCollaterals.push_back(txCollateral);
-            }
-        }
-    }
+        if (state == POOL_STATE_ACCEPTING_ENTRIES) {
+            for (const auto& txCollateral : vecSessionCollaterals) {
+                bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
+                    return *entry.txCollateral == *txCollateral;
+                });
 
-    if (nState == POOL_STATE_SIGNING) {
-        // who didn't sign?
-        LOCK(cs_coinjoin);
-        for (const auto& entry : vecEntries) {
-            for (const auto& txdsin : entry.vecTxDSIn) {
-                if (!txdsin.fHasSig) {
+                // This queue entry didn't send us the promised transaction
+                if (!fFound) {
                     LogPrint(BCLog::COINJOIN, /* Continued */
-                             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't sign), found offence\n");
-                    vecOffendersCollaterals.push_back(entry.txCollateral);
+                             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't send transaction), found "
+                             "offence\n");
+                    vecOffendersCollaterals.push_back(txCollateral);
+                }
+            }
+        } else if (state == POOL_STATE_SIGNING) {
+            // who didn't sign?
+            for (const auto& entry : vecEntries) {
+                for (const auto& txdsin : entry.vecTxDSIn) {
+                    if (!txdsin.fHasSig) {
+                        LogPrint(BCLog::COINJOIN, /* Continued */
+                                 "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't sign), found "
+                                 "offence\n");
+                        vecOffendersCollaterals.push_back(entry.txCollateral);
+                    }
                 }
             }
         }
@@ -460,20 +517,18 @@ void CCoinJoinServer::ChargeFees() const
     if (vecOffendersCollaterals.empty()) return;
 
     //mostly offending? Charge sometimes
-    if (vecOffendersCollaterals.size() >= vecSessionCollaterals.size() - 1 && GetRand<int>(/*nMax=*/100) > 33) return;
+    if (vecOffendersCollaterals.size() >= nSessionCollaterals - 1 && GetRand<int>(/*nMax=*/100) > 33) return;
 
     //everyone is an offender? That's not right
-    if (vecOffendersCollaterals.size() >= vecSessionCollaterals.size()) return;
+    if (vecOffendersCollaterals.size() >= nSessionCollaterals) return;
 
     //charge one of the offenders randomly
     Shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end(), FastRandomContext());
 
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_SIGNING) {
-        LogPrint(BCLog::COINJOIN, /* Continued */
-                 "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s",
-                 (nState == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
-        ConsumeCollateral(vecOffendersCollaterals[0]);
-    }
+    LogPrint(BCLog::COINJOIN, /* Continued */
+             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s",
+             (state == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
+    ConsumeCollateral(vecOffendersCollaterals[0]);
 }
 
 /*
@@ -541,17 +596,34 @@ void CCoinJoinServer::CheckTimeout()
 */
 void CCoinJoinServer::CheckForCompleteQueue()
 {
-    if (nState == POOL_STATE_QUEUE && IsSessionReady()) {
-        SetState(POOL_STATE_ACCEPTING_ENTRIES);
+    AssertLockNotHeld(cs_coinjoin);
 
-        CCoinJoinQueue dsq(nSessionDenom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(),
-                           GetAdjustedTime(), true);
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s) " /* Continued */
-                                     "with %d participants\n", dsq.ToString(), vecSessionCollaterals.size());
-        dsq.vchSig = m_mn_activeman.SignBasic(dsq.GetSignatureHash());
-        m_peer_manager->PeerRelayDSQ(dsq);
-        m_queueman.AddQueue(std::move(dsq));
+    int nDenom{0};
+    size_t nParticipants{0};
+    {
+        // Test the readiness condition and perform the transition under one lock, so that a
+        // message-handling thread revalidating POOL_STATE_QUEUE cannot have the state flipped
+        // out from under it and commit a collateral into a session that has already announced
+        // itself ready. The denom and participant count are captured for the log and dsq below,
+        // which run after the lock is released.
+        LOCK(cs_coinjoin);
+        if (nState != POOL_STATE_QUEUE || !IsSessionReady()) return;
+
+        SetState(POOL_STATE_ACCEPTING_ENTRIES);
+        nDenom = nSessionDenom;
+        nParticipants = vecSessionCollaterals.size();
     }
+
+    // Signing and relaying happen with cs_coinjoin released: BLS signing and network sends have
+    // no business holding the session lock.
+    CCoinJoinQueue dsq(nDenom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(), GetAdjustedTime(), true);
+    LogPrint(BCLog::COINJOIN, /* Continued */
+             "CCoinJoinServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s) " /* Continued */
+             "with %d participants\n",
+             dsq.ToString(), nParticipants);
+    dsq.vchSig = m_mn_activeman.SignBasic(dsq.GetSignatureHash());
+    m_peer_manager->PeerRelayDSQ(dsq);
+    m_queueman.AddQueue(std::move(dsq));
 }
 
 // Check to make sure a given input matches an input in the pool and its scriptSig is valid
@@ -717,8 +789,7 @@ bool CCoinJoinServer::AddScriptSig(const CTxIn& txinNew)
 // Check to make sure everything is signed
 bool CCoinJoinServer::IsSignaturesComplete() const
 {
-    AssertLockNotHeld(cs_coinjoin);
-    LOCK(cs_coinjoin);
+    AssertLockHeld(cs_coinjoin);
 
     return std::ranges::all_of(vecEntries, [](const auto& entry) {
         return std::ranges::all_of(entry.vecTxDSIn, [](const auto& txdsin) { return txdsin.fHasSig; });
@@ -807,7 +878,9 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
 
 bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet)
 {
-    if (nSessionID == 0 || IsSessionReady()) return false;
+    // Cheap gates first: IsAcceptableDSA() below runs a mempool test-accept, which a full or
+    // absent session must not pay for.
+    if (nSessionID == 0 || WITH_LOCK(cs_coinjoin, return IsSessionReady())) return false;
 
     if (!IsAcceptableDSA(dsa, nMessageIDRet)) {
         return false;
@@ -863,6 +936,8 @@ bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolM
 // Returns true if either max size has been reached or if the mix timed out and min size was reached
 bool CCoinJoinServer::IsSessionReady() const
 {
+    AssertLockHeld(cs_coinjoin);
+
     if (nState == POOL_STATE_QUEUE) {
         if ((int)vecSessionCollaterals.size() >= CoinJoin::GetMaxPoolParticipants()) {
             return true;
@@ -965,6 +1040,8 @@ void CCoinJoinServer::RelayCompletedTransaction(PoolMessage nMessageID)
 
 void CCoinJoinServer::SetState(PoolState nStateNew)
 {
+    AssertLockHeld(cs_coinjoin);
+
     if (nStateNew == POOL_STATE_ERROR) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::SetState -- Can't set state to ERROR as a Masternode. \n");
         return;

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -606,6 +606,20 @@ void CCoinJoinServer::CheckTimeout()
         // closing the session form one atomic cutoff for late entries and signatures.
         if (!CCoinJoinServer::HasTimedOut()) return;
 
+        // CheckForCompleteQueue() and CheckPool() run before this method on the scheduler thread,
+        // but a final collateral, entry, or signature can arrive after their snapshots. The
+        // message-handling thread then skips its own CheckPool() if this scheduler tick still holds
+        // cs_check_pool. Give a session that can now advance priority over resetting it; the next
+        // scheduler tick will perform the transition, finalization, or commit.
+        const int entries{GetEntriesCountLocked()};
+        const bool can_advance{
+            (nState == POOL_STATE_QUEUE && IsSessionReady()) ||
+            (nState == POOL_STATE_ACCEPTING_ENTRIES &&
+             (static_cast<size_t>(entries) == m_session_collaterals.size() ||
+              entries >= CoinJoin::GetMinPoolParticipants())) ||
+            (nState == POOL_STATE_SIGNING && IsSignaturesComplete())};
+        if (can_advance) return;
+
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
                  (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
         collateral_to_charge = SelectCollateralToCharge();

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -684,7 +684,12 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
 {
     AssertLockNotHeld(cs_coinjoin);
 
-    if (WITH_LOCK(cs_coinjoin, return size_t(GetEntriesCountLocked()) >= m_session_collaterals.size())) {
+    // Remember which session we are admitting this entry to. The validation below releases
+    // cs_coinjoin and takes cs_main, so the session can be reset underneath us before we commit.
+    const int session_id{nSessionID};
+
+    // Cheap gate before the cs_main work below; the authoritative check is at commit time.
+    if (WITH_LOCK(cs_coinjoin, return static_cast<size_t>(GetEntriesCountLocked()) >= m_session_collaterals.size())) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
         nMessageIDRet = ERR_ENTRIES_FULL;
         return false;
@@ -720,21 +725,24 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
     }
 
     std::vector<CTxIn> vin;
-    for (const auto& txin : entry.vecTxDSIn) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- txin=%s\n", __func__, txin.ToString());
+    {
         LOCK(cs_coinjoin);
-        for (const auto& inner_entry : vecEntries) {
-            if (std::ranges::any_of(inner_entry.vecTxDSIn,
-                                    [&txin](const auto& txdsin) { return txdsin.prevout == txin.prevout; })) {
-                LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: already have this txin in entries\n", __func__);
-                nMessageIDRet = ERR_ALREADY_HAVE;
-                // Two peers sent the same input? Can't really say who is the malicious one here,
-                // could be that someone is picking someone else's inputs randomly trying to force
-                // collateral consumption. Do not punish.
-                return false;
+        for (const auto& txin : entry.vecTxDSIn) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- txin=%s\n", __func__, txin.ToString());
+            for (const auto& inner_entry : vecEntries) {
+                if (std::ranges::any_of(inner_entry.vecTxDSIn,
+                                        [&txin](const auto& txdsin) { return txdsin.prevout == txin.prevout; })) {
+                    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: already have this txin in entries\n",
+                             __func__);
+                    nMessageIDRet = ERR_ALREADY_HAVE;
+                    // Two peers sent the same input? Can't really say who is the malicious one here,
+                    // could be that someone is picking someone else's inputs randomly trying to force
+                    // collateral consumption. Do not punish.
+                    return false;
+                }
             }
+            vin.emplace_back(txin);
         }
-        vin.emplace_back(txin);
     }
 
     bool fConsumeCollateral{false};
@@ -747,9 +755,32 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
         return false;
     }
 
-    WITH_LOCK(cs_coinjoin, vecEntries.push_back(entry));
+    int nEntries{0};
+    {
+        LOCK(cs_coinjoin);
 
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- adding entry %d of %d required\n", __func__, GetEntriesCount(), CoinJoin::GetMaxPoolParticipants());
+        // IsCollateralValid() and IsValidInOuts() above take cs_main and can block for a long
+        // time behind block validation, so a scheduler-thread timeout can reset the session in
+        // that window. Committing then would leave an entry of a dead session in vecEntries: the
+        // next session inherits it, counts it towards its own participants, and finalizes a
+        // transaction containing an input nobody present is going to sign.
+        if (nSessionID != session_id) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: session %d is gone!\n", __func__, session_id);
+            nMessageIDRet = ERR_SESSION;
+            return false;
+        }
+        if (static_cast<size_t>(GetEntriesCountLocked()) >= m_session_collaterals.size()) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: entries is full!\n", __func__);
+            nMessageIDRet = ERR_ENTRIES_FULL;
+            return false;
+        }
+
+        vecEntries.push_back(entry);
+        nEntries = GetEntriesCountLocked();
+    }
+
+    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- adding entry %d of %d required\n", __func__, nEntries,
+             CoinJoin::GetMaxPoolParticipants());
     nMessageIDRet = MSG_ENTRIES_ADDED;
 
     return true;

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -405,6 +405,8 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
     AssertLockNotHeld(cs_coinjoin);
 
     CTransactionRef finalTransaction;
+    std::vector<CService> participants;
+    std::vector<CTransactionRef> collaterals;
     {
         LOCK(cs_coinjoin);
         // Committing a session that is already gone would push a cleared finalMutableTransaction
@@ -415,6 +417,9 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
             return;
         }
         finalTransaction = MakeTransactionRef(finalMutableTransaction);
+        participants.reserve(vecEntries.size());
+        std::ranges::transform(vecEntries, std::back_inserter(participants), [](const auto& entry) { return entry.addr; });
+        collaterals = m_session_collaterals.txs();
     }
     uint256 hashTx = finalTransaction->GetHash();
 
@@ -428,9 +433,9 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
         if (!lockMain || !ATMPIfSaneFee(m_chainman, finalTransaction)) {
             LogPrint(BCLog::COINJOIN, /* Continued */
                      "CCoinJoinServer::CommitFinalTransaction -- ATMPIfSaneFee() error: Transaction not valid\n");
-            WITH_LOCK(cs_coinjoin, SetNull());
             // not much we can do in this case, just notify clients
-            RelayCompletedTransaction(ERR_INVALID_TX);
+            RelayCompletedTransaction(session_id, participants, ERR_INVALID_TX);
+            ResetSigningSessionIfCurrent(session_id);
             return;
         }
     }
@@ -451,14 +456,14 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
     m_peer_manager->PeerRelayInv(inv);
 
     // Tell the clients it was successful
-    RelayCompletedTransaction(MSG_SUCCESS);
+    RelayCompletedTransaction(session_id, participants, MSG_SUCCESS);
 
     // Randomly charge clients
-    ChargeRandomFees();
+    ChargeRandomFees(collaterals);
 
     // Reset
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- COMPLETED -- RESETTING\n");
-    WITH_LOCK(cs_coinjoin, SetNull());
+    ResetSigningSessionIfCurrent(session_id);
 }
 
 //
@@ -548,15 +553,9 @@ CTransactionRef CCoinJoinServer::SelectCollateralToCharge() const
     stop these kinds of attacks 1 in 10 successful transactions are charged. This
     adds up to a cost of 0.001DRK per transaction on average.
 */
-void CCoinJoinServer::ChargeRandomFees() const
+void CCoinJoinServer::ChargeRandomFees(const std::vector<CTransactionRef>& collaterals) const
 {
     AssertLockNotHeld(cs_coinjoin);
-
-    // Copy the collaterals out before consuming any: ConsumeCollateral() takes cs_main, which
-    // must not be held under cs_coinjoin, and iterating the member directly meant a concurrent
-    // SetNull() destroyed the transactions this loop was walking.
-    std::vector<CTransactionRef> collaterals;
-    WITH_LOCK(cs_coinjoin, collaterals = m_session_collaterals.txs());
 
     for (const auto& txCollateral : collaterals) {
         if (GetRand<int>(/*nMax=*/100) > 10) return;
@@ -1100,26 +1099,34 @@ void CCoinJoinServer::RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nM
     }
 }
 
-void CCoinJoinServer::RelayCompletedTransaction(PoolMessage nMessageID)
+void CCoinJoinServer::RelayCompletedTransaction(int session_id, const std::vector<CService>& participants,
+                                                PoolMessage nMessageID)
 {
     AssertLockNotHeld(cs_coinjoin);
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- nSessionID: %d  nSessionDenom: %d (%s)\n",
-        __func__, nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- nSessionID: %d\n", __func__, session_id);
 
-    // final mixing tx with empty signatures should be relayed to mixing participants only
-    LOCK(cs_coinjoin);
-    for (const auto& entry : vecEntries) {
-        bool fOk = connman.ForNode(entry.addr, [&nMessageID, this](CNode* pnode) {
+    for (const auto& addr : participants) {
+        const bool fOk = connman.ForNode(addr, [&nMessageID, session_id, this](CNode* pnode) {
             CNetMsgMaker msgMaker(pnode->GetCommonVersion());
-            connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSCOMPLETE, nSessionID.load(), nMessageID));
+            connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSCOMPLETE, session_id, nMessageID));
             return true;
         });
         if (!fOk) {
-            // no such node? maybe client disconnected or our own connection went down
-            RelayStatus(STATUS_REJECTED);
-            break;
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- participant disconnected before completion\n", __func__);
         }
     }
+}
+
+void CCoinJoinServer::ResetSigningSessionIfCurrent(int session_id)
+{
+    AssertLockNotHeld(cs_coinjoin);
+    LOCK(cs_coinjoin);
+    if (nSessionID != session_id || nState != POOL_STATE_SIGNING) {
+        LogPrint(BCLog::COINJOIN, /* Continued */
+                 "CCoinJoinServer::%s -- signing session %d is no longer current, not resetting\n", __func__, session_id);
+        return;
+    }
+    SetNull();
 }
 
 void CCoinJoinServer::SetState(PoolState nStateNew)

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -368,7 +368,7 @@ void CCoinJoinServer::CreateFinalTransaction(int session_id, bool charge_fees)
         }
 
         if (charge_fees) {
-            collateral_to_charge = SelectCollateralToCharge();
+            collateral_to_charge = SelectCollateralToCharge(FeePolicy::PROBABILISTIC);
         }
 
         CMutableTransaction txNew;
@@ -483,12 +483,9 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
  * same session. The caller must close the relevant admission path before releasing the lock and
  * consuming the returned collateral, so a late entry or signature cannot make the snapshot stale.
  */
-CTransactionRef CCoinJoinServer::SelectCollateralToCharge() const
+CTransactionRef CCoinJoinServer::SelectCollateralToCharge(FeePolicy policy) const
 {
     AssertLockHeld(cs_coinjoin);
-
-    //we don't need to charge collateral for every offence.
-    if (GetRand<int>(/*nMax=*/100) > 33) return {};
 
     std::vector<CTransactionRef> vecOffendersCollaterals;
     const PoolState state{nState};
@@ -509,15 +506,13 @@ CTransactionRef CCoinJoinServer::SelectCollateralToCharge() const
             }
         }
     } else if (state == POOL_STATE_SIGNING) {
-        // who didn't sign?
+        // who didn't sign? Include each participant once even if multiple inputs are unsigned.
         for (const auto& entry : vecEntries) {
-            for (const auto& txdsin : entry.vecTxDSIn) {
-                if (!txdsin.fHasSig) {
-                    LogPrint(BCLog::COINJOIN, /* Continued */
-                             "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't sign), "
-                             "found offence\n");
-                    vecOffendersCollaterals.push_back(entry.txCollateral);
-                }
+            if (std::ranges::any_of(entry.vecTxDSIn, [](const auto& txdsin) { return !txdsin.fHasSig; })) {
+                LogPrint(BCLog::COINJOIN, /* Continued */
+                         "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't sign), "
+                         "found offence\n");
+                vecOffendersCollaterals.push_back(entry.txCollateral);
             }
         }
     }
@@ -525,11 +520,16 @@ CTransactionRef CCoinJoinServer::SelectCollateralToCharge() const
     // no offences found
     if (vecOffendersCollaterals.empty()) return {};
 
-    //mostly offending? Charge sometimes
-    if (vecOffendersCollaterals.size() >= nSessionCollaterals - 1 && GetRand<int>(/*nMax=*/100) > 33) return {};
+    if (policy == FeePolicy::PROBABILISTIC) {
+        // we don't need to charge collateral for every offence.
+        if (GetRand<int>(/*nMax=*/100) > 33) return {};
 
-    //everyone is an offender? That's not right
-    if (vecOffendersCollaterals.size() >= nSessionCollaterals) return {};
+        //mostly offending? Charge sometimes
+        if (vecOffendersCollaterals.size() + 1 >= nSessionCollaterals && GetRand<int>(/*nMax=*/100) > 33) return {};
+
+        //everyone is an offender? That's not right
+        if (vecOffendersCollaterals.size() >= nSessionCollaterals) return {};
+    }
 
     //charge one of the offenders randomly
     Shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end(), FastRandomContext());
@@ -621,7 +621,7 @@ void CCoinJoinServer::CheckTimeout()
 
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
                  (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
-        collateral_to_charge = SelectCollateralToCharge();
+        collateral_to_charge = SelectCollateralToCharge(FeePolicy::PROBABILISTIC);
         SetNull();
     }
 

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -47,6 +47,14 @@ CCoinJoinServer::CCoinJoinServer(PeerManagerInternal* peer_manager, ChainstateMa
 
 CCoinJoinServer::~CCoinJoinServer() = default;
 
+CCoinJoinServer::InFlightMessageGuard::InFlightMessageGuard(CCoinJoinServer& server, int session_id) :
+    m_server{server},
+    m_session_id{session_id}
+{
+}
+
+CCoinJoinServer::InFlightMessageGuard::~InFlightMessageGuard() { m_server.ClearMessageInFlight(m_session_id); }
+
 void CCoinJoinServer::ProcessMessage(CNode& peer, const std::string& msg_type, CDataStream& vRecv)
 {
     if (!m_mn_sync.IsBlockchainSynced()) return;
@@ -198,12 +206,22 @@ void CCoinJoinServer::ProcessDSQUEUE(NodeId from, CDataStream& vRecv)
 
 void CCoinJoinServer::ProcessDSVIN(CNode& peer, CDataStream& vRecv)
 {
-    //do we have enough users in the current session?
-    if (!WITH_LOCK(cs_coinjoin, return IsSessionReady())) {
+    std::optional<int> session_id;
+    {
+        LOCK(cs_coinjoin);
+        // Establish the timeout cutoff before deserializing or validating the entry. CheckTimeout()
+        // will defer while this message is in flight, so an on-time submission cannot be mistaken
+        // for a missing one merely because validation outlives the deadline.
+        if (nState == POOL_STATE_ACCEPTING_ENTRIES && !HasTimedOut()) {
+            session_id = MarkMessageInFlight();
+        }
+    }
+    if (!session_id) {
         LogPrint(BCLog::COINJOIN, "DSVIN -- session not complete!\n");
         PushStatus(peer, STATUS_REJECTED, ERR_SESSION);
         return;
     }
+    const InFlightMessageGuard in_flight{*this, *session_id};
 
     CCoinJoinEntry entry;
     vRecv >> entry;
@@ -228,23 +246,27 @@ void CCoinJoinServer::ProcessDSSIGNFINALTX(CNode& peer, CDataStream& vRecv)
     // Only accept signatures while we are actually collecting them, and only
     // from peers that are active participants in this session. Otherwise a
     // stray or unauthenticated peer could abort the session for everyone.
-    if (nState != POOL_STATE_SIGNING) {
-        LogPrint(BCLog::COINJOIN, "DSSIGNFINALTX -- wrong state, nState=%d, peer=%d\n",
-                 nState.load(), peer.GetId());
-        PushStatus(peer, STATUS_REJECTED, ERR_SESSION);
-        return;
-    }
+    std::optional<int> session_id;
+    PoolMessage rejection{MSG_NOERR};
     {
         LOCK(cs_coinjoin);
-        const bool is_participant = std::ranges::any_of(
-            vecEntries, [&peer](const auto& entry) { return entry.addr == peer.addr; });
-        if (!is_participant) {
+        if (nState != POOL_STATE_SIGNING || HasTimedOut()) {
+            LogPrint(BCLog::COINJOIN, "DSSIGNFINALTX -- wrong state or timed out, nState=%d, peer=%d\n", nState.load(),
+                     peer.GetId());
+            rejection = ERR_SESSION;
+        } else if (!std::ranges::any_of(vecEntries, [&peer](const auto& entry) { return entry.addr == peer.addr; })) {
             LogPrint(BCLog::COINJOIN, "DSSIGNFINALTX -- ignoring message from non-participant peer=%d\n",
                      peer.GetId());
-            PushStatus(peer, STATUS_REJECTED, ERR_INVALID_INPUT);
-            return;
+            rejection = ERR_INVALID_INPUT;
+        } else {
+            session_id = MarkMessageInFlight();
         }
     }
+    if (!session_id) {
+        PushStatus(peer, STATUS_REJECTED, rejection);
+        return;
+    }
+    const InFlightMessageGuard in_flight{*this, *session_id};
 
     const size_t max_txins{CoinJoin::GetMaxPoolInputOutputCount()};
     std::vector<CTxIn> vecTxIn;
@@ -287,6 +309,22 @@ void CCoinJoinServer::SetNull()
     m_queueman.SetNull();
 }
 
+int CCoinJoinServer::MarkMessageInFlight()
+{
+    AssertLockHeld(cs_coinjoin);
+    assert(!m_inflight_session.has_value());
+    m_inflight_session = nSessionID;
+    return *m_inflight_session;
+}
+
+void CCoinJoinServer::ClearMessageInFlight(int session_id)
+{
+    LOCK(cs_coinjoin);
+    if (m_inflight_session == session_id) {
+        m_inflight_session.reset();
+    }
+}
+
 //
 // Check the mixing progress and send client updates if a Masternode
 //
@@ -324,9 +362,12 @@ void CCoinJoinServer::CheckPool()
             if (static_cast<size_t>(entries) == m_session_collaterals.size()) {
                 // We have an entry for each collateral
                 action = Action::Finalize;
-            } else if (CCoinJoinServer::HasTimedOut() && entries >= CoinJoin::GetMinPoolParticipants()) {
+            } else if (CCoinJoinServer::HasTimedOut() && entries >= CoinJoin::GetMinPoolParticipants() &&
+                       m_inflight_session != nSessionID) {
                 // We timed out while accepting entries but still have more than the minimum, so
-                // punish the misbehaving participants and complete the session without them
+                // punish the misbehaving participants and complete the session without them. An
+                // entry still being validated is not missing: defer to the next round, like
+                // CheckTimeout() does, instead of charging its sender.
                 action = Action::ChargeAndFinalize;
             }
         } else if (nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
@@ -369,6 +410,12 @@ void CCoinJoinServer::CreateFinalTransaction(int session_id, bool charge_fees)
 
         if (charge_fees) {
             collateral_to_charge = SelectCollateralToCharge(FeePolicy::PROBABILISTIC);
+            if (collateral_to_charge) {
+                // The submission below runs outside cs_coinjoin, and a disconnect-triggered or
+                // timeout reset can reopen admission before it settles: reserve the charge so the
+                // collateral cannot be accepted into a replacement session it could never pay for.
+                MarkPendingCharge(collateral_to_charge);
+            }
         }
 
         CMutableTransaction txNew;
@@ -396,7 +443,7 @@ void CCoinJoinServer::CreateFinalTransaction(int session_id, bool charge_fees)
     }
 
     if (collateral_to_charge) {
-        ConsumeCollateral(collateral_to_charge);
+        ConsumePendingCharge(collateral_to_charge);
     }
 }
 
@@ -534,11 +581,27 @@ CTransactionRef CCoinJoinServer::SelectCollateralToCharge(FeePolicy policy) cons
     //charge one of the offenders randomly
     Shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end(), FastRandomContext());
 
-    LogPrint(BCLog::COINJOIN, /* Continued */
-             "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't %s transaction), charging "
-             "fees: %s",
-             (state == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
-    return vecOffendersCollaterals[0];
+    const auto& selected_collateral = vecOffendersCollaterals.front();
+    if (policy == FeePolicy::PROBABILISTIC) {
+        LogPrint(BCLog::COINJOIN, /* Continued */
+                 "CCoinJoinServer::SelectCollateralToCharge -- selected non-submitting participant for probabilistic "
+                 "penalty, state=%s, participants=%d, offenders=%d, txid=%s\n",
+                 GetStateString(), nSessionCollaterals, vecOffendersCollaterals.size(),
+                 selected_collateral->GetHash().ToString());
+    } else if (vecOffendersCollaterals.size() == nSessionCollaterals) {
+        LogPrint(BCLog::COINJOIN, /* Continued */
+                 "CCoinJoinServer::SelectCollateralToCharge -- all participants failed to cooperate; selected "
+                 "participant for failed-session fee, state=%s, participants=%d, offenders=%d, txid=%s\n",
+                 GetStateString(), nSessionCollaterals, vecOffendersCollaterals.size(),
+                 selected_collateral->GetHash().ToString());
+    } else {
+        LogPrint(BCLog::COINJOIN, /* Continued */
+                 "CCoinJoinServer::SelectCollateralToCharge -- selected participant for failed-session fee, "
+                 "state=%s, participants=%d, offenders=%d, txid=%s\n",
+                 GetStateString(), nSessionCollaterals, vecOffendersCollaterals.size(),
+                 selected_collateral->GetHash().ToString());
+    }
+    return selected_collateral;
 }
 
 /*
@@ -576,6 +639,35 @@ void CCoinJoinServer::ConsumeCollateral(const CTransactionRef& txref) const
     }
 }
 
+void CCoinJoinServer::MarkPendingCharge(const CTransactionRef& txref)
+{
+    AssertLockHeld(cs_coinjoin);
+    for (const auto& txin : txref->vin) {
+        m_pending_charges.insert(txin.prevout);
+    }
+}
+
+bool CCoinJoinServer::IsCollateralPendingCharge(const CMutableTransaction& txCollateral) const
+{
+    AssertLockHeld(cs_coinjoin);
+    for (const auto& txin : txCollateral.vin) {
+        if (m_pending_charges.count(txin.prevout) > 0) return true;
+    }
+    return false;
+}
+
+void CCoinJoinServer::ConsumePendingCharge(const CTransactionRef& txref)
+{
+    AssertLockNotHeld(cs_coinjoin);
+    ConsumeCollateral(txref);
+    // Whether or not the mempool accepted the spend, the submission has settled: from here on
+    // IsCollateralValid()'s own mempool test decides whether this collateral is acceptable.
+    LOCK(cs_coinjoin);
+    for (const auto& txin : txref->vin) {
+        m_pending_charges.erase(txin.prevout);
+    }
+}
+
 bool CCoinJoinServer::HasTimedOut() const
 {
     if (nState == POOL_STATE_IDLE) return false;
@@ -602,8 +694,10 @@ void CCoinJoinServer::CheckTimeout()
         LOCK(cs_coinjoin);
 
         // Too early to do anything. Recheck while holding the lock so selecting an offender and
-        // closing the session form one atomic cutoff for late entries and signatures.
+        // closing the session form one atomic cutoff for late entries and signatures. Messages
+        // which crossed that cutoff first get to finish before we decide who failed to cooperate.
         if (!CCoinJoinServer::HasTimedOut()) return;
+        if (m_inflight_session == nSessionID) return;
 
         // CheckForCompleteQueue() and CheckPool() run before this method on the scheduler thread,
         // but a final collateral, entry, or signature can arrive after their snapshots. The
@@ -621,12 +715,20 @@ void CCoinJoinServer::CheckTimeout()
 
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
                  (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
-        collateral_to_charge = SelectCollateralToCharge(FeePolicy::PROBABILISTIC);
+        if (nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_SIGNING) {
+            collateral_to_charge = SelectCollateralToCharge(FeePolicy::GUARANTEED_ON_ABORT);
+        }
+        if (collateral_to_charge) {
+            // Reserve the charge before SetNull() reopens admission: the mempool submission below
+            // runs outside cs_coinjoin, and until it settles this collateral must not be accepted
+            // into a replacement session it could never pay for.
+            MarkPendingCharge(collateral_to_charge);
+        }
         SetNull();
     }
 
     if (collateral_to_charge) {
-        ConsumeCollateral(collateral_to_charge);
+        ConsumePendingCharge(collateral_to_charge);
     }
 }
 
@@ -928,6 +1030,16 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
             return false;
         }
 
+        // A collateral selected for a penalty stays unacceptable until its spend has settled in
+        // the mempool, where IsCollateralValid() takes over rejecting it.
+        if (IsCollateralPendingCharge(dsa.txCollateral)) {
+            LogPrint(BCLog::COINJOIN, /* Continued */
+                     "CCoinJoinServer::CreateNewSession -- collateral %s is reserved for a pending penalty\n",
+                     dsa.txCollateral.GetHash().ToString());
+            nMessageIDRet = ERR_INVALID_COLLATERAL;
+            return false;
+        }
+
         // start new session
         nMessageIDRet = MSG_NOERR;
         nSessionID = GetRand<int>(/*nMax=*/999999) + 1;
@@ -999,6 +1111,16 @@ bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolM
                  "this session\n",
                  dsa.txCollateral.GetHash().ToString(), prevout->ToStringShort());
         nMessageIDRet = ERR_ALREADY_HAVE;
+        return false;
+    }
+
+    // A collateral selected for a penalty stays unacceptable until its spend has settled in the
+    // mempool, where IsCollateralValid() takes over rejecting it.
+    if (IsCollateralPendingCharge(dsa.txCollateral)) {
+        LogPrint(BCLog::COINJOIN, /* Continued */
+                 "CCoinJoinServer::AddUserToExistingSession -- collateral %s is reserved for a pending penalty\n",
+                 dsa.txCollateral.GetHash().ToString());
+        nMessageIDRet = ERR_INVALID_COLLATERAL;
         return false;
     }
 

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -289,8 +289,40 @@ void CCoinJoinServer::ProcessDSSIGNFINALTX(CNode& peer, CDataStream& vRecv)
         nTxInIndex++;
         if (!AddScriptSig(txin)) {
             LogPrint(BCLog::COINJOIN, "DSSIGNFINALTX -- AddScriptSig() failed at %d/%d, session: %d\n", nTxInIndex, nTxInsCount, nSessionID);
-            LOCK(cs_coinjoin);
-            RelayStatus(STATUS_REJECTED);
+            CTransactionRef collateral_to_charge;
+            {
+                LOCK(cs_coinjoin);
+                // A concurrent CheckPool() can commit the fully signed session and reset the pool
+                // while this signature was being validated - committing does not wait for the
+                // in-flight mark. Against a cleared or replaced session the failure above is
+                // spurious: there is no session left to abort and nobody to charge, and relaying
+                // a rejection would poison m_relayed_abort for the next session, suppressing its
+                // guaranteed abort charge.
+                if (nSessionID != *session_id || nState != POOL_STATE_SIGNING) {
+                    LogPrint(BCLog::COINJOIN, /* Continued */
+                             "DSSIGNFINALTX -- session %d ended while the signature was validated, ignoring\n",
+                             *session_id);
+                    return;
+                }
+                // The sender is a verified participant of this signing session, so a signature
+                // that fails validation - a duplicate, an invalid script or an input that is not
+                // in the pool - is the sender's own doing, and the abort it forces on everyone
+                // else identifies the sender as the offender to charge. The participants this
+                // abort orphans must not pay for it at the timeout that follows.
+                const auto it = std::ranges::find_if(vecEntries,
+                                                     [&peer](const auto& entry) { return entry.addr == peer.addr; });
+                if (it != vecEntries.end()) {
+                    collateral_to_charge = it->txCollateral;
+                    // The submission below runs outside cs_coinjoin, and the reset that can follow
+                    // this abort would reopen admission before it settles: reserve the charge so
+                    // the collateral cannot be re-committed while its penalty spend is in flight.
+                    MarkPendingCharge(collateral_to_charge);
+                }
+                RelayStatus(STATUS_REJECTED);
+            }
+            if (collateral_to_charge) {
+                ConsumePendingCharge(collateral_to_charge);
+            }
             return;
         }
         LogPrint(BCLog::COINJOIN, "DSSIGNFINALTX -- AddScriptSig() %d/%d success\n", nTxInIndex, nTxInsCount);
@@ -304,6 +336,7 @@ void CCoinJoinServer::SetNull()
     AssertLockHeld(cs_coinjoin);
     // MN side
     m_session_collaterals.Clear();
+    m_relayed_abort = false;
 
     CCoinJoinBaseSession::SetNull();
     m_queueman.SetNull();
@@ -715,7 +748,10 @@ void CCoinJoinServer::CheckTimeout()
 
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
                  (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
-        if (nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_SIGNING) {
+        // Once we have told the participants to abort, the cooperative ones stop submitting
+        // and signing on our instruction. Failing to cooperate with a session this coordinator
+        // already gave up on identifies no offender, so nobody is charged for it.
+        if ((nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_SIGNING) && !m_relayed_abort) {
             collateral_to_charge = SelectCollateralToCharge(FeePolicy::GUARANTEED_ON_ABORT);
         }
         if (collateral_to_charge) {
@@ -1187,6 +1223,9 @@ void CCoinJoinServer::PushStatus(CNode& peer, PoolStatusUpdate nStatusUpdate, Po
 void CCoinJoinServer::RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID)
 {
     AssertLockHeld(cs_coinjoin);
+    if (nStatusUpdate == STATUS_REJECTED) {
+        m_relayed_abort = true;
+    }
     unsigned int nDisconnected{};
     // status updates should be relayed to mixing participants only
     for (const auto& entry : vecEntries) {
@@ -1207,6 +1246,7 @@ void CCoinJoinServer::RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nM
         __func__, nDisconnected, nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
 
     // notify everyone else that this session should be terminated
+    m_relayed_abort = true;
     for (const auto& entry : vecEntries) {
         connman.ForNode(entry.addr, [this](CNode* pnode) {
             PushStatus(*pnode, STATUS_REJECTED, MSG_NOERR);

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -338,10 +338,8 @@ void CCoinJoinServer::CheckPool()
     case Action::None:
         return;
     case Action::ChargeAndFinalize:
-        ChargeFees();
-        [[fallthrough]];
     case Action::Finalize:
-        CreateFinalTransaction(session_id);
+        CreateFinalTransaction(session_id, action == Action::ChargeAndFinalize);
         return;
     case Action::Commit:
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- SIGNING\n");
@@ -350,43 +348,56 @@ void CCoinJoinServer::CheckPool()
     }
 }
 
-void CCoinJoinServer::CreateFinalTransaction(int session_id)
+void CCoinJoinServer::CreateFinalTransaction(int session_id, bool charge_fees)
 {
     AssertLockNotHeld(cs_coinjoin);
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- FINALIZE TRANSACTIONS\n");
 
-    LOCK(cs_coinjoin);
+    CTransactionRef collateral_to_charge;
+    {
+        LOCK(cs_coinjoin);
 
-    // Finalizing a session that is already gone would put it back into SIGNING and reject every
-    // new one until that timed out.
-    if (nSessionID != session_id) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- session %d is gone, not finalizing\n",
-                 session_id);
-        return;
+        // Finalizing a session that is already gone would put it back into SIGNING and reject every
+        // new one until that timed out. Requiring the accepting state also makes selecting an
+        // offender and closing entry admission one atomic operation.
+        if (nSessionID != session_id || nState != POOL_STATE_ACCEPTING_ENTRIES) {
+            LogPrint(BCLog::COINJOIN, /* Continued */
+                     "CCoinJoinServer::CreateFinalTransaction -- session %d is gone or no longer accepting entries\n",
+                     session_id);
+            return;
+        }
+
+        if (charge_fees) {
+            collateral_to_charge = SelectCollateralToCharge();
+        }
+
+        CMutableTransaction txNew;
+
+        // make our new transaction
+        for (const auto& entry : vecEntries) {
+            for (const auto& txout : entry.vecTxOut) {
+                txNew.vout.push_back(txout);
+            }
+            for (const auto& txdsin : entry.vecTxDSIn) {
+                txNew.vin.push_back(txdsin);
+            }
+        }
+
+        sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());
+        sort(txNew.vout.begin(), txNew.vout.end(), CompareOutputBIP69());
+
+        finalMutableTransaction = txNew;
+        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- finalMutableTransaction=%s", /* Continued */
+                 txNew.ToString());
+
+        // request signatures from clients
+        SetState(POOL_STATE_SIGNING);
+        RelayFinalTransaction(CTransaction(finalMutableTransaction));
     }
 
-    CMutableTransaction txNew;
-
-    // make our new transaction
-    for (const auto& entry : vecEntries) {
-        for (const auto& txout : entry.vecTxOut) {
-            txNew.vout.push_back(txout);
-        }
-        for (const auto& txdsin : entry.vecTxDSIn) {
-            txNew.vin.push_back(txdsin);
-        }
+    if (collateral_to_charge) {
+        ConsumeCollateral(collateral_to_charge);
     }
-
-    sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());
-    sort(txNew.vout.begin(), txNew.vout.end(), CompareOutputBIP69());
-
-    finalMutableTransaction = txNew;
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- finalMutableTransaction=%s", /* Continued */
-             txNew.ToString());
-
-    // request signatures from clients
-    SetState(POOL_STATE_SIGNING);
-    RelayFinalTransaction(CTransaction(finalMutableTransaction));
 }
 
 void CCoinJoinServer::CommitFinalTransaction(int session_id)
@@ -462,71 +473,67 @@ void CCoinJoinServer::CommitFinalTransaction(int session_id)
 // transaction for the client to be able to enter the pool. This transaction is kept by the Masternode
 // until the transaction is either complete or fails.
 //
-void CCoinJoinServer::ChargeFees() const
+/*
+ * Select one offender while cs_coinjoin still binds the state, entries and collaterals to the
+ * same session. The caller must close the relevant admission path before releasing the lock and
+ * consuming the returned collateral, so a late entry or signature cannot make the snapshot stale.
+ */
+CTransactionRef CCoinJoinServer::SelectCollateralToCharge() const
 {
-    AssertLockNotHeld(cs_coinjoin);
+    AssertLockHeld(cs_coinjoin);
 
     //we don't need to charge collateral for every offence.
-    if (GetRand<int>(/*nMax=*/100) > 33) return;
+    if (GetRand<int>(/*nMax=*/100) > 33) return {};
 
     std::vector<CTransactionRef> vecOffendersCollaterals;
-    size_t nSessionCollaterals{0};
-    PoolState state{POOL_STATE_IDLE};
+    const PoolState state{nState};
+    const size_t nSessionCollaterals{m_session_collaterals.size()};
 
-    {
-        LOCK(cs_coinjoin);
-        // Sample the state under the lock, together with the data it describes. Reading nState
-        // separately per branch let a concurrent transition select the "didn't send" offenders
-        // and then charge and log them as "didn't sign", or pick offenders from a session the
-        // state no longer describes.
-        state = nState;
-        nSessionCollaterals = m_session_collaterals.size();
+    if (state == POOL_STATE_ACCEPTING_ENTRIES) {
+        for (const auto& txCollateral : m_session_collaterals.txs()) {
+            bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
+                return *entry.txCollateral == *txCollateral;
+            });
 
-        if (state == POOL_STATE_ACCEPTING_ENTRIES) {
-            for (const auto& txCollateral : m_session_collaterals.txs()) {
-                bool fFound = std::ranges::any_of(vecEntries, [&txCollateral](const auto& entry) {
-                    return *entry.txCollateral == *txCollateral;
-                });
-
-                // This queue entry didn't send us the promised transaction
-                if (!fFound) {
-                    LogPrint(BCLog::COINJOIN, /* Continued */
-                             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't send transaction), found "
-                             "offence\n");
-                    vecOffendersCollaterals.push_back(txCollateral);
-                }
+            // This queue entry didn't send us the promised transaction
+            if (!fFound) {
+                LogPrint(BCLog::COINJOIN, /* Continued */
+                         "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't send "
+                         "transaction), found offence\n");
+                vecOffendersCollaterals.push_back(txCollateral);
             }
-        } else if (state == POOL_STATE_SIGNING) {
-            // who didn't sign?
-            for (const auto& entry : vecEntries) {
-                for (const auto& txdsin : entry.vecTxDSIn) {
-                    if (!txdsin.fHasSig) {
-                        LogPrint(BCLog::COINJOIN, /* Continued */
-                                 "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't sign), found "
-                                 "offence\n");
-                        vecOffendersCollaterals.push_back(entry.txCollateral);
-                    }
+        }
+    } else if (state == POOL_STATE_SIGNING) {
+        // who didn't sign?
+        for (const auto& entry : vecEntries) {
+            for (const auto& txdsin : entry.vecTxDSIn) {
+                if (!txdsin.fHasSig) {
+                    LogPrint(BCLog::COINJOIN, /* Continued */
+                             "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't sign), "
+                             "found offence\n");
+                    vecOffendersCollaterals.push_back(entry.txCollateral);
                 }
             }
         }
     }
 
     // no offences found
-    if (vecOffendersCollaterals.empty()) return;
+    if (vecOffendersCollaterals.empty()) return {};
 
     //mostly offending? Charge sometimes
-    if (vecOffendersCollaterals.size() >= nSessionCollaterals - 1 && GetRand<int>(/*nMax=*/100) > 33) return;
+    if (vecOffendersCollaterals.size() >= nSessionCollaterals - 1 && GetRand<int>(/*nMax=*/100) > 33) return {};
 
     //everyone is an offender? That's not right
-    if (vecOffendersCollaterals.size() >= nSessionCollaterals) return;
+    if (vecOffendersCollaterals.size() >= nSessionCollaterals) return {};
 
     //charge one of the offenders randomly
     Shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end(), FastRandomContext());
 
     LogPrint(BCLog::COINJOIN, /* Continued */
-             "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s",
+             "CCoinJoinServer::SelectCollateralToCharge -- found uncooperative node (didn't %s transaction), charging "
+             "fees: %s",
              (state == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
-    ConsumeCollateral(vecOffendersCollaterals[0]);
+    return vecOffendersCollaterals[0];
 }
 
 /*
@@ -586,13 +593,28 @@ void CCoinJoinServer::CheckTimeout()
 {
     m_queueman.CheckQueue();
 
-    // Too early to do anything
-    if (!CCoinJoinServer::HasTimedOut()) return;
+    // CheckPool can be finalizing or committing on the message-handling thread. Skipping this tick
+    // keeps timeout reset and finalization/commit single-flight without blocking the scheduler.
+    TRY_LOCK(cs_check_pool, lock_check_pool);
+    if (!lock_check_pool) return;
 
-    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
-        (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
-    ChargeFees();
-    WITH_LOCK(cs_coinjoin, SetNull());
+    CTransactionRef collateral_to_charge;
+    {
+        LOCK(cs_coinjoin);
+
+        // Too early to do anything. Recheck while holding the lock so selecting an offender and
+        // closing the session form one atomic cutoff for late entries and signatures.
+        if (!CCoinJoinServer::HasTimedOut()) return;
+
+        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
+                 (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
+        collateral_to_charge = SelectCollateralToCharge();
+        SetNull();
+    }
+
+    if (collateral_to_charge) {
+        ConsumeCollateral(collateral_to_charge);
+    }
 }
 
 /*
@@ -764,7 +786,7 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessag
         // that window. Committing then would leave an entry of a dead session in vecEntries: the
         // next session inherits it, counts it towards its own participants, and finalizes a
         // transaction containing an input nobody present is going to sign.
-        if (nSessionID != session_id) {
+        if (nSessionID != session_id || nState != POOL_STATE_ACCEPTING_ENTRIES) {
             LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: session %d is gone!\n", __func__, session_id);
             nMessageIDRet = ERR_SESSION;
             return false;

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -26,11 +26,16 @@ class CNode;
 class CTxMemPool;
 
 class UniValue;
+namespace coinjoin_inouts_tests {
+class TestableCoinJoinServer;
+}
 
 /** Used to keep track of current status of mixing pool
  */
 class CCoinJoinServer : public CCoinJoinBaseSession, public NetHandler
 {
+    friend class coinjoin_inouts_tests::TestableCoinJoinServer;
+
 private:
     CoinJoinQueueManager m_queueman;
 
@@ -88,11 +93,12 @@ private:
 
     bool fUnitTest;
 
-    /// Serializes CheckPool() against itself. CheckPool() runs both on the scheduler thread and
-    /// on the message-handling thread, and its finalize and commit steps have to be single-shot:
-    /// relaying DSFINALTX twice makes every client sign twice, and the duplicate signatures then
-    /// abort the session for all of them. Always acquired with TRY_LOCK and never taken by any
-    /// other code path, so a contended caller skips the round rather than blocking msghand.
+    /// Serializes CheckPool() against itself and against CheckTimeout(). CheckPool() runs both on
+    /// the scheduler thread and on the message-handling thread, and its finalize and commit steps
+    /// have to be single-shot: relaying DSFINALTX twice makes every client sign twice, and the
+    /// duplicate signatures then abort the session for all of them. CheckTimeout() uses the same
+    /// guard so it cannot reset a session during finalization or commit. Production paths always
+    /// acquire it with TRY_LOCK, so a contended caller skips the round rather than blocking msghand.
     Mutex cs_check_pool;
 
     /// Add a clients entry to the pool
@@ -100,8 +106,8 @@ private:
     /// Add signature to a txin
     bool AddScriptSig(const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
-    /// Charge fees to bad actors (Charge clients a fee if they're abusive)
-    void ChargeFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    /// Choose one bad actor whose collateral should be consumed, if any.
+    CTransactionRef SelectCollateralToCharge() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     /// Rarely charge fees to pay miners
     void ChargeRandomFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Consume collateral in cases when peer misbehaved
@@ -110,7 +116,7 @@ private:
     /// Check for process
     void CheckPool() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
 
-    void CreateFinalTransaction(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CreateFinalTransaction(int session_id, bool charge_fees) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     void CommitFinalTransaction(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     /// Is this nDenom and txCollateral acceptable?
@@ -161,7 +167,7 @@ public:
     void Schedule(CScheduler& scheduler) override;
 
     bool HasTimedOut() const;
-    void CheckTimeout() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CheckTimeout() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
     void CheckForCompleteQueue() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     void GetJsonInfo(UniValue& obj) const;

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -35,6 +35,11 @@ class TestableCoinJoinServer;
 class CCoinJoinServer : public CCoinJoinBaseSession, public NetHandler
 {
     friend class coinjoin_inouts_tests::TestableCoinJoinServer;
+public:
+    enum class FeePolicy : uint8_t {
+        PROBABILISTIC,
+        GUARANTEED_ON_ABORT,
+    };
 
 private:
     CoinJoinQueueManager m_queueman;
@@ -107,7 +112,7 @@ private:
     bool AddScriptSig(const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     /// Choose one bad actor whose collateral should be consumed, if any.
-    CTransactionRef SelectCollateralToCharge() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
+    CTransactionRef SelectCollateralToCharge(FeePolicy policy) const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     /// Rarely charge fees to pay miners
     void ChargeRandomFees(const std::vector<CTransactionRef>& collaterals) const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Consume collateral in cases when peer misbehaved

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -110,6 +110,10 @@ private:
     };
     SessionCollaterals m_session_collaterals GUARDED_BY(cs_coinjoin);
     std::optional<int> m_inflight_session GUARDED_BY(cs_coinjoin);
+    /// Set once this coordinator has told the session's participants to abort (a session-wide
+    /// STATUS_REJECTED). Honest clients obey it and stop cooperating, so the guaranteed timeout
+    /// charge that follows must not treat them as offenders.
+    bool m_relayed_abort GUARDED_BY(cs_coinjoin){false};
     /// Prevouts of collaterals selected for a penalty whose mempool submission has not settled.
     /// Selection happens under cs_coinjoin but the submission must not, and the reset that follows
     /// selection reopens admission in between: without this reservation the still-unspent
@@ -131,7 +135,7 @@ private:
     /// Add a clients entry to the pool
     bool AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Add signature to a txin
-    bool AddScriptSig(const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    virtual bool AddScriptSig(const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     int MarkMessageInFlight() EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     void ClearMessageInFlight(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -12,6 +12,7 @@
 #include <protocol.h>
 #include <util/hasher.h>
 
+#include <optional>
 #include <unordered_set>
 
 class CActiveMasternodeManager;
@@ -43,12 +44,47 @@ private:
     const CMasternodeSync& m_mn_sync;
     const llmq::CInstantSendManager& m_isman;
 
-    // Mixing uses collateral transactions to trust parties entering the pool
-    // to behave honestly. If they don't it takes their money.
-    std::vector<CTransactionRef> vecSessionCollaterals;
-    // Input prevouts of every transaction in vecSessionCollaterals, so a dsa whose collateral
-    // reuses one of them can be rejected without rescanning them all.
-    std::unordered_set<COutPoint, SaltedOutpointHasher> setSessionCollateralPrevouts GUARDED_BY(cs_coinjoin);
+    /// The collateral transactions of every peer admitted to the current session.
+    ///
+    /// Mixing uses collateral transactions to trust parties entering the pool to behave
+    /// honestly. If they don't it takes their money.
+    ///
+    /// Session collaterals are only ever test-accepted, never added to the mempool, so nothing
+    /// pins their identity: the same UTXO can be re-signed into arbitrarily many distinct txids.
+    /// Matching on input prevouts is what makes a resent or replayed dsa recognisable as the
+    /// same participant.
+    class SessionCollaterals
+    {
+    public:
+        void Add(const CMutableTransaction& txCollateral)
+        {
+            m_txs.push_back(MakeTransactionRef(txCollateral));
+            for (const auto& txin : txCollateral.vin) {
+                m_prevouts.insert(txin.prevout);
+            }
+        }
+        void Clear()
+        {
+            m_txs.clear();
+            m_prevouts.clear();
+        }
+        //! The first input of txCollateral that an already admitted collateral also spends, if any.
+        std::optional<COutPoint> FindCommittedPrevout(const CMutableTransaction& txCollateral) const
+        {
+            for (const auto& txin : txCollateral.vin) {
+                if (m_prevouts.contains(txin.prevout)) return txin.prevout;
+            }
+            return std::nullopt;
+        }
+        const std::vector<CTransactionRef>& txs() const { return m_txs; }
+        size_t size() const { return m_txs.size(); }
+        bool empty() const { return m_txs.empty(); }
+
+    private:
+        std::vector<CTransactionRef> m_txs;
+        std::unordered_set<COutPoint, SaltedOutpointHasher> m_prevouts;
+    };
+    SessionCollaterals m_session_collaterals GUARDED_BY(cs_coinjoin);
 
     bool fUnitTest;
 
@@ -79,8 +115,6 @@ private:
 
     /// Is this nDenom and txCollateral acceptable?
     bool IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) const;
-    /// Record an accepted collateral and index its input prevouts
-    void CommitSessionCollateral(const CMutableTransaction& txCollateral) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     bool CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     bool AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Do we have enough users to take entries?

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -109,7 +109,7 @@ private:
     /// Choose one bad actor whose collateral should be consumed, if any.
     CTransactionRef SelectCollateralToCharge() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     /// Rarely charge fees to pay miners
-    void ChargeRandomFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void ChargeRandomFees(const std::vector<CTransactionRef>& collaterals) const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Consume collateral in cases when peer misbehaved
     void ConsumeCollateral(const CTransactionRef& txref) const;
 
@@ -141,7 +141,9 @@ private:
     void RelayFinalTransaction(const CTransaction& txFinal) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     void PushStatus(CNode& peer, PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID) const;
     void RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID = MSG_NOERR) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
-    void RelayCompletedTransaction(PoolMessage nMessageID) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void RelayCompletedTransaction(int session_id, const std::vector<CService>& participants, PoolMessage nMessageID)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void ResetSigningSessionIfCurrent(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     void ProcessDSACCEPT(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     void ProcessDSQUEUE(NodeId from, CDataStream& vRecv);

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -35,6 +35,7 @@ class TestableCoinJoinServer;
 class CCoinJoinServer : public CCoinJoinBaseSession, public NetHandler
 {
     friend class coinjoin_inouts_tests::TestableCoinJoinServer;
+
 public:
     enum class FeePolicy : uint8_t {
         PROBABILISTIC,
@@ -42,6 +43,19 @@ public:
     };
 
 private:
+    class InFlightMessageGuard
+    {
+        CCoinJoinServer& m_server;
+        const int m_session_id;
+
+    public:
+        InFlightMessageGuard(CCoinJoinServer& server, int session_id);
+        ~InFlightMessageGuard();
+
+        InFlightMessageGuard(const InFlightMessageGuard&) = delete;
+        InFlightMessageGuard& operator=(const InFlightMessageGuard&) = delete;
+    };
+
     CoinJoinQueueManager m_queueman;
 
     ChainstateManager& m_chainman;
@@ -95,6 +109,14 @@ private:
         std::unordered_set<COutPoint, SaltedOutpointHasher> m_prevouts;
     };
     SessionCollaterals m_session_collaterals GUARDED_BY(cs_coinjoin);
+    std::optional<int> m_inflight_session GUARDED_BY(cs_coinjoin);
+    /// Prevouts of collaterals selected for a penalty whose mempool submission has not settled.
+    /// Selection happens under cs_coinjoin but the submission must not, and the reset that follows
+    /// selection reopens admission in between: without this reservation the still-unspent
+    /// collateral could be committed to a replacement session that the pending charge then breaks.
+    /// Deliberately not cleared by SetNull() - a pending charge outlives the session it was
+    /// incurred in - and erased once the submission settles and the mempool takes over.
+    std::unordered_set<COutPoint, SaltedOutpointHasher> m_pending_charges GUARDED_BY(cs_coinjoin);
 
     bool fUnitTest;
 
@@ -111,12 +133,22 @@ private:
     /// Add signature to a txin
     bool AddScriptSig(const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
+    int MarkMessageInFlight() EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
+    void ClearMessageInFlight(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+
     /// Choose one bad actor whose collateral should be consumed, if any.
     CTransactionRef SelectCollateralToCharge(FeePolicy policy) const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     /// Rarely charge fees to pay miners
     void ChargeRandomFees(const std::vector<CTransactionRef>& collaterals) const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Consume collateral in cases when peer misbehaved
-    void ConsumeCollateral(const CTransactionRef& txref) const;
+    virtual void ConsumeCollateral(const CTransactionRef& txref) const;
+    /// Reserve a selected collateral's prevouts so admission rejects them until the charge settles.
+    void MarkPendingCharge(const CTransactionRef& txref) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
+    /// Does txCollateral spend a prevout reserved for a not-yet-settled penalty?
+    bool IsCollateralPendingCharge(const CMutableTransaction& txCollateral) const
+        EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
+    /// Consume a collateral previously reserved with MarkPendingCharge() and release the reservation.
+    void ConsumePendingCharge(const CTransactionRef& txref) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     /// Check for process
     void CheckPool() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -52,6 +52,13 @@ private:
 
     bool fUnitTest;
 
+    /// Serializes CheckPool() against itself. CheckPool() runs both on the scheduler thread and
+    /// on the message-handling thread, and its finalize and commit steps have to be single-shot:
+    /// relaying DSFINALTX twice makes every client sign twice, and the duplicate signatures then
+    /// abort the session for all of them. Always acquired with TRY_LOCK and never taken by any
+    /// other code path, so a contended caller skips the round rather than blocking msghand.
+    Mutex cs_check_pool;
+
     /// Add a clients entry to the pool
     bool AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Add signature to a txin
@@ -60,15 +67,15 @@ private:
     /// Charge fees to bad actors (Charge clients a fee if they're abusive)
     void ChargeFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Rarely charge fees to pay miners
-    void ChargeRandomFees() const;
+    void ChargeRandomFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Consume collateral in cases when peer misbehaved
     void ConsumeCollateral(const CTransactionRef& txref) const;
 
     /// Check for process
-    void CheckPool();
+    void CheckPool() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
 
-    void CreateFinalTransaction() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
-    void CommitFinalTransaction() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CreateFinalTransaction(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CommitFinalTransaction(int session_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     /// Is this nDenom and txCollateral acceptable?
     bool IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) const;
@@ -77,15 +84,18 @@ private:
     bool CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     bool AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Do we have enough users to take entries?
-    bool IsSessionReady() const;
+    bool IsSessionReady() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
     /// Check that all inputs are signed. (Are all inputs signed?)
-    bool IsSignaturesComplete() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    bool IsSignaturesComplete() const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     /// Check to make sure a given input matches an input in the pool and its scriptSig is valid
     bool IsInputScriptSigValid(const CTxIn& txin) const EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
-    // Set the 'state' value, with some logging and capturing when the state changed
-    void SetState(PoolState nStateNew);
+    // Set the 'state' value, with some logging and capturing when the state changed.
+    // Requires cs_coinjoin so that a transition and the session data it describes are always
+    // observed together: code that revalidates nState under the lock must not have it changed
+    // out from under it by a concurrent transition.
+    void SetState(PoolState nStateNew) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
     /// Relay mixing Messages
     void RelayFinalTransaction(const CTransaction& txFinal) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
@@ -95,8 +105,8 @@ private:
 
     void ProcessDSACCEPT(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     void ProcessDSQUEUE(NodeId from, CDataStream& vRecv);
-    void ProcessDSVIN(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
-    void ProcessDSSIGNFINALTX(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void ProcessDSVIN(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
+    void ProcessDSSIGNFINALTX(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
 
     void SetNull() override EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
@@ -110,14 +120,15 @@ public:
                              const CMasternodeSync& mn_sync, const llmq::CInstantSendManager& isman);
     ~CCoinJoinServer() override;
 
-    void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv) override;
+    void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv) override
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool);
     bool ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker) override;
     bool AlreadyHave(const CInv& inv) override;
     void Schedule(CScheduler& scheduler) override;
 
     bool HasTimedOut() const;
-    void CheckTimeout();
-    void CheckForCompleteQueue();
+    void CheckTimeout() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    void CheckForCompleteQueue() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
     void GetJsonInfo(UniValue& obj) const;
 };

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -20,6 +20,7 @@
 #include <uint256.h>
 #include <util/check.h>
 #include <util/time.h>
+#include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -205,6 +206,13 @@ public:
         locked.count_down();
         release.wait();
     }
+
+    bool ValidateInOuts(const std::vector<CTxIn>& vin, const std::vector<CTxOut>& vout, int session_denom,
+                        PoolMessage& message, bool& consume_collateral)
+    {
+        return IsValidInOuts(m_chainman.ActiveChainstate(), m_isman, mempool, vin, vout, session_denom, message,
+                             &consume_collateral);
+    }
 };
 
 static std::unique_ptr<CNode> MakePeer(NodeId id, uint32_t ipv4)
@@ -326,6 +334,28 @@ BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)
 
     server.CheckTimeout();
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+}
+
+BOOST_AUTO_TEST_CASE(server_validation_uses_session_denom_snapshot)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+
+    const int session_denom{CoinJoin::AmountToDenomination(CoinJoin::GetSmallestDenomination())};
+    const std::vector<CTxIn> vin{CTxIn{COutPoint{uint256::ONE, 0}}};
+    const std::vector<CTxOut> vout{CTxOut{CoinJoin::GetSmallestDenomination(), P2PKHScript()}};
+    PoolMessage message{MSG_NOERR};
+    bool consume_collateral{false};
+
+    // The live session denomination is zero, as it is after a concurrent SetNull(). Validation
+    // must use the denomination captured before the reset instead of treating this as a punishable
+    // denomination mismatch. The deliberately absent input makes validation stop with ERR_MISSING_TX.
+    BOOST_CHECK(!server.ValidateInOuts(vin, vout, session_denom, message, consume_collateral));
+    BOOST_CHECK_EQUAL(message, ERR_MISSING_TX);
+    BOOST_CHECK(!consume_collateral);
 }
 
 BOOST_AUTO_TEST_CASE(entry_deserializes_vectors_through_wire_cap)

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -192,6 +192,27 @@ public:
         vecEntries.push_back(std::move(entry));
     }
 
+    void SeedCompletionSession(int session_id, const CService& addr, PoolState state = POOL_STATE_SIGNING)
+    {
+        LOCK(cs_coinjoin);
+        SetNull();
+        nSessionID = session_id;
+        nState = state;
+
+        if (state == POOL_STATE_SIGNING) {
+            CCoinJoinEntry entry;
+            entry.addr = addr;
+            vecEntries.push_back(std::move(entry));
+        }
+    }
+
+    void RelayCompletion(int session_id, const CService& addr)
+    {
+        RelayCompletedTransaction(session_id, {addr}, MSG_SUCCESS);
+    }
+
+    void ResetForSession(int session_id) { ResetSigningSessionIfCurrent(session_id); }
+
     void SeedTimedOutSession()
     {
         LOCK(cs_coinjoin);
@@ -344,6 +365,31 @@ BOOST_AUTO_TEST_CASE(server_signfinaltx_participant_oversized_count_is_rejected_
                       std::ios_base::failure);
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
     BOOST_CHECK_EQUAL(server.GetEntriesCount(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(server_completion_does_not_reset_an_unreachable_or_replacement_session)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+
+    auto participant = MakePeer(/*id=*/7, /*ipv4=*/0x0a000001);
+    server.SeedCompletionSession(/*session_id=*/1, participant->addr);
+
+    // The participant is deliberately absent from connman. Failing to deliver DSCOMPLETE must not
+    // reset live session data; only CommitFinalTransaction owns the completion reset.
+    server.RelayCompletion(/*session_id=*/1, participant->addr);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
+    BOOST_CHECK_EQUAL(server.GetEntriesCount(), 1);
+
+    // A delayed tail operation from session 1 must never clear a replacement queue, even if the
+    // random wire session ID happens to be reused.
+    server.SeedCompletionSession(/*session_id=*/1, participant->addr, POOL_STATE_QUEUE);
+    server.ResetForSession(/*session_id=*/1);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_QUEUE});
+    BOOST_CHECK_EQUAL(server.GetEntriesCount(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -254,6 +254,37 @@ public:
 
     void CheckPoolForTest() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool) { CheckPool(); }
 
+    void RelayAbortForTest() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
+    {
+        LOCK(cs_coinjoin);
+        RelayStatus(STATUS_REJECTED);
+    }
+
+    //! Models the tail reset a committing CheckPool() performs concurrently.
+    void ClearPoolForTest() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
+    {
+        LOCK(cs_coinjoin);
+        SetNull();
+    }
+
+    //! Models CheckForCompleteQueue()'s transition, which does not touch abort state.
+    void EnterAcceptingEntriesState() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
+    {
+        LOCK(cs_coinjoin);
+        SetState(POOL_STATE_ACCEPTING_ENTRIES);
+    }
+
+    bool RelayedAbortForTest() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
+    {
+        LOCK(cs_coinjoin);
+        return m_relayed_abort;
+    }
+
+    bool RealAddScriptSig(const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
+    {
+        return CCoinJoinServer::AddScriptSig(txin);
+    }
+
     void SeedParticipant(const CService& addr) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
     {
         CCoinJoinEntry entry;
@@ -768,6 +799,166 @@ BOOST_AUTO_TEST_CASE(server_timeout_defers_and_commits_fully_signed_session)
     BOOST_CHECK_EQUAL(delta, static_cast<CAmount>(0.1 * COIN));
     BOOST_CHECK(server.consumed_collaterals.empty());
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+}
+
+BOOST_AUTO_TEST_CASE(server_signing_saboteur_pays_instead_of_honest_participants)
+{
+    BOOST_REQUIRE(m_node.mn_sync);
+    if (!m_node.mn_sync->IsBlockchainSynced()) m_node.mn_sync->SwitchToNextAsset();
+    BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
+
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+    auto& connman = static_cast<ConnmanTestMsg&>(*m_node.connman);
+
+    // A signing session with a saboteur that already signed and an honest participant that has
+    // not yet. The saboteur resubmits an already-known signature, which fails AddScriptSig() and
+    // makes the coordinator abort the session for everyone.
+    const auto collateral_saboteur = MakeCollateral(0);
+    const auto collateral_honest = MakeCollateral(1);
+
+    auto saboteur = MakePeer(/*id=*/7, /*ipv4=*/0x0a000001);
+    auto honest = MakePeer(/*id=*/8, /*ipv4=*/0x0a000002);
+    saboteur->fSuccessfullyConnected = true;
+    honest->fSuccessfullyConnected = true;
+
+    server.ResetForTest(POOL_STATE_SIGNING);
+    server.AddCollateralForTest(collateral_saboteur);
+    server.AddCollateralForTest(collateral_honest);
+    auto entry_saboteur = MakeEntry(collateral_saboteur, /*unsigned_inputs=*/0);
+    entry_saboteur.addr = saboteur->addr;
+    server.AddEntryForTest(entry_saboteur);
+    auto entry_honest = MakeEntry(collateral_honest, /*unsigned_inputs=*/1);
+    entry_honest.addr = honest->addr;
+    server.AddEntryForTest(entry_honest);
+
+    CNode* saboteur_node = saboteur.get();
+    connman.AddTestNode(*saboteur.release());
+    connman.AddTestNode(*honest.release());
+
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    stream << std::vector<CTxIn>{CTxIn{COutPoint{uint256::ONE, 100}}};
+    BOOST_CHECK_NO_THROW(server.ProcessMessage(*saboteur_node, NetMsgType::DSSIGNFINALTX, stream));
+
+    // The abort charges the identifiable saboteur, immediately.
+    BOOST_REQUIRE_EQUAL(server.consumed_collaterals.size(), 1U);
+    BOOST_CHECK(*server.consumed_collaterals[0] == *collateral_saboteur);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
+
+    // At the timeout that follows, the honest participant's missing signature is the result of
+    // obeying the coordinator's abort. It must not be treated as an offence.
+    server.SetTimedOutForTest();
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.consumed_collaterals.size(), 1U);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+
+    connman.ClearTestNodes();
+}
+
+BOOST_AUTO_TEST_CASE(server_stale_signature_after_commit_does_not_poison_next_session)
+{
+    BOOST_REQUIRE(m_node.mn_sync);
+    if (!m_node.mn_sync->IsBlockchainSynced()) m_node.mn_sync->SwitchToNextAsset();
+    BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
+
+    // While a DSSIGNFINALTX is being validated, a concurrent CheckPool() can commit the fully
+    // signed session and reset the pool: committing does not wait for the in-flight mark. The
+    // failure block must then recognize that the session it was admitted to has ended instead of
+    // relaying an abort that would set m_relayed_abort on an idle pool - CreateNewSession() never
+    // clears the flag, so the next session would inherit it and lose its guaranteed abort charge.
+    class MidValidationResetServer : public TestableCoinJoinServer
+    {
+    public:
+        using TestableCoinJoinServer::TestableCoinJoinServer;
+
+        bool AddScriptSig(const CTxIn& txin) override
+        {
+            // The commit lands while this signature is validated; the pool is already reset by
+            // the time the real AddScriptSig() runs, so it fails against an empty session.
+            ClearPoolForTest();
+            return RealAddScriptSig(txin);
+        }
+    };
+
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    MidValidationResetServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                    *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                    *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                    *Assert(m_node.llmq_ctx->isman));
+
+    const auto collateral = MakeCollateral(0);
+    auto participant = MakePeer(/*id=*/7, /*ipv4=*/0x0a000001);
+    server.ResetForTest(POOL_STATE_SIGNING);
+    server.AddCollateralForTest(collateral);
+    auto entry = MakeEntry(collateral, /*unsigned_inputs=*/0);
+    entry.addr = participant->addr;
+    server.AddEntryForTest(entry);
+
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    stream << std::vector<CTxIn>{CTxIn{COutPoint{uint256::ONE, 100}}};
+    BOOST_CHECK_NO_THROW(server.ProcessMessage(*participant, NetMsgType::DSSIGNFINALTX, stream));
+
+    // The stale failure charges nobody and leaves no abort mark behind.
+    BOOST_CHECK(server.consumed_collaterals.empty());
+    BOOST_CHECK(!server.RelayedAbortForTest());
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+
+    // The next session - opened without a SetNull() in between, exactly like production - must
+    // still be able to charge its own guaranteed abort fee.
+    const auto next_collateral = MakeCollateral(1);
+    PoolMessage message{MSG_NOERR};
+    BOOST_REQUIRE(server.TryAdmit(next_collateral, message));
+    server.EnterAcceptingEntriesState();
+    server.SetTimedOutForTest();
+    server.CheckTimeout();
+    BOOST_REQUIRE_EQUAL(server.consumed_collaterals.size(), 1U);
+    BOOST_CHECK(*server.consumed_collaterals[0] == *next_collateral);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+}
+
+BOOST_AUTO_TEST_CASE(server_relayed_abort_forgoes_guaranteed_timeout_charge)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+    auto& connman = static_cast<ConnmanTestMsg&>(*m_node.connman);
+
+    // Two participants that have not signed yet; one is no longer connected. A session-wide
+    // STATUS_REJECTED - as relayed when the final transaction cannot be delivered - tells the
+    // connected one to stand down, so the timeout may not charge either of them: the abort was
+    // the coordinator's, and a disconnect cannot be told apart from our own connection failing.
+    const auto collateral_connected = MakeCollateral(0);
+    const auto collateral_disconnected = MakeCollateral(1);
+
+    auto connected = MakePeer(/*id=*/7, /*ipv4=*/0x0a000001);
+    connected->fSuccessfullyConnected = true;
+
+    server.ResetForTest(POOL_STATE_SIGNING);
+    server.AddCollateralForTest(collateral_connected);
+    server.AddCollateralForTest(collateral_disconnected);
+    auto entry_connected = MakeEntry(collateral_connected, /*unsigned_inputs=*/1);
+    entry_connected.addr = connected->addr;
+    server.AddEntryForTest(entry_connected);
+    auto entry_disconnected = MakeEntry(collateral_disconnected, /*unsigned_inputs=*/1);
+    entry_disconnected.addr = MakePeer(/*id=*/8, /*ipv4=*/0x0a000002)->addr;
+    server.AddEntryForTest(entry_disconnected);
+
+    connman.AddTestNode(*connected.release());
+
+    server.RelayAbortForTest();
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
+
+    server.SetTimedOutForTest();
+    server.CheckTimeout();
+    BOOST_CHECK(server.consumed_collaterals.empty());
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+
+    connman.ClearTestNodes();
 }
 
 BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -8,6 +8,7 @@
 #include <coinjoin/coinjoin.h>
 #include <coinjoin/common.h>
 #include <coinjoin/server.h>
+#include <consensus/amount.h>
 #include <evo/chainhelper.h>
 #include <llmq/context.h>
 #include <masternode/sync.h>
@@ -18,6 +19,7 @@
 #include <streams.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
+#include <txmempool.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/time.h>
@@ -243,6 +245,14 @@ public:
                                   CMutableTransaction{*collateral}};
         return CreateNewSession(dsa, message);
     }
+
+    void SetFinalTransactionForTest(const CMutableTransaction& tx)
+    {
+        LOCK(cs_coinjoin);
+        finalMutableTransaction = tx;
+    }
+
+    void CheckPoolForTest() EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin, !cs_check_pool) { CheckPool(); }
 
     void SeedParticipant(const CService& addr) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
     {
@@ -717,6 +727,47 @@ BOOST_AUTO_TEST_CASE(server_completion_does_not_reset_an_unreachable_or_replacem
     server.ResetForSession(/*session_id=*/1);
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_QUEUE});
     BOOST_CHECK_EQUAL(server.GetEntriesCount(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(server_timeout_defers_and_commits_fully_signed_session)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+
+    // A fully signed session whose committing CheckPool() round was skipped: the final signature
+    // arrived while the scheduler held cs_check_pool, so its DSSIGNFINALTX could not commit, and
+    // the scheduler's own sample predated the signature. CheckTimeout() then runs past the
+    // deadline and must not treat the session as failed.
+    const auto collateral = MakeCollateral(0);
+    server.ResetForTest(POOL_STATE_SIGNING);
+    server.AddCollateralForTest(collateral);
+    server.AddEntryForTest(MakeEntry(collateral, /*unsigned_inputs=*/0));
+
+    CMutableTransaction final_tx;
+    final_tx.vin.emplace_back(COutPoint{uint256::ONE, 100});
+    server.SetFinalTransactionForTest(final_tx);
+    const uint256 final_hash{MakeTransactionRef(final_tx)->GetHash()};
+
+    server.SetTimedOutForTest();
+    server.CheckTimeout();
+
+    // Nobody misbehaved, so nobody may be charged and nothing may be reset: the timed-out but
+    // fully signed session defers to the next CheckPool() round.
+    BOOST_CHECK(server.consumed_collaterals.empty());
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
+
+    // That round commits it. The commit attempt is observable through the mempool prioritisation
+    // CommitFinalTransaction() applies before submitting; the submission itself fails in this
+    // fixture (the inputs do not exist), which resets the pool.
+    server.CheckPoolForTest();
+    CAmount delta{0};
+    WITH_LOCK(m_node.mempool->cs, m_node.mempool->ApplyDelta(final_hash, delta));
+    BOOST_CHECK_EQUAL(delta, static_cast<CAmount>(0.1 * COIN));
+    BOOST_CHECK(server.consumed_collaterals.empty());
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
 }
 
 BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -16,6 +16,7 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <streams.h>
+#include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/check.h>
@@ -182,7 +183,66 @@ class TestableCoinJoinServer : public CCoinJoinServer
 public:
     using CCoinJoinServer::CCoinJoinServer;
 
-    void EnterSigningState() { nState = POOL_STATE_SIGNING; }
+    mutable std::vector<CTransactionRef> consumed_collaterals;
+
+    void ConsumeCollateral(const CTransactionRef& txref) const override { consumed_collaterals.push_back(txref); }
+
+    void ResetForTest(PoolState state)
+    {
+        LOCK(cs_coinjoin);
+        SetNull();
+        nState = state;
+        nSessionID = 1;
+        consumed_collaterals.clear();
+    }
+
+    void SetTimedOutForTest()
+    {
+        LOCK(cs_coinjoin);
+        nTimeLastSuccessfulStep = GetTime() -
+            ((nState == POOL_STATE_SIGNING) ? COINJOIN_SIGNING_TIMEOUT : COINJOIN_QUEUE_TIMEOUT);
+    }
+
+    void AddCollateralForTest(const CTransactionRef& collateral)
+    {
+        LOCK(cs_coinjoin);
+        m_session_collaterals.Add(CMutableTransaction{*collateral});
+    }
+
+    void AddEntryForTest(const CCoinJoinEntry& entry)
+    {
+        LOCK(cs_coinjoin);
+        vecEntries.push_back(entry);
+    }
+
+    CTransactionRef SelectForTest(FeePolicy policy)
+    {
+        LOCK(cs_coinjoin);
+        return SelectCollateralToCharge(policy);
+    }
+
+    void ChargeRandomFeesForTest() const
+    {
+        std::vector<CTransactionRef> collaterals;
+        WITH_LOCK(cs_coinjoin, collaterals = m_session_collaterals.txs());
+        ChargeRandomFees(collaterals);
+    }
+
+    void EnterSigningState()
+    {
+        LOCK(cs_coinjoin);
+        SetState(POOL_STATE_SIGNING);
+    }
+
+    //! Offer a collateral to CreateNewSession() the way a DSACCEPT would. fUnitTest skips the
+    //! mempool-backed collateral validity check and the dsq relay, isolating admission logic.
+    bool TryAdmit(const CTransactionRef& collateral, PoolMessage& message) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
+    {
+        fUnitTest = true;
+        const CCoinJoinAccept dsa{CoinJoin::AmountToDenomination(CoinJoin::GetSmallestDenomination()),
+                                  CMutableTransaction{*collateral}};
+        return CreateNewSession(dsa, message);
+    }
 
     void SeedParticipant(const CService& addr) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin)
     {
@@ -262,6 +322,14 @@ public:
         release.wait();
     }
 
+    int MarkMessageInFlightForTest()
+    {
+        LOCK(cs_coinjoin);
+        return MarkMessageInFlight();
+    }
+
+    void ClearMessageInFlightForTest(int session_id) { ClearMessageInFlight(session_id); }
+
     bool ValidateInOuts(const std::vector<CTxIn>& vin, const std::vector<CTxOut>& vout, int session_denom,
                         PoolMessage& message, bool& consume_collateral)
     {
@@ -269,6 +337,265 @@ public:
                              &consume_collateral);
     }
 };
+
+static CTransactionRef MakeCollateral(uint32_t id)
+{
+    CMutableTransaction tx;
+    tx.vin.emplace_back(COutPoint{uint256::ONE, id});
+    tx.vout.emplace_back(CoinJoin::GetCollateralAmount(), P2PKHScript(static_cast<uint8_t>(id)));
+    return MakeTransactionRef(tx);
+}
+
+static CCoinJoinEntry MakeEntry(const CTransactionRef& collateral, size_t unsigned_inputs = 0)
+{
+    std::vector<CTxDSIn> inputs;
+    for (size_t i = 0; i < std::max<size_t>(unsigned_inputs, 1); ++i) {
+        CTxDSIn input{CTxIn{COutPoint{uint256::ONE, static_cast<uint32_t>(100 + i)}}, P2PKHScript(1), 0};
+        input.fHasSig = unsigned_inputs == 0;
+        inputs.push_back(input);
+    }
+    return CCoinJoinEntry{inputs, {}, CTransaction{*collateral}};
+}
+
+BOOST_AUTO_TEST_CASE(server_abort_fee_selects_unique_offenders)
+{
+    BOOST_REQUIRE(m_node.mn_sync);
+    m_node.mn_sync->SwitchToNextAsset();
+    BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
+
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+
+    // A queue that never became ready has no identifiable offender and charges nobody.
+    server.ResetForTest(POOL_STATE_QUEUE);
+    server.SetTimedOutForTest();
+    server.CheckTimeout();
+    BOOST_CHECK(server.consumed_collaterals.empty());
+
+    // All 20 reservations failed to submit. The abort policy still selects exactly one.
+    std::vector<CTransactionRef> collaterals;
+    server.ResetForTest(POOL_STATE_ACCEPTING_ENTRIES);
+    for (uint32_t i = 0; i < 20; ++i) {
+        collaterals.push_back(MakeCollateral(i));
+        server.AddCollateralForTest(collaterals.back());
+    }
+    BOOST_CHECK(server.SelectForTest(CCoinJoinServer::FeePolicy::PROBABILISTIC) == nullptr);
+    BOOST_CHECK(server.SelectForTest(CCoinJoinServer::FeePolicy::GUARANTEED_ON_ABORT) != nullptr);
+    server.SetTimedOutForTest();
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.consumed_collaterals.size(), 1U);
+
+    // With one submission, only one of the other 19 reservations can be selected.
+    server.ResetForTest(POOL_STATE_ACCEPTING_ENTRIES);
+    for (const auto& collateral : collaterals) server.AddCollateralForTest(collateral);
+    server.AddEntryForTest(MakeEntry(collaterals[0]));
+    for (int i = 0; i < 64; ++i) {
+        const auto selected = server.SelectForTest(CCoinJoinServer::FeePolicy::GUARANTEED_ON_ABORT);
+        BOOST_REQUIRE(selected);
+        BOOST_CHECK(*selected != *collaterals[0]);
+    }
+
+    // Three of five submitted, so only the two missing reservations are eligible.
+    server.ResetForTest(POOL_STATE_ACCEPTING_ENTRIES);
+    for (size_t i = 0; i < 5; ++i) server.AddCollateralForTest(collaterals[i]);
+    for (size_t i = 0; i < 3; ++i) server.AddEntryForTest(MakeEntry(collaterals[i]));
+    for (int i = 0; i < 64; ++i) {
+        const auto selected = server.SelectForTest(CCoinJoinServer::FeePolicy::GUARANTEED_ON_ABORT);
+        BOOST_REQUIRE(selected);
+        BOOST_CHECK(*selected == *collaterals[3] || *selected == *collaterals[4]);
+    }
+
+    // If every reservation submitted, there is no missing-entry collateral to select.
+    server.ResetForTest(POOL_STATE_ACCEPTING_ENTRIES);
+    for (size_t i = 0; i < 5; ++i) {
+        server.AddCollateralForTest(collaterals[i]);
+        server.AddEntryForTest(MakeEntry(collaterals[i]));
+    }
+    BOOST_CHECK(server.SelectForTest(CCoinJoinServer::FeePolicy::GUARANTEED_ON_ABORT) == nullptr);
+
+    // A lone non-signer is selected deterministically.
+    server.ResetForTest(POOL_STATE_SIGNING);
+    for (size_t i = 0; i < 3; ++i) {
+        server.AddCollateralForTest(collaterals[i]);
+        server.AddEntryForTest(MakeEntry(collaterals[i], i == 2 ? 1 : 0));
+    }
+    const auto lone_non_signer = server.SelectForTest(CCoinJoinServer::FeePolicy::GUARANTEED_ON_ABORT);
+    BOOST_REQUIRE(lone_non_signer);
+    BOOST_CHECK(*lone_non_signer == *collaterals[2]);
+
+    // Multiple non-signers select one member of that set; unsigned input count gives no extra weight.
+    server.ResetForTest(POOL_STATE_SIGNING);
+    server.AddCollateralForTest(collaterals[0]);
+    server.AddEntryForTest(MakeEntry(collaterals[0], 8));
+    server.AddCollateralForTest(collaterals[1]);
+    server.AddEntryForTest(MakeEntry(collaterals[1], 1));
+    size_t selected_first{0};
+    size_t selected_second{0};
+    for (int i = 0; i < 256; ++i) {
+        const auto selected = server.SelectForTest(CCoinJoinServer::FeePolicy::GUARANTEED_ON_ABORT);
+        BOOST_REQUIRE(selected);
+        if (*selected == *collaterals[0]) ++selected_first;
+        if (*selected == *collaterals[1]) ++selected_second;
+    }
+    BOOST_CHECK_GT(selected_first, 64U);
+    BOOST_CHECK_GT(selected_second, 64U);
+
+    // When every participant fails to sign, the abort policy still chooses exactly one.
+    server.SetTimedOutForTest();
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.consumed_collaterals.size(), 1U);
+
+    // A recoverable timeout retains the old probabilistic gate.
+    server.ResetForTest(POOL_STATE_ACCEPTING_ENTRIES);
+    for (size_t i = 0; i < 5; ++i) server.AddCollateralForTest(collaterals[i]);
+    for (size_t i = 0; i < 3; ++i) server.AddEntryForTest(MakeEntry(collaterals[i]));
+    bool selected_recoverable{false};
+    bool skipped_recoverable{false};
+    for (int i = 0; i < 256; ++i) {
+        if (server.SelectForTest(CCoinJoinServer::FeePolicy::PROBABILISTIC)) {
+            selected_recoverable = true;
+        } else {
+            skipped_recoverable = true;
+        }
+    }
+    BOOST_CHECK(selected_recoverable);
+    BOOST_CHECK(skipped_recoverable);
+
+    // Successful-session random charging remains independently probabilistic.
+    server.ResetForTest(POOL_STATE_SIGNING);
+    for (size_t i = 0; i < 5; ++i) server.AddCollateralForTest(collaterals[i]);
+    bool random_charge{false};
+    bool random_skip{false};
+    for (int i = 0; i < 256; ++i) {
+        server.consumed_collaterals.clear();
+        server.ChargeRandomFeesForTest();
+        random_charge |= !server.consumed_collaterals.empty();
+        random_skip |= server.consumed_collaterals.empty();
+    }
+    BOOST_CHECK(random_charge);
+    BOOST_CHECK(random_skip);
+}
+
+BOOST_AUTO_TEST_CASE(server_timeout_reset_precedes_collateral_consumption)
+{
+    BOOST_REQUIRE(m_node.mn_sync);
+    if (!m_node.mn_sync->IsBlockchainSynced()) m_node.mn_sync->SwitchToNextAsset();
+    BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
+
+    class SessionReplacingServer : public TestableCoinJoinServer
+    {
+    public:
+        using TestableCoinJoinServer::TestableCoinJoinServer;
+        mutable PoolState state_during_consume{POOL_STATE_ERROR};
+
+        void ConsumeCollateral(const CTransactionRef& txref) const override
+        {
+            state_during_consume = static_cast<PoolState>(GetState());
+            auto* self = const_cast<SessionReplacingServer*>(this);
+            self->ResetForTest(POOL_STATE_QUEUE);
+            TestableCoinJoinServer::ConsumeCollateral(txref);
+        }
+    };
+
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    SessionReplacingServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+    const auto collateral = MakeCollateral(0);
+    server.ResetForTest(POOL_STATE_ACCEPTING_ENTRIES);
+    server.AddCollateralForTest(collateral);
+    server.SetTimedOutForTest();
+
+    server.CheckTimeout();
+
+    BOOST_CHECK(server.state_during_consume == POOL_STATE_IDLE);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_QUEUE});
+    BOOST_CHECK_EQUAL(server.consumed_collaterals.size(), 1U);
+}
+
+BOOST_AUTO_TEST_CASE(server_pending_charge_blocks_readmission_until_consumed)
+{
+    // The timeout reset reopens admission before the penalty spend reaches the mempool. In that
+    // window the selected collateral is still unspent and would pass every other admission check;
+    // committing it to a replacement session would strand that session on a reservation whose
+    // funds are already promised to the penalty.
+    class ReadmissionRacingServer : public TestableCoinJoinServer
+    {
+    public:
+        using TestableCoinJoinServer::TestableCoinJoinServer;
+        mutable int readmitted_during_consume{-1};
+        mutable PoolMessage readmission_message{MSG_NOERR};
+
+        void ConsumeCollateral(const CTransactionRef& txref) const override
+        {
+            auto* self = const_cast<ReadmissionRacingServer*>(this);
+            PoolMessage message{MSG_NOERR};
+            readmitted_during_consume = self->TryAdmit(txref, message) ? 1 : 0;
+            readmission_message = message;
+            TestableCoinJoinServer::ConsumeCollateral(txref);
+        }
+    };
+
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    ReadmissionRacingServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                   *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                   *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                   *Assert(m_node.llmq_ctx->isman));
+    const auto collateral = MakeCollateral(0);
+    server.ResetForTest(POOL_STATE_ACCEPTING_ENTRIES);
+    server.AddCollateralForTest(collateral);
+    server.SetTimedOutForTest();
+
+    server.CheckTimeout();
+
+    // The pool was already reset when the consume ran, yet the pending charge kept the collateral
+    // out of a replacement session.
+    BOOST_REQUIRE_EQUAL(server.readmitted_during_consume, 0);
+    BOOST_CHECK_EQUAL(server.readmission_message, ERR_INVALID_COLLATERAL);
+    BOOST_CHECK_EQUAL(server.consumed_collaterals.size(), 1U);
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+
+    // Once the charge has settled the reservation is released and admission works again; in
+    // production the mempool, which now contains the penalty spend, takes over rejecting it.
+    PoolMessage message{MSG_NOERR};
+    BOOST_CHECK(server.TryAdmit(collateral, message));
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_QUEUE});
+}
+
+BOOST_AUTO_TEST_CASE(server_timeout_waits_for_in_flight_messages)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+    const auto collateral = MakeCollateral(0);
+
+    for (const PoolState state : {POOL_STATE_ACCEPTING_ENTRIES, POOL_STATE_SIGNING}) {
+        server.ResetForTest(state);
+        server.AddCollateralForTest(collateral);
+        if (state == POOL_STATE_SIGNING) {
+            server.AddEntryForTest(MakeEntry(collateral, /*unsigned_inputs=*/1));
+        }
+
+        const int session_id = server.MarkMessageInFlightForTest();
+        server.SetTimedOutForTest();
+        server.CheckTimeout();
+
+        BOOST_CHECK_EQUAL(server.GetState(), int{state});
+        BOOST_CHECK(server.consumed_collaterals.empty());
+
+        server.ClearMessageInFlightForTest(session_id);
+        server.CheckTimeout();
+
+        BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+        BOOST_CHECK_EQUAL(server.consumed_collaterals.size(), 1U);
+    }
+}
 
 static std::unique_ptr<CNode> MakePeer(NodeId id, uint32_t ipv4)
 {

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -198,6 +198,40 @@ public:
         nSessionID = 1;
         nState = POOL_STATE_ACCEPTING_ENTRIES;
         nTimeLastSuccessfulStep = GetTime() - COINJOIN_QUEUE_TIMEOUT;
+        for (int i = 0; i < CoinJoin::GetMinPoolParticipants(); ++i) {
+            CMutableTransaction collateral;
+            collateral.vin.emplace_back(COutPoint{uint256::ONE, static_cast<uint32_t>(i)});
+            m_session_collaterals.Add(collateral);
+        }
+    }
+
+    void SeedTimedOutActionableSession(PoolState state, bool has_missing_entry = false)
+    {
+        LOCK(cs_coinjoin);
+        SetNull();
+
+        nSessionID = 1;
+        nState = state;
+        nTimeLastSuccessfulStep = GetTime() -
+                                  (state == POOL_STATE_SIGNING ? COINJOIN_SIGNING_TIMEOUT : COINJOIN_QUEUE_TIMEOUT);
+
+        for (int i = 0; i < CoinJoin::GetMinPoolParticipants(); ++i) {
+            CMutableTransaction collateral;
+            collateral.vin.emplace_back(COutPoint{uint256::ONE, static_cast<uint32_t>(i)});
+            m_session_collaterals.Add(collateral);
+
+            if (state == POOL_STATE_QUEUE) continue;
+
+            CTxDSIn txdsin{CTxIn{COutPoint{uint256::TWO, static_cast<uint32_t>(i)}}, P2PKHScript(), 0};
+            txdsin.fHasSig = state == POOL_STATE_SIGNING;
+            vecEntries.emplace_back(std::vector<CTxDSIn>{txdsin}, std::vector<CTxOut>{}, CTransaction{collateral});
+        }
+
+        if (has_missing_entry) {
+            CMutableTransaction collateral;
+            collateral.vin.emplace_back(COutPoint{uint256::ONE, static_cast<uint32_t>(CoinJoin::GetMinPoolParticipants())});
+            m_session_collaterals.Add(collateral);
+        }
     }
 
     void HoldPoolCheck(std::latch& locked, std::latch& release)
@@ -334,6 +368,28 @@ BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)
 
     server.CheckTimeout();
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
+}
+
+BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_actionable_session)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+
+    for (const auto state : {POOL_STATE_QUEUE, POOL_STATE_ACCEPTING_ENTRIES, POOL_STATE_SIGNING}) {
+        BOOST_TEST_CONTEXT("state=" << state)
+        {
+            server.SeedTimedOutActionableSession(state);
+            server.CheckTimeout();
+            BOOST_CHECK_EQUAL(server.GetState(), int{state});
+        }
+    }
+
+    server.SeedTimedOutActionableSession(POOL_STATE_ACCEPTING_ENTRIES, /*has_missing_entry=*/true);
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_ACCEPTING_ENTRIES});
 }
 
 BOOST_AUTO_TEST_CASE(server_validation_uses_session_denom_snapshot)

--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -26,7 +26,9 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <latch>
 #include <memory>
+#include <thread>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(coinjoin_inouts_tests, TestingSetup)
@@ -171,9 +173,9 @@ BOOST_AUTO_TEST_CASE(entry_addscriptsig_matches_and_rejects)
     }
 }
 
-// Test-only subclass exposing the minimal seams needed to observe how
-// ProcessDSSIGNFINALTX treats messages from participants vs. non-participants
-// without standing up a full DKG-backed signing session.
+// Test-only subclass exposing the minimal seams needed to exercise server lifecycle behavior
+// without standing up a full DKG-backed signing session. The helpers only establish preconditions
+// and invoke the production paths; the behavior under test is not reproduced here.
 class TestableCoinJoinServer : public CCoinJoinServer
 {
 public:
@@ -187,6 +189,21 @@ public:
         entry.addr = addr;
         LOCK(cs_coinjoin);
         vecEntries.push_back(std::move(entry));
+    }
+
+    void SeedTimedOutSession()
+    {
+        LOCK(cs_coinjoin);
+        nSessionID = 1;
+        nState = POOL_STATE_ACCEPTING_ENTRIES;
+        nTimeLastSuccessfulStep = GetTime() - COINJOIN_QUEUE_TIMEOUT;
+    }
+
+    void HoldPoolCheck(std::latch& locked, std::latch& release)
+    {
+        LOCK(cs_check_pool);
+        locked.count_down();
+        release.wait();
     }
 };
 
@@ -285,6 +302,30 @@ BOOST_AUTO_TEST_CASE(server_signfinaltx_participant_oversized_count_is_rejected_
                       std::ios_base::failure);
     BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_SIGNING});
     BOOST_CHECK_EQUAL(server.GetEntriesCount(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(server_timeout_does_not_reset_during_pool_check)
+{
+    CActiveMasternodeManager mn_activeman(*Assert(m_node.connman), *Assert(m_node.dmnman), MakeSecretKey());
+    TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
+                                  *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
+                                  *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
+                                  *Assert(m_node.llmq_ctx->isman));
+    server.SeedTimedOutSession();
+
+    std::latch locked{1};
+    std::latch release{1};
+    std::thread pool_check{[&] { server.HoldPoolCheck(locked, release); }};
+    locked.wait();
+
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_ACCEPTING_ENTRIES});
+
+    release.count_down();
+    pool_check.join();
+
+    server.CheckTimeout();
+    BOOST_CHECK_EQUAL(server.GetState(), int{POOL_STATE_IDLE});
 }
 
 BOOST_AUTO_TEST_CASE(entry_deserializes_vectors_through_wire_cap)


### PR DESCRIPTION
## Issue being fixed or feature implemented

CoinJoin participants can currently reserve a coordinator slot and then abort during entry submission or signing without necessarily losing collateral. In particular, the existing probabilistic policy exempts sessions where every participant is an offender, allowing coordinated non-cooperation to repeatedly kill sessions without cost.

This PR is intentionally built on #7537, which makes fee selection and session reset atomic. It should be reviewed and merged after that prerequisite.

## What was done?

- Split offender discovery from fee policy with explicit `PROBABILISTIC` and `GUARANTEED_ON_ABORT` modes.
- Deduplicate signing offenders so participants with multiple unsigned inputs receive no extra selection weight.
- Preserve the existing probabilistic policy when enough entries remain to finalize a mix.
- Charge exactly one uniformly selected missing submitter or non-signer when non-cooperation forces a session reset.
- Keep queue timeouts free: participants are not penalized before they are asked to submit entries.
- Select the collateral and call `SetNull()` under `cs_coinjoin`, then consume the selected collateral after releasing the lock.
- Add state-aware logs with participant count, offender count, and selected collateral txid.
- Skip the guaranteed timeout charge for a session this coordinator already told its participants to abandon (session-wide `STATUS_REJECTED`): honest clients obey the abort, release their inputs, and stop signing, so they must not form the offender set. The participant whose invalid signature forced the abort is charged directly in `ProcessDSSIGNFINALTX()` instead.
- Re-evaluate `IsSignaturesComplete()` when `CheckTimeout()` inspects a signing session, and commit a fully signed transaction instead of discarding it — the final `DSSIGNFINALTX` can land in a scheduler round whose `CheckPool()` already sampled the signatures as incomplete.
- Remove an extra closing brace currently present in #7537's `server.cpp` head so the stacked branch compiles.

## How Has This Been Tested?

Built `src/test/test_dash` locally on macOS arm64 using the prebuilt depends prefix, then ran:

```
./src/test/test_dash --run_test=coinjoin_inouts_tests
test/lint/lint-whitespace.py
git diff --check
```

The unit coverage exercises queue timeouts, all/many/few/no missing entries, lone and multiple non-signers, deduplication of participants with several unsigned inputs, all-participant signing failure, timeout/reset atomicity, the recoverable probabilistic policy, successful-session random charging, committing a fully signed session at timeout, direct saboteur charging, and forgoing the guaranteed charge after a relayed abort.

## Breaking Changes

No wire-format, wallet, database, persistent-format, or consensus change. Mixed-version operation remains safe; only upgraded masternodes apply the guaranteed failed-session fee.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

This pull request was created by Codex.

