### PR TITLE
fix(qt): restore transparent background for all scroll areas

### DIFF
--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -811,7 +811,11 @@ QRadioButton::indicator:unchecked:disabled {
 QScrollArea
 ******************************************************/
 
-QScrollArea#mnWizardScroll,
+.QScrollArea {
+    background-color: #00000000;
+    border: 0px;
+}
+
 QScrollArea#mnWizardScroll > QWidget,
 QScrollArea#mnWizardScroll > QWidget > QWidget {
     background-color: #00000000;


### PR DESCRIPTION
## Issue being fixed or feature implemented
cebae5a44556 (#7618) narrowed the global `.QScrollArea` transparency rule in `general.css` to only the masternode wizard's `QScrollArea#mnWizardScroll`. As a result every other scroll area in the GUI lost its transparent background and zero border, and now paints Qt's default palette panel with a visible frame — most noticeably the scroll area hosting the send entries on the Send and CoinJoin screens.

## What was done?
Restored the global rule

```css
.QScrollArea {
    background-color: #00000000;
    border: 0px;
}
```

and kept only the wizard-specific child rules that #7618 actually needed (`QScrollArea#mnWizardScroll > QWidget` and `... > QWidget > QWidget`). The wizard's scroll areas are plain `QScrollArea` instances, so the global rule already covers the scroll area itself; the retained child rules keep the wizard's inner page widgets transparent, so the masternode wizard is unaffected by this fix. No new colors are introduced, so the `update-css-files.py` color inventories are unchanged.

## How Has This Been Tested?
Captured before/after screenshots on macOS (dark theme). Both runs use the same prebuilt `dash-qt` binary (built from 297c15bbe018, the tip of #7618) on fresh, isolated regtest datadirs with an identically created wallet, identical window size, and CSS loaded from disk via `-custom-css-dir` — "before" uses `src/qt/res/css` at develop head 7be28f8a953e, "after" uses this PR's head. The only variable between the two runs is the CSS directory.

| | Before (develop @ 7be28f8) | After (this PR) |
|---|---|---|
| CoinJoin tab | ![before-coinjoin](https://raw.githubusercontent.com/PastaPastaPasta/agent-pages/main/evidence/dash-scrollarea-css-fix-20260821/before-coinjoin.png) | ![after-coinjoin](https://raw.githubusercontent.com/PastaPastaPasta/agent-pages/main/evidence/dash-scrollarea-css-fix-20260821/after-coinjoin.png) |
| Focused crop (identical crop rect) | ![before-crop](https://raw.githubusercontent.com/PastaPastaPasta/agent-pages/main/evidence/dash-scrollarea-css-fix-20260821/before-coinjoin-crop.png) | ![after-crop](https://raw.githubusercontent.com/PastaPastaPasta/agent-pages/main/evidence/dash-scrollarea-css-fix-20260821/after-coinjoin-crop.png) |

In the "before" images the entries area sits in a distinct bordered panel (the default `QScrollArea` frame plus palette fill that appear once the rule is gone); in the "after" images it blends into the page background again. The Send tab shows the same regression and fix ([before](https://raw.githubusercontent.com/PastaPastaPasta/agent-pages/main/evidence/dash-scrollarea-css-fix-20260821/before-send.png) / [after](https://raw.githubusercontent.com/PastaPastaPasta/agent-pages/main/evidence/dash-scrollarea-css-fix-20260821/after-send.png)). How dark the default panel fill renders depends on the platform palette — on the reporting machine it was considerably darker than in these captures — but the spurious frame and fill are gone either way once the rule is restored.

## Breaking Changes
None. GUI-only CSS change; the masternode wizard styling introduced in #7618 is preserved.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
