### PR TITLE
fix(wallet): use renamed handler for locked coins signal

### DIFF
--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -820,7 +820,7 @@ public:
     }
     std::unique_ptr<Handler> handleLockedCoinsChanged(LockedCoinsChangedFn fn) override
     {
-        return MakeHandler(m_wallet->NotifyLockedCoinsChanged.connect(fn));
+        return MakeSignalHandler(m_wallet->NotifyLockedCoinsChanged.connect(fn));
     }
     std::vector<Governance::Object> getGovernanceObjects() override
     {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Merging #7648 and #7602 together broke wallet-enabled builds on `develop`: `wallet/interfaces.cpp:823:16: error: use of undeclared identifier 'MakeHandler'`. #7648 renamed the signal-handler factory to `MakeSignalHandler` as part of bitcoin/bitcoin#26298, while #7602 introduced `handleLockedCoinsChanged` using the old name.

## What was done?

Update the locked-coins notification to use `MakeSignalHandler`, matching the other wallet signal handlers and preserving connection cleanup. This was the only remaining `MakeHandler` reference in `src`.

## How Has This Been Tested?

On macOS arm64 with the prebuilt depends dependencies, wallet and Qt enabled:

- Reproduced the exact compiler error before the fix with `make -C src wallet/libbitcoin_wallet_a-interfaces.o`.
- Full `make -j15` passed, including `dashd`, `dash-qt`, and the test binaries.
- `./src/test/test_dash --run_test=wallet_tests --report_level=short`: 20 cases and 626 assertions passed.
- `QT_QPA_PLATFORM=minimal ./src/qt/test/test_dash-qt`: 90 passed, 1 skipped, 0 failed.
- `COMMIT_RANGE=upstream/develop..HEAD python3 test/lint/lint-whitespace.py` and `git diff --check` passed.

No new test is needed for this one-line API rename repair; compiling the affected translation unit directly reproduces the regression and verifies the fix.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
