### PR TITLE
test: reset stale peerman and cj_walletman before chainstate reloads

### DIFF
--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -326,6 +326,22 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
 {
     auto& chainman{*Assert(m_node.chainman)};
 
+    // peerman and cj_walletman reference llmq_ctx, the mempool and the Dash
+    // managers recreated by the reload below. No test uses them across a
+    // reload: destroy them (clearing connman's raw m_msgproc pointer first)
+    // so future use after a reload fails on a null pointer instead of
+    // silently reading freed memory; such a test must rebuild them itself,
+    // as AppInitMain constructs them only after the chainstate is loaded.
+    if (m_node.peerman) {
+        CConnman::Options connman_options;
+        connman_options.socketEventsMode = ::g_socket_events_mode;
+        m_node.connman->Init(connman_options);
+        m_node.peerman.reset();
+    }
+#ifdef ENABLE_WALLET
+    m_node.cj_walletman.reset();
+#endif // ENABLE_WALLET
+
     node::ChainstateLoadOptions options{ChainstateLoadOptionsForTest()};
 
     if (options.reindex || options.reindex_chainstate) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #7603: latent dangling references in the test fixtures.

`PeerManagerImpl` holds the mempool, dmnman, isman, clhandler and llmq_ctx by reference; `CJWalletManagerImpl` holds the chainman, dmnman, mempool and isman. `ChainTestingSetup::LoadVerifyActivateChainstate()` always recreates `llmq_ctx` (inside `LoadChainstate()`), and since #7603 its reindex path also replaces the mempool and those managers. Any `SnapshotTestSetup` test that reloads the chainstate after `SimulateNodeRestart()` therefore left `m_node.peerman` and `m_node.cj_walletman` (built earlier by `TestingSetup`) holding dangling references for the rest of the test. Nothing dereferences them today — neither object is registered as a validation interface in unit tests, no scheduled tasks or handlers exist, and their destructors don't touch the referenced objects — but any future test touching them after a reload would silently read freed memory.

## What was done?

`LoadVerifyActivateChainstate()` now destroys `cj_walletman` and `peerman` before the reload, clearing `connman`'s raw `m_msgproc` pointer first. They are intentionally *not* rebuilt (reset-only approach suggested by knst in review): no current test uses either object across a reload, and leaving them null means a future test that does touch them fails fast on a null pointer instead of silently reading freed memory. Such a test must rebuild them itself, mirroring `AppInitMain`, which constructs them only after the chainstate is loaded. Fixtures that never built them (plain `ChainTestingSetup`, the `utxo_total_supply` fuzz target, `TestingSetup`'s own constructor-time call) are unaffected.

## How Has This Been Tested?

Built `test_dash` (`--enable-debug`, macOS arm64) and ran locally: `validation_chainstatemanager_tests` (exercises the reindex path and every `SimulateNodeRestart()` reload), `coinjoin_tests`, `denialofservice_tests`, `wallet_tests`, `interfaces_tests` — all pass.

## Breaking Changes

None; test-only change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
