### PR TITLE
test: improve performance of feature_protx_version.py

### DIFF
--- a/test/functional/feature_masternode_payout_shares.py
+++ b/test/functional/feature_masternode_payout_shares.py
@@ -193,8 +193,6 @@ class MasternodePayoutSharesTest(DashTestFramework):
 
         updated_payouts = [{"address": node.getnewaddress(), "reward": 1250} for _ in range(8)]
         node.sendtoaddress(mn.fundsAddr, 1)
-        self.bump_mocktime(10 * 60 + 1)
-        self.generate(node, 1, sync_fun=self.no_op)
         update_hash = mn.update_registrar(node, submit=True, payouts=updated_payouts, fundsAddr=mn.fundsAddr)
         assert update_hash is not None
         self.bump_mocktime(10 * 60 + 1)
@@ -207,8 +205,6 @@ class MasternodePayoutSharesTest(DashTestFramework):
 
         operator_payout = node.getnewaddress()
         node.sendtoaddress(mn.fundsAddr, 1)
-        self.bump_mocktime(10 * 60 + 1)
-        self.generate(node, 1, sync_fun=self.no_op)
         service_hash = mn.update_service(
             node,
             submit=True,
@@ -254,8 +250,6 @@ class MasternodePayoutSharesTest(DashTestFramework):
             paid_owner_total += payee["amount"]
 
         node.sendtoaddress(mn.fundsAddr, 1)
-        self.bump_mocktime(10 * 60 + 1)
-        self.generate(node, 1, sync_fun=self.no_op)
         revoke_hash = mn.revoke(node, submit=True, reason=1, fundsAddr=mn.fundsAddr)
         assert revoke_hash is not None
         self.bump_mocktime(10 * 60 + 1)

--- a/test/functional/feature_masternode_payout_shares.py
+++ b/test/functional/feature_masternode_payout_shares.py
@@ -86,8 +86,7 @@ class MasternodePayoutSharesTest(DashTestFramework):
         oversized_payouts = [{"address": node.getnewaddress(), "reward": 1000} for _ in range(9)]
 
         collateral_txid = node.sendmany("", {mn.collateral_address: mn.get_collateral_value(), mn.fundsAddr: 1})
-        self.bump_mocktime(10 * 60 + 1)
-        self.generate(node, 1, sync_fun=self.no_op)
+        self.bury_tx(node, collateral_txid)
         mn.collateral_txid = collateral_txid
         mn.collateral_vout = mn.get_collateral_vout(node, collateral_txid)
 
@@ -128,8 +127,7 @@ class MasternodePayoutSharesTest(DashTestFramework):
             fundsAddr=mn.fundsAddr,
         )
         assert protx_hash is not None
-        self.bump_mocktime(10 * 60 + 1)
-        self.generate(node, 1, sync_fun=self.no_op)
+        self.bury_tx(node, protx_hash)
         mn.set_params(proTxHash=protx_hash)
 
         raw = node.getrawtransaction(protx_hash, 1)
@@ -195,8 +193,7 @@ class MasternodePayoutSharesTest(DashTestFramework):
         node.sendtoaddress(mn.fundsAddr, 1)
         update_hash = mn.update_registrar(node, submit=True, payouts=updated_payouts, fundsAddr=mn.fundsAddr)
         assert update_hash is not None
-        self.bump_mocktime(10 * 60 + 1)
-        self.generate(node, 1, sync_fun=self.no_op)
+        self.bury_tx(node, update_hash)
 
         update_raw = node.getrawtransaction(update_hash, 1)
         assert_equal(update_raw["proUpRegTx"]["version"], 3)
@@ -213,8 +210,7 @@ class MasternodePayoutSharesTest(DashTestFramework):
             fundsAddr=mn.fundsAddr,
         )
         assert service_hash is not None
-        self.bump_mocktime(10 * 60 + 1)
-        self.generate(node, 1, sync_fun=self.no_op)
+        self.bury_tx(node, service_hash)
 
         info = node.protx("info", protx_hash)
         assert_equal(info["state"]["version"], 3)
@@ -252,8 +248,7 @@ class MasternodePayoutSharesTest(DashTestFramework):
         node.sendtoaddress(mn.fundsAddr, 1)
         revoke_hash = mn.revoke(node, submit=True, reason=1, fundsAddr=mn.fundsAddr)
         assert revoke_hash is not None
-        self.bump_mocktime(10 * 60 + 1)
-        self.generate(node, 1, sync_fun=self.no_op)
+        self.bury_tx(node, revoke_hash)
 
         info = node.protx("info", protx_hash)
         assert_equal(info["state"]["version"], 3)

--- a/test/functional/feature_protx_version.py
+++ b/test/functional/feature_protx_version.py
@@ -180,9 +180,8 @@ class ProTxVersionTest(DashTestFramework):
         assert_equal(state['version'], 2)
         payout_before = state['payoutAddress']
         node.sendtoaddress(payout_mn.fundsAddr, 1)
-        payout_mn.update_service(node, submit=True, addrs_core_p2p=[f'127.0.0.1:{payout_mn.nodePort}'])
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        self.generate(node, 1)
+        upserv_hash = payout_mn.update_service(node, submit=True, addrs_core_p2p=[f'127.0.0.1:{payout_mn.nodePort}'])
+        self.bury_tx(node, upserv_hash)
         state = node.protx('info', payout_mn.proTxHash)['state']
         assert_equal(state['version'], 3)
         assert_equal([p['address'] for p in state['payouts']], [payout_before])
@@ -194,8 +193,7 @@ class ProTxVersionTest(DashTestFramework):
         self.log.info("A v3 ProUpRegTx reusing the basic operator key is accepted, but leaves the "
                       "stored masternode version at 3 even no operator key change took place")
         protx_result = mn.update_registrar(node, submit=True, fundsAddr=mn.fundsAddr)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        tip = self.generate(node, 1)[0]
+        tip = self.bury_tx(node, protx_result)
         assert_equal(node.getrawtransaction(protx_result, 1, tip)['proUpRegTx']['version'], 3)
         assert_equal(node.protx('info', mn.proTxHash)['state']['version'], 3)
 
@@ -208,10 +206,9 @@ class ProTxVersionTest(DashTestFramework):
         legacy_mn.pubKeyOperator = new_operator['public']
         legacy_mn.keyOperator = new_operator['secret']
         migrate_result = legacy_mn.update_registrar(node, submit=True, fundsAddr=legacy_mn.fundsAddr)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         assert legacy_mn.nodeIdx is not None
         old_peer_ids = self.get_peer_ids(legacy_mn.nodeIdx)
-        tip = self.generate(node, 1, sync_fun=self.no_op)[0]
+        tip = self.bury_tx(node, migrate_result, sync_fun=self.no_op)
         assert_equal(node.getrawtransaction(migrate_result, 1, tip)['proUpRegTx']['version'], 3)
         assert_equal(node.protx('info', legacy_mn.proTxHash)['state']['version'], 3)
         # Changing the operator key makes every peer drop its existing connections to this
@@ -249,12 +246,11 @@ class ProTxVersionTest(DashTestFramework):
         node.sendtoaddress(surviving_legacy_mn.fundsAddr, 1)
         upserv_hash = surviving_legacy_mn.update_service(node, submit=True,
                                                          addrs_core_p2p=[f'127.0.0.1:{surviving_legacy_mn.nodePort}'])
-        self.bump_mocktime(10 * 60 + 1)
         # Same CMNAuth disconnect as a key rotation: SetStateVersion re-encodes pubKeyOperator, so
         # skip sync_all until the old peers are gone and this node is reconnected.
         assert surviving_legacy_mn.nodeIdx is not None
         old_peer_ids = self.get_peer_ids(surviving_legacy_mn.nodeIdx)
-        tip = self.generate(node, 1, sync_fun=self.no_op)[0]
+        tip = self.bury_tx(node, upserv_hash, sync_fun=self.no_op)
         assert_equal(node.getrawtransaction(upserv_hash, 1, tip)['proUpServTx']['version'], 3)
         state = node.protx('info', surviving_legacy_mn.proTxHash)['state']
         assert_equal(state['version'], 3)  # migrated in place
@@ -276,10 +272,8 @@ class ProTxVersionTest(DashTestFramework):
         self.nodes[0].sendtoaddress(funds_address, 1)
 
         protx_result = revoke_mn.revoke(self.nodes[0], submit=True, reason=1, fundsAddr=funds_address)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         old_peer_ids = self.get_peer_ids(node_idx)
-        tip = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
-        assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
+        self.bury_tx(self.nodes[0], protx_result, sync_fun=self.no_op)
         # Revoking a MN makes every peer drop its existing connections to it. Wait for that to
         # happen and then reconnect the corresponding node back to let sync_blocks finish
         # correctly.
@@ -296,9 +290,7 @@ class ProTxVersionTest(DashTestFramework):
         self.nodes[0].sendtoaddress(mn.fundsAddr, 1)
 
         protx_result = mn.update_service(self.nodes[0], submit=True, addrs_core_p2p=[f'127.0.0.2:{mn.nodePort}'])
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        tip = self.generate(self.nodes[0], 1)[0]
-        assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
+        self.bury_tx(self.nodes[0], protx_result)
 
         for node in self.nodes:
             protx_info = node.protx('info', mn.proTxHash)

--- a/test/functional/feature_protx_version.py
+++ b/test/functional/feature_protx_version.py
@@ -56,9 +56,9 @@ class ProTxVersionTest(DashTestFramework):
             '-testactivationheight=v19@200',
             # Wide enough a window that v24 does not activate on its own during the body of this
             # test; it is activated explicitly at the end.
-            f'-vbparams=v24:{self.mocktime}:999999999999:450:10:8:6:5:0',
-        ]] * 6
-        self.set_dash_test_params(6, 5, evo_count=2, extra_args=self.extra_args)
+            f'-vbparams=v24:{self.mocktime}:999999999999:350:10:8:6:5:0',
+        ]] * 2
+        self.set_dash_test_params(2, 1, evo_count=2, extra_args=self.extra_args)
 
     def get_peer_ids(self, node_idx):
         return {peer['id'] for peer in self.nodes[node_idx].getpeerinfo()}
@@ -146,7 +146,7 @@ class ProTxVersionTest(DashTestFramework):
 
         self.log.info("Checking that adding more regular MNs after v19 doesn't break DKGs and IS/CLs")
 
-        for i in range(6):
+        for i in range(3):
             new_mn: MasternodeInfo = self.dynamically_add_masternode(evo=False, rnd=(10 + i))
             assert new_mn is not None
             if i == 0:
@@ -156,15 +156,15 @@ class ProTxVersionTest(DashTestFramework):
                 # Kept at its basic (v2) state and update_service'd after v24 to check the payout is preserved
                 payout_mn = new_mn
 
-        # mine more quorums and make sure everything still works
+        # mine more quorums and make sure everything still works between v19 and v24
         prev_quorum = None
-        for _ in range(5):
+        for _ in range(2):
             quorum = self.mine_quorum()
             assert prev_quorum != quorum
-
-        self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
+            self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
 
         self.test_protx_v24_versioning(new_mn, migrate_legacy_mn, surviving_legacy_mn, basic_mn, payout_mn)
+
 
     def test_protx_v24_versioning(self, mn: MasternodeInfo, legacy_mn: MasternodeInfo,
                                   surviving_legacy_mn: MasternodeInfo, basic_mn: MasternodeInfo,

--- a/test/functional/feature_protx_version.py
+++ b/test/functional/feature_protx_version.py
@@ -180,8 +180,6 @@ class ProTxVersionTest(DashTestFramework):
         assert_equal(state['version'], 2)
         payout_before = state['payoutAddress']
         node.sendtoaddress(payout_mn.fundsAddr, 1)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        self.generate(node, 1)
         payout_mn.update_service(node, submit=True, addrs_core_p2p=[f'127.0.0.1:{payout_mn.nodePort}'])
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
         self.generate(node, 1)
@@ -189,8 +187,6 @@ class ProTxVersionTest(DashTestFramework):
         assert_equal(state['version'], 3)
         assert_equal([p['address'] for p in state['payouts']], [payout_before])
         node.sendtoaddress(mn.fundsAddr, 1)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        self.generate(node, 1)
 
         self.log.info("A basic-scheme masternode reports version 2 before any post-v24 update")
         assert_equal(node.protx('info', mn.proTxHash)['state']['version'], 2)
@@ -206,8 +202,6 @@ class ProTxVersionTest(DashTestFramework):
         self.log.info("Migration v1 [legacy] protx masternode to v3 by update-registar with a rotated key")
         assert_equal(node.protx('info', legacy_mn.proTxHash)['state']['version'], 1)
         node.sendtoaddress(legacy_mn.fundsAddr, 1)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        self.generate(node, 1)
         # Switch to a fresh basic-scheme operator key and the non-legacy update_registrar RPC
         legacy_mn.legacy = False
         new_operator = node.bls('generate') # basic (non-legacy) scheme
@@ -253,8 +247,6 @@ class ProTxVersionTest(DashTestFramework):
         assert_equal(node.protx('info', surviving_legacy_mn.proTxHash)['state']['version'], 1)
         key_before = node.protx('info', surviving_legacy_mn.proTxHash)['state']['pubKeyOperator']
         node.sendtoaddress(surviving_legacy_mn.fundsAddr, 1)
-        self.bump_mocktime(10 * 60 + 1)  # make the funding tx safe to include in a block
-        self.generate(node, 1)
         upserv_hash = surviving_legacy_mn.update_service(node, submit=True,
                                                          addrs_core_p2p=[f'127.0.0.1:{surviving_legacy_mn.nodePort}'])
         self.bump_mocktime(10 * 60 + 1)
@@ -281,10 +273,7 @@ class ProTxVersionTest(DashTestFramework):
 
     def test_revoke_protx(self, node_idx, revoke_mn: MasternodeInfo):
         funds_address = self.nodes[0].getnewaddress()
-        fund_txid = self.nodes[0].sendtoaddress(funds_address, 1)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        tip = self.generate(self.nodes[0], 1)[0]
-        assert_equal(self.nodes[0].getrawtransaction(fund_txid, 1, tip)['confirmations'], 1)
+        self.nodes[0].sendtoaddress(funds_address, 1)
 
         protx_result = revoke_mn.revoke(self.nodes[0], submit=True, reason=1, fundsAddr=funds_address)
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
@@ -304,10 +293,7 @@ class ProTxVersionTest(DashTestFramework):
                 return
 
     def test_update_service_protx(self, mn: MasternodeInfo):
-        fund_txid = self.nodes[0].sendtoaddress(mn.fundsAddr, 1)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        tip = self.generate(self.nodes[0], 1)[0]
-        assert_equal(self.nodes[0].getrawtransaction(fund_txid, 1, tip)['confirmations'], 1)
+        self.nodes[0].sendtoaddress(mn.fundsAddr, 1)
 
         protx_result = mn.update_service(self.nodes[0], submit=True, addrs_core_p2p=[f'127.0.0.2:{mn.nodePort}'])
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block

--- a/test/functional/rpc_netinfo.py
+++ b/test/functional/rpc_netinfo.py
@@ -62,6 +62,11 @@ class EvoNode:
         self.mn.set_params(nodePort=p2p_port(node.index))
         self.node = node
 
+    def bury_tx(self, test: BitcoinTestFramework, node: TestNode, txid: str):
+        test.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
+        chain_tip = test.generate(node, 1)[0]
+        assert_equal(node.getrawtransaction(txid, 1, chain_tip)['confirmations'], 1)
+
     def generate_collateral(self, test: BitcoinTestFramework):
         assert self.mn.nodeIdx is not None
         # Generate enough blocks to cover collateral amount
@@ -70,7 +75,7 @@ class EvoNode:
             test.generate(self.node, 10, sync_fun=test.no_op)
         # Create collateral UTXO
         collateral_txid = self.node.sendmany("", {self.mn.collateral_address: self.mn.get_collateral_value(), self.mn.fundsAddr: 1})
-        self.mn.bury_tx(test, self.mn.nodeIdx, collateral_txid, 1)
+        self.bury_tx(test, self.node, collateral_txid)
         collateral_vout = self.mn.get_collateral_vout(self.node, collateral_txid)
         self.mn.set_params(collateral_txid=collateral_txid, collateral_vout=collateral_vout)
 
@@ -105,7 +110,7 @@ class EvoNode:
         assert protx_output is not None
         # Bury ProTx transaction and check if masternode is online
         self.mn.set_params(proTxHash=protx_output, operator_reward=0)
-        self.mn.bury_tx(test, self.mn.nodeIdx, protx_output, 1)
+        self.bury_tx(test, self.node, protx_output)
         assert_equal(self.is_mn_visible(), True)
         test.log.debug(f"Registered EvoNode with collateral_txid={self.mn.collateral_txid}, collateral_vout={self.mn.collateral_vout}, provider_txid={self.mn.proTxHash}")
         return self.mn.proTxHash
@@ -118,7 +123,7 @@ class EvoNode:
         if (code and msg) or not submit:
             return protx_output
         assert protx_output is not None
-        self.mn.bury_tx(test, self.mn.nodeIdx, protx_output, 1)
+        self.bury_tx(test, self.node, protx_output)
         assert_equal(self.is_mn_visible(), True)
         test.log.debug(f"Updated EvoNode with collateral_txid={self.mn.collateral_txid}, collateral_vout={self.mn.collateral_vout}, provider_txid={self.mn.proTxHash}")
         return protx_output
@@ -140,7 +145,7 @@ class EvoNode:
         raw_tx = self.node.signrawtransactionwithwallet(raw_tx)['hex']
         # Send that transaction, resulting txid is new collateral
         new_collateral_txid = self.node.sendrawtransaction(raw_tx)
-        self.mn.bury_tx(test, self.mn.nodeIdx, new_collateral_txid, 1)
+        self.bury_tx(test, self.node, new_collateral_txid)
         new_collateral_vout = self.mn.get_collateral_vout(self.node, new_collateral_txid)
         old_protx_hash = self.mn.proTxHash
         self.mn.set_params(proTxHash="", collateral_txid=new_collateral_txid, collateral_vout=new_collateral_vout)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1184,10 +1184,6 @@ class MasternodeInfo:
     nodeIdx: Optional[int] = None
     friendlyName: Optional[str] = None
 
-    def bury_tx(self, test: BitcoinTestFramework, genIdx: int, txid: str, depth: int):
-        chain_tip = test.generate(test.nodes[genIdx], depth)[0]
-        assert_equal(test.nodes[genIdx].getrawtransaction(txid, 1, chain_tip)['confirmations'], depth)
-
     def generate_addresses(self, node: TestNode, force_all: bool = False):
         if not self.collateral_address or force_all:
             self.collateral_address = node.getnewaddress()
@@ -1654,6 +1650,13 @@ class DashTestFramework(BitcoinTestFramework):
         self.log.info("Successfully started and synced proTx:"+str(created_mn_info.proTxHash))
         return created_mn_info
 
+    def bury_tx(self, node: TestNode, txid: Optional[str], sync_fun=None):
+        assert txid is not None
+        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
+        chain_tip = self.generate(node, 1, sync_fun=sync_fun)[0]
+        assert_equal(node.getrawtransaction(txid, 1, chain_tip)['confirmations'], 1)
+        return chain_tip
+
     def dynamically_prepare_masternode(self, idx, evo=False, rnd=None) -> MasternodeInfo:
         mn = MasternodeInfo(evo=evo, legacy=(not softfork_active(self.nodes[0], 'v19')))
         mn.generate_addresses(self.nodes[0])
@@ -1665,8 +1668,7 @@ class DashTestFramework(BitcoinTestFramework):
 
         outputs = {mn.collateral_address: mn.get_collateral_value(), mn.fundsAddr: 1}
         collateral_txid = self.nodes[0].sendmany("", outputs)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        mn.bury_tx(self, genIdx=0, txid=collateral_txid, depth=1)
+        self.bury_tx(self.nodes[0], txid=collateral_txid)
         collateral_vout = mn.get_collateral_vout(self.nodes[0], collateral_txid)
 
         addrs_core_p2p = ['127.0.0.1:%d' % node_p2p_port]
@@ -1677,8 +1679,7 @@ class DashTestFramework(BitcoinTestFramework):
                                    platform_node_id=platform_node_id, addrs_platform_p2p=addrs_platform_p2p, addrs_platform_https=addrs_platform_https)
         assert protx_result is not None
 
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        mn.bury_tx(self, genIdx=0, txid=protx_result, depth=1)
+        self.bury_tx(self.nodes[0], txid=protx_result)
 
         mn.set_params(proTxHash=protx_result, operator_reward=operatorReward, collateral_txid=collateral_txid, collateral_vout=collateral_vout, nodePort=node_p2p_port)
         self.mninfo.append(mn)
@@ -1703,8 +1704,7 @@ class DashTestFramework(BitcoinTestFramework):
         try:
             protx_result = evo_info.update_service(self.nodes[0], True, f'127.0.0.1:{evo_info.nodePort}', platform_node_id, addrs_platform_p2p, addrs_platform_https, operator_reward_address, funds_address)
             assert protx_result is not None
-            self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-            evo_info.bury_tx(self, genIdx=0, txid=protx_result, depth=1)
+            self.bury_tx(self.nodes[0], txid=protx_result)
             self.log.info("Updated EvoNode %s: platformNodeID=%s, platformP2PPort=%s, platformHTTPPort=%s" % (evo_info.proTxHash, platform_node_id, addrs_platform_p2p, addrs_platform_https))
             protx_success = True
         except Exception:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1697,9 +1697,7 @@ class DashTestFramework(BitcoinTestFramework):
         addrs_platform_p2p = r + 1
         addrs_platform_https = r + 2
 
-        fund_txid = self.nodes[0].sendtoaddress(funds_address, 1)
-        self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
-        evo_info.bury_tx(self, genIdx=0, txid=fund_txid, depth=1)
+        self.nodes[0].sendtoaddress(funds_address, 1)
 
         protx_success = False
         try:


### PR DESCRIPTION
## Issue being fixed or feature implemented
feature_protx_version.py creates too many nodes and generates too many quorums, more than needed.


## What was done?
Firstly, updated amount of nodes created on startup for feature_protx_version.py:
     - 1 regular node, 5 MNs -> 1 regular node, 1 MNs
     - Checking that adding more regular MNs after v19 doesn't break DKGs and IS/CLs: 3 nodes added instead 6
     - 2 extra quorums are mined instead 5 to ensure that chainlocks works [only 2 active quorums for llmq test]
     - reduced amount of blocks for v24 activation as test requires now 330 blocks for pre-v24 scenarious [used to be 450]


Secondly, avoided mining a block only to confirm a fee-funding output before it matters; it duplicated bump of mocktime + block generation.

Thirdly, moved bury_tx helper to DashTestFramework, fold the mocktime bump into it and use in feature_protx_version and feature_masternode_payout_shares.



## How Has This Been Tested?
Run 10 times, median time is recorded.

develop:
```
feature_protx_version.py                               | ✓ Passed  | 155 s
```
PR:
```
feature_protx_version.py                               | ✓ Passed  | 105 s
```

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

