### PR TITLE
fix: trim trailing zeros in proposal amounts

### DIFF
--- a/src/qt/proposalmodel.cpp
+++ b/src/qt/proposalmodel.cpp
@@ -19,6 +19,29 @@
 #include <algorithm>
 #include <cmath>
 
+namespace {
+//! Formats an amount at the user's configured decimal precision, dropping
+//! insignificant trailing zeros ("1.00 DASH" -> "1 DASH").
+QString formatProposalAmount(const BitcoinUnit& unit, const CAmount& amount)
+{
+    const QString suffix{QLatin1Char(' ') + BitcoinUnits::name(unit)};
+    QString result{BitcoinUnits::floorWithUnit(unit, amount, /*plussign=*/false, BitcoinUnits::SeparatorStyle::ALWAYS)};
+    result.chop(suffix.size());
+
+    if (result.contains('.')) {
+        while (result.endsWith('0')) {
+            result.chop(1);
+        }
+
+        if (result.endsWith('.')) {
+            result.chop(1);
+        }
+    }
+
+    return result + suffix;
+}
+} // anonymous namespace
+
 Proposal::Proposal(ClientModel& client_model, const CGovernanceObject& govObj,
                    const interfaces::GOV::GovernanceInfo& govInfo, int collateral_confs,
                    bool is_broadcast) :
@@ -213,8 +236,7 @@ QVariant ProposalModel::data(const QModelIndex& index, int role) const
         case Column::END_DATE:
             return proposal->endDate().date();
         case Column::PAYMENT_AMOUNT: {
-            return BitcoinUnits::floorWithUnit(m_display_unit, proposal->paymentAmount(), false,
-                                               BitcoinUnits::SeparatorStyle::ALWAYS);
+            return formatProposalAmount(m_display_unit, proposal->paymentAmount());
         }
         case Column::VOTING_STATUS: {
             const int margin = proposal->getAbsoluteYesCount() - nAbsVoteReq;


### PR DESCRIPTION
## Issue being fixed or feature implemented

Governance proposal amounts were displayed with fixed-width trailing zeros (for example, `1.00000000 DASH`). This adds unnecessary visual noise to the proposal list and makes scanning amounts harder.

## What was done?

The Governance payment-amount column now formats the amount at the user's configured decimal precision (the `digits` display option, default 2 — the same precision the column used before), then removes only insignificant trailing zeros and any bare trailing decimal point.

- `1.00000000 DASH` renders as `1 DASH`
- `1.10 DASH` renders as `1.1 DASH`
- `15.27 DASH` is unchanged

No amount value is rounded beyond what the display-precision setting already did, and the model's sort/underlying values still use the integer amount.

## How Has This Been Tested?

- Built `dash-qt` successfully on macOS ARM64.
- Ran a disposable regtest governance fixture with five masternodes and three proposals.
- Verified the GUI dropped the padded zero fractions from the amount column while honoring the configured decimal precision.
- Ran `git diff --check`.

## Breaking Changes

None. This is a GUI display-only change; sorting and model values continue to use the integer amount.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

This pull request was created by Codex.
