### PR TITLE
fix(wallet): don't cache CoinJoin rounds for txes unknown to the wallet

### DIFF
--- a/src/wallet/coinjoin.cpp
+++ b/src/wallet/coinjoin.cpp
@@ -284,10 +284,13 @@ int CWallet::GetRealOutpointCoinJoinRounds(const COutPoint& outpoint, int nRound
     const CWalletTx* wtx{GetWalletTx(outpoint.hash)};
 
     if (wtx == nullptr || wtx->tx == nullptr) {
-        // no such tx in this wallet
-        *nRoundsRef = -1;
+        // No such tx in this wallet: don't memoize the result, the wallet may
+        // still learn about the tx later (e.g. a rescan in progress) and nothing
+        // invalidates the cache when it does. RPCs feed user-supplied outpoints
+        // into this via IsFullyMixed, so this path is reachable for any outpoint.
+        mapOutpointRoundsCache.erase(pair.first);
         WalletCJLogPrint(this, "%s FAILED    %-70s %3d\n", __func__, outpoint.ToStringShort(), -1);
-        return *nRoundsRef;
+        return -1;
     }
 
     // bounds check

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -552,6 +552,29 @@ BOOST_FIXTURE_TEST_CASE(coinjoin_rebalance_rounds_reset_tests, CTransactionBuild
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(coinjoin_rounds_cache_unknown_tx_tests, CTransactionBuilderTestSetup)
+{
+    constexpr CAmount nDenomAmount{10000100}; // 0.100001 DASH
+    BOOST_REQUIRE(CoinJoin::IsDenominatedAmount(nDenomAmount));
+
+    CompactTallyItem tallyItem = GetTallyItem({nDenomAmount});
+    const CScript scriptOurs = GetScriptForRawPubKey(coinbaseKey.GetPubKey());
+
+    CMutableTransaction mtxMix;
+    mtxMix.vin.emplace_back(tallyItem.outpoints[0]);
+    mtxMix.vout.emplace_back(nDenomAmount, scriptOurs);
+    const COutPoint outpointMixed{mtxMix.GetHash(), 0};
+
+    // Queried before the wallet knows the tx, the way RPCs do for user-supplied
+    // preset inputs: unknown, reported as -1
+    BOOST_CHECK_EQUAL(wallet->GetRealOutpointCoinJoinRounds(outpointMixed), -1);
+
+    // Once the wallet learns the tx its rounds are computed from it; the miss
+    // above must not stick in mapOutpointRoundsCache
+    BOOST_REQUIRE(wallet->AddToWallet(MakeTransactionRef(mtxMix), TxStateInMempool{}));
+    BOOST_CHECK_EQUAL(wallet->GetRealOutpointCoinJoinRounds(outpointMixed), 1);
+}
+
 BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
 {
     // NOTE: Mock wallet version is FEATURE_BASE which means that it uses uncompressed pubkeys


### PR DESCRIPTION
## Issue being fixed or feature implemented
Follow-up to #7261. `CWallet::GetRealOutpointCoinJoinRounds()` memoizes its result in `mapOutpointRoundsCache`, including the `-1` it returns for an outpoint whose transaction the wallet has no record of. Nothing invalidates that entry when the wallet later learns about the transaction — the only invalidation is `ClearCoinJoinRoundsCache()`, called from the `coinjoinsalt` RPCs.

This used to be unreachable in practice because every caller passed wallet-owned outpoints. Since #7261, `fundrawtransaction`, `send` and `walletcreatefundedpsbt` feed arbitrary user-supplied preset inputs into `IsFullyMixed()`, so querying an outpoint before the wallet knows its transaction (e.g. while a rescan is still running) permanently poisons the cache: once the wallet does add that transaction, a coin that is in fact a fully mixed denomination keeps reporting `-1` rounds for the lifetime of the wallet in memory. It is then excluded from `use_cj` spends, missing from the anonymized balance in `getbalances`, and re-qualifies for mixing, so the client would re-mix (and pay fees on) an already-mixed coin.

## What was done?
Don't memoize the unknown-transaction result: drop the just-inserted cache entry on that path and return `-1` directly. The recursion in `GetRealOutpointCoinJoinRounds()` only descends into inputs for which `InputIsMine()` is true, which requires the previous transaction to be in `mapWallet`, so the directly queried outpoint is the only case that can be unknown — the emplace-based cycle protection for the recursive path is unaffected.

Added a unit regression test that queries an outpoint before the wallet knows its transaction (expects `-1`) and again after `AddToWallet()` (expects the real rounds). The test fails with `-1 != 1` without the fix.

## How Has This Been Tested?
- New regression test in `src/wallet/test/coinjoin_tests.cpp`: `./src/test/test_dash --run_test=coinjoin_tests` passes with the fix and fails without it.
- `test/functional/test_runner.py rpc_coinjoin.py wallet_send.py wallet_fundrawtransaction.py` all pass locally (macOS arm64, `--enable-debug`).

## Breaking Changes
None. The only behavior change is that an unknown outpoint is re-evaluated on subsequent queries instead of being permanently cached as having no rounds.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
