### PR TITLE
fix: isolate missing quorums in InstantSend batches

### DIFF
--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -152,8 +152,9 @@ std::unique_ptr<NetInstantSend::BatchVerificationData> NetInstantSend::BuildVeri
                                               : m_qman.GetQuorum(llmq_params.type, islock->cycleHash);
 
         if (!quorum) {
-            // should not happen, but if one fails to select, all others will also fail to select
-            return nullptr;
+            // Different cycle hashes can select different quorums within the same batch.
+            data->batchVerifier.badMessages.emplace(hash);
+            continue;
         }
         uint256 signHash = llmq::SignHash{llmq_params.type, quorum->qc->quorumHash, id, islock->txid}.Get();
         data->batchVerifier.PushMessage(nodeId, hash, signHash, sig, quorum->qc->quorumPublicKey);

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -79,6 +79,7 @@ protected:
     void NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const chainlock::ChainLockSig>& clsig) override;
 
 private:
+    friend struct NetInstantSendTest;
     struct BatchVerificationData;
 
     bool ValidateIncomingISLock(const instantsend::InstantSendLock& islock, NodeId node_id);

--- a/src/test/evo_islock_tests.cpp
+++ b/src/test/evo_islock_tests.cpp
@@ -8,12 +8,14 @@
 #include <instantsend/lock.h>
 #include <instantsend/net_instantsend.h>
 #include <llmq/context.h>
+#include <llmq/quorumsman.h>
 #include <llmq/signhash.h>
 #include <llmq/signing.h>
 #include <primitives/transaction.h>
 #include <spork.h>
 #include <streams.h>
 #include <test/util/llmq_tests.h>
+#include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/strencodings.h>
@@ -32,6 +34,60 @@ struct NetInstantSendTest : RegTestingSetup {
 };
 
 BOOST_AUTO_TEST_SUITE(evo_islock_tests)
+
+BOOST_FIXTURE_TEST_CASE(received_genesis_cycle_has_no_quorum, TestChain100Setup)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+    constexpr const char* REGTEST_SPORK_PRIVKEY{"cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"};
+    BOOST_REQUIRE(m_node.sporkman->SetSporkAddress(Params().SporkAddress()));
+    BOOST_REQUIRE(m_node.sporkman->SetPrivKey(REGTEST_SPORK_PRIVKEY));
+    BOOST_REQUIRE(m_node.sporkman->UpdateSpork(SPORK_2_INSTANTSEND_ENABLED, 0).has_value());
+    auto& isman = *m_node.isman;
+    auto& qman = *m_node.llmq_ctx->qman;
+    auto& sigman = *m_node.llmq_ctx->sigman;
+    NetInstantSend net{m_node.peerman.get(), isman,           nullptr,        sigman, qman, *m_node.chainlocks,
+                       *m_node.chainman,     *m_node.mempool, *m_node.mn_sync};
+    const auto params = Params().GetLLMQ(Params().GetConsensus().llmqTypeDIP0024InstantSend).value();
+    BOOST_REQUIRE(params.useRotation);
+    const CChain& chain = *WITH_LOCK(cs_main, return &m_node.chainman->ActiveChain());
+    WITH_LOCK(cs_main, isman.CacheTipHeight(chain.Tip()));
+    BOOST_REQUIRE_GT(isman.GetTipHeight(), params.dkgInterval);
+
+    // A peer can supply a known cycle boundary from before any quorums existed.
+    instantsend::InstantSendLock islock;
+    islock.txid = GetRandHash();
+    islock.inputs.emplace_back(GetRandHash(), 0);
+    islock.cycleHash = WITH_LOCK(cs_main, return chain.Genesis()->GetBlockHash());
+    CBLSSecretKey key;
+    key.MakeNewKey();
+    const bool legacy = bls::bls_legacy_scheme.load();
+    islock.sig.Set(key.Sign(islock.GetRequestId(), legacy), legacy);
+    auto peer = MakeTestPeer(/*id=*/1);
+    m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    stream << islock;
+    net.ProcessMessage(*peer, NetMsgType::ISDLOCK, stream);
+
+    const auto pending = isman.FetchPendingLocks();
+    BOOST_REQUIRE_EQUAL(pending.m_pending_is.size(), 1U);
+    const auto hash = ::SerializeHash(islock);
+    BOOST_CHECK(pending.m_pending_is.front().islock_hash == hash);
+    BOOST_CHECK_EQUAL(pending.m_pending_is.front().node_id, peer->GetId());
+    BOOST_REQUIRE(pending.m_pending_is.front().islock->sig.Get().IsValid());
+    BOOST_REQUIRE(!sigman.HasRecoveredSig(params.type, islock.GetRequestId(), islock.txid));
+
+    for (const int offset : {0, params.dkgInterval}) {
+        // BuildVerificationBatch selects cycleHeight + dkgInterval - 1 for this old cycle.
+        BOOST_CHECK(
+            !llmq::SelectQuorumForSigning(params, chain, qman, islock.GetRequestId(), params.dkgInterval - 1, offset));
+        const auto failed = NetInstantSendTest::ProcessBatch(net, params, offset, pending.m_pending_is);
+        BOOST_CHECK(failed.contains(hash));
+        BOOST_CHECK(!isman.AlreadyHave(CInv{MSG_ISDLOCK, hash}));
+    }
+    CNodeStateStats stats;
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer->GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 0);
+}
 
 BOOST_FIXTURE_TEST_CASE(missing_quorum_does_not_drop_batch, NetInstantSendTest)
 {

--- a/src/test/evo_islock_tests.cpp
+++ b/src/test/evo_islock_tests.cpp
@@ -4,18 +4,82 @@
 
 #include <consensus/consensus.h>
 #include <hash.h>
+#include <instantsend/instantsend.h>
 #include <instantsend/lock.h>
+#include <instantsend/net_instantsend.h>
+#include <llmq/context.h>
 #include <llmq/signhash.h>
+#include <llmq/signing.h>
 #include <primitives/transaction.h>
+#include <spork.h>
 #include <streams.h>
+#include <test/util/llmq_tests.h>
+#include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/strencodings.h>
+#include <validation.h>
 
 #include <string_view>
 
 #include <boost/test/unit_test.hpp>
 
+struct NetInstantSendTest : RegTestingSetup {
+    static Uint256HashSet ProcessBatch(NetInstantSend& net, const Consensus::LLMQParams& params, int offset,
+                                       const std::vector<instantsend::PendingISLockEntry>& locks)
+    {
+        return net.ProcessPendingInstantSendLocks(params, offset, /*ban=*/true, locks);
+    }
+};
+
 BOOST_AUTO_TEST_SUITE(evo_islock_tests)
+
+BOOST_FIXTURE_TEST_CASE(missing_quorum_does_not_drop_batch, NetInstantSendTest)
+{
+    constexpr const char* REGTEST_SPORK_PRIVKEY{"cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"};
+    BOOST_REQUIRE(m_node.sporkman->SetSporkAddress(Params().SporkAddress()));
+    BOOST_REQUIRE(m_node.sporkman->SetPrivKey(REGTEST_SPORK_PRIVKEY));
+    BOOST_REQUIRE(m_node.sporkman->UpdateSpork(SPORK_2_INSTANTSEND_ENABLED, 0).has_value());
+    auto& sigman = *m_node.llmq_ctx->sigman;
+    NetInstantSend net{m_node.peerman.get(), *m_node.isman,    nullptr,         sigman,         *m_node.llmq_ctx->qman,
+                       *m_node.chainlocks,   *m_node.chainman, *m_node.mempool, *m_node.mn_sync};
+    const auto cycle_hash = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Genesis()->GetBlockHash());
+    CBLSSecretKey key;
+    key.MakeNewKey();
+
+    for (const auto type : {Consensus::LLMQType::LLMQ_TEST_DIP0024, Consensus::LLMQType::LLMQ_TEST_INSTANTSEND}) {
+        const auto& params = llmq::testutils::GetLLMQParams(type);
+        std::vector<instantsend::PendingISLockEntry> locks;
+        for (int i = 0; i < 3; ++i) {
+            auto islock = std::make_shared<instantsend::InstantSendLock>();
+            islock->txid = GetRandHash();
+            islock->inputs.emplace_back(GetRandHash(), 0);
+            islock->cycleHash = cycle_hash;
+            const auto sign_hash = llmq::SignHash{type, cycle_hash, islock->GetRequestId(), islock->txid}.Get();
+            const bool legacy = bls::bls_legacy_scheme.load();
+            islock->sig.Set(key.Sign(sign_hash, legacy), legacy);
+            if (i != 1) {
+                // Exercise the already-verified path on either side of an unavailable quorum.
+                BOOST_REQUIRE(sigman.ProcessRecoveredSig(
+                    std::make_shared<llmq::CRecoveredSig>(type, cycle_hash, islock->GetRequestId(), islock->txid,
+                                                          islock->sig)));
+            }
+            locks.push_back({{i == 2 ? 2 : 1, islock}, ::SerializeHash(*islock)});
+        }
+
+        const auto failed = ProcessBatch(net, params, /*offset=*/0, locks);
+        BOOST_CHECK_EQUAL(failed.size(), 1U);
+        BOOST_CHECK(failed.contains(locks[1].islock_hash));
+        BOOST_CHECK(m_node.isman->AlreadyHave(CInv{MSG_ISDLOCK, locks[0].islock_hash}));
+        BOOST_CHECK(!m_node.isman->AlreadyHave(CInv{MSG_ISDLOCK, locks[1].islock_hash}));
+        BOOST_CHECK(m_node.isman->AlreadyHave(CInv{MSG_ISDLOCK, locks[2].islock_hash}));
+
+        const auto retried = ProcessBatch(net, params, params.dkgInterval, {locks[1]});
+        BOOST_CHECK(retried.contains(locks[1].islock_hash));
+        BOOST_CHECK(!m_node.isman->AlreadyHave(CInv{MSG_ISDLOCK, locks[1].islock_hash}));
+        BOOST_CHECK(!sigman.HasRecoveredSig(type, locks[1].islock->GetRequestId(), locks[1].islock->txid));
+        BOOST_CHECK(sigman.FetchPendingReconstructed().empty());
+    }
+}
 
 uint256 CalculateRequestId(const std::vector<COutPoint>& inputs)
 {


### PR DESCRIPTION
## Issue being fixed or feature implemented
A peer can send a structurally valid ISDLOCK with the genesis block as its cycle hash and an arbitrary parseable BLS signature. The receive path accepts the known cycle-boundary hash, but a mature mainnet node selects signing height 287, before DIP0024 activation, so no quorum is available. The current early return then discards the entire dequeued batch, including unrelated locks that could otherwise be processed.

## What was done?
Mark only the affected lock as a failed message and continue building the batch. Existing verification-result handling keeps that lock unaccepted and routes it through the previous-active-set retry without penalizing its peer solely for the unavailable quorum.

Add a receive-path regression that serializes a peer-supplied genesis-cycle lock, passes it through `NetInstantSend::ProcessMessage`, fetches the real pending queue, and verifies missing-quorum handling without peer punishment. This uses a mined regtest chain and does not inject quorum or recovered-signature state.

Retain the batch-isolation regression placing an unavailable-quorum lock between two locks with cached recovered signatures, including one from the same peer. Cover rotating and non-rotating quorum selection, the retry path, and the absence of acceptance or reconstructed signatures for the failed lock.

## How Has This Been Tested?
- Local macOS arm64 build with prebuilt depends: `make -j8`.
- `./src/test/test_dash --run_test=evo_islock_tests --log_level=message`.
- All 10 cases in `evo_islock_tests` pass. The receive-path regression fails at both expected failure-set checks when the original `return nullptr` is restored, and passes with the fix.
- Changed-line clang-format, whitespace/assertion lint, and independent security/code review.

## Breaking Changes
None. Signature verification and quorum selection rules are unchanged.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

This pull request was created by Codex.
