### PR TITLE
test: cover use_cj success path in rpc_coinjoin.py

### DIFF
--- a/test/functional/rpc_coinjoin.py
+++ b/test/functional/rpc_coinjoin.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import random
+from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.blocktools import COINBASE_MATURITY
@@ -20,6 +21,7 @@ from test_framework.util import (
 )
 
 # See coinjoin/options.h
+COINJOIN_RANDOM_ROUNDS = 3
 COINJOIN_ROUNDS_DEFAULT = 4
 COINJOIN_ROUNDS_MAX = 16
 COINJOIN_ROUNDS_MIN = 2
@@ -60,6 +62,7 @@ class CoinJoinTest(BitcoinTestFramework):
         w3 = node.get_wallet_rpc('w3')
         self.generatetoaddress(node, COINBASE_MATURITY + 1, w3.getnewaddress())
         self.test_use_cj_option(w3)
+        self.test_use_cj_success(w3)
         w3.unloadwallet()
 
         if not self.options.descriptors:
@@ -150,6 +153,58 @@ class CoinJoinTest(BitcoinTestFramework):
 
         # The same input is spendable once "use_cj" is not requested
         assert_equal(node.sendall(recipients=[addr], options={'inputs': [input_ref]})['complete'], True)
+
+    def test_use_cj_success(self, node):
+        self.log.info('"use_cj" option should spend fully mixed coins and mark the transaction as CoinJoin')
+        # Node-global setting, restored at the end of this subtest
+        node.setcoinjoinrounds(COINJOIN_ROUNDS_MIN)
+
+        # Fund two denominated outputs. The funding transaction pays a fee and
+        # has non-denominated change, so both outputs start at 0 rounds.
+        denom = Decimal('0.00100001')
+        funding_txid = node.send(outputs=[{node.getnewaddress(): denom}, {node.getnewaddress(): denom}])['txid']
+        self.generate(self.nodes[0], 1)
+        funding_tx = node.gettransaction(txid=funding_txid, verbose=True)['decoded']
+        inputs = [{'txid': funding_txid, 'vout': out['n']} for out in funding_tx['vout'] if out['value'] == denom]
+        assert_equal(len(inputs), 2)
+
+        # Simulate mixing: a same-denomination, fee-free self-spend advances each
+        # output by one round. Zero-fee transactions are not relayed, so mine them
+        # directly. COINJOIN_ROUNDS_MIN + COINJOIN_RANDOM_ROUNDS rounds make
+        # IsFullyMixed() deterministic regardless of the wallet's salt.
+        for _ in range(COINJOIN_ROUNDS_MIN + COINJOIN_RANDOM_ROUNDS):
+            raw_tx = node.createrawtransaction(inputs, [{node.getnewaddress(): denom}, {node.getnewaddress(): denom}])
+            signed_tx = node.signrawtransactionwithwallet(raw_tx)
+            assert_equal(signed_tx['complete'], True)
+            txid = node.decoderawtransaction(signed_tx['hex'])['txid']
+            self.generateblock(self.nodes[0], output=node.getnewaddress(), transactions=[signed_tx['hex']])
+            inputs = [{'txid': txid, 'vout': n} for n in range(2)]
+
+        # Both coins report full rounds and count towards the anonymized balance
+        mixed_utxos = [(u['txid'], u['vout']) for u in node.listunspent()
+                       if u['coinjoin_rounds'] == COINJOIN_ROUNDS_MIN + COINJOIN_RANDOM_ROUNDS]
+        assert_equal(sorted(mixed_utxos), sorted((i['txid'], i['vout']) for i in inputs))
+        assert_equal(node.getbalances()['mine']['coinjoin'], 2 * denom)
+
+        # "send" accepts a fully mixed preset input; the transaction is marked as
+        # CoinJoin and pays the remainder as fee instead of creating change
+        res = node.send(outputs={node.getnewaddress(): Decimal('0.0009')}, options={'inputs': [inputs[0]], 'use_cj': True})
+        assert_equal(res['complete'], True)
+        tx = node.gettransaction(txid=res['txid'], verbose=True)
+        assert_equal(tx['DS'], '1')
+        assert_equal([(txin['txid'], txin['vout']) for txin in tx['decoded']['vin']],
+                     [(inputs[0]['txid'], inputs[0]['vout'])])
+        assert_equal(len(tx['decoded']['vout']), 1)
+
+        # "sendall" with automatic selection sweeps the remaining fully mixed coin
+        res = node.sendall(recipients=[node.getnewaddress()], options={'use_cj': True})
+        assert_equal(res['complete'], True)
+        tx = node.gettransaction(txid=res['txid'], verbose=True)
+        assert_equal(tx['DS'], '1')
+        assert_equal([(txin['txid'], txin['vout']) for txin in tx['decoded']['vin']],
+                     [(inputs[1]['txid'], inputs[1]['vout'])])
+
+        node.setcoinjoinrounds(COINJOIN_ROUNDS_DEFAULT)
 
     def test_setcoinjoinamount(self, node):
         self.log.info('"setcoinjoinamount" should update mixing target')

--- a/test/functional/rpc_coinjoin.py
+++ b/test/functional/rpc_coinjoin.py
@@ -128,6 +128,19 @@ class CoinJoinTest(BitcoinTestFramework):
         node.newkeypool()
         assert_equal(node.getcoinjoininfo()['running'], False)
 
+    def simulate_mixing(self, node, inputs, denom, rounds):
+        # A same-denomination, fee-free self-spend advances each output by one
+        # round. Zero-fee transactions are not relayed, so mine them directly.
+        for _ in range(rounds):
+            outputs = [{node.getnewaddress(): denom} for _ in inputs]
+            raw_tx = node.createrawtransaction(inputs, outputs)
+            signed_tx = node.signrawtransactionwithwallet(raw_tx)
+            assert_equal(signed_tx['complete'], True)
+            txid = node.decoderawtransaction(signed_tx['hex'])['txid']
+            self.generateblock(self.nodes[0], output=node.getnewaddress(), transactions=[signed_tx['hex']])
+            inputs = [{'txid': txid, 'vout': n} for n in range(len(inputs))]
+        return inputs
+
     def test_use_cj_option(self, node):
         self.log.info('"use_cj" option should spend fully mixed coins only')
         addr = node.getnewaddress()
@@ -168,17 +181,10 @@ class CoinJoinTest(BitcoinTestFramework):
         inputs = [{'txid': funding_txid, 'vout': out['n']} for out in funding_tx['vout'] if out['value'] == denom]
         assert_equal(len(inputs), 2)
 
-        # Simulate mixing: a same-denomination, fee-free self-spend advances each
-        # output by one round. Zero-fee transactions are not relayed, so mine them
-        # directly. COINJOIN_ROUNDS_MIN + COINJOIN_RANDOM_ROUNDS rounds make
-        # IsFullyMixed() deterministic regardless of the wallet's salt.
-        for _ in range(COINJOIN_ROUNDS_MIN + COINJOIN_RANDOM_ROUNDS):
-            raw_tx = node.createrawtransaction(inputs, [{node.getnewaddress(): denom}, {node.getnewaddress(): denom}])
-            signed_tx = node.signrawtransactionwithwallet(raw_tx)
-            assert_equal(signed_tx['complete'], True)
-            txid = node.decoderawtransaction(signed_tx['hex'])['txid']
-            self.generateblock(self.nodes[0], output=node.getnewaddress(), transactions=[signed_tx['hex']])
-            inputs = [{'txid': txid, 'vout': n} for n in range(2)]
+        # COINJOIN_ROUNDS_MIN + COINJOIN_RANDOM_ROUNDS rounds make IsFullyMixed()
+        # deterministic regardless of the wallet's salt.
+        rounds = COINJOIN_ROUNDS_MIN + COINJOIN_RANDOM_ROUNDS
+        inputs = self.simulate_mixing(node, inputs, denom, rounds)
 
         # Both coins report full rounds and count towards the anonymized balance
         mixed_utxos = [(u['txid'], u['vout']) for u in node.listunspent()


### PR DESCRIPTION
## Issue being fixed or feature implemented
Follow-up to #7261. The `use_cj` tests added there only exercise failure paths: the test wallet never holds a fully mixed coin, so nothing verifies that a successful `use_cj` spend actually selects mixed inputs, suppresses change, or records the `DS="1"` CoinJoin marker that `FinishTransaction()` now attaches via `CommitTransaction()`. A regression in any of those would pass the suite unnoticed.

## What was done?
Added a success-path subtest to `test/functional/rpc_coinjoin.py`. It builds two fully mixed coins by simulating mixing: same-denomination, fee-free self-spends advance a denominated output by one round each, and they are mined directly via `generateblock` since zero-fee transactions are not relayed. Chaining `COINJOIN_ROUNDS_MIN + COINJOIN_RANDOM_ROUNDS` rounds makes `IsFullyMixed()` deterministic regardless of the wallet's salt (the salt-based coin flip only applies strictly below that threshold).

It then asserts:
- both coins report full `coinjoin_rounds` in `listunspent` and count towards the `getbalances` anonymized balance;
- `send` accepts a fully mixed preset input (the positive counterpart of the rejection tests from #7261), spends exactly that input, creates no change output (the remainder is paid as fee, as fully mixed coins are spent in whole denominations) and records `DS="1"`;
- `sendall` with automatic selection sweeps exactly the remaining fully mixed coin and records `DS="1"`.

`setcoinjoinrounds` is a node-global setting; the subtest pins it to `COINJOIN_ROUNDS_MIN` and restores the default at the end so later subtests are unaffected.

## How Has This Been Tested?
`test/functional/test_runner.py rpc_coinjoin.py` passes locally (macOS arm64, `--enable-debug` build, both descriptor and legacy wallet paths of the runner's default). `test/lint/lint-python.py` clean.

## Breaking Changes
None, test-only change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
