### PR TITLE
fix: exempt a MN's own ProRegTx from collateral-reuse mempool conflicts

### DIFF
--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -1521,6 +1521,34 @@ void FuncTestMempoolProRegReplacementUpdateConflict(TestChainSetup& setup)
                                                MakeTransactionRef(tx_reg_replace)};
         testPool.removeForBlock(connected, tip_height() + 1);
         BOOST_CHECK_EQUAL(testPool.size(), 0U);
+
+        // ProUpReg and ProUpRev for the replaced MN conflict with a pending replacement too.
+        CKey votingKey;
+        votingKey.MakeNewKey(true);
+        CBLSSecretKey operatorKey3;
+        operatorKey3.MakeNewKey();
+        auto tx_up_reg = CreateProUpRegTx(chainman, utxos, proTxHash, ownerKey, operatorKey3.GetPublicKey(),
+                                          votingKey.GetPubKey().GetID(), scriptPayout, setup.coinbaseKey);
+        auto tx_up_rev = CreateProUpRevTx(chainman, utxos, proTxHash, operatorKey, setup.coinbaseKey);
+
+        testPool.addUnchecked(entry.FromTx(tx_reg_replace));
+        BOOST_CHECK(testPool.existsProviderTxConflict(CTransaction(tx_up_reg)));
+        BOOST_CHECK(testPool.existsProviderTxConflict(CTransaction(tx_up_rev)));
+        testPool.removeRecursive(CTransaction(tx_reg_replace), MemPoolRemovalReason::MANUAL);
+        BOOST_CHECK_EQUAL(testPool.size(), 0U);
+
+        // The MN's own ProRegTx is not a replacement. While a reorg is being processed the
+        // tip list can still contain the MN whose registration is being resubmitted; if
+        // either direction were treated as a conflict, the resubmitted registration (or its
+        // updates) would be dropped even though the pair is mineable together.
+        testPool.addUnchecked(entry.FromTx(tx_up_serv));
+        BOOST_CHECK(!testPool.existsProviderTxConflict(CTransaction(tx_reg)));
+        testPool.removeRecursive(CTransaction(tx_up_serv), MemPoolRemovalReason::MANUAL);
+
+        testPool.addUnchecked(entry.FromTx(tx_reg));
+        BOOST_CHECK(!testPool.existsProviderTxConflict(CTransaction(tx_up_serv)));
+        BOOST_CHECK(!testPool.existsProviderTxConflict(CTransaction(tx_up_reg)));
+        BOOST_CHECK(!testPool.existsProviderTxConflict(CTransaction(tx_up_rev)));
     }
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1431,6 +1431,16 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         return false;
     };
 
+    // A pending ProRegTx claiming a live MN's collateral replaces (deletes) that MN when
+    // mined, so an update targeting the MN could never be mined afterwards. The MN's own
+    // ProRegTx (same hash, e.g. resubmitted while a reorg is being processed) replaces
+    // nothing and is not a conflict.
+    auto collateralReusedInMempool = [&](const CDeterministicMN& dmn) EXCLUSIVE_LOCKS_REQUIRED(cs) {
+        AssertLockHeld(cs);
+        auto it = mapProTxCollaterals.find(dmn.collateralOutpoint);
+        return it != mapProTxCollaterals.end() && it->second != dmn.proTxHash;
+    };
+
     const uint256 tx_hash{tx.GetHash()};
     if (tx.nType == TRANSACTION_PROVIDER_REGISTER) {
         const auto opt_proTx = GetTxPayload<CProRegTx>(tx);
@@ -1462,10 +1472,12 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
             // A replacement ProRegTx deletes the live MN backed by this collateral. Any
             // in-mempool update that still targets that MN's proTxHash would then fail
             // BuildNewListFromBlock with bad-protx-hash if both were mined in one block.
-            if (auto dmn = m_dmnman.GetListAtChainTip().GetMNByCollateral(proTx.collateralOutpoint)) {
-                if (mapProTxRefs.find(dmn->proTxHash) != mapProTxRefs.end()) {
-                    return true;
-                }
+            // Exempt the MN's own registration: while a reorg is being processed the tip
+            // list can still contain the MN whose ProRegTx is being resubmitted, and
+            // re-registering the same MN replaces nothing.
+            if (auto dmn = m_dmnman.GetListAtChainTip().GetMNByCollateral(proTx.collateralOutpoint);
+                dmn && dmn->proTxHash != tx_hash && mapProTxRefs.count(dmn->proTxHash)) {
+                return true;
             }
         }
         return false;
@@ -1487,11 +1499,8 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
                 return true;
             }
         }
-        // Conflict with a replacement ProRegTx that reuses this MN's external collateral.
-        if (auto dmn = m_dmnman.GetListAtChainTip().GetMN(opt_proTx->proTxHash)) {
-            if (mapProTxCollaterals.count(dmn->collateralOutpoint)) {
-                return true;
-            }
+        if (auto dmn = m_dmnman.GetListAtChainTip().GetMN(opt_proTx->proTxHash); dmn && collateralReusedInMempool(*dmn)) {
+            return true;
         }
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_REGISTRAR) {
         const auto opt_proTx = GetTxPayload<CProUpRegTx>(tx);
@@ -1507,8 +1516,7 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
             LogPrint(BCLog::MEMPOOL, "%s: ERROR: Masternode is not in the list, proTxHash: %s\n", __func__, proTx.proTxHash.ToString());
             return true; // i.e. failed to find validated ProTx == conflict
         }
-        // Conflict with a replacement ProRegTx that reuses this MN's external collateral.
-        if (mapProTxCollaterals.count(dmn->collateralOutpoint)) {
+        if (collateralReusedInMempool(*dmn)) {
             return true;
         }
         // only allow one operator key change in the mempool
@@ -1533,8 +1541,7 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
             LogPrint(BCLog::MEMPOOL, "%s: ERROR: Masternode is not in the list, proTxHash: %s\n", __func__, proTx.proTxHash.ToString());
             return true; // i.e. failed to find validated ProTx == conflict
         }
-        // Conflict with a replacement ProRegTx that reuses this MN's external collateral.
-        if (mapProTxCollaterals.count(dmn->collateralOutpoint)) {
+        if (collateralReusedInMempool(*dmn)) {
             return true;
         }
         // only allow one operator key change in the mempool


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #7489. The collateral-reuse conflict checks it added can reject a valid transaction, because they only test that *some* matching mempool entry exists — they never check *whose* entry it is.

The failure sequence:

1. Masternode X is registered with external collateral C, and a ProUpServTx for X is sitting in the mempool.
2. The block containing X's ProRegTx is disconnected (reorg or `invalidateblock`).
3. The reorg logic resubmits the disconnected ProRegTx to the mempool. At that moment dmnman's tip list has not been rolled back yet — `SynchronousUpdatedBlockTip()` only fires after `MaybeUpdateMempoolForReorg()` has run — so `GetMNByCollateral(C)` still resolves to X.
4. The #7489 check now reasons: "this ProRegTx replaces X, and a mempool transaction still references X — conflict", and rejects X's **own registration** as `protx-dup`. `MaybeUpdateMempoolForReorg()` then drops it from the mempool for good.

That rejection is wrong. The resubmitted ProRegTx "replaces" the masternode it itself created, i.e. it replaces nothing, and registration followed by update is a perfectly mineable pair — there is no conflict to prevent.

## What was done?

Exempt a masternode's own registration from the collateral-reuse conflict, in both directions:

- The ProRegTx branch of `existsProviderTxConflict()` skips the `mapProTxRefs` lookup when the resolved masternode's `proTxHash` equals the incoming transaction's own hash.
- The three update branches (ProUpServTx/ProUpRegTx/ProUpRevTx) now share one `collateralReusedInMempool()` helper that requires the pending ProRegTx to be a *different* transaction, mirroring the `it->second != proTxHash` form the neighbouring `mapProTxAddresses`/`mapProTxPlatformNodeIDs` checks already use. This also deduplicates the check #7489 spelled out three times.

The update-side change is defensive rather than a reachable bug today: `CheckSpecialTx()` rejects an update for an unconfirmed masternode before `existsProviderTxConflict()` runs, so only the ProRegTx direction can currently misfire. Making the identity requirement explicit keeps the two directions symmetric instead of accidentally different.

## How Has This Been Tested?

Extended `test_mempool_proreg_replacement_update_conflict` in `src/test/evo_deterministicmns_tests.cpp`:

- positive coverage for the ProUpRegTx and ProUpRevTx admission branches (a coverage gap flagged in #7489 review — only ProUpServTx was exercised);
- negative controls for the exemption in both directions: with an update pending, the masternode's own ProRegTx must be accepted; with the masternode's own ProRegTx pending, its updates must be accepted.

The three negative-control assertions fail on current `develop` without the fix (verified against the #7489 merge commit) and pass with it; `evo_dip3_activation_tests` passes (38 cases). Built and run on macOS/arm64.

## Breaking Changes

None. Mempool policy only, and strictly narrowing: the only newly-accepted pairs are a masternode's own registration alongside its own updates, which are mineable together.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
