### PR TITLE
fix(qt): identify asset lock transactions in history

### DIFF
--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -67,13 +67,15 @@ CTransactionRef MakeSpecialTransaction(uint16_t type, const COutPoint& input, CA
     return MakeTransactionRef(std::move(tx));
 }
 
-CTransactionRef MakeAssetLockTransaction(const COutPoint& input, CAmount amount, const CScript& credit_script)
+CTransactionRef MakeAssetLockTransaction(const COutPoint& input, CAmount amount, const CScript& credit_script,
+                                         std::optional<CTxOut> core_output = std::nullopt)
 {
     CMutableTransaction tx;
     tx.nVersion = CTransaction::SPECIAL_VERSION;
     tx.nType = TRANSACTION_ASSET_LOCK;
     tx.vin.emplace_back(input);
     tx.vout.emplace_back(amount, CScript{} << OP_RETURN << std::vector<unsigned char>{});
+    if (core_output) tx.vout.emplace_back(std::move(*core_output));
     SetTxPayload(tx, CAssetLockPayload{{CTxOut{amount, credit_script}}, CAssetLockPayload::INITIAL_VERSION});
     return MakeTransactionRef(std::move(tx));
 }
@@ -276,6 +278,9 @@ void ProviderTransactionTests::providerTransactionHistory()
     const CAmount asset_lock_fee{5000};
     const CTransactionRef asset_lock{MakeAssetLockTransaction(make_owned_input(4),
                                                               input_amount(4) - asset_lock_fee, external_script)};
+    const CAmount received_core_amount{COIN};
+    const CTransactionRef received_from_asset_lock{MakeAssetLockTransaction(
+        COutPoint{uint256::TWO, 7}, 2 * COIN, external_script, CTxOut{received_core_amount, own_script})};
 
     std::vector<ExpectedRecord> expected{
         {registration->GetHash(), TransactionRecord::MasternodeRegistration, -registration_fee,
@@ -292,7 +297,8 @@ void ProviderTransactionTests::providerTransactionHistory()
          QString{"Locks funds for use on Dash Platform"}},
     };
 
-    for (const CTransactionRef& tx : {registration, update_service, update_registrar, update_revoke, asset_lock}) {
+    for (const CTransactionRef& tx :
+         {registration, update_service, update_registrar, update_revoke, asset_lock, received_from_asset_lock}) {
         QVERIFY(wallet->AddToWallet(tx, TxStateInactive{}) != nullptr);
     }
 
@@ -307,6 +313,18 @@ void ProviderTransactionTests::providerTransactionHistory()
 
         // Transactions loaded before the model is constructed exercise the wallet-restart path.
         CheckProviderRecords(*model, expected);
+
+        const std::vector<int> asset_lock_rows{FindTransactionRows(*model, asset_lock->GetHash())};
+        QCOMPARE(asset_lock_rows.size(), size_t{1});
+        const QModelIndex asset_lock_index{model->index(asset_lock_rows.front(), 0)};
+        QVERIFY(!asset_lock_index.data(TransactionTableModel::LongDescriptionRole).toString().contains("Output index"));
+
+        const std::vector<int> received_rows{FindTransactionRows(*model, received_from_asset_lock->GetHash())};
+        QCOMPARE(received_rows.size(), size_t{1});
+        const QModelIndex received_index{model->index(received_rows.front(), 0)};
+        QCOMPARE(received_index.data(TransactionTableModel::TypeRole).toInt(),
+                 static_cast<int>(TransactionRecord::RecvWithAddress));
+        QCOMPARE(received_index.data(TransactionTableModel::AmountRole).toLongLong(), received_core_amount);
 
         // Add an externally funded registration after model construction to exercise live wallet
         // notification. Its owned output is the wallet's positive net change and still yields one

--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -4,6 +4,8 @@
 
 #include <qt/test/providertransactiontests.h>
 
+#include <evo/assetlocktx.h>
+#include <evo/specialtx.h>
 #include <interfaces/chain.h>
 #include <interfaces/node.h>
 #include <key.h>
@@ -22,6 +24,7 @@
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -61,6 +64,17 @@ CTransactionRef MakeSpecialTransaction(uint16_t type, const COutPoint& input, CA
     tx.nType = type;
     tx.vin.emplace_back(input);
     tx.vout.emplace_back(output_amount, output_script);
+    return MakeTransactionRef(std::move(tx));
+}
+
+CTransactionRef MakeAssetLockTransaction(const COutPoint& input, CAmount amount, const CScript& credit_script)
+{
+    CMutableTransaction tx;
+    tx.nVersion = CTransaction::SPECIAL_VERSION;
+    tx.nType = TRANSACTION_ASSET_LOCK;
+    tx.vin.emplace_back(input);
+    tx.vout.emplace_back(amount, CScript{} << OP_RETURN << std::vector<unsigned char>{});
+    SetTxPayload(tx, CAssetLockPayload{{CTxOut{amount, credit_script}}, CAssetLockPayload::INITIAL_VERSION});
     return MakeTransactionRef(std::move(tx));
 }
 
@@ -171,6 +185,8 @@ void ProviderTransactionTests::transactionTypeSettingPersistence_data()
     QTest::newRow("masternode") << (TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
                                     TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate))
                                 << QString{"Masternode"};
+    QTest::newRow("asset-lock") << TransactionFilterProxy::TYPE(TransactionRecord::AssetLock)
+                                << QString{"Asset Lock"};
     QTest::newRow("data") << TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction)
                           << QString{"Data Transaction"};
     QTest::newRow("dust") << TransactionFilterProxy::TYPE(TransactionRecord::DustReceive)
@@ -257,8 +273,9 @@ void ProviderTransactionTests::providerTransactionHistory()
                                                                   external_script)};
     const CTransactionRef update_revoke{MakeSpecialTransaction(TRANSACTION_PROVIDER_UPDATE_REVOKE, make_owned_input(3),
                                                                input_amount(3) - revoke_fee, own_script)};
-    const CTransactionRef other_special_tx{
-        MakeSpecialTransaction(TRANSACTION_ASSET_LOCK, make_owned_input(4), input_amount(4) - 5000, own_script)};
+    const CAmount asset_lock_fee{5000};
+    const CTransactionRef asset_lock{MakeAssetLockTransaction(make_owned_input(4),
+                                                              input_amount(4) - asset_lock_fee, external_script)};
 
     std::vector<ExpectedRecord> expected{
         {registration->GetHash(), TransactionRecord::MasternodeRegistration, -registration_fee,
@@ -271,9 +288,11 @@ void ProviderTransactionTests::providerTransactionHistory()
          QString{"Masternode Update"}, QString{"Updates an existing masternode"}},
         {update_revoke->GetHash(), TransactionRecord::MasternodeUpdate, -revoke_fee, QString{"Masternode Update"},
          QString{"Updates an existing masternode"}},
+        {asset_lock->GetHash(), TransactionRecord::AssetLock, -input_amount(4), QString{"Asset Lock"},
+         QString{"Locks funds for use on Dash Platform"}},
     };
 
-    for (const CTransactionRef& tx : {registration, update_service, update_registrar, update_revoke, other_special_tx}) {
+    for (const CTransactionRef& tx : {registration, update_service, update_registrar, update_revoke, asset_lock}) {
         QVERIFY(wallet->AddToWallet(tx, TxStateInactive{}) != nullptr);
     }
 
@@ -288,13 +307,6 @@ void ProviderTransactionTests::providerTransactionHistory()
 
         // Transactions loaded before the model is constructed exercise the wallet-restart path.
         CheckProviderRecords(*model, expected);
-
-        const std::vector<int> other_rows{FindTransactionRows(*model, other_special_tx->GetHash())};
-        QCOMPARE(other_rows.size(), size_t{1});
-        QCOMPARE(model->index(other_rows.front(), 0).data(TransactionTableModel::TypeRole).toInt(),
-                 static_cast<int>(TransactionRecord::SendToSelf));
-        QCOMPARE(model->index(other_rows.front(), TransactionTableModel::Type).data(Qt::DisplayRole).toString(),
-                 QString{"Payment to yourself"});
 
         // Add an externally funded registration after model construction to exercise live wallet
         // notification. Its owned output is the wallet's positive net change and still yields one
@@ -311,10 +323,17 @@ void ProviderTransactionTests::providerTransactionHistory()
 
         const quint32 masternode_filter{TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
                                         TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate)};
+        const int masternode_count{static_cast<int>(std::count_if(expected.cbegin(), expected.cend(),
+                                                                 [](const ExpectedRecord& record) {
+                                                                     return record.type == TransactionRecord::MasternodeRegistration ||
+                                                                            record.type == TransactionRecord::MasternodeUpdate;
+                                                                 }))};
         TransactionFilterProxy filter;
         filter.setSourceModel(model);
         filter.setTypeFilter(masternode_filter);
-        QCOMPARE(filter.rowCount(), static_cast<int>(expected.size()));
+        QCOMPARE(filter.rowCount(), masternode_count);
+        filter.setTypeFilter(TransactionFilterProxy::TYPE(TransactionRecord::AssetLock));
+        QCOMPARE(filter.rowCount(), 1);
 
 #if defined(Q_OS_MACOS)
         if (QApplication::platformName() == "minimal") {
@@ -332,6 +351,8 @@ void ProviderTransactionTests::providerTransactionHistory()
             QVERIFY(type_widget != nullptr);
             const int masternode_row{type_widget->findText("Masternode")};
             QCOMPARE(type_widget->itemData(masternode_row).toUInt(), masternode_filter);
+            QCOMPARE(type_widget->itemData(type_widget->findText("Asset Lock")).toUInt(),
+                     TransactionFilterProxy::TYPE(TransactionRecord::AssetLock));
 
             QListView* const type_list{qobject_cast<QListView*>(type_widget->view())};
             QVERIFY(type_list != nullptr);
@@ -353,7 +374,7 @@ void ProviderTransactionTests::providerTransactionHistory()
             QCOMPARE(QSettings{}.value("transactionTypeFilter").toUInt(), masternode_filter);
             QTableView* const table{transaction_view.findChild<QTableView*>("transactionView")};
             QVERIFY(table != nullptr);
-            QCOMPARE(table->model()->rowCount(), static_cast<int>(expected.size()));
+            QCOMPARE(table->model()->rowCount(), masternode_count);
 
             struct RestoreCase {
                 quint32 saved_filter;
@@ -364,6 +385,9 @@ void ProviderTransactionTests::providerTransactionHistory()
                 {TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction),
                  TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction),
                  QString{"Data Transaction"}},
+                {TransactionFilterProxy::TYPE(TransactionRecord::AssetLock),
+                 TransactionFilterProxy::TYPE(TransactionRecord::AssetLock),
+                 QString{"Asset Lock"}},
                 {TransactionFilterProxy::TYPE(TransactionRecord::DustReceive),
                  TransactionFilterProxy::TYPE(TransactionRecord::DustReceive),
                  QString{"Dust Receive"}},

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -105,8 +105,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     CAmount nCredit = wtx.credit;
     CAmount nDebit = wtx.debit;
     CAmount nNet = nCredit - nDebit;
-    const bool is_masternode_transaction{rec->type == TransactionRecord::MasternodeRegistration ||
-                                         rec->type == TransactionRecord::MasternodeUpdate};
+    const bool is_transaction_level_record{rec->type == TransactionRecord::MasternodeRegistration ||
+                                           rec->type == TransactionRecord::MasternodeUpdate ||
+                                           rec->type == TransactionRecord::AssetLock};
 
     strHTML += "<b>" + tr("Status") + ":</b> " + FormatTxStatus(status, inMempool);
     strHTML += "<br>";
@@ -130,14 +131,14 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // From
     //
-    if (!is_masternode_transaction && wtx.is_coinbase) {
+    if (!is_transaction_level_record && wtx.is_coinbase) {
         strHTML += "<b>" + tr("Source") + ":</b> " + tr("Generated") + "<br>";
-    } else if (!is_masternode_transaction && wtx.is_platform_transfer) {
+    } else if (!is_transaction_level_record && wtx.is_platform_transfer) {
         strHTML += "<b>" + tr("Source") + ":</b> " + tr("Platform Transfer") + "<br>";
-    } else if (!is_masternode_transaction && wtx.value_map.count("from") && !wtx.value_map["from"].empty()) {
+    } else if (!is_transaction_level_record && wtx.value_map.count("from") && !wtx.value_map["from"].empty()) {
         // Online transaction
         strHTML += "<b>" + tr("From") + ":</b> " + GUIUtil::HtmlEscape(wtx.value_map["from"]) + "<br>";
-    } else if (!is_masternode_transaction) {
+    } else if (!is_transaction_level_record) {
         // Offline transaction
         if (nNet > 0)
         {
@@ -165,7 +166,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // To
     //
-    if (!is_masternode_transaction && wtx.value_map.count("to") && !wtx.value_map["to"].empty()) {
+    if (!is_transaction_level_record && wtx.value_map.count("to") && !wtx.value_map["to"].empty()) {
         // Online transaction
         std::string strAddress = wtx.value_map["to"];
         strHTML += "<b>" + tr("To") + ":</b> ";
@@ -180,7 +181,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // Amount
     //
-    if (!is_masternode_transaction && wtx.is_coinbase && nCredit == 0) {
+    if (!is_transaction_level_record && wtx.is_coinbase && nCredit == 0) {
         //
         // Coinbase
         //
@@ -193,12 +194,12 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         else
             strHTML += "(" + tr("not accepted") + ")";
         strHTML += "<br>";
-    } else if (!is_masternode_transaction && nNet > 0) {
+    } else if (!is_transaction_level_record && nNet > 0) {
         //
         // Credit
         //
         strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nNet) + "<br>";
-    } else if (!is_masternode_transaction) {
+    } else if (!is_transaction_level_record) {
         isminetype fAllFromMe = ISMINE_SPENDABLE;
         for (const isminetype mine : wtx.txin_is_mine)
         {
@@ -296,7 +297,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.value_map["comment"], true) + "<br>";
 
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";
-    if (!is_masternode_transaction) {
+    if (!is_transaction_level_record) {
         strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
     }
     strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx.tx->GetTotalSize()) + " bytes<br>";

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -120,6 +120,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     case TransactionRecord::MasternodeUpdate:
         strHTML += "<b>" + tr("Type") + ":</b> " + tr("Masternode Update") + "<br>";
         break;
+    case TransactionRecord::AssetLock:
+        strHTML += "<b>" + tr("Type") + ":</b> " + tr("Asset Lock") + "<br>";
+        break;
     default:
         break;
     }

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -37,7 +37,7 @@ public:
     static constexpr quint32 ALL_TYPES = 0xFFFFFFFF;
     /** Type filter bit field (all types except excluded) */
     static constexpr quint32 COMMON_TYPES = ALL_TYPES & ~EXCLUDED_TYPES;
-    static_assert(TransactionRecord::MasternodeUpdate < 32,
+    static_assert(TransactionRecord::AssetLock < 32,
                   "TransactionRecord::Type no longer fits in the quint32 type filter");
 
     static constexpr quint32 TYPE(int type) { return TransactionTypeToBit(type); }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -61,7 +61,13 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
     uint256 hash = wtx.tx->GetHash();
     std::map<std::string, std::string> mapValue = wtx.value_map;
 
-    if (const auto special_type = SpecialTransactionRecordType(*wtx.tx)) {
+    // Check if any inputs belong to this wallet (for special transaction handling and dust detection)
+    const bool isFromMe{std::any_of(wtx.txin_is_mine.cbegin(), wtx.txin_is_mine.cend(),
+                                    [](const isminetype mine) { return mine; })};
+    const auto special_type{SpecialTransactionRecordType(*wtx.tx)};
+    const bool is_asset_lock{special_type == TransactionRecord::AssetLock};
+
+    if (special_type && (!is_asset_lock || isFromMe)) {
         TransactionRecord record(hash, nTime, *special_type, /*_strAddress=*/"", std::min<CAmount>(nNet, 0),
                                  std::max<CAmount>(nNet, 0));
         record.involvesWatchAddress = std::any_of(wtx.txin_is_mine.begin(), wtx.txin_is_mine.end(),
@@ -73,15 +79,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
     }
 
     auto& coinJoinOptions = node.coinJoinOptions();
-
-    // Check if any inputs belong to this wallet (for dust detection)
-    bool isFromMe = false;
-    for (const isminetype mine : wtx.txin_is_mine) {
-        if (mine) {
-            isFromMe = true;
-            break;
-        }
-    }
 
     if (nNet > 0 || wtx.is_coinbase || wtx.is_platform_transfer)
     {
@@ -135,7 +132,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
 
                 parts.append(sub);
             }
-            else if (!wtx.is_coinbase && IsDataScript(txout.scriptPubKey))
+            else if (!wtx.is_coinbase && !is_asset_lock && IsDataScript(txout.scriptPubKey))
             {
                 TransactionRecord sub(hash, nTime);
                 sub.credit = txout.nValue;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -29,7 +29,7 @@ bool TransactionRecord::showTransaction()
     return true;
 }
 
-static std::optional<TransactionRecord::Type> MasternodeRecordType(const CTransaction& tx)
+static std::optional<TransactionRecord::Type> SpecialTransactionRecordType(const CTransaction& tx)
 {
     if (!tx.IsSpecialTxVersion()) return std::nullopt;
 
@@ -40,6 +40,8 @@ static std::optional<TransactionRecord::Type> MasternodeRecordType(const CTransa
     case TRANSACTION_PROVIDER_UPDATE_REGISTRAR:
     case TRANSACTION_PROVIDER_UPDATE_REVOKE:
         return TransactionRecord::MasternodeUpdate;
+    case TRANSACTION_ASSET_LOCK:
+        return TransactionRecord::AssetLock;
     default:
         return std::nullopt;
     }
@@ -59,8 +61,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
     uint256 hash = wtx.tx->GetHash();
     std::map<std::string, std::string> mapValue = wtx.value_map;
 
-    if (const auto mn_type = MasternodeRecordType(*wtx.tx)) {
-        TransactionRecord record(hash, nTime, *mn_type, /*_strAddress=*/"", std::min<CAmount>(nNet, 0),
+    if (const auto special_type = SpecialTransactionRecordType(*wtx.tx)) {
+        TransactionRecord record(hash, nTime, *special_type, /*_strAddress=*/"", std::min<CAmount>(nNet, 0),
                                  std::max<CAmount>(nNet, 0));
         record.involvesWatchAddress = std::any_of(wtx.txin_is_mine.begin(), wtx.txin_is_mine.end(),
                                                   [](const isminetype mine) { return mine & ISMINE_WATCH_ONLY; }) ||

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -94,6 +94,8 @@ public:
         MasternodeRegistration,
         /// ProUpServTx, ProUpRegTx, or ProUpRevTx for an existing masternode
         MasternodeUpdate,
+        /// AssetLockTx that moves funds from Core into Platform
+        AssetLock,
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -441,6 +441,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Masternode Registration");
     case TransactionRecord::MasternodeUpdate:
         return tr("Masternode Update");
+    case TransactionRecord::AssetLock:
+        return tr("Asset Lock");
 
     case TransactionRecord::CoinJoinMixing:
         return tr("%1 Mixing").arg(QString::fromStdString(gCoinJoinName));
@@ -498,6 +500,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::DataTransaction:
     case TransactionRecord::MasternodeRegistration:
     case TransactionRecord::MasternodeUpdate:
+    case TransactionRecord::AssetLock:
     case TransactionRecord::Other:
         break; // use fail-over here
     } // no default case, so the compiler can warn about missing cases
@@ -529,6 +532,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::DataTransaction:
     case TransactionRecord::MasternodeRegistration:
     case TransactionRecord::MasternodeUpdate:
+    case TransactionRecord::AssetLock:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BAREADDRESS);
     case TransactionRecord::SendToOther:
     case TransactionRecord::RecvFromOther:
@@ -564,6 +568,7 @@ QVariant TransactionTableModel::amountColor(const TransactionRecord *rec) const
     case TransactionRecord::SendToAddress:
     case TransactionRecord::SendToOther:
     case TransactionRecord::DataTransaction:
+    case TransactionRecord::AssetLock:
     case TransactionRecord::Other:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::RED);
     case TransactionRecord::SendToSelf:
@@ -636,6 +641,10 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
     case TransactionRecord::MasternodeUpdate:
         tooltip += QString("\n") + tr("Updates an existing masternode registration. The amount is this wallet's net "
                                       "balance change, normally only the network fee.");
+        break;
+    case TransactionRecord::AssetLock:
+        tooltip += QString("\n") + tr("Locks funds for use on Dash Platform. The amount is this wallet's net balance "
+                                      "change, including the network fee.");
         break;
     default:
         break;

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -98,6 +98,7 @@ TransactionView::TransactionView(QWidget* parent) :
     typeWidget->addItem(tr("Masternode"), TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
                                               TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate));
     typeWidget->addItem(tr("Platform Transfer"), TransactionFilterProxy::TYPE(TransactionRecord::PlatformTransfer));
+    typeWidget->addItem(tr("Asset Lock"), TransactionFilterProxy::TYPE(TransactionRecord::AssetLock));
     typeWidget->addItem(tr("Data Transaction"), TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction));
     typeWidget->addItem(tr("Dust Receive"), TransactionFilterProxy::TYPE(TransactionRecord::DustReceive));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));


### PR DESCRIPTION
## Issue being fixed or feature implemented

Dash Qt currently classifies outgoing asset-lock transactions as `Data Transaction` because their on-chain output is an `OP_RETURN`. This hides the transaction's actual purpose and makes wallet history misleading. For example, asset lock's are decoded as special transaction type 8 but appears as generic data in the GUI.

The Core transaction does not identify whether a version 1 asset lock is later consumed by an identity, transparent Platform, or shielded state transition, so `Asset Lock` is the accurate transaction-level label for all asset-lock versions.

## What was done?

- Classify special transaction type 8 as a dedicated `Asset Lock` transaction record before generic output decomposition.
- Display asset locks as one transaction-level history row with the wallet's full net balance change, including the network fee.
- Add `Asset Lock` labels to the history table and transaction details, along with a dedicated history filter and explanatory tooltip.
- Append the new record type so persisted transaction-filter bit values remain stable.
- Extend Qt regression coverage with a realistic version 1 asset lock containing an on-chain `OP_RETURN` and a credit output in its extra payload.

## How Has This Been Tested?

Tested on macOS arm64 using the repository depends build:

- `make -j13`
- `QT_QPA_PLATFORM=minimal ./src/qt/test/test_dash-qt` (all tests passed; expected macOS/minimal platform skips remained)
- `test/lint/lint-includes.py`
- `test/lint/lint-qt-translation.py`
- `test/lint/lint-whitespace.py`
- `test/lint/lint-files.py`

The Qt regression verifies classification, amount, tooltip, history filtering, persisted filter selection, and model reconstruction after a simulated wallet restart.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas _(N/A: the classification follows the existing special-transaction pattern and adds no non-obvious algorithm)_
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation _(N/A: this changes the in-application transaction label and tooltip; no user documentation describes the old label)_
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

This pull request was created by Codex.
