### PR TITLE
fix: restore the intended cs_main scope in FinalizeNode

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1739,8 +1739,8 @@ void PeerManagerImpl::ReattemptInitialBroadcast(CScheduler& scheduler)
 void PeerManagerImpl::FinalizeNode(const CNode& node) {
     NodeId nodeid = node.GetId();
     int misbehavior{0};
-    LOCK(cs_main);
     {
+    LOCK(cs_main);
     {
         // We remove the PeerRef from g_peer_map here, but we don't always
         // destruct the Peer. Sometimes another thread is still holding a


### PR DESCRIPTION
## Issue being fixed or feature implemented
40906b2bbb ("partial bitcoin#20228: Make addrman a top-level component", PR #5163) transposed two lines when backporting upstream 3fc06d3d7b. Upstream opens a scope and takes cs_main inside it:

    int misbehavior{0};
    {
    LOCK(cs_main);
    {

while the backport landed the LOCK before the scope:

    int misbehavior{0};
    LOCK(cs_main);
    {
    {

The braces still balance, so this compiled and went unnoticed, but cs_main ended up held for the whole function instead of just that block. The `} // cs_main` marker has been wrong ever since.

It stayed harmless because the only code below the marker is `CAddrMan::Connected()` and a `LogPrint`, neither of which contends for anything meaningful. It stops being harmless as soon as someone adds work below the marker that takes a contended lock, since the comment says they are outside cs_main when they are not.

## What was done?
Restore the upstream shape. No behavior change: nothing below the marker requires cs_main, and misbehavior and nodeid are declared above the scope. Discovered while reviewing #7563.

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

