### PR TITLE
backport: bitcoin#35117 i2p: clean up SAM error logging

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -282,7 +282,7 @@ std::string Session::Reply::Get(const std::string& key) const
     const auto& pos = keys.find(key);
     if (pos == keys.end() || !pos->second.has_value()) {
         throw std::runtime_error(
-            strprintf("Missing %s= in the reply to \"%s\": \"%s\"", key, request, full));
+            strprintf("Missing %s= in the reply to \"%s\"", key, request));
     }
     return pos->second.value();
 }
@@ -317,7 +317,7 @@ Session::Reply Session::SendRequestAndGetReply(const Sock& sock,
 
     if (check_result_ok && reply.Get("RESULT") != "OK") {
         throw std::runtime_error(
-            strprintf("Unexpected reply to \"%s\": \"%s\"", request, reply.full));
+            strprintf("Reply to \"%s\": had a RESULT not equal to OK.", reply.request));
     }
 
     return reply;


### PR DESCRIPTION
## Issue being fixed or feature implemented
A failed I2P SAM `SESSION CREATE` request can expose the persistent destination private key in the node log. Generic SAM errors also echo raw router-controlled replies.

## What was done?
Backport https://github.com/bitcoin/bitcoin/pull/35117, commit `b6c367044288f83ab61c1a77ad34c33adf39ecf6`, without code changes. Use the existing redacted request for non-OK results and omit raw replies from both non-OK and missing-field errors. The complete upstream patch is included; no prerequisites or hunks are omitted.

## How Has This Been Tested?
- Full local macOS arm64 build with prebuilt depends: `make -j15`.
- Existing I2P unit suite: `./src/test/test_dash --run_test=i2p_tests --log_level=message` (3 cases passed).
- Existing functional tests: `p2p_i2p_ports.py` and `p2p_i2p_sessions.py` (both passed using the existing Python environment with `dash_hash`).
- Whitespace and assertion lint passed; the final patch ID matches the upstream commit.
- No additional regression tests are included, matching the upstream patch and the review request.

## Breaking Changes
No network behavior changes. Generic SAM error messages no longer include raw router replies.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added or updated relevant unit/integration/functional/e2e tests

This pull request was created by Codex.
