### PR TITLE
test: prove missing InstantSend quorum is reachable from peers [v2]

### DIFF
--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -79,7 +79,6 @@ protected:
     void NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const chainlock::ChainLockSig>& clsig) override;
 
 private:
-    friend struct NetInstantSendTest;
     struct BatchVerificationData;
 
     bool ValidateIncomingISLock(const instantsend::InstantSendLock& islock, NodeId node_id);

--- a/src/test/evo_islock_tests.cpp
+++ b/src/test/evo_islock_tests.cpp
@@ -4,138 +4,18 @@
 
 #include <consensus/consensus.h>
 #include <hash.h>
-#include <instantsend/instantsend.h>
 #include <instantsend/lock.h>
-#include <instantsend/net_instantsend.h>
-#include <llmq/context.h>
-#include <llmq/quorumsman.h>
 #include <llmq/signhash.h>
-#include <llmq/signing.h>
 #include <primitives/transaction.h>
-#include <spork.h>
 #include <streams.h>
-#include <test/util/llmq_tests.h>
-#include <test/util/net.h>
-#include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/strencodings.h>
-#include <validation.h>
 
 #include <string_view>
 
 #include <boost/test/unit_test.hpp>
 
-struct NetInstantSendTest : RegTestingSetup {
-    static Uint256HashSet ProcessBatch(NetInstantSend& net, const Consensus::LLMQParams& params, int offset,
-                                       const std::vector<instantsend::PendingISLockEntry>& locks)
-    {
-        return net.ProcessPendingInstantSendLocks(params, offset, /*ban=*/true, locks);
-    }
-};
-
 BOOST_AUTO_TEST_SUITE(evo_islock_tests)
-
-BOOST_FIXTURE_TEST_CASE(received_genesis_cycle_has_no_quorum, TestChain100Setup)
-{
-    LOCK(NetEventsInterface::g_msgproc_mutex);
-    constexpr const char* REGTEST_SPORK_PRIVKEY{"cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"};
-    BOOST_REQUIRE(m_node.sporkman->SetSporkAddress(Params().SporkAddress()));
-    BOOST_REQUIRE(m_node.sporkman->SetPrivKey(REGTEST_SPORK_PRIVKEY));
-    BOOST_REQUIRE(m_node.sporkman->UpdateSpork(SPORK_2_INSTANTSEND_ENABLED, 0).has_value());
-    auto& isman = *m_node.isman;
-    auto& qman = *m_node.llmq_ctx->qman;
-    auto& sigman = *m_node.llmq_ctx->sigman;
-    NetInstantSend net{m_node.peerman.get(), isman,           nullptr,        sigman, qman, *m_node.chainlocks,
-                       *m_node.chainman,     *m_node.mempool, *m_node.mn_sync};
-    const auto params = Params().GetLLMQ(Params().GetConsensus().llmqTypeDIP0024InstantSend).value();
-    BOOST_REQUIRE(params.useRotation);
-    const CChain& chain = *WITH_LOCK(cs_main, return &m_node.chainman->ActiveChain());
-    WITH_LOCK(cs_main, isman.CacheTipHeight(chain.Tip()));
-    BOOST_REQUIRE_GT(isman.GetTipHeight(), params.dkgInterval);
-
-    // A peer can supply a known cycle boundary from before any quorums existed.
-    instantsend::InstantSendLock islock;
-    islock.txid = GetRandHash();
-    islock.inputs.emplace_back(GetRandHash(), 0);
-    islock.cycleHash = WITH_LOCK(cs_main, return chain.Genesis()->GetBlockHash());
-    CBLSSecretKey key;
-    key.MakeNewKey();
-    const bool legacy = bls::bls_legacy_scheme.load();
-    islock.sig.Set(key.Sign(islock.GetRequestId(), legacy), legacy);
-    auto peer = MakeTestPeer(/*id=*/1);
-    m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
-    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
-    stream << islock;
-    net.ProcessMessage(*peer, NetMsgType::ISDLOCK, stream);
-
-    const auto pending = isman.FetchPendingLocks();
-    BOOST_REQUIRE_EQUAL(pending.m_pending_is.size(), 1U);
-    const auto hash = ::SerializeHash(islock);
-    BOOST_CHECK(pending.m_pending_is.front().islock_hash == hash);
-    BOOST_CHECK_EQUAL(pending.m_pending_is.front().node_id, peer->GetId());
-    BOOST_REQUIRE(pending.m_pending_is.front().islock->sig.Get().IsValid());
-    BOOST_REQUIRE(!sigman.HasRecoveredSig(params.type, islock.GetRequestId(), islock.txid));
-
-    for (const int offset : {0, params.dkgInterval}) {
-        // BuildVerificationBatch selects cycleHeight + dkgInterval - 1 for this old cycle.
-        BOOST_CHECK(
-            !llmq::SelectQuorumForSigning(params, chain, qman, islock.GetRequestId(), params.dkgInterval - 1, offset));
-        const auto failed = NetInstantSendTest::ProcessBatch(net, params, offset, pending.m_pending_is);
-        BOOST_CHECK(failed.contains(hash));
-        BOOST_CHECK(!isman.AlreadyHave(CInv{MSG_ISDLOCK, hash}));
-    }
-    CNodeStateStats stats;
-    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer->GetId(), stats));
-    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 0);
-}
-
-BOOST_FIXTURE_TEST_CASE(missing_quorum_does_not_drop_batch, NetInstantSendTest)
-{
-    constexpr const char* REGTEST_SPORK_PRIVKEY{"cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"};
-    BOOST_REQUIRE(m_node.sporkman->SetSporkAddress(Params().SporkAddress()));
-    BOOST_REQUIRE(m_node.sporkman->SetPrivKey(REGTEST_SPORK_PRIVKEY));
-    BOOST_REQUIRE(m_node.sporkman->UpdateSpork(SPORK_2_INSTANTSEND_ENABLED, 0).has_value());
-    auto& sigman = *m_node.llmq_ctx->sigman;
-    NetInstantSend net{m_node.peerman.get(), *m_node.isman,    nullptr,         sigman,         *m_node.llmq_ctx->qman,
-                       *m_node.chainlocks,   *m_node.chainman, *m_node.mempool, *m_node.mn_sync};
-    const auto cycle_hash = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Genesis()->GetBlockHash());
-    CBLSSecretKey key;
-    key.MakeNewKey();
-
-    for (const auto type : {Consensus::LLMQType::LLMQ_TEST_DIP0024, Consensus::LLMQType::LLMQ_TEST_INSTANTSEND}) {
-        const auto& params = llmq::testutils::GetLLMQParams(type);
-        std::vector<instantsend::PendingISLockEntry> locks;
-        for (int i = 0; i < 3; ++i) {
-            auto islock = std::make_shared<instantsend::InstantSendLock>();
-            islock->txid = GetRandHash();
-            islock->inputs.emplace_back(GetRandHash(), 0);
-            islock->cycleHash = cycle_hash;
-            const auto sign_hash = llmq::SignHash{type, cycle_hash, islock->GetRequestId(), islock->txid}.Get();
-            const bool legacy = bls::bls_legacy_scheme.load();
-            islock->sig.Set(key.Sign(sign_hash, legacy), legacy);
-            if (i != 1) {
-                // Exercise the already-verified path on either side of an unavailable quorum.
-                BOOST_REQUIRE(sigman.ProcessRecoveredSig(
-                    std::make_shared<llmq::CRecoveredSig>(type, cycle_hash, islock->GetRequestId(), islock->txid,
-                                                          islock->sig)));
-            }
-            locks.push_back({{i == 2 ? 2 : 1, islock}, ::SerializeHash(*islock)});
-        }
-
-        const auto failed = ProcessBatch(net, params, /*offset=*/0, locks);
-        BOOST_CHECK_EQUAL(failed.size(), 1U);
-        BOOST_CHECK(failed.contains(locks[1].islock_hash));
-        BOOST_CHECK(m_node.isman->AlreadyHave(CInv{MSG_ISDLOCK, locks[0].islock_hash}));
-        BOOST_CHECK(!m_node.isman->AlreadyHave(CInv{MSG_ISDLOCK, locks[1].islock_hash}));
-        BOOST_CHECK(m_node.isman->AlreadyHave(CInv{MSG_ISDLOCK, locks[2].islock_hash}));
-
-        const auto retried = ProcessBatch(net, params, params.dkgInterval, {locks[1]});
-        BOOST_CHECK(retried.contains(locks[1].islock_hash));
-        BOOST_CHECK(!m_node.isman->AlreadyHave(CInv{MSG_ISDLOCK, locks[1].islock_hash}));
-        BOOST_CHECK(!sigman.HasRecoveredSig(type, locks[1].islock->GetRequestId(), locks[1].islock->txid));
-        BOOST_CHECK(sigman.FetchPendingReconstructed().empty());
-    }
-}
 
 uint256 CalculateRequestId(const std::vector<COutPoint>& inputs)
 {

--- a/test/functional/p2p_instantsend.py
+++ b/test/functional/p2p_instantsend.py
@@ -3,7 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-from test_framework.messages import msg_qsendrecsigs
+import random
+from io import BytesIO
+
+from test_framework.messages import COutPoint, msg_isdlock, msg_qsendrecsigs
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error, force_finish_mnsync
@@ -57,6 +60,7 @@ class InstantSendTest(DashTestFramework):
         self.test_mempool_doublespend()
         self.test_block_doublespend()
         self.test_isdlock_relayed_to_recsigs_observer()
+        self.test_genesis_cycle_islock_isolated()
         self.test_instantsend_after_restart()
 
     def test_block_doublespend(self):
@@ -170,6 +174,38 @@ class InstantSendTest(DashTestFramework):
 
         for node, _ in observers:
             node.disconnect_p2ps()
+
+    def test_genesis_cycle_islock_isolated(self):
+        self.log.info("A missing-quorum ISDLOCK must not drop the genuine locks batched with it")
+        # A genesis-block cycle hash resolves to height 0, a valid rotation boundary, but selects a
+        # signing height from before any quorum, so the lock has no quorum. Before the fix that
+        # dropped the whole verification batch, taking any genuine lock that shared it. We isolate a
+        # node so its only lock source is our peer, then hand it a genuine lock next to the crafted
+        # one; sending both back-to-back lands them in one batch, and a few tries make it certain.
+        controller = self.nodes[0]
+        target = self.nodes[self.isolated_idx]
+        connected = [n for i, n in enumerate(self.nodes) if i != self.isolated_idx]
+        self.isolate_node(self.isolated_idx)
+        target.setnetworkactive(True)
+        peer = target.add_p2p_connection(P2PInterface())
+        genesis_hash = int(target.getblockhash(0), 16)
+
+        for _ in range(5):
+            txid = controller.sendtoaddress(controller.getnewaddress(), 1)
+            self.wait_for_instantlock(txid, nodes=connected)
+            genuine = msg_isdlock()
+            genuine.deserialize(BytesIO(bytes.fromhex(controller.getislocks([txid])[0]["hex"])))
+            # Reusing a real signature keeps sig.IsValid() true so the crafted lock reaches quorum selection.
+            poisoned = msg_isdlock(1, [COutPoint(random.getrandbits(256), 0)], random.getrandbits(256),
+                                   genesis_hash, genuine.sig)
+            target.sendrawtransaction(controller.getrawtransaction(txid))
+            peer.send_message(poisoned)
+            peer.send_message(genuine)
+            peer.sync_with_ping()
+            self.wait_until(lambda txid=txid: target.getrawtransaction(txid, True)["instantlock"], timeout=20)
+
+        target.disconnect_p2ps()
+        self.reconnect_isolated_node(self.isolated_idx, 0)
 
     def test_instantsend_after_restart(self):
         self.log.info("Testing InstantSend works after full restart without new blocks")


### PR DESCRIPTION
## Issue being fixed or feature implemented

A peer can send a structurally valid ISDLOCK with the genesis block as its cycle hash and an arbitrary parseable BLS signature. The receive path accepts the known cycle-boundary hash, but a mature mainnet node selects signing height 287, before DIP0024 activation, so no quorum is available. The current early return then discards the entire dequeued batch, including unrelated locks that could otherwise be processed.

Current regression tests asserts current implementation and testing environment is very much spefic on the current implementation rather than really testing behaviour.

## What was done?

Regression test is removed and added a new functional test's scenario with a genuine lock that shares a batch with the poisoned one still gets applied by reverting commit 71cf6252599d1e716e0f5e68628eb9cddd935069 and partial revert for 2e7f4a9a37894b28cdfb288a7087e9cbd4964cab




## How Has This Been Tested?
It runs 5 attemps just to be sure that it doesn't get to the different batch and slip out from validation by mistake. Asserts the target reports instantlock true for the genuine transaction, and that the peer stays connected.

Tested by reverting changes from #7662 - functional tests fails as expected:

        2026-09-12T10:55:16.127000Z TestFramework (INFO): A missing-quorum ISDLOCK must not drop the genuine locks batched with it
    2026-09-12T10:55:17.541000Z TestFramework (INFO): Expecting InstantLock for ['dd3f8e9b6b0d2db0eefae805169a5f01d37acf615739f7cdaf35fa8f117097d5']
    2026-09-12T10:55:37.656000Z TestFramework.utils (ERROR): wait_until() failed. Predicate: ''''
                self.wait_until(lambda txid=txid: target.getrawtransaction(txid, True)["instantlock"], timeout=20)
    '''
    2026-09-12T10:55:37.656000Z TestFramework (ERROR): Assertion failed
    Traceback (most recent call last):
      File "/DASH/test/functional/test_framework/test_framework.py", line 164, in main
        self.run_test()
        ~~~~~~~~~~~~~^^
      File "/DASH/test/functional/p2p_instantsend.py", line 63, in run_test
        self.test_genesis_cycle_islock_isolated()
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/DASH/test/functional/p2p_instantsend.py", line 205, in test_genesis_cycle_islock_isolated
        self.wait_until(lambda txid=txid: target.getrawtransaction(txid, True)["instantlock"], timeout=20)
        ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/DASH/test/functional/test_framework/test_framework.py", line 908, in wait_until
        return wait_until_helper(test_function, timeout=timeout, lock=lock, timeout_factor=self.options.timeout_factor, sleep=sleep, do_assert=do_assert)
      File "/DASH/test/functional/test_framework/util.py", line 298, in wait_until_helper
        raise AssertionError("Predicate {} not true after {} seconds".format(predicate_source, timeout))
    AssertionError: Predicate ''''
                self.wait_until(lambda txid=txid: target.getrawtransaction(txid, True)["instantlock"], timeout=20)
    ''' not true after 20 seconds
    2026-09-12T10:55:37.708000Z TestFramework (INFO): Stopping nodes



## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

