### PR TITLE
backport: partial bitcoin#33079 to run more asan jobs at the same time

### DIFF
--- a/ci/dash/test_integrationtests.sh
+++ b/ci/dash/test_integrationtests.sh
@@ -28,6 +28,11 @@ fi
 
 cd "build-ci/dashcore-$BUILD_TARGET"
 
+if [ -n "${CI_LIMIT_STACK_SIZE}" ]; then
+  # Upstream uses 512, which segfaults dashd during test framework startup.
+  ulimit -s 1024
+fi
+
 if [ "$SOCKETEVENTS" = "" ]; then
   # Let's switch socketevents mode to some random mode
   R=$((RANDOM%3))

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -10,7 +10,7 @@ export CONTAINER_NAME=ci_native_asan
 export PACKAGES="clang-19 llvm-19 libclang-rt-19-dev python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
 # Reuses the depends built for the linux64 target, which uses the defaults.
 export DEP_OPTS=""
-export TEST_RUNNER_EXTRA="--timeout-factor=4 -j2"  # Increase timeout because sanitizers slow down
+export TEST_RUNNER_EXTRA="--timeout-factor=4 -j4"  # Increase timeout because sanitizers slow down
 export CI_LIMIT_STACK_SIZE=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --enable-crash-hooks --with-gui=qt5 --without-bdb --with-sqlite \

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -11,6 +11,7 @@ export PACKAGES="clang-19 llvm-19 libclang-rt-19-dev python3-zmq qtbase5-dev qtt
 # Reuses the depends built for the linux64 target, which uses the defaults.
 export DEP_OPTS=""
 export TEST_RUNNER_EXTRA="--timeout-factor=4 -j2"  # Increase timeout because sanitizers slow down
+export CI_LIMIT_STACK_SIZE=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --enable-crash-hooks --with-gui=qt5 --without-bdb --with-sqlite \
 --with-sanitizers=address,float-divide-by-zero,integer,undefined \


### PR DESCRIPTION
## Issue being fixed or feature implemented
Having 4jobs for asan causes functional tests to be aborted without an explanation on CI in logs.
Most likely it's caused by short memory and amount of jobs has been reduced to only 2 jobs.

## What was done?
Backport bitcoin#33079 partially + increased amount of jobs


## How Has This Been Tested?
Local tests shown that RAM used significantly reduced if 33079 included:

      8 MiB (default)  14335 MiB
      2048 KiB         12912 MiB
      1024 KiB         10657 MiB

Probably it will let to run more than 2 jobs at once.


## Breaking Changes
N/A

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

