### PR TITLE
chore: add default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @UdjinM6 @knst @PastaPastaPasta


### PR DESCRIPTION
## Issue being fixed or feature implemented

Pull requests currently do not automatically request review from the core maintainers responsible for repository-wide changes.

## What was done?

Added a repository-wide CODEOWNERS rule that assigns the three default code owners to every changed path.

## How Has This Been Tested?

Validated the file and patch with `git diff --check`. No runtime tests are needed for this GitHub metadata-only change.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
