### PR TITLE
fix(net): clean up disconnected peer state

### DIFF
--- a/src/llmq/net_signing.cpp
+++ b/src/llmq/net_signing.cpp
@@ -288,10 +288,11 @@ void NetSigning::WorkThreadSigning()
         constexpr auto CLEANUP_INTERVAL{5s};
         if (cleanupThrottler.TryCleanup(CLEANUP_INTERVAL)) {
             m_sig_manager.Cleanup();
-            // Drop pending recovered sigs queued by banned peers so a flood's backlog does not
-            // persist after the peer is banned (RemoveBannedNodeStates only cleans the sig-shares
-            // subsystem, not m_sig_manager's pending recovered sigs).
-            m_sig_manager.RemoveNodesIf([this](NodeId node_id) { return m_peer_manager->PeerIsBanned(node_id); });
+            // Drop pending recovered sigs from disconnected or discouraged peers so their backlog
+            // does not outlive the connection that created it.
+            m_sig_manager.RemoveNodesIf([this](NodeId node_id) {
+                return m_peer_manager->PeerIsDisconnectedOrDiscouraged(node_id);
+            });
         }
 
         // TODO Wakeup when pending signing is needed?
@@ -301,11 +302,12 @@ void NetSigning::WorkThreadSigning()
     }
 }
 
-void NetSigning::RemoveBannedNodeStates()
+void NetSigning::RemoveDisconnectedOrDiscouragedNodeStates()
 {
     assert(m_shares_manager != nullptr);
-    // Called regularly to cleanup local node states for banned nodes
-    m_shares_manager->RemoveNodesIf([this](NodeId node_id) { return m_peer_manager->PeerIsBanned(node_id); });
+    m_shares_manager->RemoveNodesIf([this](NodeId node_id) {
+        return m_peer_manager->PeerIsDisconnectedOrDiscouraged(node_id);
+    });
 }
 
 void NetSigning::BanNode(NodeId nodeId)
@@ -323,7 +325,7 @@ void NetSigning::WorkThreadCleaning()
     assert(m_shares_manager);
 
     while (!workInterrupt) {
-        RemoveBannedNodeStates();
+        RemoveDisconnectedOrDiscouragedNodeStates();
 
         m_shares_manager->SendMessages();
         m_shares_manager->Cleanup();

--- a/src/llmq/net_signing.h
+++ b/src/llmq/net_signing.h
@@ -71,7 +71,7 @@ private:
         std::unordered_map<NodeId, std::vector<CSigShare>>&& sigSharesByNodes,
         std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr, StaticSaltedHasher>&& quorums);
 
-    void RemoveBannedNodeStates();
+    void RemoveDisconnectedOrDiscouragedNodeStates();
     void BanNode(NodeId nodeid);
 
 private:

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -619,7 +619,6 @@ public:
                         const std::chrono::microseconds time_received, const std::atomic<bool>& interruptMsgProc) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_recent_confirmed_transactions_mutex, !m_most_recent_block_mutex, g_msgproc_mutex);
     void UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds) override;
-    bool IsBanned(NodeId pnode) override EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_peer_mutex);
     size_t GetRequestedObjectCount(NodeId nodeid) const override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Implements external handlers logic */
@@ -632,7 +631,7 @@ public:
 
     /** Implement PeerManagerInternal */
     void PeerMisbehaving(const NodeId pnode, const int howmuch, const std::string& message = "") override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
-    bool PeerIsBanned(const NodeId node_id) override EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_peer_mutex);
+    bool PeerIsDisconnectedOrDiscouraged(const NodeId node_id) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void PeerEraseObjectRequest(const NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool PeerConsumeObjectRequest(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     GetDataResponse PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
@@ -1897,16 +1896,13 @@ void PeerManagerImpl::Misbehaving(Peer& peer, int howmuch, const std::string& me
              peer.m_id, score_before, score_now, warning, message_prefixed);
 }
 
-bool PeerManagerImpl::IsBanned(NodeId pnode)
+bool PeerManagerImpl::PeerIsDisconnectedOrDiscouraged(const NodeId node_id)
 {
-    PeerRef peer = GetPeerRef(pnode);
-    if (peer == nullptr)
-        return false;
+    PeerRef peer = GetPeerRef(node_id);
+    if (peer == nullptr) return true;
+
     LOCK(peer->m_misbehavior_mutex);
-    if (peer->m_should_discourage) {
-        return true;
-    }
-    return false;
+    return peer->m_should_discourage;
 }
 
 bool PeerManagerImpl::MaybePunishNodeForBlock(NodeId nodeid, const BlockValidationState& state,
@@ -6711,11 +6707,6 @@ void PeerManagerImpl::PeerMisbehaving(const NodeId pnode, const int howmuch, con
 {
     PeerRef peer = GetPeerRef(pnode);
     if (peer) Misbehaving(*peer, howmuch, message);
-}
-
-bool PeerManagerImpl::PeerIsBanned(const NodeId node_id)
-{
-    return IsBanned(node_id);
 }
 
 void PeerManagerImpl::PeerEraseObjectRequest(const NodeId nodeid, const CInv& inv)

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -81,7 +81,8 @@ class PeerManagerInternal
 {
 public:
     virtual void PeerMisbehaving(const NodeId pnode, const int howmuch, const std::string& message = "") = 0;
-    virtual bool PeerIsBanned(const NodeId node_id) = 0;
+    /** Whether the peer is no longer connected or has crossed the discouragement threshold. */
+    virtual bool PeerIsDisconnectedOrDiscouraged(const NodeId node_id) = 0;
     /** Complete this peer's pending announcement of the inv, so it is not requested from them
      *  again. Announcements of the same inv by other peers are unaffected: an invalid or unusable
      *  object must not stop us from fetching it from honest peers.
@@ -219,8 +220,6 @@ public:
 
     /** This function is used for testing the stale tip eviction logic, see denialofservice_tests.cpp */
     virtual void UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds) = 0;
-
-    virtual bool IsBanned(NodeId pnode) = 0;
 
     virtual size_t GetRequestedObjectCount(NodeId nodeid) const = 0;
 

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -338,7 +338,9 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     peerLogic->InitializeNode(*nodes[0], NODE_NETWORK);
     nodes[0]->fSuccessfullyConnected = true;
     connman->AddTestNode(*nodes[0]);
+    BOOST_CHECK(!peerLogic->PeerIsDisconnectedOrDiscouraged(nodes[0]->GetId()));
     peerLogic->UnitTestMisbehaving(nodes[0]->GetId(), DISCOURAGEMENT_THRESHOLD); // Should be discouraged
+    BOOST_CHECK(peerLogic->PeerIsDisconnectedOrDiscouraged(nodes[0]->GetId()));
     BOOST_CHECK(peerLogic->SendMessages(nodes[0]));
     BOOST_CHECK(banman->IsDiscouraged(addr[0]));
     BOOST_CHECK(nodes[0]->fDisconnect);
@@ -358,6 +360,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     nodes[1]->fSuccessfullyConnected = true;
     connman->AddTestNode(*nodes[1]);
     peerLogic->UnitTestMisbehaving(nodes[1]->GetId(), DISCOURAGEMENT_THRESHOLD - 1);
+    BOOST_CHECK(!peerLogic->PeerIsDisconnectedOrDiscouraged(nodes[1]->GetId()));
     BOOST_CHECK(peerLogic->SendMessages(nodes[1]));
     // [0] is still discouraged/disconnected.
     BOOST_CHECK(banman->IsDiscouraged(addr[0]));
@@ -399,6 +402,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
 
     for (CNode* node : nodes) {
         peerLogic->FinalizeNode(*node);
+        BOOST_CHECK(peerLogic->PeerIsDisconnectedOrDiscouraged(node->GetId()));
     }
     connman->ClearTestNodes();
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

`PeerManagerImpl::IsBanned(NodeId)` did not report a persistent `BanMan` ban. It only checked whether the live peer object had crossed the discouragement threshold, and returned false after `FinalizeNode` removed that object. The misleading name obscured the lifecycle behavior and caused LLMQ cleanup predicates to retain queued state when they ran after peer finalization.

## What was done?

- Replace the ambiguous `IsBanned` / `PeerIsBanned` interface with `PeerIsDisconnectedOrDiscouraged`.
- Treat a missing peer object as disconnected, allowing LLMQ recovered-signature and signature-share cleanup to remove state after finalization.
- Rename the LLMQ cleanup helper to describe the state it actually removes.
- Add unit-test assertions for connected, discouraged, and finalized peer states.

## How Has This Been Tested?

Tested on macOS arm64 using the depends toolchain:

- `make -j13`
- `./src/test/test_dash --run_test=denialofservice_tests`
- `test/lint/all-lint.py`
- `git diff --check`

The full lint suite passed; its Python lint step reported that `flake8` was not installed.

## Breaking Changes

None. The renamed interface is internal to the networking and LLMQ implementation.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
