### PR TITLE
docs: clarify backport assertion policy exceptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,12 @@ Short version, in order of preference:
   (best-effort) by `test/lint/lint-assertions.py` for `src/rpc/` and
   `src/wallet/rpc*`.
 
+The production-crash guidance above does not apply to C++ regression and
+unit-test sources under `src/test/` and `src/wallet/test/`. They compile into test
+binaries, not user-facing `dashd` or `dash-qt`; `assert`, `Assert`, `Assume`,
+and related fatal test checks are all acceptable. Do not flag the choice among
+them as a production-crash risk.
+
 None of these validate input. Data from peers, RPC arguments, wallet files, or
 on-disk state must be checked and rejected through normal error handling -
 asserting on it turns a peer-triggered inconsistency into a remote crash.
@@ -173,6 +179,11 @@ source-history work, not only conflict resolution.
 - Keep upstream backport commits as close to 1:1 as practical. Put shared Dash
   repair work on a staging/base branch instead of hiding it inside an unrelated
   upstream backport commit.
+- When reviewing Bitcoin Core backports, absent a clear bug, prefer staying
+  aligned with upstream. Do not request Dash-only policy or style changes, such
+  as replacing an assertion primitive solely to match this guide. Dash-specific
+  correctness, security, or consensus issues are valid reasons to adapt
+  upstream code.
 - Compare the upstream diff to the Dash diff file by file.
 - Check prerequisite PRs. If an upstream hunk depends on a helper, test, type,
   or file introduced by an earlier Bitcoin PR, either backport the prerequisite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,12 @@ Short version, in order of preference:
   (best-effort) by `test/lint/lint-assertions.py` for `src/rpc/` and
   `src/wallet/rpc*`.
 
+The production-crash guidance above does not apply to C++ regression and
+unit-test sources under `src/test/` and `src/wallet/test/`. They compile into test
+binaries, not user-facing `dashd` or `dash-qt`; `assert`, `Assert`, `Assume`,
+and related fatal test checks are all acceptable. Do not flag the choice among
+them as a production-crash risk.
+
 None of these validate input. Data from peers, RPC arguments, wallet files, or
 on-disk state must be checked and rejected through normal error handling -
 asserting on it turns a peer-triggered inconsistency into a remote crash.
@@ -173,6 +179,11 @@ source-history work, not only conflict resolution.
 - Keep upstream backport commits as close to 1:1 as practical. Put shared Dash
   repair work on a staging/base branch instead of hiding it inside an unrelated
   upstream backport commit.
+- When reviewing Bitcoin Core backports, absent a clear bug, prefer staying
+  aligned with upstream. Do not request Dash-only policy or style changes, such
+  as replacing an assertion primitive solely to match this guide. Dash-specific
+  correctness, security, or consensus issues are valid reasons to adapt
+  upstream code.
 - Compare the upstream diff to the Dash diff file by file.
 - Check prerequisite PRs. If an upstream hunk depends on a helper, test, type,
   or file introduced by an earlier Bitcoin PR, either backport the prerequisite


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #7615. Its condensed agent guidance correctly protects user-facing binaries, but reviewers can apply it too broadly to Bitcoin Core backports and test-only code. For example, the review comment in #7646 proposed replacing upstream `assert` calls in `src/wallet/test/util.cpp` solely to satisfy the production assertion policy, even though that source is linked into the unit-test binary rather than `dashd` or `dash-qt`.

## What was done?

Updated the byte-identical `AGENTS.md` and `CLAUDE.md` guides to clarify two boundaries:

- For Bitcoin Core backports, absent a clear bug, prefer remaining aligned with upstream rather than requesting Dash-only policy or style changes. Dash-specific correctness, security, and consensus issues remain valid reasons to adapt upstream code.
- In C++ regression and unit-test sources under `src/test/` and `src/wallet/test/`, `assert`, `Assert`, `Assume`, and related fatal test checks are all acceptable. Their selection should not be flagged as a production-crash risk because these sources compile into test binaries, not user-facing applications.

The exception is intentionally limited to the two requested test directories. The production-binary safety and untrusted-input guidance from #7615 remains unchanged. `doc/developer-notes.md` is also unchanged because this follow-up scopes agent/reviewer behavior rather than weakening the developer-facing production guidance.

## How Has This Been Tested?

Documentation-only change. Validation performed:

- `cmp -s AGENTS.md CLAUDE.md`
- `test/lint/lint-whitespace.py`
- `codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=test/lint/spelling.ignore-words.txt AGENTS.md CLAUDE.md`
- `git diff --check upstream/develop..HEAD`
- Exact-head pre-PR review gate: `ship` with zero findings

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
