### PR TITLE
feat(wallet): let a deliberate unlock opt out of the automatic coin locks

### DIFF
--- a/doc/release-notes-7635.md
+++ b/doc/release-notes-7635.md
@@ -1,0 +1,16 @@
+Wallet changes
+--------------
+
+- Unlocking an output with `lockunspent` (or through the Dash-Qt coin control
+  dialog) now also opts that output out of the automatic masternode-collateral
+  and dust-protection locks. Previously those automatic locks were reapplied on
+  every wallet load, which silently undid the unlock and left the output
+  unspendable with no indication why. Locking the output again hands it back to
+  the automatic protection, as long as that lock is persistent: `lockunspent`
+  writes a lock to the wallet file only when asked to, and a memory-only lock
+  leaves the decision standing. Registering the output as a masternode
+  collateral also ends the opt-out and locks the output again, because the
+  decision was made about an ordinary coin and does not carry over to live
+  collateral. The opt-out is stored in the wallet file; an older Dash Core
+  release reading the same wallet ignores the record and reapplies the automatic
+  locks as it did before. (#7635)

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -224,6 +224,14 @@ public:
     //! Unlock the provided coins in a single batch.
     virtual bool unlockCoins(const std::vector<COutPoint>& outputs) = 0;
 
+    //! Lock a coin because the user asked for it, handing it back to the automatic
+    //! masternode-collateral and dust locks. Use lockCoin() for anything else.
+    virtual bool lockCoinByUser(const COutPoint& output, bool write_to_db) = 0;
+
+    //! Unlock a coin because the user asked for it, opting it out of those automatic
+    //! locks. Use unlockCoin() to release an internal or transient hold.
+    virtual bool unlockCoinByUser(const COutPoint& output) = 0;
+
     //! Set dust protection threshold (does not lock anything by itself).
     virtual void setDustProtectionThreshold(CAmount threshold) = 0;
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -312,7 +312,7 @@ void CoinControlDialog::lockCoin()
         contextMenuItem->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
 
     COutPoint outpt(uint256S(contextMenuItem->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), contextMenuItem->data(COLUMN_ADDRESS, VOutRole).toUInt());
-    model->wallet().lockCoin(outpt, /*write_to_db=*/true);
+    model->wallet().lockCoinByUser(outpt, /*write_to_db=*/true);
     contextMenuItem->setDisabled(true);
     contextMenuItem->setIcon(COLUMN_CHECKBOX, GUIUtil::getIcon("lock_closed", GUIUtil::ThemedColor::RED));
     updateLabelLocked();
@@ -322,7 +322,7 @@ void CoinControlDialog::lockCoin()
 void CoinControlDialog::unlockCoin()
 {
     COutPoint outpt(uint256S(contextMenuItem->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), contextMenuItem->data(COLUMN_ADDRESS, VOutRole).toUInt());
-    model->wallet().unlockCoin(outpt);
+    model->wallet().unlockCoinByUser(outpt);
     contextMenuItem->setDisabled(false);
     contextMenuItem->setIcon(COLUMN_CHECKBOX, QIcon());
     updateLabelLocked();

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -491,7 +491,7 @@ void TransactionView::unlockDust()
 
     // Create the outpoint and unlock
     COutPoint outpoint(hash, outputIdx);
-    model->wallet().unlockCoin(outpoint);
+    model->wallet().unlockCoinByUser(outpoint);
 
     // Refresh the transaction view to update the display
     model->getTransactionTableModel()->refreshWallet(true);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -40,51 +40,6 @@
 #include <optional>
 #include <vector>
 
-static CMutableTransaction CreateSpendTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, const CScript& scriptPayout, CAmount amount, const CKey& coinbaseKey)
-{
-    CMutableTransaction tx;
-    const auto spent = FundTransaction(chainman, tx, utxos, scriptPayout, amount);
-    SignTransaction(tx, spent, coinbaseKey);
-    return tx;
-}
-
-static COutPoint GetCollateralOutpoint(const CMutableTransaction& tx)
-{
-    for (size_t i = 0; i < tx.vout.size(); ++i) {
-        if (tx.vout[i].nValue == dmn_types::Regular.collat_amount) {
-            return COutPoint(tx.GetHash(), i);
-        }
-    }
-    return COutPoint();
-}
-
-// ProRegTx that references a pre-existing collateral output instead of funding the collateral inline.
-static CMutableTransaction CreateProRegTxExternalCollateral(const ChainstateManager& chainman, SimpleUTXOMap& utxos, int port, const COutPoint& collateralOutpoint, const CScript& scriptPayout, const CKey& ownerKey, const CBLSSecretKey& operatorKey, const CKey& collateralKey, const CKey& coinbaseKey)
-{
-    CProRegTx proTx;
-    proTx.nVersion = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false);
-    proTx.netInfo = NetInfoInterface::MakeNetInfo(proTx.nVersion);
-    BOOST_CHECK_EQUAL(proTx.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, strprintf("1.1.1.1:%d", port)),
-                      NetInfoStatus::Success);
-    proTx.collateralOutpoint = collateralOutpoint;
-    proTx.keyIDOwner = ownerKey.GetPubKey().GetID();
-    proTx.pubKeyOperator.Set(operatorKey.GetPublicKey(), bls::bls_legacy_scheme.load());
-    proTx.keyIDVoting = ownerKey.GetPubKey().GetID();
-    proTx.scriptPayout = scriptPayout;
-
-    CMutableTransaction tx;
-    tx.nVersion = 3;
-    tx.nType = TRANSACTION_PROVIDER_REGISTER;
-    // The collateral is external (referenced via collateralOutpoint), so this tx only needs to fund a fee.
-    const auto spent = FundTransaction(chainman, tx, utxos, scriptPayout, /*amount=*/1 * COIN);
-    proTx.inputsHash = CalcTxInputsHash(CTransaction(tx));
-    CMessageSigner::SignMessage(proTx.MakeSignString(), proTx.vchSig, collateralKey);
-    SetTxPayload(tx, proTx);
-    SignTransaction(tx, spent, coinbaseKey);
-
-    return tx;
-}
-
 static CMutableTransaction CreateProUpServTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, const uint256& proTxHash, const CBLSSecretKey& operatorKey, int port, const CScript& scriptOperatorPayout, const CKey& coinbaseKey,
                                              uint16_t version = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false))
 {

--- a/src/test/util/masternode.cpp
+++ b/src/test/util/masternode.cpp
@@ -9,6 +9,7 @@
 #include <evo/providertx.h>
 #include <evo/specialtx.h>
 #include <key.h>
+#include <messagesigner.h>
 #include <script/interpreter.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
@@ -92,6 +93,54 @@ void SignTransaction(CMutableTransaction& tx, const SimpleUTXOMap& coins, const 
 
     std::map<int, bilingual_str> input_errors;
     Assert(::SignTransaction(tx, &keystore, coins, SIGHASH_ALL, input_errors));
+}
+
+CMutableTransaction CreateSpendTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos,
+                                  const CScript& script_payout, CAmount amount, const CKey& coinbase_key)
+{
+    CMutableTransaction tx;
+    const auto spent = FundTransaction(chainman, tx, utxos, script_payout, amount);
+    SignTransaction(tx, spent, coinbase_key);
+    return tx;
+}
+
+COutPoint GetCollateralOutpoint(const CMutableTransaction& tx)
+{
+    for (size_t i = 0; i < tx.vout.size(); ++i) {
+        if (tx.vout[i].nValue == dmn_types::Regular.collat_amount) {
+            return COutPoint(tx.GetHash(), i);
+        }
+    }
+    return COutPoint();
+}
+
+CMutableTransaction CreateProRegTxExternalCollateral(const ChainstateManager& chainman, SimpleUTXOMap& utxos, int port,
+                                                     const COutPoint& collateral_outpoint, const CScript& script_payout,
+                                                     const CKey& owner_key, const CBLSSecretKey& operator_key,
+                                                     const CKey& collateral_key, const CKey& coinbase_key)
+{
+    CProRegTx pro_tx;
+    pro_tx.nVersion = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false);
+    pro_tx.netInfo = NetInfoInterface::MakeNetInfo(pro_tx.nVersion);
+    Assert(pro_tx.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, strprintf("1.1.1.1:%d", port)) == NetInfoStatus::Success);
+    pro_tx.collateralOutpoint = collateral_outpoint;
+    pro_tx.keyIDOwner = owner_key.GetPubKey().GetID();
+    pro_tx.pubKeyOperator.Set(operator_key.GetPublicKey(), bls::bls_legacy_scheme.load());
+    pro_tx.keyIDVoting = owner_key.GetPubKey().GetID();
+    pro_tx.scriptPayout = script_payout;
+
+    CMutableTransaction tx;
+    tx.nVersion = 3;
+    tx.nType = TRANSACTION_PROVIDER_REGISTER;
+    // The collateral is external, referenced through collateralOutpoint, so this transaction
+    // only has to fund a fee.
+    const auto spent = FundTransaction(chainman, tx, utxos, script_payout, /*amount=*/1 * COIN);
+    pro_tx.inputsHash = CalcTxInputsHash(CTransaction(tx));
+    CMessageSigner::SignMessage(pro_tx.MakeSignString(), pro_tx.vchSig, collateral_key);
+    SetTxPayload(tx, pro_tx);
+    SignTransaction(tx, spent, coinbase_key);
+
+    return tx;
 }
 
 CMutableTransaction CreateProRegTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, int port,

--- a/src/test/util/masternode.h
+++ b/src/test/util/masternode.h
@@ -27,6 +27,16 @@ void SignTransaction(CMutableTransaction& tx, const SimpleUTXOMap& coins, const 
 CMutableTransaction CreateProRegTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, int port,
                                    const CScript& script_payout, const CKey& coinbase_key, CKey& owner_key_ret,
                                    CBLSSecretKey& operator_key_ret);
+//! Spend `amount` to `script_payout`, e.g. to create a collateral output.
+CMutableTransaction CreateSpendTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos,
+                                  const CScript& script_payout, CAmount amount, const CKey& coinbase_key);
+//! The first output of `tx` holding a regular masternode collateral, or a null outpoint.
+COutPoint GetCollateralOutpoint(const CMutableTransaction& tx);
+//! ProRegTx that references a pre-existing collateral output instead of funding one inline.
+CMutableTransaction CreateProRegTxExternalCollateral(const ChainstateManager& chainman, SimpleUTXOMap& utxos, int port,
+                                                     const COutPoint& collateral_outpoint, const CScript& script_payout,
+                                                     const CKey& owner_key, const CBLSSecretKey& operator_key,
+                                                     const CKey& collateral_key, const CKey& coinbase_key);
 CScript GenerateRandomAddress();
 
 #endif // BITCOIN_TEST_UTIL_MASTERNODE_H

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -385,6 +385,18 @@ public:
         std::unique_ptr<WalletBatch> batch = std::make_unique<WalletBatch>(m_wallet->GetDatabase());
         return m_wallet->UnlockCoin(output, batch.get());
     }
+    bool lockCoinByUser(const COutPoint& output, bool write_to_db) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        std::unique_ptr<WalletBatch> batch = write_to_db ? std::make_unique<WalletBatch>(m_wallet->GetDatabase()) : nullptr;
+        return m_wallet->LockCoinByUser(output, batch.get());
+    }
+    bool unlockCoinByUser(const COutPoint& output) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        WalletBatch batch{m_wallet->GetDatabase()};
+        return m_wallet->UnlockCoinByUser(output, &batch);
+    }
     bool isLockedCoin(const COutPoint& output) override
     {
         LOCK(m_wallet->cs_wallet);
@@ -400,7 +412,7 @@ public:
         LOCK(m_wallet->cs_wallet);
         WalletBatch batch(m_wallet->GetDatabase());
         for (const auto& output : outputs) {
-            if (!m_wallet->LockCoin(output, &batch)) return false;
+            if (!m_wallet->LockCoinByUser(output, &batch)) return false;
         }
         return true;
     }
@@ -409,7 +421,7 @@ public:
         LOCK(m_wallet->cs_wallet);
         WalletBatch batch(m_wallet->GetDatabase());
         for (const auto& output : outputs) {
-            if (!m_wallet->UnlockCoin(output, &batch)) return false;
+            if (!m_wallet->UnlockCoinByUser(output, &batch)) return false;
         }
         return true;
     }

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -412,9 +412,9 @@ RPCHelpMan lockunspent()
     // Atomically set (un)locked status for the outputs.
     for (const COutPoint& outpt : outputs) {
         if (fUnlock) {
-            if (!pwallet->UnlockCoin(outpt, batch.get())) throw JSONRPCError(RPC_WALLET_ERROR, "Unlocking coin failed");
+            if (!pwallet->UnlockCoinByUser(outpt, batch.get())) throw JSONRPCError(RPC_WALLET_ERROR, "Unlocking coin failed");
         } else {
-            if (!pwallet->LockCoin(outpt, batch.get())) throw JSONRPCError(RPC_WALLET_ERROR, "Locking coin failed");
+            if (!pwallet->LockCoinByUser(outpt, batch.get())) throw JSONRPCError(RPC_WALLET_ERROR, "Locking coin failed");
         }
     }
 

--- a/src/wallet/test/availablecoins_tests.cpp
+++ b/src/wallet/test/availablecoins_tests.cpp
@@ -4,6 +4,13 @@
 
 #include <coinjoin/coinjoin.h>
 #include <txmempool.h>
+#include <bls/bls.h>
+#include <evo/deterministicmns.h>
+#include <evo/dmn_types.h>
+#include <evo/providertx.h>
+#include <evo/specialtx.h>
+#include <interfaces/chain.h>
+#include <test/util/masternode.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/coinjoin.h>
@@ -18,7 +25,8 @@ BOOST_FIXTURE_TEST_SUITE(availablecoins_tests, WalletTestingSetup)
 class AvailableCoinsTestingSetup : public TestChain100Setup
 {
 public:
-    AvailableCoinsTestingSetup()
+    explicit AvailableCoinsTestingSetup(const std::vector<const char*>& extra_args = {}) :
+        TestChain100Setup{CBaseChainParams::REGTEST, extra_args}
     {
         CreateAndProcessBlock({}, {});
         wallet = CreateSyncedWallet(*m_node.chain, *m_node.coinjoin_loader, *m_node.chainman, m_args, coinbaseKey);
@@ -28,6 +36,18 @@ public:
     {
         wallet.reset();
     }
+    //! Feed a mined block to the wallet the way the node would.
+    void ConnectToWallet(const CBlock& block)
+    {
+        const CBlockIndex* tip{WITH_LOCK(m_node.chainman->GetMutex(), return m_node.chainman->ActiveChain().Tip())};
+        const uint256 block_hash{block.GetHash()};
+        interfaces::BlockInfo block_info{block_hash};
+        block_info.prev_hash = &block.hashPrevBlock;
+        block_info.height = tip->nHeight;
+        block_info.data = &block;
+        wallet->blockConnected(block_info);
+    }
+
     CWalletTx& AddTx(CRecipient recipient)
     {
         CTransactionRef tx;
@@ -152,6 +172,229 @@ BOOST_FIXTURE_TEST_CASE(MempoolRemovalInvalidatesAnonymizableTally, AvailableCoi
     // tally must not keep handing out its outputs.
     wallet->transactionRemovedFromMempool(tx, MemPoolRemovalReason::EXPIRY);
     BOOST_CHECK(!tallied(*dest));
+}
+
+BOOST_FIXTURE_TEST_CASE(DeliberateUnlockSurvivesAutomaticLocking, AvailableCoinsTestingSetup)
+{
+    LOCK(wallet->cs_wallet);
+    wallet->m_dust_protection_threshold = 1 * COIN;
+
+    const auto dest{wallet->GetNewDestination("")};
+    BOOST_ASSERT(dest);
+
+    // An external transaction pays us a dust-protection target; AddToWallet() locks it.
+    CMutableTransaction dust_mtx;
+    dust_mtx.vin.emplace_back(COutPoint{uint256::ONE, 0});
+    dust_mtx.vout.emplace_back(COIN / 100, GetScriptForDestination(*dest));
+    const CTransactionRef dust_tx{MakeTransactionRef(dust_mtx)};
+    const COutPoint dust_outpoint{dust_tx->GetHash(), 0};
+    BOOST_CHECK(wallet->AddToWallet(dust_tx, TxStateInMempool{}));
+    BOOST_CHECK(wallet->IsLockedCoin(dust_outpoint));
+
+    // The user releases the automatic lock because the spend is really intended.
+    WalletBatch batch{wallet->GetDatabase()};
+    BOOST_CHECK(wallet->UnlockCoinByUser(dust_outpoint, &batch));
+    BOOST_CHECK(wallet->IsAutoLockOptOut(dust_outpoint));
+
+    // A wallet load reapplies the automatic locks, so the decision has to outlive it.
+    wallet->LockExistingDustOutputs();
+    BOOST_CHECK(!wallet->IsLockedCoin(dust_outpoint));
+
+    // A lock the caller keeps in memory only leaves the decision standing.
+    BOOST_CHECK(wallet->LockCoinByUser(dust_outpoint, /*batch=*/nullptr));
+    BOOST_CHECK(wallet->IsAutoLockOptOut(dust_outpoint));
+    BOOST_CHECK(wallet->UnlockCoin(dust_outpoint, &batch));
+
+    // Locking again persistently hands the outpoint back to the automatic protection.
+    BOOST_CHECK(wallet->LockCoinByUser(dust_outpoint, &batch));
+    BOOST_CHECK(!wallet->IsAutoLockOptOut(dust_outpoint));
+    BOOST_CHECK(wallet->UnlockCoin(dust_outpoint, &batch));
+    wallet->LockExistingDustOutputs();
+    BOOST_CHECK(wallet->IsLockedCoin(dust_outpoint));
+}
+
+// The shared fixture leaves the chain at height 101, so activate DIP3 just above it
+// instead of mining to the regtest default of 432.
+struct MasternodeCollateralTestingSetup : public AvailableCoinsTestingSetup {
+    MasternodeCollateralTestingSetup() :
+        AvailableCoinsTestingSetup{{"-dip3params=105:500", "-testactivationheight=v20@105",
+                                    "-testactivationheight=mn_rr@105"}}
+    {
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(DeliberateUnlockSurvivesCollateralAutoLocking, MasternodeCollateralTestingSetup)
+{
+    const CScript wallet_script{GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()))};
+    while (WITH_LOCK(m_node.chainman->GetMutex(), return m_node.chainman->ActiveChain().Height()) <
+           Params().GetConsensus().DIP0003Height) {
+        CreateAndProcessBlock({}, wallet_script);
+    }
+
+    CKey owner_key;
+    CBLSSecretKey operator_key;
+    auto utxos{BuildSimpleUtxoMap(m_coinbase_txns)};
+    CMutableTransaction pro_reg_mtx{CreateProRegTx(*m_node.chainman, utxos, /*port=*/1, wallet_script,
+                                                   coinbaseKey, owner_key, operator_key)};
+    const CTransactionRef pro_reg_tx{MakeTransactionRef(pro_reg_mtx)};
+    const CBlock block{CreateAndProcessBlock({pro_reg_mtx}, wallet_script)};
+    const CBlockIndex* tip{WITH_LOCK(m_node.chainman->GetMutex(), return m_node.chainman->ActiveChain().Tip())};
+    {
+        LOCK(::cs_main);
+        m_node.dmnman->UpdatedBlockTip(tip);
+        BOOST_REQUIRE(m_node.dmnman->GetListAtChainTip().HasMN(pro_reg_tx->GetHash()));
+    }
+
+    const uint256 block_hash{block.GetHash()};
+    interfaces::BlockInfo block_info{block_hash};
+    block_info.prev_hash = &block.hashPrevBlock;
+    block_info.height = tip->nHeight;
+    block_info.data = &block;
+    wallet->blockConnected(block_info);
+
+    const COutPoint collateral{pro_reg_tx->GetHash(), 0};
+    BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(collateral)));
+
+    // Unlocking the collateral deliberately opts it out of the automatic protection, so
+    // that a reload cannot silently take back the decision to spend it.
+    {
+        LOCK(wallet->cs_wallet);
+        WalletBatch batch{wallet->GetDatabase()};
+        BOOST_CHECK(wallet->UnlockCoinByUser(collateral, &batch));
+        BOOST_CHECK(wallet->IsAutoLockOptOut(collateral));
+    }
+    wallet->AutoLockMasternodeCollaterals();
+    BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return !wallet->IsLockedCoin(collateral)));
+
+    // Locking it again hands it back to the automatic protection.
+    {
+        LOCK(wallet->cs_wallet);
+        WalletBatch batch{wallet->GetDatabase()};
+        BOOST_CHECK(wallet->LockCoinByUser(collateral, &batch));
+        BOOST_CHECK(!wallet->IsAutoLockOptOut(collateral));
+        BOOST_CHECK(wallet->UnlockCoin(collateral, &batch));
+    }
+    wallet->AutoLockMasternodeCollaterals();
+    BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(collateral)));
+}
+
+BOOST_FIXTURE_TEST_CASE(CollateralRegistrationSupersedesDeliberateUnlock, MasternodeCollateralTestingSetup)
+{
+    const CScript wallet_script{GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()))};
+    while (WITH_LOCK(m_node.chainman->GetMutex(), return m_node.chainman->ActiveChain().Height()) <
+           Params().GetConsensus().DIP0003Height) {
+        CreateAndProcessBlock({}, wallet_script);
+    }
+
+    // An ordinary output of collateral size, mined and known to the wallet.
+    auto utxos{BuildSimpleUtxoMap(m_coinbase_txns)};
+    CMutableTransaction collateral_mtx{CreateSpendTx(*m_node.chainman, utxos, wallet_script,
+                                                     dmn_types::Regular.collat_amount, coinbaseKey)};
+    const CBlock collateral_block{CreateAndProcessBlock({collateral_mtx}, wallet_script)};
+    ConnectToWallet(collateral_block);
+    const COutPoint collateral{GetCollateralOutpoint(collateral_mtx)};
+    BOOST_REQUIRE(!collateral.hash.IsNull());
+
+    // The user unlocks it while it is still an ordinary coin.
+    {
+        LOCK(wallet->cs_wallet);
+        WalletBatch batch{wallet->GetDatabase()};
+        BOOST_REQUIRE(wallet->LockCoinByUser(collateral, &batch));
+        BOOST_REQUIRE(wallet->UnlockCoinByUser(collateral, &batch));
+        BOOST_REQUIRE(wallet->IsAutoLockOptOut(collateral));
+        BOOST_REQUIRE(!wallet->IsLockedCoin(collateral));
+    }
+
+    // Registering it as an external collateral makes that decision obsolete: it was made
+    // about a coin that was not protected, and the collateral is live now.
+    CKey owner_key;
+    owner_key.MakeNewKey(true);
+    CBLSSecretKey operator_key;
+    operator_key.MakeNewKey();
+    CMutableTransaction pro_reg_mtx{CreateProRegTxExternalCollateral(*m_node.chainman, utxos, /*port=*/1, collateral,
+                                                                     wallet_script, owner_key, operator_key,
+                                                                     coinbaseKey, coinbaseKey)};
+    const CBlock block{CreateAndProcessBlock({pro_reg_mtx}, wallet_script)};
+    const CBlockIndex* tip{WITH_LOCK(m_node.chainman->GetMutex(), return m_node.chainman->ActiveChain().Tip())};
+    {
+        LOCK(::cs_main);
+        m_node.dmnman->UpdatedBlockTip(tip);
+        BOOST_REQUIRE(m_node.dmnman->GetListAtChainTip().HasMNByCollateral(collateral));
+    }
+    ConnectToWallet(block);
+
+    LOCK(wallet->cs_wallet);
+    BOOST_CHECK(!wallet->IsAutoLockOptOut(collateral));
+    BOOST_CHECK(wallet->IsLockedCoin(collateral));
+}
+
+BOOST_FIXTURE_TEST_CASE(SpentOptOutsAreNotRecheckedEachBlock, AvailableCoinsTestingSetup)
+{
+    LOCK(wallet->cs_wallet);
+
+    const auto dest{wallet->GetNewDestination("")};
+    BOOST_ASSERT(dest);
+
+    // Shaped so that the chain would report it as a collateral, to show the spend is what
+    // keeps it out of the per-block recheck rather than its shape.
+    CProRegTx payload;
+    payload.nVersion = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false);
+    payload.netInfo = NetInfoInterface::MakeNetInfo(payload.nVersion);
+    payload.collateralOutpoint.n = 0;
+
+    CMutableTransaction mtx;
+    mtx.nVersion = 3;
+    mtx.nType = TRANSACTION_PROVIDER_REGISTER;
+    mtx.vin.emplace_back(COutPoint{uint256::ONE, 0});
+    mtx.vout.emplace_back(dmn_types::Regular.collat_amount, GetScriptForDestination(*dest));
+    SetTxPayload(mtx, payload);
+    const CTransactionRef pro_reg_tx{MakeTransactionRef(mtx)};
+    const COutPoint collateral{pro_reg_tx->GetHash(), 0};
+    BOOST_REQUIRE(wallet->AddToWallet(pro_reg_tx, TxStateInMempool{}));
+    wallet->LoadAutoLockOptOut(collateral, /*was_collateral=*/false);
+
+    // Spending it puts the outpoint beyond registration for good.
+    CMutableTransaction spend_mtx;
+    spend_mtx.vin.emplace_back(collateral);
+    spend_mtx.vout.emplace_back(dmn_types::Regular.collat_amount / 2, GetScriptForDestination(*dest));
+    BOOST_REQUIRE(wallet->AddToWallet(MakeTransactionRef(spend_mtx), TxStateInMempool{}));
+    BOOST_REQUIRE(wallet->IsSpent(collateral));
+
+    const CBlock block{CreateAndProcessBlock({}, GetScriptForDestination(*dest))};
+    ConnectToWallet(block);
+
+    // The spent outpoint is never handed to the collateral lookup, and the record stays,
+    // so abandoning the spend would bring the decision back into play.
+    BOOST_CHECK(wallet->IsAutoLockOptOut(collateral));
+    BOOST_CHECK(!wallet->IsLockedCoin(collateral));
+}
+
+BOOST_FIXTURE_TEST_CASE(DeliberateUnlockPrecedesDustProtection, AvailableCoinsTestingSetup)
+{
+    LOCK(wallet->cs_wallet);
+
+    const auto dest{wallet->GetNewDestination("")};
+    BOOST_ASSERT(dest);
+
+    CMutableTransaction mtx;
+    mtx.vin.emplace_back(COutPoint{uint256::ONE, 0});
+    mtx.vout.emplace_back(COIN / 100, GetScriptForDestination(*dest));
+    const CTransactionRef tx{MakeTransactionRef(mtx)};
+    const COutPoint outpoint{tx->GetHash(), 0};
+
+    // Dust protection is off, so nothing locks the output automatically.
+    BOOST_CHECK(wallet->AddToWallet(tx, TxStateInMempool{}));
+    BOOST_CHECK(!wallet->IsLockedCoin(outpoint));
+
+    WalletBatch batch{wallet->GetDatabase()};
+    BOOST_CHECK(wallet->LockCoinByUser(outpoint, &batch));
+    BOOST_CHECK(wallet->UnlockCoinByUser(outpoint, &batch));
+
+    // Turning dust protection on afterwards must not take the unlock back: an output can
+    // become a target long after the user decided to spend it.
+    wallet->m_dust_protection_threshold = 1 * COIN;
+    wallet->LockExistingDustOutputs();
+    BOOST_CHECK(!wallet->IsLockedCoin(outpoint));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -243,7 +243,7 @@ BOOST_FIXTURE_TEST_CASE(coinjoin_pending_observation_tests, CTransactionBuilderT
     const COutPoint outpointInMempool = tallyItem.outpoints[3];
 
     // A denominated coin the user locked themselves, e.g. via `lockunspent`
-    WITH_LOCK(wallet->cs_wallet, wallet->LockCoin(outpointUserLocked));
+    WITH_LOCK(wallet->cs_wallet, wallet->LockCoinByUser(outpointUserLocked));
 
     BOOST_CHECK(m_node.cj_walletman->doForClient("", [&](CCoinJoinClientManager& cj_man) {
         // A user-created lock is never adopted as a pending observation: it has no
@@ -334,7 +334,7 @@ BOOST_FIXTURE_TEST_CASE(coinjoin_pending_observation_tests, CTransactionBuilderT
         BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 1);
 
         // A manual unlock (e.g. via lockunspent) purges the pending entry
-        WITH_LOCK(wallet->cs_wallet, wallet->UnlockCoin(outpointInMempool));
+        WITH_LOCK(wallet->cs_wallet, wallet->UnlockCoinByUser(outpointInMempool));
         cj_man.CheckPendingObservations(*m_node.mempool);
         BOOST_CHECK(!cj_man.IsPendingObservation(outpointInMempool));
         BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 0);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <evo/providertx.h>
+#include <evo/specialtx.h>
+#include <evo/dmn_types.h>
+#include <bls/bls.h>
 #include <wallet/wallet.h>
 
 #include <future>
@@ -56,14 +60,17 @@ class FailBatch : public DatabaseBatch
 {
 private:
     bool m_pass{true};
+    bool m_pass_erase{true};
+    bool m_pass_write{true};
     bool ReadKey(CDataStream&&, CDataStream&) override { return m_pass; }
-    bool WriteKey(CDataStream&&, CDataStream&&, bool) override { return m_pass; }
-    bool EraseKey(CDataStream&&) override { return m_pass; }
+    bool WriteKey(CDataStream&&, CDataStream&&, bool) override { return m_pass && m_pass_write; }
+    bool EraseKey(CDataStream&&) override { return m_pass && m_pass_erase; }
     bool HasKey(CDataStream&&) override { return m_pass; }
-    bool ErasePrefix(Span<const std::byte>) override { return m_pass; }
+    bool ErasePrefix(Span<const std::byte>) override { return m_pass && m_pass_erase; }
 
 public:
-    explicit FailBatch(bool pass) : m_pass(pass) {}
+    FailBatch(bool pass, bool pass_erase, bool pass_write) :
+        m_pass(pass), m_pass_erase(pass_erase), m_pass_write(pass_write) {}
     void Flush() override {}
     void Close() override {}
 
@@ -83,7 +90,9 @@ public:
 class FailDatabase : public WalletDatabase
 {
 public:
-    bool m_pass{true}; // false when this db should fail
+    bool m_pass{true};       // false when this db should fail
+    bool m_pass_erase{true}; // false when only erases should fail
+    bool m_pass_write{true}; // false when only writes should fail
 
     void Open() override {}
     void AddRef() override {}
@@ -97,7 +106,7 @@ public:
     void ReloadDbEnv() override {}
     std::string Filename() override { return "faildb"; }
     std::string Format() override { return "faildb"; }
-    std::unique_ptr<DatabaseBatch> MakeBatch(bool = true) override { return std::make_unique<FailBatch>(m_pass); }
+    std::unique_ptr<DatabaseBatch> MakeBatch(bool = true) override { return std::make_unique<FailBatch>(m_pass, m_pass_erase, m_pass_write); }
 };
 } // namespace
 
@@ -115,6 +124,130 @@ BOOST_AUTO_TEST_CASE(interface_coin_lock_ownership)
     BOOST_CHECK(wallet_interface->unlockCoin(outpoint));
     BOOST_CHECK(wallet_interface->acquireCoinLock(outpoint, /*write_to_db=*/false) == interfaces::CoinLockResult::ACQUIRED);
     BOOST_CHECK(wallet_interface->unlockCoin(outpoint));
+}
+
+BOOST_AUTO_TEST_CASE(unlock_coin_by_user_failed_persist)
+{
+    auto database{std::make_unique<FailDatabase>()};
+    auto* database_ptr{database.get()};
+    auto wallet{std::make_shared<CWallet>(m_node.chain.get(), m_coinjoin_loader.get(), "", m_args,
+                                          std::move(database))};
+    BOOST_REQUIRE(wallet->LoadWallet() == DBErrors::LOAD_OK);
+    const COutPoint outpoint{uint256::ONE, 0};
+
+    LOCK(wallet->cs_wallet);
+    {
+        WalletBatch batch{wallet->GetDatabase()};
+        BOOST_REQUIRE(wallet->LockCoin(outpoint, &batch));
+    }
+
+    // An unlock that failed to persist must not leave a durable opt-out behind: the coin
+    // is still locked on disk, so a reload would find the two records contradicting.
+    // Only erases fail, so writing the opt-out would succeed if it were attempted first.
+    database_ptr->m_pass_erase = false;
+    WalletBatch batch{wallet->GetDatabase()};
+    BOOST_CHECK(!wallet->UnlockCoinByUser(outpoint, &batch));
+    BOOST_CHECK(!wallet->IsAutoLockOptOut(outpoint));
+}
+
+BOOST_AUTO_TEST_CASE(unlock_all_coins_failed_persist)
+{
+    auto database{std::make_unique<FailDatabase>()};
+    auto* database_ptr{database.get()};
+    auto wallet{std::make_shared<CWallet>(m_node.chain.get(), m_coinjoin_loader.get(), "", m_args,
+                                          std::move(database))};
+    BOOST_REQUIRE(wallet->LoadWallet() == DBErrors::LOAD_OK);
+    const COutPoint outpoint{uint256::ONE, 0};
+
+    LOCK(wallet->cs_wallet);
+    BOOST_REQUIRE(wallet->LockCoin(outpoint));
+
+    // The lock record is erased but the opt-out write fails, so the rollback has to run:
+    // an opt-out left in memory alone would be gone after a reload.
+    database_ptr->m_pass_write = false;
+    BOOST_CHECK(!wallet->UnlockAllCoins());
+    BOOST_CHECK(!wallet->IsAutoLockOptOut(outpoint));
+}
+
+BOOST_AUTO_TEST_CASE(collateral_reclaim_locks_despite_failed_erase)
+{
+    auto database{std::make_unique<FailDatabase>()};
+    auto* database_ptr{database.get()};
+    auto wallet{std::make_shared<CWallet>(m_node.chain.get(), m_coinjoin_loader.get(), "", m_args,
+                                          std::move(database))};
+    BOOST_REQUIRE(wallet->LoadWallet() == DBErrors::LOAD_OK);
+
+    CProRegTx payload;
+    payload.nVersion = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false);
+    payload.netInfo = NetInfoInterface::MakeNetInfo(payload.nVersion);
+    payload.collateralOutpoint.n = 0;
+
+    CMutableTransaction mtx;
+    mtx.nVersion = 3;
+    mtx.nType = TRANSACTION_PROVIDER_REGISTER;
+    mtx.vin.emplace_back(COutPoint{uint256::ONE, 0});
+    CKey collateral_key;
+    collateral_key.MakeNewKey(true);
+    mtx.vout.emplace_back(dmn_types::Regular.collat_amount,
+                          GetScriptForDestination(PKHash(collateral_key.GetPubKey())));
+    SetTxPayload(mtx, payload);
+    const CTransactionRef pro_reg_tx{MakeTransactionRef(mtx)};
+    const COutPoint collateral{pro_reg_tx->GetHash(), 0};
+
+    LOCK(wallet->cs_wallet);
+    BOOST_REQUIRE(wallet->AddToWallet(pro_reg_tx, TxStateInMempool{}));
+    wallet->LoadAutoLockOptOut(collateral, /*was_collateral=*/false);
+
+    // The opt-out record cannot be dropped, but the collateral is live: it has to end up
+    // locked anyway, and the record has to stay in memory so it still matches disk.
+    database_ptr->m_pass_erase = false;
+    wallet->LockProTxCoins({collateral});
+    BOOST_CHECK(wallet->IsLockedCoin(collateral));
+    BOOST_CHECK(wallet->IsAutoLockOptOut(collateral));
+}
+
+BOOST_AUTO_TEST_CASE(unlock_coin_by_user_without_batch_erases_lock)
+{
+    auto database{std::make_unique<FailDatabase>()};
+    auto* database_ptr{database.get()};
+    auto wallet{std::make_shared<CWallet>(m_node.chain.get(), m_coinjoin_loader.get(), "", m_args,
+                                          std::move(database))};
+    BOOST_REQUIRE(wallet->LoadWallet() == DBErrors::LOAD_OK);
+    const COutPoint outpoint{uint256::ONE, 0};
+
+    LOCK(wallet->cs_wallet);
+    {
+        WalletBatch batch{wallet->GetDatabase()};
+        BOOST_REQUIRE(wallet->LockCoinByUser(outpoint, &batch));
+    }
+
+    // Unlocking without a batch must still take the persisted lock with it, so a failing
+    // erase has to fail the call rather than leave a durable lock beside a durable opt-out.
+    database_ptr->m_pass_erase = false;
+    BOOST_CHECK(!wallet->UnlockCoinByUser(outpoint, /*batch=*/nullptr));
+    BOOST_CHECK(!wallet->IsAutoLockOptOut(outpoint));
+}
+
+BOOST_AUTO_TEST_CASE(unlock_all_coins_failed_erase)
+{
+    auto database{std::make_unique<FailDatabase>()};
+    auto* database_ptr{database.get()};
+    auto wallet{std::make_shared<CWallet>(m_node.chain.get(), m_coinjoin_loader.get(), "", m_args,
+                                          std::move(database))};
+    BOOST_REQUIRE(wallet->LoadWallet() == DBErrors::LOAD_OK);
+    const COutPoint outpoint{uint256::ONE, 0};
+
+    LOCK(wallet->cs_wallet);
+    {
+        WalletBatch batch{wallet->GetDatabase()};
+        BOOST_REQUIRE(wallet->LockCoin(outpoint, &batch));
+    }
+
+    // The lock record survives the failed erase, so no opt-out may be recorded alongside
+    // it: writes still succeed here, so the opt-out would land if it were attempted.
+    database_ptr->m_pass_erase = false;
+    BOOST_CHECK(!wallet->UnlockAllCoins());
+    BOOST_CHECK(!wallet->IsAutoLockOptOut(outpoint));
 }
 
 BOOST_AUTO_TEST_CASE(interface_coin_lock_failed_persist)

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -50,5 +50,36 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_unknown_descriptor, TestingSetup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(wallet_load_autolock_optout, TestingSetup)
+{
+    CMutableTransaction mtx;
+    mtx.vin.emplace_back(COutPoint{uint256::ONE, 0});
+    mtx.vout.emplace_back(1000, CScript());
+    const CTransactionRef tx{MakeTransactionRef(mtx)};
+    const COutPoint known{tx->GetHash(), 0};
+    const COutPoint unknown{uint256::ONE, 3};
+
+    std::unique_ptr<WalletDatabase> database = CreateMockWalletDatabase();
+    {
+        WalletBatch batch(*database, false);
+        BOOST_CHECK(batch.WriteTx(CWalletTx{tx, TxStateInactive{}}));
+        BOOST_CHECK(batch.WriteAutoLockOptOut(known, /*was_collateral=*/true));
+        BOOST_CHECK(batch.WriteAutoLockOptOut(unknown, /*was_collateral=*/true));
+    }
+
+    const std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), /*coinjoin_loader=*/nullptr, "", m_args, std::move(database)));
+    BOOST_CHECK_EQUAL(wallet->LoadWallet(), DBErrors::LOAD_OK);
+
+    LOCK(wallet->cs_wallet);
+    // A deliberate unlock outlives the reload that reapplies the automatic locks.
+    BOOST_CHECK(wallet->IsAutoLockOptOut(known));
+    // A record whose output the wallet no longer knows about is dropped instead.
+    BOOST_CHECK(!wallet->IsAutoLockOptOut(unknown));
+
+    WalletBatch batch(wallet->GetDatabase());
+    BOOST_CHECK(wallet->LockCoinByUser(known, &batch));
+    BOOST_CHECK(!wallet->IsAutoLockOptOut(known));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1501,9 +1501,30 @@ void CWallet::blockConnected(const interfaces::BlockInfo& block)
         transactionRemovedFromMempool(block.data->vtx[index], MemPoolRemovalReason::BLOCK);
     }
 
+    // A registration in this block can turn an outpoint the user unlocked while it was an
+    // ordinary coin into a masternode collateral. Only those records need re-checking, so
+    // this stays proportional to how many outputs the user unlocked rather than to the
+    // wallet size.
+    ReclaimRegisteredCollaterals(batch);
+
     // reset cache to make sure no longer immature coins are included
     fAnonymizableTallyCached = false;
     fAnonymizableTallyCachedNonDenom = false;
+}
+
+void CWallet::ReclaimRegisteredCollaterals(WalletBatch& batch)
+{
+    AssertLockHeld(cs_wallet);
+    std::set<COutPoint> candidates;
+    for (const auto& [output, was_collateral] : m_autolock_optout) {
+        // An outpoint a live wallet transaction spends cannot be registered, and asking
+        // the chain about it on every block for the rest of the wallet's life would be
+        // pure waste. The record outlives the spend, so abandoning or conflicting that
+        // transaction brings the decision back into play.
+        if (!was_collateral && !IsSpent(output)) candidates.insert(output);
+    }
+    if (candidates.empty()) return;
+    LockProTxCoins(candidates, &batch);
 }
 
 void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
@@ -2455,6 +2476,22 @@ DBErrors CWallet::LoadWallet()
         assert(m_internal_spk_managers == nullptr);
     }
 
+    // Drop opt-outs for outputs the wallet no longer knows about, so that a record cannot
+    // outlive the output it refers to (ZapSelectTx() removes transactions). Only after a
+    // clean load: a partial one may simply not have read the transaction yet.
+    if (nLoadWalletRet == DBErrors::LOAD_OK && !m_autolock_optout.empty()) {
+        WalletBatch batch(GetDatabase());
+        for (auto it = m_autolock_optout.begin(); it != m_autolock_optout.end();) {
+            const auto wtx_it{mapWallet.find(it->first.hash)};
+            const bool known{wtx_it != mapWallet.end() && it->first.n < wtx_it->second.tx->vout.size()};
+            if (!known && batch.EraseAutoLockOptOut(it->first)) {
+                it = m_autolock_optout.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
     if (HaveChain()) {
         const std::optional<int> tip_height = chain().getHeight();
         if (tip_height) {
@@ -2782,13 +2819,94 @@ bool CWallet::UnlockCoin(const COutPoint& output, WalletBatch* batch)
     return true;
 }
 
+void CWallet::LoadAutoLockOptOut(const COutPoint& output, bool was_collateral)
+{
+    AssertLockHeld(cs_wallet);
+    m_autolock_optout.emplace(output, was_collateral);
+}
+
+bool CWallet::IsAutoLockOptOut(const COutPoint& output) const
+{
+    AssertLockHeld(cs_wallet);
+    return m_autolock_optout.count(output) > 0;
+}
+
+bool CWallet::IsProTxCollateral(const COutPoint& output) const
+{
+    AssertLockHeld(cs_wallet);
+    return !ListProTxCoins({output}).empty();
+}
+
+bool CWallet::PersistAutoLockOptOut(const COutPoint& output, bool optout, WalletBatch& batch)
+{
+    AssertLockHeld(cs_wallet);
+    if (!optout) return batch.EraseAutoLockOptOut(output);
+    return batch.WriteAutoLockOptOut(output, m_autolock_optout.at(output));
+}
+
+// The opt-out is updated only once the lock change itself has stuck, so that a call which
+// fails leaves nothing durable behind, and rolled back in memory when its own write fails,
+// so that what this process believes always matches what a reload would find.
+bool CWallet::LockCoinByUser(const COutPoint& output, WalletBatch* batch)
+{
+    AssertLockHeld(cs_wallet);
+    if (!LockCoin(output, batch)) return false;
+    // A lock the caller keeps in memory only must not clear the opt-out durably: the lock
+    // is gone after a reload while the decision it was taken against would not be, and the
+    // automatic protection would take the output back.
+    if (batch == nullptr) return true;
+    if (const auto it{m_autolock_optout.find(output)}; it != m_autolock_optout.end()) {
+        const bool was_collateral{it->second};
+        m_autolock_optout.erase(it);
+        if (!PersistAutoLockOptOut(output, /*optout=*/false, *batch)) {
+            m_autolock_optout.emplace(output, was_collateral);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CWallet::UnlockCoinByUser(const COutPoint& output, WalletBatch* batch)
+{
+    AssertLockHeld(cs_wallet);
+    if (batch == nullptr) {
+        // Unlocking is always persistent, and both records have to move together, so a
+        // caller that brought no batch gets one covering the pair rather than just the
+        // opt-out.
+        WalletBatch temp_batch(GetDatabase());
+        return UnlockCoinByUser(output, &temp_batch);
+    }
+    if (!UnlockCoin(output, batch)) return false;
+    // Recorded whether or not an automatic protection currently targets `output`: one may
+    // start to (a ProRegTx registers it as collateral, the dust threshold is raised) long
+    // after the user made the decision.
+    if (m_autolock_optout.emplace(output, IsProTxCollateral(output)).second &&
+        !PersistAutoLockOptOut(output, /*optout=*/true, *batch)) {
+        m_autolock_optout.erase(output);
+        return false;
+    }
+    return true;
+}
+
 bool CWallet::UnlockAllCoins()
 {
     AssertLockHeld(cs_wallet);
     bool success = true;
     WalletBatch batch(GetDatabase());
-    for (auto it = setLockedCoins.begin(); it != setLockedCoins.end(); ++it) {
-        success &= batch.EraseLockedUTXO(*it);
+    for (const auto& output : setLockedCoins) {
+        if (!batch.EraseLockedUTXO(output)) {
+            // The lock record is still on disk, so recording an opt-out for it would leave
+            // a reload finding the coin locked and the automatic protection told to skip it.
+            success = false;
+            continue;
+        }
+        // Unlocking everything is a deliberate unlock of each output in turn, so the
+        // automatic protections must not take them back on the next load either.
+        if (m_autolock_optout.emplace(output, IsProTxCollateral(output)).second &&
+            !batch.WriteAutoLockOptOut(output, m_autolock_optout.at(output))) {
+            m_autolock_optout.erase(output);
+            success = false;
+        }
     }
     setLockedCoins.clear();
     return success;
@@ -2827,8 +2945,31 @@ std::vector<COutPoint> CWallet::ListProTxCoins(const std::set<COutPoint>& utxos)
 void CWallet::LockProTxCoins(const std::set<COutPoint>& utxos, WalletBatch* batch)
 {
     AssertLockHeld(cs_wallet);
+    // The lock and the opt-out have to be persisted together, so a caller that brought no
+    // batch gets one covering both rather than leaving the lock in memory alone.
+    std::optional<WalletBatch> temp_batch;
+    if (batch == nullptr) {
+        temp_batch.emplace(GetDatabase());
+        batch = &*temp_batch;
+    }
     for (const auto& utxo : ListProTxCoins(utxos)) {
-        LockCoin(utxo, batch);
+        if (const auto it{m_autolock_optout.find(utxo)}; it != m_autolock_optout.end()) {
+            // The user unlocked a coin that has since been registered as a collateral, so
+            // their decision was about something else: the collateral has to be protected
+            // however the registration reached us.
+            if (it->second) continue;
+            // If the record cannot be dropped it stays in memory too, so the two agree and
+            // the next block retries. Locking below protects the collateral either way.
+            if (PersistAutoLockOptOut(utxo, /*optout=*/false, *batch)) {
+                m_autolock_optout.erase(it);
+            } else {
+                WalletLogPrintf("Failed to drop the automatic-lock opt-out for masternode collateral %s\n",
+                                utxo.ToStringShort());
+            }
+        }
+        if (!LockCoin(utxo, batch)) {
+            WalletLogPrintf("Failed to persist the lock for masternode collateral %s\n", utxo.ToStringShort());
+        }
     }
 }
 
@@ -2837,6 +2978,7 @@ bool CWallet::IsDustProtectionTarget(const CWalletTx& wtx, unsigned int output_i
     AssertLockHeld(cs_wallet);
 
     if (m_dust_protection_threshold <= 0) return false;
+    if (IsAutoLockOptOut(COutPoint(wtx.GetHash(), output_index))) return false;
 
     const CTransactionRef& tx = wtx.tx;
     if (tx->IsCoinBase() || tx->nType != TRANSACTION_NORMAL) return false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -337,6 +337,18 @@ private:
     TxSpends mapTxSpends GUARDED_BY(cs_wallet);
     void AddToSpends(const COutPoint& outpoint, const uint256& wtxid, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void AddToSpends(const CWalletTx& wtx, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    /** Outpoints the user unlocked deliberately, and which the automatic
+     *  masternode-collateral and dust locks therefore leave alone until the user locks
+     *  them again. Persisted, because the automatic locks are reapplied on every load. */
+    /** Maps each opted-out outpoint to whether it already was a masternode collateral when
+     *  the user unlocked it. An outpoint that only became one afterwards is taken back by
+     *  the automatic protection: the decision was made about an ordinary coin. */
+    std::map<COutPoint, bool> m_autolock_optout GUARDED_BY(cs_wallet);
+    bool PersistAutoLockOptOut(const COutPoint& output, bool optout, WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsProTxCollateral(const COutPoint& output) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    /** Take back the automatic protection on outpoints the user unlocked while they were
+     *  ordinary coins and that have since been registered as masternode collaterals. */
+    void ReclaimRegisteredCollaterals(WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::set<COutPoint> setWalletUTXO;
     /** Add new UTXOs to the wallet UTXO set
@@ -659,6 +671,18 @@ public:
     bool IsLockedCoin(const COutPoint& output) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool LockCoin(const COutPoint& output, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool UnlockCoin(const COutPoint& output, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    /** Lock/unlock `output` because the user asked for it, rather than as part of an
+     *  automatic protection or an internal transient hold.
+     *
+     *  Unlocking this way also opts `output` out of the automatic masternode-collateral
+     *  and dust locks, which are otherwise reapplied on every wallet load and would put
+     *  the lock back on. Locking it again clears the opt-out and hands the outpoint back
+     *  to the automatic protections. */
+    bool LockCoinByUser(const COutPoint& output, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool UnlockCoinByUser(const COutPoint& output, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void LoadAutoLockOptOut(const COutPoint& output, bool was_collateral) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    /** Has the user unlocked `output` deliberately, opting it out of the automatic locks? */
+    bool IsAutoLockOptOut(const COutPoint& output) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool UnlockAllCoins() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     const std::set<COutPoint>& ListLockedCoins() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     std::vector<COutPoint> ListProTxCoins() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -49,6 +49,7 @@ const std::string HDCHAIN{"hdchain"};
 const std::string HDPUBKEY{"hdpubkey"};
 const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
+const std::string AUTOLOCK_OPTOUT{"autolockoptout"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
 const std::string MINVERSION{"minversion"};
@@ -346,6 +347,17 @@ bool WalletBatch::WriteLockedUTXO(const COutPoint& output)
 bool WalletBatch::EraseLockedUTXO(const COutPoint& output)
 {
     return EraseIC(std::make_pair(DBKeys::LOCKED_UTXO, std::make_pair(output.hash, output.n)));
+}
+
+bool WalletBatch::WriteAutoLockOptOut(const COutPoint& output, bool was_collateral)
+{
+    return WriteIC(std::make_pair(DBKeys::AUTOLOCK_OPTOUT, std::make_pair(output.hash, output.n)),
+                   uint8_t{was_collateral});
+}
+
+bool WalletBatch::EraseAutoLockOptOut(const COutPoint& output)
+{
+    return EraseIC(std::make_pair(DBKeys::AUTOLOCK_OPTOUT, std::make_pair(output.hash, output.n)));
 }
 
 class CWalletScanState {
@@ -810,6 +822,18 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 wss.crypted_mnemonics.insert(std::make_pair(std::make_pair(desc_id, pubkey.GetID()), std::make_pair(mnemonic, mnemonic_passphrase)));
             }
 
+        } else if (strType == DBKeys::AUTOLOCK_OPTOUT) {
+            uint256 hash;
+            uint32_t n;
+            ssKey >> hash;
+            ssKey >> n;
+            // A value that cannot be read is treated as a collateral the user unlocked, the
+            // reading that leaves their decision standing.
+            uint8_t was_collateral{1};
+            try {
+                ssValue >> was_collateral;
+            } catch (const std::ios_base::failure&) {}
+            pwallet->LoadAutoLockOptOut(COutPoint(hash, n), was_collateral != 0);
         } else if (strType == DBKeys::LOCKED_UTXO) {
             uint256 hash;
             uint32_t n;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -81,6 +81,7 @@ extern const std::string HDCHAIN;
 extern const std::string HDPUBKEY;
 extern const std::string KEY;
 extern const std::string KEYMETA;
+extern const std::string AUTOLOCK_OPTOUT;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
 extern const std::string MINVERSION;
@@ -246,6 +247,9 @@ public:
 
     bool WriteLockedUTXO(const COutPoint& output);
     bool EraseLockedUTXO(const COutPoint& output);
+
+    bool WriteAutoLockOptOut(const COutPoint& output, bool was_collateral);
+    bool EraseAutoLockOptOut(const COutPoint& output);
 
     bool WriteAddressPreviouslySpent(const CTxDestination& dest, bool previously_spent);
     bool WriteAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& receive_request);

--- a/test/functional/wallet_dust_protection.py
+++ b/test/functional/wallet_dust_protection.py
@@ -13,6 +13,7 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    find_vout_for_address,
 )
 
 # 1 DASH = 100_000_000 duffs
@@ -48,6 +49,8 @@ class WalletDustProtectionTest(BitcoinTestFramework):
         self.test_above_threshold_not_locked()
         self.test_disabled_threshold()
         self.test_existing_utxos_locked_on_restart()
+        self.test_deliberate_unlock_survives_restart()
+        self.test_deliberate_unlock_precedes_protection()
         self.test_multi_wallet()
         self.test_invalid_args()
 
@@ -175,6 +178,75 @@ class WalletDustProtectionTest(BitcoinTestFramework):
 
         # Cleanup
         node3.lockunspent(True, locked)
+
+    def test_deliberate_unlock_survives_restart(self):
+        """A UTXO the user unlocked deliberately must stay unlocked across restarts."""
+        self.log.info("Test: deliberate unlock survives restart")
+        node1 = self.nodes[1]  # dust protection at 10000 duffs
+
+        addr = node1.getnewaddress()
+        txid = self.nodes[0].sendtoaddress(addr, 9000 * DUFFS)
+        self.generate(self.nodes[0], 1)
+
+        outpoint = {"txid": txid, "vout": find_vout_for_address(node1, txid, addr)}
+        assert outpoint in node1.listlockunspent()
+
+        # Unlocking is the documented way to spend a protected output.
+        node1.lockunspent(True, [outpoint])
+        assert outpoint not in node1.listlockunspent()
+
+        # The automatic protection is reapplied on every load, so a deliberate unlock
+        # has to outlive that or the output could never be spent.
+        self.restart_node(1, self.extra_args[1])
+        # node1 sits in the middle of the node0 <- node1 <- node2 <- node3 chain.
+        self.connect_nodes(1, 0)
+        self.connect_nodes(2, 1)
+        assert outpoint not in node1.listlockunspent()
+
+        # A memory-only lock (the `lockunspent` default) does not take the decision back:
+        # the lock itself is gone after the restart, so the output must still be unlocked.
+        node1.lockunspent(False, [outpoint])
+        self.restart_node(1, self.extra_args[1])
+        # node1 sits in the middle of the node0 <- node1 <- node2 <- node3 chain.
+        self.connect_nodes(1, 0)
+        self.connect_nodes(2, 1)
+        assert outpoint not in node1.listlockunspent()
+
+        # Locking it persistently does hand the output back to the automatic protection.
+        node1.lockunspent(False, [outpoint], True)
+        self.restart_node(1, self.extra_args[1])
+        self.connect_nodes(1, 0)
+        self.connect_nodes(2, 1)
+        assert outpoint in node1.listlockunspent()
+
+        # `lockunspent true` with no outputs unlocks everything, and is just as deliberate.
+        node1.lockunspent(True)
+        assert_equal(node1.listlockunspent(), [])
+        self.restart_node(1, self.extra_args[1])
+        self.connect_nodes(1, 0)
+        self.connect_nodes(2, 1)
+        assert_equal(node1.listlockunspent(), [])
+
+    def test_deliberate_unlock_precedes_protection(self):
+        """Unlocking before dust protection is enabled must still opt the output out."""
+        self.log.info("Test: deliberate unlock precedes protection")
+        node3 = self.nodes[3]  # no dust protection
+
+        addr = node3.getnewaddress()
+        txid = self.nodes[0].sendtoaddress(addr, 7000 * DUFFS)
+        self.generate(self.nodes[0], 1)
+        outpoint = {"txid": txid, "vout": find_vout_for_address(node3, txid, addr)}
+
+        # Nothing locks it yet, so lock and unlock it by hand.
+        assert outpoint not in node3.listlockunspent()
+        node3.lockunspent(False, [outpoint], True)
+        node3.lockunspent(True, [outpoint])
+        assert outpoint not in node3.listlockunspent()
+
+        # Enabling dust protection afterwards must not take the unlock back.
+        self.restart_node(3, ["-dustrelayfee=0", "-dustprotectionthreshold=10000"])
+        self.connect_nodes(3, 2)
+        assert outpoint not in node3.listlockunspent()
 
     def test_multi_wallet(self):
         """Dust protection should work across multiple wallets on the same node."""

--- a/test/lint/lint-coin-lock-callers.py
+++ b/test/lint/lint-coin-lock-callers.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check that nothing starts calling the raw coin-lock primitives unnoticed.
+#
+# CWallet::LockCoin()/UnlockCoin() change only the lock. The deliberate-unlock
+# variants, LockCoinByUser()/UnlockCoinByUser(), also record that the user made
+# the decision, so that the automatic masternode-collateral and dust locks leave
+# the outpoint alone. Picking the wrong one is silent: a user path on the raw
+# primitives loses the decision on the next wallet load, and an internal hold on
+# the ByUser variants leaves a live collateral unprotected.
+#
+# A new caller therefore has to be a deliberate choice. Add it below with a note
+# saying which kind it is.
+#
+# Limits worth knowing: tests are skipped, because they legitimately drive the raw
+# primitives to set a fixture up, so a test that means to model a user action has to
+# pick the right one on its own. A file already on the list is trusted for any further
+# raw call it grows. Untracked files are not scanned, since this walks `git ls-files`.
+
+import re
+import sys
+
+from subprocess import check_output
+
+# file -> why its calls use the raw primitives
+ALLOWED = {
+    "src/coinjoin/client.cpp": "mixing holds its own session inputs, never user intent",
+    "src/wallet/interfaces.cpp": "lockCoin()/unlockCoin() keep their upstream meaning; "
+                                 "the GUI's user actions call the ByUser variants",
+    "src/wallet/rpc/spend.cpp": "locks the coins a just-created transaction spends",
+    "src/wallet/spend.cpp": "locks the coins a just-created transaction spends",
+    "src/wallet/walletdb.cpp": "replays persisted locks while loading",
+    "src/wallet/wallet.cpp": "defines the primitives and the automatic protections",
+    "src/wallet/wallet.h": "declares the primitives",
+    "src/interfaces/wallet.h": "declares both the plain and the ByUser interface methods",
+    "src/evo/providertx_service.cpp": "releases the transient hold CollateralLockGuard takes",
+    "src/qt/masternodewizard.cpp": "releases the transient hold taken while preparing a registration",
+}
+
+TEST_PREFIXES = ("src/test/", "src/wallet/test/", "src/qt/test/")
+
+# Matches both surfaces: CWallet::(Un)LockCoin() and interfaces::Wallet::(un)lockCoin().
+# The plural bulk helpers, (un)lockCoins(), are Dash-specific user paths and do not match.
+# Only member calls, so that a class of its own with a lockCoin() slot does not match.
+CALL = re.compile(r"[.>]\s*(?:un|Un)?[lL]ockCoin\s*\(")
+
+
+def main():
+    files = check_output(["git", "ls-files", "--", "src/*.cpp", "src/*.h"], text=True, encoding="utf8").splitlines()
+    unexpected = []
+    for path in files:
+        if path in ALLOWED or path.startswith(TEST_PREFIXES):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                content = handle.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for number, line in enumerate(content.splitlines(), start=1):
+            if CALL.search(line) and "ByUser" not in line:
+                unexpected.append(f"{path}:{number}: {line.strip()}")
+
+    if unexpected:
+        print("New caller(s) of the raw coin-lock primitives:")
+        print("\n".join(unexpected))
+        print()
+        print("Use LockCoinByUser()/UnlockCoinByUser() when the user asked for the lock "
+              "change, so the automatic masternode-collateral and dust locks do not undo "
+              "it. Otherwise add the file to ALLOWED in this script with a short reason.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Issue being fixed or feature implemented

`AutoLockMasternodeCollaterals()` runs from `AddWallet()` on every wallet load and locks every masternode collateral it finds; `LockExistingDustOutputs()` does the same for dust-protection targets when a wallet is created from file. Both recompute lock policy from scratch, so neither can tell an outpoint that was never unlocked from one the user unlocked on purpose.

Unlocking is the documented way to spend a protected output — see the comment above `AutoLockMasternodeCollaterals()`: *"They can still be unlocked manually if a spend is really intended"* — and `lockunspent` is how you do it. But the decision only lasts until the next restart, at which point the automatic locks silently take it back and the output becomes unspendable again with no indication why. `AvailableCoins()` skips locked coins for every `CoinType` except `ONLY_MASTERNODE_COLLATERAL`, which is only used by the `masternode outputs` listing RPC, so an automatically re-locked collateral simply stops being selectable.

To reproduce: with `-dustprotectionthreshold` set, receive a dust-sized payment from someone else, `lockunspent true` the output to spend it, restart the node, and observe it locked again. The same happens with a 1000 DASH masternode collateral you unlocked in order to spend it.

## What was done?

Record the user's decision rather than trying to infer it.

A deliberate unlock adds the outpoint to `m_autolock_optout`, persisted as `DBKeys::AUTOLOCK_OPTOUT` because the automatic locks outlive a restart. Locking the output again clears the record and hands it back to the automatic protection. The two chokepoints that apply those locks — `LockProTxCoins()` and `IsDustProtectionTarget()` — skip outpoints carrying the record, which covers every path that reapplies them.

Only genuinely user-driven paths record intent: the `lockunspent` RPC and the Qt coin-control entry points. `interfaces::Wallet::unlockCoin()` was also being used to drop the transient hold `CollateralLockGuard` takes around a ProTx submission, so `acquireCoinLock()` gains a matching `releaseCoinLock()` and the guard uses that instead, which keeps an internal hold from being mistaken for a user decision.

The record is written only alongside the lock change it belongs to:

* a lock the caller keeps in memory only — the `lockunspent` default — leaves the decision standing, because that lock is gone after a reload while the decision would not be;
* an unlock always persists both records together, including the no-batch entry point;
* a failed write is rolled back in memory, so what the running process believes always matches what a reload would find;
* records whose output the wallet no longer knows about (for example after `removeprunedfunds`) are dropped after a clean load, so a record cannot outlive its output.

An output can also *become* a target after the user unlocked it — a ProRegTx registering it as collateral, or `-dustprotectionthreshold` being raised — so the record is written regardless of whether a protection currently targets the outpoint.

## How Has This Been Tested?

Unit tests:

* `availablecoins_tests/DeliberateUnlockSurvivesAutomaticLocking` — the decision survives `LockExistingDustOutputs()`, a memory-only lock leaves it standing, and a persistent lock hands the output back.
* `availablecoins_tests/DeliberateUnlockPrecedesDustProtection` — unlocking before dust protection is enabled still opts the output out.
* `walletload_tests/wallet_load_autolock_optout` — the record round-trips through the wallet database, and a record for an output the wallet does not know about is pruned instead.
* `wallet_tests/unlock_coin_by_user_failed_persist`, `wallet_tests/unlock_coin_by_user_without_batch_erases_lock`, `wallet_tests/unlock_all_coins_failed_erase`, `wallet_tests/unlock_all_coins_failed_persist` — failure injection over the existing `FailDatabase` fixture, which gained a flag so erases can fail while writes succeed. These pin the rule that a failed call leaves nothing durable behind and never leaves memory and disk disagreeing.

Functional test `wallet_dust_protection.py` gained `test_deliberate_unlock_survives_restart` and `test_deliberate_unlock_precedes_protection`, covering the real `lockunspent` RPC path across real node restarts, including the no-argument `lockunspent true` form.

Every one of these was checked to be a genuine regression test by mutating the corresponding code and confirming the expected assertions fail.

Ran `availablecoins_tests`, `walletload_tests`, `wallet_tests`, `coinjoin_tests`, `walletdb_tests`, and `wallet_dust_protection.py` on both `--descriptors` and `--legacy-wallet`. Built with the full tree including Qt on macOS (aarch64-apple-darwin).

## Breaking Changes

A deliberate unlock now survives a restart, where previously it did not. That is the point of the change, but it is a user-visible difference in what `lockunspent` means over time.

The wallet gains a new database record type, `autolockoptout`. An older Dash Core release reading the same wallet treats it as an unknown record — `ReadKeyValue()` only counts unrecognized keys — and reapplies the automatic locks exactly as it does today, so downgrading is safe.

No consensus, network or serialization changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
