### PR TITLE
test: spread masternode-heavy functional tests apart in test_runner.py to fix asan job

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -108,30 +108,30 @@ BASE_SCRIPTS = [
     'mempool_updatefromblock.py',
     'mempool_persist.py --descriptors',
     'p2p_quorum_data.py',
+    'feature_llmq_simplepose.py', # NOTE: needs dash_hash to pass
     'p2p_instantsend.py',
     'feature_protx_version.py',
     'feature_asset_locks.py', # NOTE: needs dash_hash to pass
-    'feature_llmq_connections.py', # NOTE: needs dash_hash to pass
+    'feature_llmq_signing.py', # NOTE: needs dash_hash to pass
     'feature_llmq_is_retroactive.py', # NOTE: needs dash_hash to pass
     'feature_llmq_chainlocks.py', # NOTE: needs dash_hash to pass
-    'feature_llmq_simplepose.py', # NOTE: needs dash_hash to pass
-    'feature_dip3_deterministicmns.py --descriptors', # NOTE: needs dash_hash to pass
     'feature_masternode_payout_shares.py',
-    'feature_llmq_signing.py', # NOTE: needs dash_hash to pass
     'feature_llmq_signing.py --spork21', # NOTE: needs dash_hash to pass
     'feature_llmq_simplepose.py --disable-spork23', # NOTE: needs dash_hash to pass
     'feature_llmq_rotation.py', # NOTE: needs dash_hash to pass
     'feature_llmq_evo.py', # NOTE: needs dash_hash to pass
-    'feature_llmq_is_cl_conflicts.py', # NOTE: needs dash_hash to pass
     'feature_llmq_dkgerrors.py', # NOTE: needs dash_hash to pass
     'feature_llmq_dkg_intake.py', # NOTE: needs dash_hash to pass
     'feature_llmq_singlenode.py', # NOTE: needs dash_hash to pass
+    'feature_llmq_connections.py', # NOTE: needs dash_hash to pass
+    'feature_llmq_is_cl_conflicts.py', # NOTE: needs dash_hash to pass
     'feature_dip4_coinbasemerkleroots.py', # NOTE: needs dash_hash to pass
     'feature_mnehf.py', # NOTE: needs dash_hash to pass
     'feature_masternode_params.py', # NOTE: needs dash_hash to pass
     'feature_governance.py --descriptors',
     'feature_governance_cl.py --descriptors',
     'rpc_verifyislock.py',
+    'feature_dip3_deterministicmns.py --descriptors', # NOTE: needs dash_hash to pass
     'feature_notifications.py',
     # vv Tests less than 60s vv
     'rpc_psbt.py --legacy-wallet',


### PR DESCRIPTION
# Issue being fixed or feature implemented
ASan CI job was OOM-killed [guess, no proof] - https://github.com/dashpay/dash/actions/runs/33900161711/job/101121790181?pr=7646

As tested locally [with no asan, numbers are estimation because my workstation hardware configuration and CI are not the same anyway]:
    
The first biggest peak 4426 MB PSS / 6123 MB RSS with 37 dashd at 345 s, all 37 belonging to the four named tests with feature_protx_version (15 dashd), feature_llmq_connections (11 dashd), feature_llmq_is_retroactive and feature_asset_locks

The second biggest peak is 3935 MB, 34 dashd: during feature_dip3_deterministicmns (13 dashd), feature_llmq_rotation.py (9 dashd), 2 instances of feature_llmq_simplepose (6+6).

## What was done?
Moving some masternode functional tests within the list reduces the number of dashd processes that run on the same time with -j4.


## How Has This Been Tested?
By simulation [done by Fable 5.1], expected memory peak should be significantly reduced: -j4 3900 → 3124 MB.
There's no regression for -j6 5327 → 5300 and -j8 7349 → 7003 [by simulation]

On CI for PR asan job succeed while on develop fails: https://github.com/dashpay/dash/actions/runs/34049601389/job/101534812733 

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

